### PR TITLE
fix: cdk app starter test code syntax and linting errors

### DIFF
--- a/src/awscdk-app-ts.ts
+++ b/src/awscdk-app-ts.ts
@@ -225,8 +225,8 @@ app.synth();`;
     }
 
     const testCode = `import '@aws-cdk/assert/jest';
-import { MyStack } from '../src/main'
 import { App } from '@aws-cdk/core';
+import { MyStack } from '../src/main';
 
 test('Snapshot', () => {
   const app = new App();


### PR DESCRIPTION
This PR fixes syntax and linting errors in the starter code for `AwsCdkTypeScriptApp`.
