### PR TITLE
docs(readme): clone url update

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Contributions of all kinds are welcome! See our [code of conduct](./CODE_OF_COND
 To check out a development environment:
 
 ```bash
-$ git clone git@github.com:eladb/projen
+$ git clone git@github.com:projen/projen
 $ cd projen
 $ yarn
 ```


### PR DESCRIPTION
Hi! Here's a *very* small PR to update the "git clone" url in the readme since projen now seems to live at `projen/projen` instead of `eladb/projen`!