### PR TITLE
feat: introduce Subdir component

### DIFF
--- a/API.md
+++ b/API.md
@@ -109,6 +109,7 @@ Name|Description
 
 Name|Description
 ----|-----------
+[IComponentScope](#projen-icomponentscope)|A scope for components.
 [IDockerComposeServiceName](#projen-idockercomposeservicename)|An interface providing the name of a docker compose service.
 [IDockerComposeVolumeBinding](#projen-idockercomposevolumebinding)|Volume binding information.
 [IDockerComposeVolumeConfig](#projen-idockercomposevolumeconfig)|Storage for volume configuration.
@@ -198,6 +199,7 @@ const project = new ConstructLibraryAws({
 project.synth();
 ```
 
+__Implements__: [IComponentScope](#projen-icomponentscope)
 __Extends__: [ConstructLibrary](#projen-constructlibrary)
 
 ### Initializer
@@ -340,6 +342,7 @@ addCdkTestDependencies(...deps: string[]): void
 
 AWS CDK app in TypeScript.
 
+__Implements__: [IComponentScope](#projen-icomponentscope)
 __Extends__: [TypeScriptAppProject](#projen-typescriptappproject)
 
 ### Initializer
@@ -475,10 +478,10 @@ Represents a project component.
 
 
 ```ts
-new Component(project: Project)
+new Component(project: IComponentScope)
 ```
 
-* **project** (<code>[Project](#projen-project)</code>)  *No description*
+* **project** (<code>[IComponentScope](#projen-icomponentscope)</code>)  *No description*
 
 
 
@@ -487,7 +490,7 @@ new Component(project: Project)
 
 Name | Type | Description 
 -----|------|-------------
-**project**🔹 | <code>[Project](#projen-project)</code> | <span></span>
+**project**🔹 | <code>[IComponentScope](#projen-icomponentscope)</code> | <span></span>
 
 ### Methods
 
@@ -526,6 +529,7 @@ synthesize(_outdir: string): void
 
 A multi-language library for CDK constructs.
 
+__Implements__: [IComponentScope](#projen-icomponentscope)
 __Extends__: [JsiiProject](#projen-jsiiproject)
 __Implemented by__: [AwsCdkConstructLibrary](#projen-awscdkconstructlibrary), [ConstructLibraryAws](#projen-constructlibraryaws), [ConstructLibraryCdk8s](#projen-constructlibrarycdk8s)
 
@@ -621,6 +625,7 @@ new ConstructLibrary(options: ConstructLibraryOptions)
 
 
 
+__Implements__: [IComponentScope](#projen-icomponentscope)
 __Extends__: [AwsCdkConstructLibrary](#projen-awscdkconstructlibrary)
 
 ### Initializer
@@ -723,6 +728,7 @@ A multi-language (jsii) construct library which vends constructs designed to
 use within the CDK for Kubernetes (CDK8s), with a friendly workflow and
 automatic publishing to the construct catalog.
 
+__Implements__: [IComponentScope](#projen-icomponentscope)
 __Extends__: [ConstructLibrary](#projen-constructlibrary)
 
 ### Initializer
@@ -880,10 +886,10 @@ __Extends__: [Component](#projen-component)
 
 
 ```ts
-new DockerCompose(project: Project, props?: DockerComposeProps)
+new DockerCompose(project: IComponentScope, props?: DockerComposeProps)
 ```
 
-* **project** (<code>[Project](#projen-project)</code>)  *No description*
+* **project** (<code>[IComponentScope](#projen-icomponentscope)</code>)  *No description*
 * **props** (<code>[DockerComposeProps](#projen-dockercomposeprops)</code>)  *No description*
   * **nameSuffix** (<code>string</code>)  A name to add to the docker-compose.yml filename. __*Default*__: no name is added
   * **services** (<code>Map<string, [DockerComposeServiceDescription](#projen-dockercomposeservicedescription)></code>)  Service descriptions. __*Optional*__
@@ -1157,10 +1163,10 @@ __Implemented by__: [GithubWorkflow](#projen-githubworkflow), [IgnoreFile](#proj
 
 
 ```ts
-new FileBase(project: Project, filePath: string, options?: FileBaseOptions)
+new FileBase(project: IComponentScope, filePath: string, options?: FileBaseOptions)
 ```
 
-* **project** (<code>[Project](#projen-project)</code>)  *No description*
+* **project** (<code>[IComponentScope](#projen-icomponentscope)</code>)  *No description*
 * **filePath** (<code>string</code>)  *No description*
 * **options** (<code>[FileBaseOptions](#projen-filebaseoptions)</code>)  *No description*
   * **committed** (<code>boolean</code>)  Indicates whether this file should be committed to git or ignored. __*Default*__: true
@@ -1220,10 +1226,10 @@ __Extends__: [FileBase](#projen-filebase)
 
 
 ```ts
-new GithubWorkflow(project: Project, name: string)
+new GithubWorkflow(project: IComponentScope, name: string)
 ```
 
-* **project** (<code>[Project](#projen-project)</code>)  *No description*
+* **project** (<code>[IComponentScope](#projen-icomponentscope)</code>)  *No description*
 * **name** (<code>string</code>)  *No description*
 
 
@@ -1283,10 +1289,10 @@ __Extends__: [FileBase](#projen-filebase)
 
 
 ```ts
-new IgnoreFile(project: Project, filePath: string)
+new IgnoreFile(project: IComponentScope, filePath: string)
 ```
 
-* **project** (<code>[Project](#projen-project)</code>)  *No description*
+* **project** (<code>[IComponentScope](#projen-icomponentscope)</code>)  *No description*
 * **filePath** (<code>string</code>)  *No description*
 
 
@@ -1391,6 +1397,7 @@ addIgnorePattern(pattern: string): void
 
 Multi-language jsii library project.
 
+__Implements__: [IComponentScope](#projen-icomponentscope)
 __Extends__: [TypeScriptProject](#projen-typescriptproject)
 
 ### Initializer
@@ -1501,10 +1508,10 @@ __Extends__: [FileBase](#projen-filebase)
 
 
 ```ts
-new JsonFile(project: Project, filePath: string, options: JsonFileOptions)
+new JsonFile(project: IComponentScope, filePath: string, options: JsonFileOptions)
 ```
 
-* **project** (<code>[Project](#projen-project)</code>)  *No description*
+* **project** (<code>[IComponentScope](#projen-icomponentscope)</code>)  *No description*
 * **filePath** (<code>string</code>)  *No description*
 * **options** (<code>[JsonFileOptions](#projen-jsonfileoptions)</code>)  *No description*
   * **committed** (<code>boolean</code>)  Indicates whether this file should be committed to git or ignored. __*Default*__: true
@@ -1551,10 +1558,10 @@ __Extends__: [FileBase](#projen-filebase)
 
 
 ```ts
-new License(project: Project, spdx: string, options: LicenseOptions)
+new License(project: IComponentScope, spdx: string, options: LicenseOptions)
 ```
 
-* **project** (<code>[Project](#projen-project)</code>)  *No description*
+* **project** (<code>[IComponentScope](#projen-icomponentscope)</code>)  *No description*
 * **spdx** (<code>string</code>)  *No description*
 * **options** (<code>[LicenseOptions](#projen-licenseoptions)</code>)  *No description*
   * **copyrightOwner** (<code>string</code>)  Copyright owner. __*Default*__: ""
@@ -1591,10 +1598,10 @@ __Extends__: [FileBase](#projen-filebase)
 
 
 ```ts
-new Makefile(project: Project, filePath: string, options?: MakefileOptions)
+new Makefile(project: IComponentScope, filePath: string, options?: MakefileOptions)
 ```
 
-* **project** (<code>[Project](#projen-project)</code>)  *No description*
+* **project** (<code>[IComponentScope](#projen-icomponentscope)</code>)  *No description*
 * **filePath** (<code>string</code>)  *No description*
 * **options** (<code>[MakefileOptions](#projen-makefileoptions)</code>)  *No description*
   * **committed** (<code>boolean</code>)  Indicates whether this file should be committed to git or ignored. __*Default*__: true
@@ -1702,10 +1709,10 @@ __Extends__: [Component](#projen-component)
 
 
 ```ts
-new Mergify(project: Project, options?: MergifyOptions)
+new Mergify(project: IComponentScope, options?: MergifyOptions)
 ```
 
-* **project** (<code>[Project](#projen-project)</code>)  *No description*
+* **project** (<code>[IComponentScope](#projen-icomponentscope)</code>)  *No description*
 * **options** (<code>[MergifyOptions](#projen-mergifyoptions)</code>)  *No description*
   * **rules** (<code>Array<[MergifyRule](#projen-mergifyrule)></code>)  *No description* __*Optional*__
 
@@ -1757,6 +1764,7 @@ new NextComponent(project: NodeProject, options: NextComponentOptions)
 
 Next.js project without TypeScript.
 
+__Implements__: [IComponentScope](#projen-icomponentscope)
 __Extends__: [NodeProject](#projen-nodeproject)
 
 ### Initializer
@@ -1893,6 +1901,7 @@ __Returns__:
 
 Next.js project with TypeScript.
 
+__Implements__: [IComponentScope](#projen-icomponentscope)
 __Extends__: [TypeScriptAppProject](#projen-typescriptappproject)
 
 ### Initializer
@@ -2034,6 +2043,7 @@ Name | Type | Description
 
 Node.js project.
 
+__Implements__: [IComponentScope](#projen-icomponentscope)
 __Extends__: [Project](#projen-project)
 
 ### Initializer
@@ -2426,6 +2436,7 @@ removeScript(name: string): void
 
 Base project.
 
+__Implements__: [IComponentScope](#projen-icomponentscope)
 
 ### Initializer
 
@@ -2517,10 +2528,10 @@ __Extends__: [TextFile](#projen-textfile)
 
 
 ```ts
-new PullRequestTemplate(project: Project, options?: PullRequestTemplateOptions)
+new PullRequestTemplate(project: IComponentScope, options?: PullRequestTemplateOptions)
 ```
 
-* **project** (<code>[Project](#projen-project)</code>)  *No description*
+* **project** (<code>[IComponentScope](#projen-icomponentscope)</code>)  *No description*
 * **options** (<code>[PullRequestTemplateOptions](#projen-pullrequesttemplateoptions)</code>)  *No description*
   * **lines** (<code>Array<string></code>)  The contents of the template. __*Default*__: a standard default template will be created.
 
@@ -2553,6 +2564,7 @@ new ReactComponent(project: NodeProject, options: ReactComponentOptions)
 
 React project without TypeScript.
 
+__Implements__: [IComponentScope](#projen-icomponentscope)
 __Extends__: [NodeProject](#projen-nodeproject)
 
 ### Initializer
@@ -2687,6 +2699,7 @@ __Returns__:
 
 React project with TypeScript.
 
+__Implements__: [IComponentScope](#projen-icomponentscope)
 __Extends__: [TypeScriptAppProject](#projen-typescriptappproject)
 
 ### Initializer
@@ -2931,10 +2944,10 @@ __Extends__: [FileBase](#projen-filebase)
 Defines a text file.
 
 ```ts
-new TextFile(project: Project, filePath: string, options?: TextFileOptions)
+new TextFile(project: IComponentScope, filePath: string, options?: TextFileOptions)
 ```
 
-* **project** (<code>[Project](#projen-project)</code>)  The project.
+* **project** (<code>[IComponentScope](#projen-icomponentscope)</code>)  The project.
 * **filePath** (<code>string</code>)  File path.
 * **options** (<code>[TextFileOptions](#projen-textfileoptions)</code>)  Options.
   * **committed** (<code>boolean</code>)  Indicates whether this file should be committed to git or ignored. __*Default*__: true
@@ -2986,10 +2999,10 @@ __Extends__: [FileBase](#projen-filebase)
 
 
 ```ts
-new TomlFile(project: Project, filePath: string, options: TomlFileOptions)
+new TomlFile(project: IComponentScope, filePath: string, options: TomlFileOptions)
 ```
 
-* **project** (<code>[Project](#projen-project)</code>)  *No description*
+* **project** (<code>[IComponentScope](#projen-icomponentscope)</code>)  *No description*
 * **filePath** (<code>string</code>)  *No description*
 * **options** (<code>[TomlFileOptions](#projen-tomlfileoptions)</code>)  *No description*
   * **committed** (<code>boolean</code>)  Indicates whether this file should be committed to git or ignored. __*Default*__: true
@@ -3028,6 +3041,7 @@ __Returns__:
 
 TypeScript app.
 
+__Implements__: [IComponentScope](#projen-icomponentscope)
 __Extends__: [TypeScriptProject](#projen-typescriptproject)
 
 ### Initializer
@@ -3124,6 +3138,7 @@ new TypeScriptAppProject(options: TypeScriptProjectOptions)
 
 
 
+__Implements__: [IComponentScope](#projen-icomponentscope)
 __Extends__: [TypeScriptProject](#projen-typescriptproject)
 
 ### Initializer
@@ -3220,6 +3235,7 @@ new TypeScriptLibraryProject(options: TypeScriptProjectOptions)
 
 TypeScript project.
 
+__Implements__: [IComponentScope](#projen-icomponentscope)
 __Extends__: [NodeProject](#projen-nodeproject)
 
 ### Initializer
@@ -4062,6 +4078,39 @@ Name | Type | Description
 **committed**?🔹 | <code>boolean</code> | Indicates whether this file should be committed to git or ignored.<br/>__*Default*__: true
 **editGitignore**?🔹 | <code>boolean</code> | Update the project's .gitignore file.<br/>__*Default*__: true
 **readonly**?🔹 | <code>boolean</code> | Whether the generated file should be readonly.<br/>__*Default*__: true
+
+
+
+## interface IComponentScope 🔹 <a id="projen-icomponentscope"></a>
+
+__Implemented by__: [AwsCdkConstructLibrary](#projen-awscdkconstructlibrary), [AwsCdkTypeScriptApp](#projen-awscdktypescriptapp), [ConstructLibraryAws](#projen-constructlibraryaws), [ConstructLibraryCdk8s](#projen-constructlibrarycdk8s), [JsiiProject](#projen-jsiiproject), [NextJsProject](#projen-nextjsproject), [NextJsTypeScriptProject](#projen-nextjstypescriptproject), [NodeProject](#projen-nodeproject), [Project](#projen-project), [ReactProject](#projen-reactproject), [ReactTypeScriptProject](#projen-reacttypescriptproject), [TypeScriptAppProject](#projen-typescriptappproject), [TypeScriptLibraryProject](#projen-typescriptlibraryproject), [TypeScriptProject](#projen-typescriptproject)
+
+A scope for components.
+
+i.e., a project or a subdirectory.
+
+### Properties
+
+
+Name | Type | Description 
+-----|------|-------------
+**gitignore**🔹 | <code>[IgnoreFile](#projen-ignorefile)</code> | <span></span>
+
+### Methods
+
+
+#### addTip(message)🔹 <a id="projen-icomponentscope-addtip"></a>
+
+Prints a "tip" message during synthesis.
+
+```ts
+addTip(message: string): void
+```
+
+* **message** (<code>string</code>)  The message.
+
+
+
 
 
 

--- a/src/component.ts
+++ b/src/component.ts
@@ -1,10 +1,28 @@
-import { Project } from './project';
+import { IgnoreFile } from './ignore-file';
+
+/**
+ * A scope for components. i.e., a project or a subdirectory.
+ */
+export interface IComponentScope {
+  readonly gitignore: IgnoreFile;
+
+  /**
+   * @internal
+   */
+  _addComponent(component: Component): void;
+
+  /**
+   * Prints a "tip" message during synthesis.
+   * @param message The message
+   */
+  addTip(message: string): void;
+}
 
 /**
  * Represents a project component.
  */
 export class Component {
-  constructor(public readonly project: Project) {
+  constructor(public readonly project: IComponentScope) {
     project._addComponent(this);
   }
 

--- a/src/docker-compose.ts
+++ b/src/docker-compose.ts
@@ -1,5 +1,4 @@
-import { Component } from './component';
-import { Project } from './project';
+import { Component, IComponentScope } from './component';
 import { decamelizeKeysRecursively } from './util';
 import { YamlFile } from './yaml';
 
@@ -103,7 +102,7 @@ export class DockerCompose extends Component {
 
   private readonly services: Record<string, DockerComposeService>;
 
-  constructor(project: Project, props?: DockerComposeProps) {
+  constructor(project: IComponentScope, props?: DockerComposeProps) {
     super(project);
 
     const nameSuffix = props?.nameSuffix ? `${props!.nameSuffix}.yml` : 'yml';

--- a/src/file.ts
+++ b/src/file.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
 import { resolve } from './_resolve';
-import { Component } from './component';
-import { Project } from './project';
+import { Component, IComponentScope } from './component';
 import { writeFile } from './util';
 
 export interface FileBaseOptions {
@@ -32,7 +31,7 @@ export abstract class FileBase extends Component {
   public readonly path: string;
   public readonly: boolean;
 
-  constructor(project: Project, filePath: string, options: FileBaseOptions = { }) {
+  constructor(project: IComponentScope, filePath: string, options: FileBaseOptions = { }) {
     super(project);
 
     this.readonly = options.readonly ?? true;

--- a/src/github-workflow.ts
+++ b/src/github-workflow.ts
@@ -1,14 +1,14 @@
 import * as YAML from 'yaml';
 import { GENERATION_DISCLAIMER } from './common';
+import { IComponentScope } from './component';
 import { FileBase, IResolver } from './file';
-import { Project } from './project';
 
 export class GithubWorkflow extends FileBase {
   private readonly name: string;
   private events: { [event: string]: any } = { };
   private jobs: { [jobid: string]: any } = { };
 
-  constructor(project: Project, name: string) {
+  constructor(project: IComponentScope, name: string) {
     super(project, `.github/workflows/${name.toLocaleLowerCase()}.yml`);
     this.name = name;
   }

--- a/src/ignore-file.ts
+++ b/src/ignore-file.ts
@@ -1,12 +1,12 @@
 import { GENERATION_DISCLAIMER } from './common';
+import { IComponentScope } from './component';
 import { FileBase, IResolver } from './file';
-import { Project } from './project';
 
 export class IgnoreFile extends FileBase {
   private readonly excludes = new Array<string>();
   private readonly includes = new Array<string>();
 
-  constructor(project: Project, filePath: string) {
+  constructor(project: IComponentScope, filePath: string) {
     super(project, filePath, { editGitignore: filePath !== '.gitignore' });
   }
 

--- a/src/json.ts
+++ b/src/json.ts
@@ -1,5 +1,5 @@
+import { IComponentScope } from './component';
 import { FileBase, FileBaseOptions, IResolver } from './file';
-import { Project } from './project';
 
 export interface JsonFileOptions extends FileBaseOptions {
   readonly obj: any;
@@ -8,7 +8,7 @@ export interface JsonFileOptions extends FileBaseOptions {
 export class JsonFile extends FileBase {
   protected readonly obj: object;
 
-  constructor(project: Project, filePath: string, options: JsonFileOptions) {
+  constructor(project: IComponentScope, filePath: string, options: JsonFileOptions) {
     super(project, filePath, options);
 
     if (!options.obj) {

--- a/src/license.ts
+++ b/src/license.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs-extra';
+import { IComponentScope } from './component';
 import { FileBase, IResolver } from './file';
-import { Project } from './project';
 
 export interface LicenseOptions {
   /**
@@ -21,7 +21,7 @@ export interface LicenseOptions {
 export class License extends FileBase {
   private readonly text: string;
 
-  constructor(project: Project, spdx: string, options: LicenseOptions) {
+  constructor(project: IComponentScope, spdx: string, options: LicenseOptions) {
     super(project, 'LICENSE');
 
     const textFile = `${__dirname}/../license-text/${spdx}.txt`;

--- a/src/makefile.ts
+++ b/src/makefile.ts
@@ -1,5 +1,5 @@
+import { IComponentScope } from './component';
 import { FileBase, FileBaseOptions, IResolver } from './file';
-import { Project } from './project';
 
 /**
  * A Make rule.
@@ -69,7 +69,7 @@ export class Makefile extends FileBase {
   private readonly all: AllRule;
 
 
-  constructor(project: Project, filePath: string, options: MakefileOptions = {}) {
+  constructor(project: IComponentScope, filePath: string, options: MakefileOptions = {}) {
     super(project, filePath, options);
 
     const all = options.all ? options.all : [];

--- a/src/mergify.ts
+++ b/src/mergify.ts
@@ -1,5 +1,4 @@
-import { Component } from './component';
-import { Project } from './project';
+import { Component, IComponentScope } from './component';
 import { YamlFile } from './yaml';
 
 export interface MergifyRule {
@@ -15,7 +14,7 @@ export interface MergifyOptions {
 export class Mergify extends Component {
   private readonly rules = new Array<MergifyRule>();
 
-  constructor(project: Project, options: MergifyOptions = { }) {
+  constructor(project: IComponentScope, options: MergifyOptions = { }) {
     super(project);
 
     new YamlFile(project, '.mergify.yml', {

--- a/src/pr-template.ts
+++ b/src/pr-template.ts
@@ -1,4 +1,4 @@
-import { Project } from './project';
+import { IComponentScope } from './component';
 import { TextFile } from './textfile';
 
 /**
@@ -17,7 +17,7 @@ export interface PullRequestTemplateOptions {
  * Template for GitHub pull requests.
  */
 export class PullRequestTemplate extends TextFile {
-  constructor(project: Project, options: PullRequestTemplateOptions = { }) {
+  constructor(project: IComponentScope, options: PullRequestTemplateOptions = { }) {
     super(project, '.github/pull_request_template.md', {
       lines: options.lines ?? [
         'Fixes #',

--- a/src/project.ts
+++ b/src/project.ts
@@ -1,7 +1,7 @@
 import * as chalk from 'chalk';
 import { cleanup } from './cleanup';
 import { printStartMenu } from './cli/cmds/start-app';
-import { Component } from './component';
+import { Component, IComponentScope } from './component';
 import { IgnoreFile } from './ignore-file';
 import * as logging from './logging';
 import { Start } from './start';
@@ -9,7 +9,7 @@ import { Start } from './start';
 /**
  * Base project
  */
-export class Project {
+export class Project implements IComponentScope {
   public readonly gitignore: IgnoreFile;
 
   private readonly components = new Array<Component>();

--- a/src/react.ts
+++ b/src/react.ts
@@ -1,9 +1,8 @@
 import * as path from 'path';
 import * as fs from 'fs-extra';
-import { Component } from './component';
+import { Component, IComponentScope } from './component';
 import { FileBase, FileBaseOptions, IResolver } from './file';
 import { NodeProject, NodeProjectOptions } from './node-project';
-import { Project } from './project';
 import { Semver } from './semver';
 import { StartEntryCategory } from './start';
 import { TypeScriptAppProject, TypeScriptJsxMode, TypeScriptModuleResolution, TypeScriptProjectOptions } from './typescript';
@@ -404,7 +403,7 @@ export class ReactTypeDef extends FileBase {
 }
 
 class ReactAppCss extends FileBase {
-  constructor(project: Project, filePath: string, options: FileBaseOptions = {}) {
+  constructor(project: IComponentScope, filePath: string, options: FileBaseOptions = {}) {
     super(project, filePath, options);
   }
 
@@ -454,7 +453,7 @@ class ReactAppCss extends FileBase {
 }
 
 class ReactIndexCss extends FileBase {
-  constructor(project: Project, filePath: string, options: FileBaseOptions = {}) {
+  constructor(project: IComponentScope, filePath: string, options: FileBaseOptions = {}) {
     super(project, filePath, options);
   }
 
@@ -479,7 +478,7 @@ class ReactIndexCss extends FileBase {
 }
 
 class ReactSetupTests extends FileBase {
-  constructor(project: Project, filePath: string, options: FileBaseOptions = {}) {
+  constructor(project: IComponentScope, filePath: string, options: FileBaseOptions = {}) {
     super(project, filePath, options);
   }
 
@@ -496,7 +495,7 @@ class ReactSetupTests extends FileBase {
 }
 
 class ReactAppTest extends FileBase {
-  constructor(project: Project, filePath: string, options: FileBaseOptions = {}) {
+  constructor(project: IComponentScope, filePath: string, options: FileBaseOptions = {}) {
     super(project, filePath, options);
   }
 

--- a/src/subdir.ts
+++ b/src/subdir.ts
@@ -1,0 +1,52 @@
+import * as path from 'path';
+import { Component, IComponentScope } from './component';
+import { IgnoreFile } from './ignore-file';
+
+/**
+ * Options for `SubdirComponent`
+ */
+export interface SubdirComponentOptions {
+  /**
+   * Path relative to the project's synth directory to use as a subdirectory.
+   */
+  readonly subdirPath: string;
+}
+
+/**
+ * A sub-directory in which to synthesize components.
+ */
+export class Subdir extends Component implements IComponentScope {
+  readonly gitignore: IgnoreFile;
+  readonly components: Component[];
+  readonly subdirPath: string;
+
+  constructor(public readonly project: IComponentScope, private readonly options: SubdirComponentOptions) {
+    super(project);
+    this.components = [];
+    this.gitignore = new IgnoreFile(this, '.gitignore');
+    this.subdirPath = options.subdirPath;
+  }
+
+  /**
+   * @internal
+   */
+  _addComponent(component: Component): void {
+    this.components.push(component);
+  }
+
+  addTip(message: string): void {
+    this.project.addTip(message);
+  }
+
+  synthesize(outdir: string) {
+    const subDir = path.join(outdir, this.options.subdirPath);
+
+    for (const comp of this.components) {
+      comp.synthesize(subDir);
+    }
+
+    for (const comp of this.components) {
+      comp.postSynthesize(subDir);
+    }
+  }
+}

--- a/src/subdir.ts
+++ b/src/subdir.ts
@@ -16,9 +16,9 @@ export interface SubdirComponentOptions {
  * A sub-directory in which to synthesize components.
  */
 export class Subdir extends Component implements IComponentScope {
-  readonly gitignore: IgnoreFile;
-  readonly components: Component[];
-  readonly subdirPath: string;
+  public readonly gitignore: IgnoreFile;
+  public readonly subdirPath: string;
+  private readonly components: Component[];
 
   constructor(public readonly project: IComponentScope, private readonly options: SubdirComponentOptions) {
     super(project);

--- a/src/subdir.ts
+++ b/src/subdir.ts
@@ -3,28 +3,16 @@ import { Component, IComponentScope } from './component';
 import { IgnoreFile } from './ignore-file';
 
 /**
- * Options for `SubdirComponent`
- */
-export interface SubdirComponentOptions {
-  /**
-   * Path relative to the project's synth directory to use as a subdirectory.
-   */
-  readonly subdirPath: string;
-}
-
-/**
  * A sub-directory in which to synthesize components.
  */
 export class Subdir extends Component implements IComponentScope {
   public readonly gitignore: IgnoreFile;
-  public readonly subdirPath: string;
   private readonly components: Component[];
 
-  constructor(public readonly project: IComponentScope, private readonly options: SubdirComponentOptions) {
+  constructor(public readonly project: IComponentScope, public readonly subdirPath: string) {
     super(project);
     this.components = [];
     this.gitignore = new IgnoreFile(this, '.gitignore');
-    this.subdirPath = options.subdirPath;
   }
 
   /**
@@ -39,7 +27,7 @@ export class Subdir extends Component implements IComponentScope {
   }
 
   synthesize(outdir: string) {
-    const subDir = path.join(outdir, this.options.subdirPath);
+    const subDir = path.join(outdir, this.subdirPath);
 
     for (const comp of this.components) {
       comp.synthesize(subDir);

--- a/src/textfile.ts
+++ b/src/textfile.ts
@@ -1,5 +1,5 @@
+import { IComponentScope } from './component';
 import { FileBase, FileBaseOptions, IResolver } from './file';
-import { Project } from './project';
 
 /**
  * Options for `TextFile`.
@@ -26,7 +26,7 @@ export class TextFile extends FileBase {
    * @param filePath File path
    * @param options Options
    */
-  constructor(project: Project, filePath: string, options: TextFileOptions = { }) {
+  constructor(project: IComponentScope, filePath: string, options: TextFileOptions = { }) {
     super(project, filePath, options);
 
     this.lines = options.lines ?? [];

--- a/src/toml.ts
+++ b/src/toml.ts
@@ -1,6 +1,6 @@
 import * as TOML from '@iarna/toml';
+import { IComponentScope } from './component';
 import { FileBase, FileBaseOptions, IResolver } from './file';
-import { Project } from './project';
 
 export interface TomlFileOptions extends FileBaseOptions {
   /**
@@ -15,7 +15,7 @@ export interface TomlFileOptions extends FileBaseOptions {
 export class TomlFile extends FileBase {
   protected readonly obj: object;
 
-  constructor(project: Project, filePath: string, options: TomlFileOptions) {
+  constructor(project: IComponentScope, filePath: string, options: TomlFileOptions) {
     super(project, filePath, options);
 
     if (!options.obj) {

--- a/src/yaml.ts
+++ b/src/yaml.ts
@@ -1,15 +1,15 @@
 import * as YAML from 'yaml';
 import { GENERATION_DISCLAIMER } from './common';
+import { IComponentScope } from './component';
 import { IResolver } from './file';
 import { JsonFile, JsonFileOptions } from './json';
-import { Project } from './project';
 
 export interface YamlFileOptions extends JsonFileOptions {
 
 }
 
 export class YamlFile extends JsonFile {
-  constructor(project: Project, filePath: string, options: YamlFileOptions) {
+  constructor(project: IComponentScope, filePath: string, options: YamlFileOptions) {
     super(project, filePath, options);
   }
 

--- a/test/subdir.test.ts
+++ b/test/subdir.test.ts
@@ -69,6 +69,8 @@ test('creates several subdirs', () => {
   const p = new Project();
 
   // WHEN
+
+  // Frontend Dockerfile and context in its own directory
   const frontend = new Subdir(p, {
     subdirPath: 'frontend',
   });
@@ -79,6 +81,7 @@ test('creates several subdirs', () => {
     ],
   });
 
+  // API Dockerfile and context in its own directory
   const api = new Subdir(p, {
     subdirPath: 'cms',
   });
@@ -89,7 +92,7 @@ test('creates several subdirs', () => {
     ],
   });
 
-  // Dockerfile at the root
+  // Docker compose at the root
   new DockerCompose(p, {
     services: {
       http: {

--- a/test/subdir.test.ts
+++ b/test/subdir.test.ts
@@ -1,0 +1,126 @@
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import { DockerCompose, Project, TextFile } from '../src';
+import * as logging from '../src/logging';
+import { Subdir } from '../src/subdir';
+
+logging.disable();
+
+let tempDir: string;
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(__dirname, 'tmp.subdir'));
+});
+
+afterEach(() => {
+  if (tempDir) {
+    fs.removeSync(tempDir);
+  }
+});
+
+test('creates a subdir', () => {
+  // GIVEN
+  const p = new Project();
+
+  // WHEN
+  new Subdir(p, {
+    subdirPath: 'mysubdir',
+  });
+  p.synth(tempDir);
+
+  // THEN
+  fs.existsSync(path.join(tempDir, '.gitignore'));
+  fs.existsSync(path.join(tempDir, 'mysubdir', '.gitignore'));
+});
+
+test('adds gitignores to the right file', () => {
+  // GIVEN
+  const p = new Project();
+
+  // WHEN
+  const sub = new Subdir(p, {
+    subdirPath: 'mysubdir',
+  });
+  sub.gitignore.exclude('ignore-me');
+  p.synth(tempDir);
+
+  // THEN
+  expect(fs.readFileSync(path.join(tempDir, 'mysubdir', '.gitignore')).toString('utf8')).toContain('ignore-me');
+});
+
+test('creates a text file in a subdir', () => {
+  // GIVEN
+  const p = new Project();
+  const subdir = new Subdir(p, {
+    subdirPath: 'mysubdir',
+  });
+
+  // WHEN
+  new TextFile(subdir, 'example.txt', {
+    lines: ['foo', 'bar', 'baz'],
+  });
+  p.synth(tempDir);
+
+  // THEN
+  fs.existsSync(path.join(tempDir, 'mysubdir', 'example.txt'));
+});
+
+test('creates several subdirs', () => {
+  // GIVEN
+  const p = new Project();
+
+  // WHEN
+  const frontend = new Subdir(p, {
+    subdirPath: 'frontend',
+  });
+
+  new TextFile(frontend, 'Dockerfile', {
+    lines: [
+      'FROM nginx',
+    ],
+  });
+
+  const api = new Subdir(p, {
+    subdirPath: 'cms',
+  });
+
+  new TextFile(api, 'Dockerfile', {
+    lines: [
+      'FROM wordpress',
+    ],
+  });
+
+  // Dockerfile at the root
+  new DockerCompose(p, {
+    services: {
+      http: {
+        imageBuild: {
+          context: frontend.subdirPath,
+        },
+        ports: [
+          DockerCompose.portMapping(8080, 3000),
+        ],
+      },
+      api: {
+        imageBuild: {
+          context: api.subdirPath,
+        },
+        ports: [
+          DockerCompose.portMapping(8081, 80),
+        ],
+      },
+      database: {
+        image: 'mysql:8',
+        volumes: [
+          DockerCompose.namedVolume('mysql', '/var/lib/mysql'),
+        ],
+      },
+    },
+  });
+
+  p.synth(tempDir);
+
+  // THEN
+  expect(fs.existsSync(path.join(tempDir, 'docker-compose.yml'))).toBeTruthy();
+  expect(fs.existsSync(path.join(tempDir, frontend.subdirPath, 'Dockerfile'))).toBeTruthy();
+  expect(fs.existsSync(path.join(tempDir, api.subdirPath, 'Dockerfile'))).toBeTruthy();
+});

--- a/test/subdir.test.ts
+++ b/test/subdir.test.ts
@@ -22,9 +22,7 @@ test('creates a subdir', () => {
   const p = new Project();
 
   // WHEN
-  new Subdir(p, {
-    subdirPath: 'mysubdir',
-  });
+  new Subdir(p, 'mysubdir');
   p.synth(tempDir);
 
   // THEN
@@ -37,9 +35,7 @@ test('adds gitignores to the right file', () => {
   const p = new Project();
 
   // WHEN
-  const sub = new Subdir(p, {
-    subdirPath: 'mysubdir',
-  });
+  const sub = new Subdir(p, 'mysubdir');
   sub.gitignore.exclude('ignore-me');
   p.synth(tempDir);
 
@@ -50,9 +46,7 @@ test('adds gitignores to the right file', () => {
 test('creates a text file in a subdir', () => {
   // GIVEN
   const p = new Project();
-  const subdir = new Subdir(p, {
-    subdirPath: 'mysubdir',
-  });
+  const subdir = new Subdir(p, 'mysubdir');
 
   // WHEN
   new TextFile(subdir, 'example.txt', {
@@ -67,14 +61,10 @@ test('creates a text file in a subdir', () => {
 test('creates a text file in a subdir nested in subdir', () => {
   const p = new Project();
 
-  const subdir = new Subdir(p, {
-    subdirPath: 'mysubdir',
-  });
+  const subdir = new Subdir(p, 'mysubdir');
 
   // WHEN
-  const nestedSubdir = new Subdir(subdir, {
-    subdirPath: 'deeper',
-  });
+  const nestedSubdir = new Subdir(subdir, 'deeper');
 
   new TextFile(nestedSubdir, 'example.txt', {
     lines: ['foo', 'bar', 'baz'],
@@ -93,9 +83,7 @@ test('creates several subdirs', () => {
   // WHEN
 
   // Frontend Dockerfile and context in its own directory
-  const frontend = new Subdir(p, {
-    subdirPath: 'frontend',
-  });
+  const frontend = new Subdir(p, 'frontend');
 
   new TextFile(frontend, 'Dockerfile', {
     lines: [
@@ -104,9 +92,7 @@ test('creates several subdirs', () => {
   });
 
   // API Dockerfile and context in its own directory
-  const api = new Subdir(p, {
-    subdirPath: 'cms',
-  });
+  const api = new Subdir(p, 'cms');
 
   new TextFile(api, 'Dockerfile', {
     lines: [

--- a/test/subdir.test.ts
+++ b/test/subdir.test.ts
@@ -64,6 +64,28 @@ test('creates a text file in a subdir', () => {
   fs.existsSync(path.join(tempDir, 'mysubdir', 'example.txt'));
 });
 
+test('creates a text file in a subdir nested in subdir', () => {
+  const p = new Project();
+
+  const subdir = new Subdir(p, {
+    subdirPath: 'mysubdir',
+  });
+
+  // WHEN
+  const nestedSubdir = new Subdir(subdir, {
+    subdirPath: 'deeper',
+  });
+
+  new TextFile(nestedSubdir, 'example.txt', {
+    lines: ['foo', 'bar', 'baz'],
+  });
+
+  p.synth(tempDir);
+
+  // THEN
+  expect(fs.existsSync(path.join(tempDir, 'mysubdir', 'deeper', 'example.txt'))).toBeTruthy();
+});
+
 test('creates several subdirs', () => {
   // GIVEN
   const p = new Project();


### PR DESCRIPTION
Fixes #243 

Introduces a subdir component that allows components to be synthesized relative to a subdirectory.

Example:

```ts
// Root project
const p = new Project();

// Subdirectory 'mysubdir'
const subdir = new Subdir(p, 'mysubdir');

// example.txt in the sub directory 'mysubdir'
new TextFile(subdir, 'example.txt', {
  lines: ['foo', 'bar', 'baz'],
});
```