### PR TITLE
chore: moves eladb/projen -> projen/projen, fixes spelling

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -3,7 +3,7 @@ const { JsiiProject, JsonFile } = require('./lib');
 const project = new JsiiProject({
   name: 'projen',
   description: 'A new generation of project generators',
-  repository: 'https://github.com/eladb/projen.git',
+  repository: 'https://github.com/projen/projen.git',
   authorName: 'Elad Ben-Israel',
   authorEmail: 'benisrae@amazon.com',
   stability: 'experimental',

--- a/API.md
+++ b/API.md
@@ -284,7 +284,7 @@ new AwsCdkConstructLibrary(options: AwsCdkConstructLibraryOptions)
   * **rootdir** (<code>string</code>)  *No description* __*Default*__: "."
   * **stability** (<code>string</code>)  *No description* __*Optional*__
   * **catalog** (<code>[Catalog](#projen-catalog)</code>)  Libraries will be picked up by the construct catalog when they are published to npm as jsii modules and will be published under:. __*Default*__: new version will be announced
-  * **cdkVersion** (<code>string</code>)  Minmum target version this library is tested against. 
+  * **cdkVersion** (<code>string</code>)  Minimum target version this library is tested against. 
   * **cdkAssert** (<code>boolean</code>)  Install the @aws-cdk/assert library? __*Default*__: true
   * **cdkDependencies** (<code>Array<string></code>)  Which AWS CDK modules (those that start with "@aws-cdk/") does this library require when consumed? __*Optional*__
   * **cdkTestDependencies** (<code>Array<string></code>)  AWS CDK modules required for testing. __*Optional*__
@@ -707,7 +707,7 @@ new ConstructLibraryAws(options: AwsCdkConstructLibraryOptions)
   * **rootdir** (<code>string</code>)  *No description* __*Default*__: "."
   * **stability** (<code>string</code>)  *No description* __*Optional*__
   * **catalog** (<code>[Catalog](#projen-catalog)</code>)  Libraries will be picked up by the construct catalog when they are published to npm as jsii modules and will be published under:. __*Default*__: new version will be announced
-  * **cdkVersion** (<code>string</code>)  Minmum target version this library is tested against. 
+  * **cdkVersion** (<code>string</code>)  Minimum target version this library is tested against. 
   * **cdkAssert** (<code>boolean</code>)  Install the @aws-cdk/assert library? __*Default*__: true
   * **cdkDependencies** (<code>Array<string></code>)  Which AWS CDK modules (those that start with "@aws-cdk/") does this library require when consumed? __*Optional*__
   * **cdkTestDependencies** (<code>Array<string></code>)  AWS CDK modules required for testing. __*Optional*__
@@ -854,7 +854,7 @@ Name | Type | Description
 
 #### addIgnore(dependencyName, ...versions)🔹 <a id="projen-dependabot-addignore"></a>
 
-Ignores a depepdency from automatic updates.
+Ignores a dependency from automatic updates.
 
 ```ts
 addIgnore(dependencyName: string, ...versions: string[]): void
@@ -3428,7 +3428,7 @@ Name | Type | Description
 -----|------|-------------
 **authorAddress**🔹 | <code>string</code> | Email or URL of the library author.
 **authorName**🔹 | <code>string</code> | The name of the library author.
-**cdkVersion**🔹 | <code>string</code> | Minmum target version this library is tested against.
+**cdkVersion**🔹 | <code>string</code> | Minimum target version this library is tested against.
 **name**🔹 | <code>string</code> | The name of the library.
 **repository**🔹 | <code>string</code> | Git repository URL.
 **allowLibraryDependencies**?🔹 | <code>boolean</code> | Allow the project to include `peerDependencies` and `bundledDependencies`.<br/>__*Default*__: true
@@ -3626,7 +3626,7 @@ Name | Type | Description
 -----|------|-------------
 **authorAddress**⚠️ | <code>string</code> | Email or URL of the library author.
 **authorName**⚠️ | <code>string</code> | The name of the library author.
-**cdkVersion**⚠️ | <code>string</code> | Minmum target version this library is tested against.
+**cdkVersion**⚠️ | <code>string</code> | Minimum target version this library is tested against.
 **name**⚠️ | <code>string</code> | The name of the library.
 **repository**⚠️ | <code>string</code> | Git repository URL.
 **allowLibraryDependencies**?⚠️ | <code>boolean</code> | Allow the project to include `peerDependencies` and `bundledDependencies`.<br/>__*Default*__: true

--- a/README.md
+++ b/README.md
@@ -35,18 +35,18 @@ Currently supported project types (use `npx projen new` without a type for a
 list):
 
 <!-- <macro exec="node ./scripts/readme-projects.js"> -->
-* [awscdk-app-ts](https://github.com/eladb/projen/blob/master/API.md#projen-awscdktypescriptapp) - AWS CDK app in TypeScript.
-* [awscdk-construct](https://github.com/eladb/projen/blob/master/API.md#projen-awscdkconstructlibrary) - AWS CDK construct library project.
-* [cdk8s-construct](https://github.com/eladb/projen/blob/master/API.md#projen-constructlibrarycdk8s) - CDK8s construct library project.
-* [jsii](https://github.com/eladb/projen/blob/master/API.md#projen-jsiiproject) - Multi-language jsii library project.
-* [nextjs](https://github.com/eladb/projen/blob/master/API.md#projen-nextjsproject) - Next.js project without TypeScript.
-* [nextjs-ts](https://github.com/eladb/projen/blob/master/API.md#projen-nextjstypescriptproject) - Next.js project with TypeScript.
-* [node](https://github.com/eladb/projen/blob/master/API.md#projen-nodeproject) - Node.js project.
-* [project](https://github.com/eladb/projen/blob/master/API.md#projen-project) - Base project.
-* [react](https://github.com/eladb/projen/blob/master/API.md#projen-reactproject) - React project without TypeScript.
-* [react-ts](https://github.com/eladb/projen/blob/master/API.md#projen-reacttypescriptproject) - React project with TypeScript.
-* [typescript](https://github.com/eladb/projen/blob/master/API.md#projen-typescriptproject) - TypeScript project.
-* [typescript-app](https://github.com/eladb/projen/blob/master/API.md#projen-typescriptappproject) - TypeScript app.
+* [awscdk-app-ts](https://github.com/projen/projen/blob/master/API.md#projen-awscdktypescriptapp) - AWS CDK app in TypeScript.
+* [awscdk-construct](https://github.com/projen/projen/blob/master/API.md#projen-awscdkconstructlibrary) - AWS CDK construct library project.
+* [cdk8s-construct](https://github.com/projen/projen/blob/master/API.md#projen-constructlibrarycdk8s) - CDK8s construct library project.
+* [jsii](https://github.com/projen/projen/blob/master/API.md#projen-jsiiproject) - Multi-language jsii library project.
+* [nextjs](https://github.com/projen/projen/blob/master/API.md#projen-nextjsproject) - Next.js project without TypeScript.
+* [nextjs-ts](https://github.com/projen/projen/blob/master/API.md#projen-nextjstypescriptproject) - Next.js project with TypeScript.
+* [node](https://github.com/projen/projen/blob/master/API.md#projen-nodeproject) - Node.js project.
+* [project](https://github.com/projen/projen/blob/master/API.md#projen-project) - Base project.
+* [react](https://github.com/projen/projen/blob/master/API.md#projen-reactproject) - React project without TypeScript.
+* [react-ts](https://github.com/projen/projen/blob/master/API.md#projen-reacttypescriptproject) - React project with TypeScript.
+* [typescript](https://github.com/projen/projen/blob/master/API.md#projen-typescriptproject) - TypeScript project.
+* [typescript-app](https://github.com/projen/projen/blob/master/API.md#projen-typescriptappproject) - TypeScript app.
 <!-- </macro> -->
 
 > Use `npx projen new PROJECT-TYPE --help` to view a list of command line

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A new generation of project generators",
   "repository": {
     "type": "git",
-    "url": "https://github.com/eladb/projen.git"
+    "url": "https://github.com/projen/projen.git"
   },
   "bin": {
     "projen": "bin/projen"

--- a/src/awscdk-construct.ts
+++ b/src/awscdk-construct.ts
@@ -6,7 +6,7 @@ import { Semver } from './semver';
  */
 export interface AwsCdkConstructLibraryOptions extends ConstructLibraryOptions {
   /**
-   * Minmum target version this library is tested against.
+   * Minimum target version this library is tested against.
    *
    * @default 1.60.0
    */

--- a/src/dependabot.ts
+++ b/src/dependabot.ts
@@ -187,7 +187,7 @@ export class Dependabot {
   }
 
   /**
-   * Ignores a depepdency from automatic updates.
+   * Ignores a dependency from automatic updates.
    *
    * @param dependencyName Use to ignore updates for dependencies with matching
    * names, optionally using `*` to match zero or more characters.

--- a/src/inventory.ts
+++ b/src/inventory.ts
@@ -92,7 +92,7 @@ export function discover(...moduleDirs: string[]) {
     }
 
     const [, typename] = fqn.split('.');
-    const docsurl = `https://github.com/eladb/projen/blob/master/API.md#projen-${typename.toLocaleLowerCase()}`;
+    const docsurl = `https://github.com/projen/projen/blob/master/API.md#projen-${typename.toLocaleLowerCase()}`;
     let pjid = typeinfo.docs?.custom?.pjid ?? decamelize(typename).replace(/_project$/, '');
     result.push({
       moduleName: typeinfo.assembly,

--- a/src/jest.ts
+++ b/src/jest.ts
@@ -77,7 +77,7 @@ export class Jest {
     if (options.typescript) {
       this.config.preset = 'ts-jest';
 
-      // only processs .ts files
+      // only process .ts files
       this.config.testMatch = [
         '**/__tests__/**/*.ts?(x)',
         '**/?(*.)+(spec|test).ts?(x)',

--- a/src/jsii-project.ts
+++ b/src/jsii-project.ts
@@ -100,7 +100,7 @@ export interface JsiiProjectOptions extends NodeProjectCommonOptions {
   /**
    * Automatically run API compatibility test against the latest version published to npm after compilation.
    *
-   * - You can manually run compatbility tests using `yarn compat` if this feature is disabled.
+   * - You can manually run compatibility tests using `yarn compat` if this feature is disabled.
    * - You can ignore compatibility failures by adding lines to a ".compatignore" file.
    *
    * @default false

--- a/src/node-project.ts
+++ b/src/node-project.ts
@@ -488,7 +488,7 @@ export interface NodeProjectOptions extends NodeProjectCommonOptions {
 
   /**
    * License's SPDX identifier.
-   * See https://github.com/eladb/projen/tree/master/license-text for a list of supported licenses.
+   * See https://github.com/projen/projen/tree/master/license-text for a list of supported licenses.
    */
   readonly license?: string;
 

--- a/src/projen-upgrade.ts
+++ b/src/projen-upgrade.ts
@@ -14,7 +14,7 @@ export interface ProjenUpgradeOptions {
 
   /**
    * Apply labels to the PR. For example, you can add the label "auto-merge",
-   * which, in-tandem with mergify configuraiton will automatically merge these
+   * which, in-tandem with mergify configuration will automatically merge these
    * PRs if their build passes.
    *
    * @default []

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -245,7 +245,7 @@ export class TypeScriptProject extends NodeProject {
       // if we test before compilation, remove the lib/ directory before running
       // tests so that we get a clean slate for testing.
       if (!compileBeforeTest) {
-        // make sure to delete "lib" *before* runninng tests to ensure that
+        // make sure to delete "lib" *before* running tests to ensure that
         // test code does not take a dependency on "lib" and instead on "src".
         this.addTestCommand(`rm -fr ${this.libdir}/`);
       }

--- a/src/yaml.ts
+++ b/src/yaml.ts
@@ -14,7 +14,7 @@ export class YamlFile extends JsonFile {
   }
 
   protected synthesizeContent(resolver: IResolver) {
-    // sanitize object references by serializaing and deserializing to JSON
+    // sanitize object references by serializing and deserializing to JSON
     const sanitized = JSON.parse(JSON.stringify(resolver.resolve(this.obj)));
     return [
       `# ${GENERATION_DISCLAIMER}`,

--- a/test/__snapshots__/inventory.test.ts.snap
+++ b/test/__snapshots__/inventory.test.ts.snap
@@ -4,7 +4,7 @@ exports[`inventory 1`] = `
 Array [
   Object {
     "docs": "AWS CDK app in TypeScript.",
-    "docsurl": "https://github.com/eladb/projen/blob/master/API.md#projen-awscdktypescriptapp",
+    "docsurl": "https://github.com/projen/projen/blob/master/API.md#projen-awscdktypescriptapp",
     "fqn": "projen.AwsCdkTypeScriptApp",
     "moduleName": "projen",
     "options": Array [
@@ -780,7 +780,7 @@ jest typescript tests and only if all tests pass, run the compiler.",
   },
   Object {
     "docs": "AWS CDK construct library project.",
-    "docsurl": "https://github.com/eladb/projen/blob/master/API.md#projen-awscdkconstructlibrary",
+    "docsurl": "https://github.com/projen/projen/blob/master/API.md#projen-awscdkconstructlibrary",
     "fqn": "projen.AwsCdkConstructLibrary",
     "moduleName": "projen",
     "options": Array [
@@ -937,7 +937,7 @@ jest typescript tests and only if all tests pass, run the compiler.",
       },
       Object {
         "default": "1.60.0",
-        "docs": "Minmum target version this library is tested against.",
+        "docs": "Minimum target version this library is tested against.",
         "name": "cdkVersion",
         "path": Array [
           "cdkVersion",
@@ -1485,7 +1485,7 @@ jest typescript tests and only if all tests pass, run the compiler.",
   },
   Object {
     "docs": "CDK8s construct library project.",
-    "docsurl": "https://github.com/eladb/projen/blob/master/API.md#projen-constructlibrarycdk8s",
+    "docsurl": "https://github.com/projen/projen/blob/master/API.md#projen-constructlibrarycdk8s",
     "fqn": "projen.ConstructLibraryCdk8s",
     "moduleName": "projen",
     "options": Array [
@@ -2159,7 +2159,7 @@ jest typescript tests and only if all tests pass, run the compiler.",
   },
   Object {
     "docs": "Multi-language jsii library project.",
-    "docsurl": "https://github.com/eladb/projen/blob/master/API.md#projen-jsiiproject",
+    "docsurl": "https://github.com/projen/projen/blob/master/API.md#projen-jsiiproject",
     "fqn": "projen.JsiiProject",
     "moduleName": "projen",
     "options": Array [
@@ -2823,7 +2823,7 @@ jest typescript tests and only if all tests pass, run the compiler.",
   },
   Object {
     "docs": "Next.js project without TypeScript.",
-    "docsurl": "https://github.com/eladb/projen/blob/master/API.md#projen-nextjsproject",
+    "docsurl": "https://github.com/projen/projen/blob/master/API.md#projen-nextjsproject",
     "fqn": "projen.NextJsProject",
     "moduleName": "projen",
     "options": Array [
@@ -3469,7 +3469,7 @@ jest typescript tests and only if all tests pass, run the compiler.",
   },
   Object {
     "docs": "Next.js project with TypeScript.",
-    "docsurl": "https://github.com/eladb/projen/blob/master/API.md#projen-nextjstypescriptproject",
+    "docsurl": "https://github.com/projen/projen/blob/master/API.md#projen-nextjstypescriptproject",
     "fqn": "projen.NextJsTypeScriptProject",
     "moduleName": "projen",
     "options": Array [
@@ -4204,7 +4204,7 @@ jest typescript tests and only if all tests pass, run the compiler.",
   },
   Object {
     "docs": "Node.js project.",
-    "docsurl": "https://github.com/eladb/projen/blob/master/API.md#projen-nodeproject",
+    "docsurl": "https://github.com/projen/projen/blob/master/API.md#projen-nodeproject",
     "fqn": "projen.NodeProject",
     "moduleName": "projen",
     "options": Array [
@@ -4828,7 +4828,7 @@ jest typescript tests and only if all tests pass, run the compiler.",
   },
   Object {
     "docs": "Base project.",
-    "docsurl": "https://github.com/eladb/projen/blob/master/API.md#projen-project",
+    "docsurl": "https://github.com/projen/projen/blob/master/API.md#projen-project",
     "fqn": "projen.Project",
     "moduleName": "projen",
     "options": Array [],
@@ -4837,7 +4837,7 @@ jest typescript tests and only if all tests pass, run the compiler.",
   },
   Object {
     "docs": "React project without TypeScript.",
-    "docsurl": "https://github.com/eladb/projen/blob/master/API.md#projen-reactproject",
+    "docsurl": "https://github.com/projen/projen/blob/master/API.md#projen-reactproject",
     "fqn": "projen.ReactProject",
     "moduleName": "projen",
     "options": Array [
@@ -5472,7 +5472,7 @@ jest typescript tests and only if all tests pass, run the compiler.",
   },
   Object {
     "docs": "React project with TypeScript.",
-    "docsurl": "https://github.com/eladb/projen/blob/master/API.md#projen-reacttypescriptproject",
+    "docsurl": "https://github.com/projen/projen/blob/master/API.md#projen-reacttypescriptproject",
     "fqn": "projen.ReactTypeScriptProject",
     "moduleName": "projen",
     "options": Array [
@@ -6196,7 +6196,7 @@ jest typescript tests and only if all tests pass, run the compiler.",
   },
   Object {
     "docs": "TypeScript project.",
-    "docsurl": "https://github.com/eladb/projen/blob/master/API.md#projen-typescriptproject",
+    "docsurl": "https://github.com/projen/projen/blob/master/API.md#projen-typescriptproject",
     "fqn": "projen.TypeScriptProject",
     "moduleName": "projen",
     "options": Array [
@@ -6920,7 +6920,7 @@ jest typescript tests and only if all tests pass, run the compiler.",
   },
   Object {
     "docs": "TypeScript app.",
-    "docsurl": "https://github.com/eladb/projen/blob/master/API.md#projen-typescriptappproject",
+    "docsurl": "https://github.com/projen/projen/blob/master/API.md#projen-typescriptappproject",
     "fqn": "projen.TypeScriptAppProject",
     "moduleName": "projen",
     "options": Array [


### PR DESCRIPTION
- chore: moves `eladb/projen` -> `projen/projen`, fixes spelling for src/ and test/ ; ignores CHANGELOG.md
