### PR TITLE
fix: github/vscode accessors should not be available in subprojects

### DIFF
--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -1,25 +1,19 @@
 import { Component } from '../component';
-import { Project } from '../project';
 import { Dependabot, DependabotOptions } from './dependabot';
 import { Mergify, MergifyRule } from './mergify';
 import { PullRequestTemplate } from './pr-template';
 import { GithubWorkflow } from './workflows';
 
 export class GitHub extends Component {
-  private _mergify?: Mergify;
-
-  constructor(project: Project) {
-    super(project);
-
-  }
+  private mergify?: Mergify;
 
   public addMergifyRules(...rules: MergifyRule[]) {
-    if (!this._mergify) {
-      this._mergify = new Mergify(this);
+    if (!this.mergify) {
+      this.mergify = new Mergify(this);
     }
 
     for (const r of rules) {
-      this._mergify.addRule(r);
+      this.mergify.addRule(r);
     }
   }
 

--- a/src/project.ts
+++ b/src/project.ts
@@ -63,13 +63,17 @@ export class Project {
 
   /**
    * Access all github components.
+   *
+   * This will be `undefined` for subprojects.
    */
-  public readonly github?: GitHub;
+  public readonly github: GitHub | undefined;
 
   /**
    * Access all VSCode components.
+   *
+   * This will be `undefined` for subprojects.
    */
-  public readonly vscode?: VsCode;
+  public readonly vscode: VsCode | undefined;
 
   constructor(options: ProjectOptions = { }) {
     this.parent = options.parent;
@@ -105,8 +109,12 @@ export class Project {
     // ------------------------------------------------------------------------
 
     this.gitignore = new IgnoreFile(this, '.gitignore');
-    this.github = new GitHub(this);
-    this.vscode = new VsCode(this);
+
+    // we only allow these global services to be used in root projects
+    this.github = !this.parent ? new GitHub(this) : undefined;
+    this.vscode = !this.parent ? new VsCode(this) : undefined;
+
+
     new SampleReadme(this, '# my project');
   }
 


### PR DESCRIPTION
Since these are "global" services, their accessors will now be `undefined` in subprojects. This will allow subprojects to decide how to deal with things like workflows, IDE integration, etc.

