### PR TITLE
test(license): do not install projen during test

### DIFF
--- a/test/node-project.test.ts
+++ b/test/node-project.test.ts
@@ -7,6 +7,7 @@ test('license file is added by default', () => {
     name: 'test-node-project',
     start: false,
     mergify: false,
+    projenDevDependency: false,
   });
 
   // THEN
@@ -20,6 +21,7 @@ test('license file is not added if licensed is false', () => {
     licensed: false,
     start: false,
     mergify: false,
+    projenDevDependency: false,
   });
 
   // THEN


### PR DESCRIPTION
* Installing projen during tests fails while releasing
  because yarn tries to install the to-be-released
  version of projen