### PR TITLE
chore(cdk): remove deprecated Semver

### DIFF
--- a/API.md
+++ b/API.md
@@ -296,7 +296,7 @@ new AwsCdkConstructLibrary(options: AwsCdkConstructLibraryOptions)
 
 Name | Type | Description 
 -----|------|-------------
-**version**🔹 | <code>[Semver](#projen-semver)</code> | The target CDK version for this library.
+**version**🔹 | <code>string</code> | The target CDK version for this library.
 
 ### Methods
 
@@ -444,7 +444,7 @@ Name | Type | Description
 -----|------|-------------
 **appEntrypoint**🔹 | <code>string</code> | The CDK app entrypoint.
 **cdkConfig**🔹 | <code>any</code> | Contents of `cdk.json`.
-**cdkVersion**🔹 | <code>[Semver](#projen-semver)</code> | The CDK version this app is using.
+**cdkVersion**🔹 | <code>string</code> | The CDK version this app is using.
 
 ### Methods
 

--- a/src/awscdk-app-ts.ts
+++ b/src/awscdk-app-ts.ts
@@ -22,6 +22,8 @@ export enum CdkApprovalLevel {
 export interface AwsCdkTypeScriptAppOptions extends TypeScriptProjectOptions {
   /**
    * AWS CDK version to use.
+   *
+   * @default 1.63.0
    */
   readonly cdkVersion: string;
 

--- a/src/awscdk-app-ts.ts
+++ b/src/awscdk-app-ts.ts
@@ -105,7 +105,7 @@ export class AwsCdkTypeScriptApp extends TypeScriptAppProject {
     this.cdkVersion = options.cdkVersionPinning ? options.cdkVersion : `^${options.cdkVersion}`;
 
     // CLI
-    this.addDevDeps(`aws-cdk@${this.cdkVersion}`);
+    this.addDevDeps(this.formatModuleSpec('aws-cdk'));
 
     this.addCdkDependency('@aws-cdk/assert');
     this.addCdkDependency('@aws-cdk/core');
@@ -170,7 +170,11 @@ export class AwsCdkTypeScriptApp extends TypeScriptAppProject {
    * @param modules The list of modules to depend on
    */
   public addCdkDependency(...modules: string[]) {
-    this.addDeps(...modules.map(m => `${m}@${this.cdkVersion}`));
+    this.addDeps(...modules.map(this.formatModuleSpec));
+  }
+
+  private formatModuleSpec(module: string): string {
+    return `${module}@${this.cdkVersion}`;
   }
 }
 

--- a/src/awscdk-app-ts.ts
+++ b/src/awscdk-app-ts.ts
@@ -2,7 +2,6 @@ import * as path from 'path';
 import * as fs from 'fs-extra';
 import { Component } from './component';
 import { JsonFile } from './json';
-import { Semver } from './semver';
 import { StartEntryCategory } from './start';
 import { TypeScriptAppProject, TypeScriptProjectOptions } from './typescript';
 
@@ -23,8 +22,6 @@ export enum CdkApprovalLevel {
 export interface AwsCdkTypeScriptAppOptions extends TypeScriptProjectOptions {
   /**
    * AWS CDK version to use.
-   *
-   * @default 1.63.0
    */
   readonly cdkVersion: string;
 
@@ -75,7 +72,7 @@ export class AwsCdkTypeScriptApp extends TypeScriptAppProject {
   /**
    * The CDK version this app is using.
    */
-  public readonly cdkVersion: Semver;
+  public readonly cdkVersion: string;
 
   /**
    * Contents of `cdk.json`.
@@ -103,10 +100,10 @@ export class AwsCdkTypeScriptApp extends TypeScriptAppProject {
 
     this.appEntrypoint = options.appEntrypoint ?? 'main.ts';
 
-    this.cdkVersion = options.cdkVersionPinning ? Semver.pinned(options.cdkVersion) : Semver.caret(options.cdkVersion);
+    this.cdkVersion = options.cdkVersionPinning ? options.cdkVersion : `^${options.cdkVersion}`;
 
     // CLI
-    this.addDevDependencies({ 'aws-cdk': this.cdkVersion });
+    this.addDevDeps(`aws-cdk@${this.cdkVersion}`);
 
     this.addCdkDependency('@aws-cdk/assert');
     this.addCdkDependency('@aws-cdk/core');
@@ -171,10 +168,7 @@ export class AwsCdkTypeScriptApp extends TypeScriptAppProject {
    * @param modules The list of modules to depend on
    */
   public addCdkDependency(...modules: string[]) {
-    for (const m of modules) {
-      // since synthesis runs at build time, CDK dependencies should be dev-dependencies
-      this.addDependencies({ [m]: this.cdkVersion });
-    }
+    this.addDeps(...modules.map(m => `${m}@${this.cdkVersion}`));
   }
 }
 

--- a/src/awscdk-construct.ts
+++ b/src/awscdk-construct.ts
@@ -1,5 +1,4 @@
 import { ConstructLibraryOptions, ConstructLibrary } from './construct-lib';
-import { Semver } from './semver';
 
 /**
  * Options for the construct-lib-aws project.
@@ -101,7 +100,7 @@ export class AwsCdkConstructLibrary extends ConstructLibrary {
   /**
    * The target CDK version for this library.
    */
-  public readonly version: Semver;
+  public readonly version: string;
 
   constructor(options: AwsCdkConstructLibraryOptions) {
     super({
@@ -111,12 +110,12 @@ export class AwsCdkConstructLibrary extends ConstructLibrary {
       },
     });
 
-    this.version = Semver.caret(options.cdkVersion);
+    this.version = `^${options.cdkVersion}`;
 
-    this.addPeerDependencies({ constructs: Semver.caret('3.0.4') });
+    this.addPeerDeps('constructs@^3.0.4');
 
     if (options.cdkAssert ?? true) {
-      this.addDevDependencies({ '@aws-cdk/assert': this.version });
+      this.addDevDeps(`@aws-cdk/assert@${this.version}`);
     }
 
     this.addCdkDependencies(...options.cdkDependencies ?? []);
@@ -137,10 +136,8 @@ export class AwsCdkConstructLibrary extends ConstructLibrary {
    */
   public addCdkDependencies(...deps: string[]) {
     // this ugliness will go away in cdk v2.0
-    for (const dep of deps) {
-      this.addPeerDependencies({ [dep]: this.version });
-      this.addDependencies({ [dep]: this.version });
-    }
+    this.addDeps(...deps.map(m => `${m}@${this.version}`));
+    this.addDeps(...deps.map(m => `${m}@${this.version}`));
   }
 
   /**
@@ -149,9 +146,7 @@ export class AwsCdkConstructLibrary extends ConstructLibrary {
    * @param deps names of cdk modules (e.g. `@aws-cdk/aws-lambda`).
    */
   public addCdkTestDependencies(...deps: string[]) {
-    for (const dep of deps) {
-      this.addDevDependencies({ [dep]: this.version });
-    }
+    this.addDevDeps(...deps.map(m => `${m}@${this.version}`));
   }
 }
 

--- a/src/awscdk-construct.ts
+++ b/src/awscdk-construct.ts
@@ -136,7 +136,7 @@ export class AwsCdkConstructLibrary extends ConstructLibrary {
    */
   public addCdkDependencies(...deps: string[]) {
     // this ugliness will go away in cdk v2.0
-    this.addDeps(...deps.map(m => `${m}@${this.version}`));
+    this.addPeerDeps(...deps.map(m => `${m}@${this.version}`));
     this.addDeps(...deps.map(m => `${m}@${this.version}`));
   }
 

--- a/src/awscdk-construct.ts
+++ b/src/awscdk-construct.ts
@@ -115,7 +115,7 @@ export class AwsCdkConstructLibrary extends ConstructLibrary {
     this.addPeerDeps('constructs@^3.0.4');
 
     if (options.cdkAssert ?? true) {
-      this.addDevDeps(`@aws-cdk/assert@${this.version}`);
+      this.addDevDeps(this.formatModuleSpec('@aws-cdk/assert'));
     }
 
     this.addCdkDependencies(...options.cdkDependencies ?? []);
@@ -136,8 +136,8 @@ export class AwsCdkConstructLibrary extends ConstructLibrary {
    */
   public addCdkDependencies(...deps: string[]) {
     // this ugliness will go away in cdk v2.0
-    this.addPeerDeps(...deps.map(m => `${m}@${this.version}`));
-    this.addDeps(...deps.map(m => `${m}@${this.version}`));
+    this.addPeerDeps(...deps.map(this.formatModuleSpec));
+    this.addDeps(...deps.map(this.formatModuleSpec));
   }
 
   /**
@@ -146,7 +146,11 @@ export class AwsCdkConstructLibrary extends ConstructLibrary {
    * @param deps names of cdk modules (e.g. `@aws-cdk/aws-lambda`).
    */
   public addCdkTestDependencies(...deps: string[]) {
-    this.addDevDeps(...deps.map(m => `${m}@${this.version}`));
+    this.addDevDeps(...deps.map(this.formatModuleSpec));
+  }
+
+  private formatModuleSpec(module: string): string {
+    return `${module}@${this.version}`;
   }
 }
 

--- a/test/__snapshots__/inventory.test.ts.snap
+++ b/test/__snapshots__/inventory.test.ts.snap
@@ -143,6 +143,7 @@ Array [
         "type": "unknown",
       },
       Object {
+        "default": "1.63.0",
         "docs": "AWS CDK version to use.",
         "name": "cdkVersion",
         "path": Array [

--- a/test/__snapshots__/inventory.test.ts.snap
+++ b/test/__snapshots__/inventory.test.ts.snap
@@ -143,7 +143,6 @@ Array [
         "type": "unknown",
       },
       Object {
-        "default": "1.63.0",
         "docs": "AWS CDK version to use.",
         "name": "cdkVersion",
         "path": Array [

--- a/yarn.lock
+++ b/yarn.lock
@@ -495,7 +495,7 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@jsii/spec@^1.13.0", "@jsii/spec@^1.14.0", "@jsii/spec@^1.9.0":
+"@jsii/spec@^1.14.0", "@jsii/spec@^1.9.0":
   version "1.14.0"
   resolved "https://registry.yarnpkg.com/@jsii/spec/-/spec-1.14.0.tgz#79ef7626616e3cd6eaf503f8f4c0c9640c220a5b"
   integrity sha512-hgJG0d1W+VgXZD8TeXt4wlFwdkT9izUN5fY+yzKkh+zZUNebEayXDP6LXOFD4iJZ83nUGjEVayzaZt4rAhwt5A==
@@ -3638,7 +3638,7 @@ jsii-pacmak@^1.11.0:
     xmlbuilder "^15.1.1"
     yargs "^16.1.0"
 
-jsii-reflect@^1.13.0, jsii-reflect@^1.14.0, jsii-reflect@^1.9.0:
+jsii-reflect@^1.14.0, jsii-reflect@^1.9.0:
   version "1.14.0"
   resolved "https://registry.yarnpkg.com/jsii-reflect/-/jsii-reflect-1.14.0.tgz#c8c1f1026b45b0cd9022677868d8548b8562ee43"
   integrity sha512-LOImMIFu/DgRNdgXloA5OVGOtEOZsm1UQ2qQHQ3O0MHWgqGvyBRYPh7wwgytucB37lGEz8KgphiJ/gmTAcA1oA==


### PR DESCRIPTION
Removes the use of the deprecate Semver class and old-style dependency methods.