### PR TITLE
chore: add InternalConsoleOptions enum to VSCode launch config

### DIFF
--- a/src/vscode/launch-config.ts
+++ b/src/vscode/launch-config.ts
@@ -26,7 +26,8 @@ export interface Presentation {
 }
 /**
  * VSCode launch configuration ServerReadyAction interface
- * "if you want to open a URL in a web browser whenever the program under debugging outputs a specific message to the debug console or integrated terminal."
+ * "if you want to open a URL in a web browser whenever the program under debugging 
+ * outputs a specific message to the debug console or integrated terminal."
  * Source: https://code.visualstudio.com/docs/editor/debugging#_launchjson-attributes
  */
 export interface ServerReadyAction {

--- a/src/vscode/launch-config.ts
+++ b/src/vscode/launch-config.ts
@@ -26,7 +26,7 @@ export interface Presentation {
 }
 /**
  * VSCode launch configuration ServerReadyAction interface
- * "if you want to open a URL in a web browser whenever the program under debugging 
+ * "if you want to open a URL in a web browser whenever the program under debugging
  * outputs a specific message to the debug console or integrated terminal."
  * Source: https://code.visualstudio.com/docs/editor/debugging#_launchjson-attributes
  */

--- a/src/vscode/launch-config.ts
+++ b/src/vscode/launch-config.ts
@@ -3,6 +3,16 @@ import { JsonFile } from '../json';
 import { VsCode } from './vscode';
 
 /**
+ * Controls the visibility of the VSCode Debug Console panel during a debugging session
+ * Source: https://code.visualstudio.com/docs/editor/debugging#_launchjson-attributes
+ */
+export enum InternalConsoleOptions {
+  NEVER_OPEN = 'neverOpen',
+  OPEN_ON_FIRST_SESSION_START = 'openOnFirstSessionStart',
+  OPEN_ON_SESSION_START = 'openOnSessionStart',
+}
+
+/**
  * VSCode launch configuration Presentation interface
  * "using the order, group, and hidden attributes in the presentation object you can sort,
  * group, and hide configurations and compounds in the Debug configuration dropdown
@@ -35,10 +45,7 @@ export interface VsCodeLaunchConfigurationEntry {
   readonly name: string;
   readonly args?: string[];
   readonly debugServer?: number;
-  readonly internalConsoleOptions?:
-  | 'neverOpen'
-  | 'openOnFirstSessionStart'
-  | 'openOnSessionStart';
+  readonly internalConsoleOptions?: InternalConsoleOptions;
   readonly runtimeArgs?: string[];
   readonly postDebugTask?: string;
   readonly preLaunchTask?: string;

--- a/test/vscode-launch-config.test.ts
+++ b/test/vscode-launch-config.test.ts
@@ -1,5 +1,5 @@
-import { synthSnapshot, TestProject } from './util';
 import { InternalConsoleOptions } from '../src/vscode/launch-config';
+import { synthSnapshot, TestProject } from './util';
 
 const VSCODE_DEBUGGER_FILE = '.vscode/launch.json';
 

--- a/test/vscode-launch-config.test.ts
+++ b/test/vscode-launch-config.test.ts
@@ -1,4 +1,5 @@
 import { synthSnapshot, TestProject } from './util';
+import { InternalConsoleOptions } from '../src/vscode/launch-config';
 
 const VSCODE_DEBUGGER_FILE = '.vscode/launch.json';
 
@@ -74,6 +75,7 @@ test('adding multiple launch configuration entries', () => {
     program: '${workspaceFolder}/lib/index.js',
     preLaunchTask: 'tsc: build - tsconfig.json',
     outFiles: ['${workspaceFolder}/lib/**/*.js'],
+    internalConsoleOptions: InternalConsoleOptions.OPEN_ON_SESSION_START,
   });
 
   launchConfig?.addConfiguration({
@@ -106,6 +108,7 @@ test('adding multiple launch configuration entries', () => {
           program: '${workspaceFolder}/lib/index.js',
           preLaunchTask: 'tsc: build - tsconfig.json',
           outFiles: ['${workspaceFolder}/lib/**/*.js'],
+          internalConsoleOptions: 'openOnSessionStart',
         },
         {
           type: 'pwa-chrome',


### PR DESCRIPTION
As requested in https://github.com/projen/projen/pull/316#discussion_r536107141