### PR TITLE
fix(cli): "new --from" scoped packages is broken

### DIFF
--- a/src/cli/cmds/new.ts
+++ b/src/cli/cmds/new.ts
@@ -259,9 +259,6 @@ function newProjectFromModule(baseDir: string, spec: string, args: any) {
     .discover(...modules)
     .filter(x => x.moduleName !== 'projen'); // filter built-in project types
 
-  console.log('PROJECTS');
-  console.log(projects);
-
   if (projects.length < 1) {
     throw new Error(`No projects found after installing ${spec}. The module must export at least one class which extends projen.Project`);
   }

--- a/src/cli/cmds/new.ts
+++ b/src/cli/cmds/new.ts
@@ -85,7 +85,14 @@ class Command implements yargs.CommandModule {
   }
 }
 
-function generateProjenConfig(baseDir: string, type: inventory.ProjectType, params: Record<string, any>, comments: boolean) {
+/**
+ *
+ * @param baseDir Base directory for reading and writing files
+ * @param type Project type
+ * @param params Object with parameter default values. Values should be strings
+ * @param comments Whether to include optional parameters in commented out form
+ */
+function generateProjenConfig(baseDir: string, type: inventory.ProjectType, params: Record<string, string>, comments: boolean) {
   const configPath = path.join(baseDir, PROJEN_RC);
   if (fs.existsSync(configPath)) {
     logging.error(`Directory ${baseDir} already contains ${PROJEN_RC}`);
@@ -119,7 +126,7 @@ function makePadding(paddingLength: number): string {
  * @param params Object with parameter default values
  * @param comments Whether to include optional parameters in commented out form
  */
-function renderParams(type: inventory.ProjectType, params: Record<string, any>, comments: boolean) {
+function renderParams(type: inventory.ProjectType, params: Record<string, string>, comments: boolean) {
   // preprocessing
   const renders: Record<string, string> = {};
   const optionsWithDefaults: string[] = [];
@@ -252,6 +259,9 @@ function newProjectFromModule(baseDir: string, spec: string, args: any) {
     .discover(...modules)
     .filter(x => x.moduleName !== 'projen'); // filter built-in project types
 
+  console.log('PROJECTS');
+  console.log(projects);
+
   if (projects.length < 1) {
     throw new Error(`No projects found after installing ${spec}. The module must export at least one class which extends projen.Project`);
   }
@@ -282,7 +292,7 @@ function newProjectFromModule(baseDir: string, spec: string, args: any) {
  * @param args Command line arguments
  * @param additionalProps Additional parameters to include in .projenrc.js
  */
-function newProject(baseDir: string, type: inventory.ProjectType, args: any, additionalProps?: Record<string, any>) {
+function newProject(baseDir: string, type: inventory.ProjectType, args: any, additionalProps?: Record<string, string>) {
   // convert command line arguments to project props using type information
   const props = commandLineToProps(type, args);
 

--- a/src/inventory.ts
+++ b/src/inventory.ts
@@ -93,9 +93,10 @@ export function discover(...moduleDirs: string[]) {
     discoverJsii(dir);
 
     if (dir.includes('@') && fs.lstatSync(dir).isDirectory()) {
-      fs.readdirSync(dir).map(file => path.join(dir, file)).forEach(child => {
+      const childDirs = fs.readdirSync(dir).map(file => path.join(dir, file));
+      for (const child of childDirs) {
         discoverJsii(child);
-      });
+      }
     }
   }
 

--- a/src/inventory.ts
+++ b/src/inventory.ts
@@ -77,15 +77,25 @@ interface JsiiType {
 export function discover(...moduleDirs: string[]) {
   const jsii: JsiiTypes = {};
 
+  const discoverJsii = (dir: string) => {
+    const jsiiFile = path.join(dir, '.jsii');
+    if (!fs.existsSync(jsiiFile)) { return; } // no jsii manifest
+
+    const manifest = fs.readJsonSync(jsiiFile);
+    for (const [fqn, type] of Object.entries(manifest.types as JsiiTypes)) {
+      jsii[fqn] = type;
+    }
+  };
+
   // read all .jsii manifests from all modules (incl. projen itself) and merge
   // them all into a single map of fqn->type.
   for (const dir of [...moduleDirs, PROJEN_MODULE_ROOT]) {
-    const jsiiFile = path.join(dir, '.jsii');
-    if (!fs.existsSync(jsiiFile)) { continue; } // no jsii manifest
-    const manifest = fs.readJsonSync(jsiiFile);
+    discoverJsii(dir);
 
-    for (const [fqn, type] of Object.entries(manifest.types as JsiiTypes)) {
-      jsii[fqn] = type;
+    if (dir.includes('@') && fs.lstatSync(dir).isDirectory()) {
+      fs.readdirSync(dir).map(file => path.join(dir, file)).forEach(child => {
+        discoverJsii(child);
+      });
     }
   }
 
@@ -114,7 +124,7 @@ export function discover(...moduleDirs: string[]) {
 }
 
 function discoverOptions(jsii: JsiiTypes, fqn: string): ProjectOption[] {
-  const options: { [name: string]: ProjectOption } = { };
+  const options: { [name: string]: ProjectOption } = {};
   const params = jsii[fqn]?.initializer?.parameters ?? [];
   const optionsParam = params[0];
   const optionsTypeFqn = optionsParam?.type?.fqn;


### PR DESCRIPTION
Fixes #296 

* Alters inventory discovery to check for child directories for scoped packages
* #280 - sets the new project `additionalProps` to be `Record<string, string>` in order to be in line with the 280 bugfix change from yesterday