### PR TITLE
chore: integration tests

### DIFF
--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -1,0 +1,1499 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`cdk-watchful.projenrc.js 1`] = `
+Object {
+  ".eslintrc.json": Object {
+    "env": Object {
+      "jest": true,
+      "node": true,
+    },
+    "extends": Array [
+      "plugin:import/typescript",
+    ],
+    "ignorePatterns": Array [
+      "*.js",
+      "!.projenrc.js",
+      "*.d.ts",
+      "node_modules/",
+      "*.generated.ts",
+      "coverage",
+    ],
+    "overrides": Array [
+      Object {
+        "files": Array [
+          ".projenrc.js",
+        ],
+        "rules": Object {
+          "@typescript-eslint/no-require-imports": "off",
+          "import/no-extraneous-dependencies": "off",
+        },
+      },
+    ],
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": Object {
+      "ecmaVersion": 2018,
+      "project": "./tsconfig.jest.json",
+      "sourceType": "module",
+    },
+    "plugins": Array [
+      "@typescript-eslint",
+      "import",
+    ],
+    "root": true,
+    "rules": Object {
+      "@typescript-eslint/indent": Array [
+        "error",
+        2,
+      ],
+      "@typescript-eslint/member-delimiter-style": Array [
+        "error",
+      ],
+      "@typescript-eslint/member-ordering": Array [
+        "error",
+        Object {
+          "default": Array [
+            "public-static-field",
+            "public-static-method",
+            "protected-static-field",
+            "protected-static-method",
+            "private-static-field",
+            "private-static-method",
+            "field",
+            "constructor",
+            "method",
+          ],
+        },
+      ],
+      "@typescript-eslint/no-floating-promises": Array [
+        "error",
+      ],
+      "@typescript-eslint/no-require-imports": Array [
+        "error",
+      ],
+      "@typescript-eslint/no-shadow": Array [
+        "error",
+      ],
+      "@typescript-eslint/return-await": Array [
+        "error",
+      ],
+      "array-bracket-newline": Array [
+        "error",
+        "consistent",
+      ],
+      "array-bracket-spacing": Array [
+        "error",
+        "never",
+      ],
+      "brace-style": Array [
+        "error",
+        "1tbs",
+        Object {
+          "allowSingleLine": true,
+        },
+      ],
+      "comma-dangle": Array [
+        "error",
+        "always-multiline",
+      ],
+      "comma-spacing": Array [
+        "error",
+        Object {
+          "after": true,
+          "before": false,
+        },
+      ],
+      "curly": Array [
+        "error",
+        "multi-line",
+        "consistent",
+      ],
+      "dot-notation": Array [
+        "error",
+      ],
+      "import/no-extraneous-dependencies": Array [
+        "error",
+        Object {
+          "devDependencies": Array [
+            "**/build-tools/**",
+            "**/test/**",
+          ],
+          "optionalDependencies": false,
+          "peerDependencies": true,
+        },
+      ],
+      "import/no-unresolved": Array [
+        "error",
+      ],
+      "import/order": Array [
+        "warn",
+        Object {
+          "alphabetize": Object {
+            "caseInsensitive": true,
+            "order": "asc",
+          },
+          "groups": Array [
+            "builtin",
+            "external",
+          ],
+        },
+      ],
+      "indent": Array [
+        "off",
+      ],
+      "key-spacing": Array [
+        "error",
+      ],
+      "keyword-spacing": Array [
+        "error",
+      ],
+      "max-len": Array [
+        "error",
+        Object {
+          "code": 150,
+          "ignoreComments": true,
+          "ignoreRegExpLiterals": true,
+          "ignoreStrings": true,
+          "ignoreTemplateLiterals": true,
+          "ignoreUrls": true,
+        },
+      ],
+      "no-bitwise": Array [
+        "error",
+      ],
+      "no-duplicate-imports": Array [
+        "error",
+      ],
+      "no-multi-spaces": Array [
+        "error",
+        Object {
+          "ignoreEOLComments": false,
+        },
+      ],
+      "no-multiple-empty-lines": Array [
+        "error",
+      ],
+      "no-return-await": Array [
+        "off",
+      ],
+      "no-shadow": Array [
+        "off",
+      ],
+      "no-trailing-spaces": Array [
+        "error",
+      ],
+      "object-curly-newline": Array [
+        "error",
+        Object {
+          "consistent": true,
+          "multiline": true,
+        },
+      ],
+      "object-curly-spacing": Array [
+        "error",
+        "always",
+      ],
+      "object-property-newline": Array [
+        "error",
+        Object {
+          "allowAllPropertiesOnSameLine": true,
+        },
+      ],
+      "quote-props": Array [
+        "error",
+        "consistent-as-needed",
+      ],
+      "quotes": Array [
+        "error",
+        "single",
+        Object {
+          "avoidEscape": true,
+        },
+      ],
+      "semi": Array [
+        "error",
+        "always",
+      ],
+      "space-before-blocks": Array [
+        "error",
+      ],
+    },
+    "settings": Object {
+      "import/parsers": Object {
+        "@typescript-eslint/parser": Array [
+          ".ts",
+          ".tsx",
+        ],
+      },
+      "import/resolver": Object {
+        "node": Object {},
+        "typescript": Object {
+          "directory": "./tsconfig.json",
+        },
+      },
+    },
+  },
+  ".github/dependabot.yml": "# ~~ Generated by projen. To modify, edit .projenrc.js and run \\"npx projen\\".
+
+version: 2
+updates:
+  - package-ecosystem: npm
+    versioning-strategy: lockfile-only
+    directory: /
+    schedule:
+      interval: daily
+    ignore:
+      - dependency-name: projen
+",
+  ".github/pull_request_template.md": "Fixes #",
+  ".github/workflows/build.yml": "# ~~ Generated by projen. To modify, edit .projenrc.js and run \\"npx projen\\".
+name: Build
+on:
+  pull_request: {}
+  workflow_dispatch: {}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      CI: \\"true\\"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.0.0
+      - name: Install dependencies
+        run: yarn install --check-files --frozen-lockfile
+      - name: Synthesize project files
+        run: npx projen
+      - name: Anti-tamper check
+        run: git diff --exit-code
+      - name: Set git identity
+        run: |-
+          git config user.name \\"Auto-bump\\"
+          git config user.email \\"github-actions@github.com\\"
+      - name: Build
+        run: npx projen build
+      - name: Anti-tamper check
+        run: git diff --exit-code
+    container:
+      image: jsii/superchain
+",
+  ".github/workflows/projenupgrade.yml": "# ~~ Generated by projen. To modify, edit .projenrc.js and run \\"npx projen\\".
+name: ProjenUpgrade
+on:
+  schedule:
+    - cron: 0 6 * * *
+  workflow_dispatch: {}
+jobs:
+  upgrade:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.0.0
+      - name: Install dependencies
+        run: yarn install --check-files --frozen-lockfile
+      - name: Synthesize project files
+        run: npx projen
+      - name: Upgrade projen
+        run: npx projen projen:upgrade
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
+          commit-message: \\"chore: upgrade projen\\"
+          branch: auto/projen-upgrade
+          title: \\"chore: upgrade projen\\"
+          body: This PR upgrades projen to the latest version
+          labels: auto-merge
+",
+  ".github/workflows/rebuild-bot.yml": "# ~~ Generated by projen. To modify, edit .projenrc.js and run \\"npx projen\\".
+name: rebuild-bot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch: {}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      CI: \\"true\\"
+    if: \${{ github.event.issue.pull_request && contains(github.event.comment.body,
+      '@projen rebuild') }}
+    steps:
+      - name: Post comment to issue
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: \${{ github.event.issue.number }}
+          body: \\"_projen_: Rebuild started\\"
+      - name: Get pull request branch
+        id: query_pull_request
+        env:
+          PULL_REQUEST_URL: \${{ github.event.issue.pull_request.url }}
+        run: |-
+          rm -f /tmp/pr.json
+          curl --silent $PULL_REQUEST_URL > /tmp/pr.json
+          BRANCH_STR=$(cat /tmp/pr.json | jq \\".head.ref\\")
+          REPO_NAME=$(cat /tmp/pr.json | jq \\".head.repo.full_name\\")
+          echo \\"::set-output name=branch::$(node -p $BRANCH_STR)\\"
+          echo \\"::set-output name=repo::$(node -p $REPO_NAME)\\"
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: \${{ steps.query_pull_request.outputs.branch }}
+          repository: \${{ steps.query_pull_request.outputs.repo }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.0.0
+      - name: Install dependencies
+        run: yarn install --check-files --frozen-lockfile
+      - name: Synthesize project files
+        run: npx projen
+      - name: Set git identity
+        run: |-
+          git config user.name \\"Auto-bump\\"
+          git config user.email \\"github-actions@github.com\\"
+      - name: Build
+        run: npx projen build
+      - name: Commit changes
+        run: 'git commit -am \\"chore: update generated files\\"'
+      - name: Push changes
+        run: git push --follow-tags origin $BRANCH
+        env:
+          BRANCH: \${{ steps.query_pull_request.outputs.branch }}
+      - name: Post comment to issue
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: \${{ github.event.issue.number }}
+          body: \\"_projen_: Rebuild complete. Updates pushed to pull request branch.\\"
+",
+  ".github/workflows/release.yml": "# ~~ Generated by projen. To modify, edit .projenrc.js and run \\"npx projen\\".
+name: Release
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch: {}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      CI: \\"true\\"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.0.0
+      - name: Install dependencies
+        run: yarn install --check-files --frozen-lockfile
+      - name: Synthesize project files
+        run: npx projen
+      - name: Anti-tamper check
+        run: git diff --exit-code
+      - name: Set git identity
+        run: |-
+          git config user.name \\"Auto-bump\\"
+          git config user.email \\"github-actions@github.com\\"
+      - name: Bump to next version
+        run: npx projen bump
+      - name: Build
+        run: npx projen build
+      - name: Anti-tamper check
+        run: git diff --exit-code
+      - name: Push changes
+        run: git push --follow-tags origin $BRANCH
+        env:
+          BRANCH: \${{ github.ref }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2.1.1
+        with:
+          name: dist
+          path: dist
+    container:
+      image: jsii/superchain
+  release_npm:
+    name: Release to NPM
+    needs: build
+    runs-on: ubuntu-latest
+    container:
+      image: jsii/superchain
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: dist
+      - name: Release
+        run: npx -p jsii-release jsii-release-npm
+        env:
+          NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
+          NPM_DIST_TAG: latest
+          NPM_REGISTRY: registry.npmjs.org
+  release_maven:
+    name: Release to Maven
+    needs: build
+    runs-on: ubuntu-latest
+    container:
+      image: jsii/superchain
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: dist
+      - name: Release
+        run: npx -p jsii-release jsii-release-maven
+        env:
+          MAVEN_GPG_PRIVATE_KEY: \${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          MAVEN_GPG_PRIVATE_KEY_PASSPHRASE: \${{ secrets.MAVEN_GPG_PRIVATE_KEY_PASSPHRASE }}
+          MAVEN_PASSWORD: \${{ secrets.MAVEN_PASSWORD }}
+          MAVEN_USERNAME: \${{ secrets.MAVEN_USERNAME }}
+          MAVEN_STAGING_PROFILE_ID: \${{ secrets.MAVEN_STAGING_PROFILE_ID }}
+  release_pypi:
+    name: Release to PyPi
+    needs: build
+    runs-on: ubuntu-latest
+    container:
+      image: jsii/superchain
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: dist
+      - name: Release
+        run: npx -p jsii-release jsii-release-pypi
+        env:
+          TWINE_USERNAME: \${{ secrets.TWINE_USERNAME }}
+          TWINE_PASSWORD: \${{ secrets.TWINE_PASSWORD }}
+",
+  ".gitignore": "# ~~ Generated by projen. To modify, edit .projenrc.js and run \\"npx projen\\".
+node_modules/
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+# Diagnostic reports (https://nodejs.org/api/report.html)
+report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+# Directory for instrumented libs generated by jscoverage/JSCover
+lib-cov
+# Coverage directory used by tools like istanbul
+coverage
+*.lcov
+# nyc test coverage
+.nyc_output
+# Compiled binary addons (https://nodejs.org/api/addons.html)
+build/Release
+# Dependency directories
+jspm_packages/
+# TypeScript cache
+*.tsbuildinfo
+# Optional eslint cache
+.eslintcache
+# Output of 'npm pack'
+*.tgz
+# Yarn Integrity file
+.yarn-integrity
+# parcel-bundler cache (https://parceljs.org/)
+.cache
+# jest-junit artifacts
+/test-reports/
+junit.xml
+/coverage
+/lib
+/dist
+.jsii
+tsconfig.json
+.env
+.idea
+example/*.js
+example/*.d.ts
+!/.projen/tasks.json
+!/package.json
+!/.npmignore
+!/LICENSE
+!/.projenrc.js
+!version.json
+!/.versionrc.json
+!/test
+!/.github/workflows/build.yml
+!/.github/workflows/release.yml
+!/.mergify.yml
+!/.github/dependabot.yml
+!/.github/workflows/projenupgrade.yml
+!/.github/pull_request_template.md
+!/.github/workflows/rebuild-bot.yml
+!/src
+!/tsconfig.jest.json
+!/.eslintrc.json
+!/API.md",
+  ".mergify.yml": "# ~~ Generated by projen. To modify, edit .projenrc.js and run \\"npx projen\\".
+
+pull_request_rules:
+  - name: Automatic merge on approval and successful build
+    actions:
+      merge:
+        method: squash
+        commit_message: title+body
+        strict: smart
+        strict_method: merge
+      delete_head_branch: {}
+    conditions:
+      - \\"#approved-reviews-by>=1\\"
+      - status-success=build
+  - name: Automatic merge PRs with auto-merge label upon successful build
+    actions:
+      merge:
+        method: squash
+        commit_message: title+body
+        strict: smart
+        strict_method: merge
+      delete_head_branch: {}
+    conditions:
+      - label=auto-merge
+      - status-success=build
+  - name: Merge pull requests from dependabot if CI passes
+    conditions:
+      - author=dependabot[bot]
+      - status-success=build
+    actions:
+      merge:
+        method: merge
+        commit_message: title+body
+",
+  ".npmignore": "# ~~ Generated by projen. To modify, edit .projenrc.js and run \\"npx projen\\".
+/.projenrc.js
+/.versionrc.json
+/coverage
+/test
+/.mergify.yml
+/src
+dist
+/tsconfig.json
+/.github
+/.vscode
+/.idea
+/.projenrc.js
+/tsconfig.jest.json
+/.eslintrc.json
+!/lib
+!/lib/**/*.js
+!/lib/**/*.d.ts
+!.jsii",
+  ".projen/tasks.json": Object {
+    "//": "~~ Generated by projen. To modify, edit .projenrc.js and run \\"npx projen\\".",
+    "env": Object {
+      "PATH": "$(npx node -e \\"console.log(process.env.PATH)\\")",
+    },
+    "tasks": Object {
+      "build": Object {
+        "category": "00.build",
+        "description": "Full release build (test+compile)",
+        "name": "build",
+        "steps": Array [
+          Object {
+            "spawn": "test",
+          },
+          Object {
+            "spawn": "compile",
+          },
+          Object {
+            "spawn": "package",
+          },
+        ],
+      },
+      "bump": Object {
+        "category": "20.release",
+        "condition": "! git log --oneline -1 | grep -q \\"chore(release):\\"",
+        "description": "Commits a bump to the package version based on conventional commits",
+        "name": "bump",
+        "steps": Array [
+          Object {
+            "exec": "standard-version",
+          },
+        ],
+      },
+      "clobber": Object {
+        "category": "30.maintain",
+        "condition": "git diff --exit-code > /dev/null",
+        "description": "hard resets to HEAD of origin and cleans the local repo",
+        "env": Object {
+          "BRANCH": "$(git branch --show-current)",
+        },
+        "name": "clobber",
+        "steps": Array [
+          Object {
+            "exec": "git checkout -b scratch",
+            "name": "save current HEAD in \\"scratch\\" branch",
+          },
+          Object {
+            "exec": "git checkout $BRANCH",
+          },
+          Object {
+            "exec": "git fetch origin",
+            "name": "fetch latest changes from origin",
+          },
+          Object {
+            "exec": "git reset --hard origin/$BRANCH",
+            "name": "hard reset to origin commit",
+          },
+          Object {
+            "exec": "git clean -fdx",
+            "name": "clean all untracked files",
+          },
+          Object {
+            "say": "ready to rock! (unpushed commits are under the \\"scratch\\" branch)",
+          },
+        ],
+      },
+      "compat": Object {
+        "category": "20.release",
+        "description": "Perform API compatibility check against latest version",
+        "name": "compat",
+        "steps": Array [
+          Object {
+            "exec": "jsii-diff npm:$(node -p \\"require('./package.json').name\\") -k --ignore-file .compatignore || (echo \\"
+UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .compatignore to skip.
+\\" && exit 1)",
+          },
+        ],
+      },
+      "compile": Object {
+        "category": "00.build",
+        "description": "Only compile",
+        "name": "compile",
+        "steps": Array [
+          Object {
+            "exec": "jsii --silence-warnings=reserved-word --no-fix-peer-dependencies",
+          },
+          Object {
+            "spawn": "docgen",
+          },
+        ],
+      },
+      "docgen": Object {
+        "category": "20.release",
+        "description": "Generate API.md from .jsii manifest",
+        "name": "docgen",
+        "steps": Array [
+          Object {
+            "exec": "jsii-docgen",
+          },
+        ],
+      },
+      "eslint": Object {
+        "category": "10.test",
+        "description": "Runs eslint against the codebase",
+        "name": "eslint",
+        "steps": Array [
+          Object {
+            "exec": "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test .projenrc.js",
+          },
+        ],
+      },
+      "package": Object {
+        "category": "20.release",
+        "description": "Create an npm tarball",
+        "name": "package",
+        "steps": Array [
+          Object {
+            "exec": "jsii-pacmak",
+          },
+        ],
+      },
+      "projen:upgrade": Object {
+        "category": "30.maintain",
+        "description": "upgrades projen to the latest version",
+        "name": "projen:upgrade",
+        "steps": Array [
+          Object {
+            "exec": "yarn upgrade -L projen",
+          },
+          Object {
+            "exec": "CI=\\"\\" yarn projen",
+          },
+        ],
+      },
+      "release": Object {
+        "category": "20.release",
+        "condition": "! git log --oneline -1 | grep -q \\"chore(release):\\"",
+        "description": "Bumps version & push to master",
+        "name": "release",
+        "steps": Array [
+          Object {
+            "spawn": "bump",
+          },
+          Object {
+            "exec": "git push --follow-tags origin master",
+          },
+        ],
+      },
+      "test": Object {
+        "category": "10.test",
+        "description": "Run tests",
+        "name": "test",
+        "steps": Array [
+          Object {
+            "exec": "rm -fr lib/",
+          },
+          Object {
+            "exec": "jest --passWithNoTests --all --updateSnapshot",
+          },
+          Object {
+            "spawn": "eslint",
+          },
+        ],
+      },
+      "test:update": Object {
+        "category": "10.test",
+        "description": "Update jest snapshots",
+        "name": "test:update",
+        "steps": Array [
+          Object {
+            "exec": "jest --updateSnapshot",
+          },
+        ],
+      },
+      "test:watch": Object {
+        "category": "10.test",
+        "description": "Run jest in watch mode",
+        "name": "test:watch",
+        "steps": Array [
+          Object {
+            "exec": "jest --watch",
+          },
+        ],
+      },
+      "watch": Object {
+        "category": "00.build",
+        "description": "Watch & compile in the background",
+        "name": "watch",
+        "steps": Array [
+          Object {
+            "exec": "jsii -w --silence-warnings=reserved-word --no-fix-peer-dependencies",
+          },
+        ],
+      },
+    },
+  },
+  ".projenrc.js": "const { ConstructLibraryAws, Semver } = require('projen');
+
+const project = new ConstructLibraryAws({
+  name: 'cdk-watchful',
+  description: 'Watching your CDK apps since 2019',
+
+  authorName: 'Elad Ben-Israel',
+  authorEmail: 'elad.benisrael@gmail.com',
+  repository: 'https://github.com/eladb/cdk-watchful.git',
+  keywords: [
+    'cloudwatch',
+    'monitoring',
+  ],
+
+  catalog: {
+    twitter: 'emeshbi',
+  },
+
+  // creates PRs for projen upgrades
+  projenUpgradeSecret: 'PROJEN_GITHUB_TOKEN',
+
+  cdkVersion: '1.75.0',
+  cdkDependencies: [
+    '@aws-cdk/aws-apigateway',
+    '@aws-cdk/aws-cloudwatch',
+    '@aws-cdk/aws-cloudwatch-actions',
+    '@aws-cdk/aws-dynamodb',
+    '@aws-cdk/aws-ecs',
+    '@aws-cdk/aws-ecs-patterns',
+    '@aws-cdk/aws-elasticloadbalancingv2',
+    '@aws-cdk/aws-events',
+    '@aws-cdk/aws-events-targets',
+    '@aws-cdk/aws-lambda',
+    '@aws-cdk/aws-rds',
+    '@aws-cdk/aws-sns',
+    '@aws-cdk/aws-sns-subscriptions',
+    '@aws-cdk/aws-sqs',
+    '@aws-cdk/core',
+  ],
+
+  devDeps: [
+    'aws-sdk',
+  ],
+
+  // jsii publishing
+
+  java: {
+    javaPackage: 'com.github.eladb.watchful',
+    mavenGroupId: 'com.github.eladb',
+    mavenArtifactId: 'cdk-watchful',
+  },
+
+  python: {
+    distName: 'cdk-watchful',
+    module: 'cdk_watchful',
+  },
+
+  minNodeVersion: '14.0.0',
+});
+
+project.gitignore.exclude('.env', '.idea');
+project.gitignore.exclude('example/*.js', 'example/*.d.ts');
+
+project.synth();
+",
+  ".versionrc.json": Object {
+    "bumpFiles": Array [
+      Object {
+        "filename": "version.json",
+        "type": "json",
+      },
+    ],
+    "commitAll": true,
+    "packageFiles": Array [
+      Object {
+        "filename": "version.json",
+        "type": "json",
+      },
+    ],
+    "scripts": Object {
+      "postbump": "npx projen && git add .",
+    },
+  },
+  "LICENSE": "                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      \\"License\\" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      \\"Licensor\\" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      \\"Legal Entity\\" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      \\"control\\" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      \\"You\\" (or \\"Your\\") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      \\"Source\\" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      \\"Object\\" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      \\"Work\\" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      \\"Derivative Works\\" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      \\"Contribution\\" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, \\"submitted\\"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as \\"Not a Contribution.\\"
+
+      \\"Contributor\\" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a \\"NOTICE\\" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an \\"AS IS\\" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets \\"[]\\"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same \\"printed page\\" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2020 Elad Ben-Israel
+
+   Licensed under the Apache License, Version 2.0 (the \\"License\\");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an \\"AS IS\\" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+",
+  "README.md": "# my project",
+  "cdk-watchful.projenrc.js": "const { ConstructLibraryAws, Semver } = require('projen');
+
+const project = new ConstructLibraryAws({
+  name: 'cdk-watchful',
+  description: 'Watching your CDK apps since 2019',
+
+  authorName: 'Elad Ben-Israel',
+  authorEmail: 'elad.benisrael@gmail.com',
+  repository: 'https://github.com/eladb/cdk-watchful.git',
+  keywords: [
+    'cloudwatch',
+    'monitoring',
+  ],
+
+  catalog: {
+    twitter: 'emeshbi',
+  },
+
+  // creates PRs for projen upgrades
+  projenUpgradeSecret: 'PROJEN_GITHUB_TOKEN',
+
+  cdkVersion: '1.75.0',
+  cdkDependencies: [
+    '@aws-cdk/aws-apigateway',
+    '@aws-cdk/aws-cloudwatch',
+    '@aws-cdk/aws-cloudwatch-actions',
+    '@aws-cdk/aws-dynamodb',
+    '@aws-cdk/aws-ecs',
+    '@aws-cdk/aws-ecs-patterns',
+    '@aws-cdk/aws-elasticloadbalancingv2',
+    '@aws-cdk/aws-events',
+    '@aws-cdk/aws-events-targets',
+    '@aws-cdk/aws-lambda',
+    '@aws-cdk/aws-rds',
+    '@aws-cdk/aws-sns',
+    '@aws-cdk/aws-sns-subscriptions',
+    '@aws-cdk/aws-sqs',
+    '@aws-cdk/core',
+  ],
+
+  devDeps: [
+    'aws-sdk',
+  ],
+
+  // jsii publishing
+
+  java: {
+    javaPackage: 'com.github.eladb.watchful',
+    mavenGroupId: 'com.github.eladb',
+    mavenArtifactId: 'cdk-watchful',
+  },
+
+  python: {
+    distName: 'cdk-watchful',
+    module: 'cdk_watchful',
+  },
+
+  minNodeVersion: '14.0.0',
+});
+
+project.gitignore.exclude('.env', '.idea');
+project.gitignore.exclude('example/*.js', 'example/*.d.ts');
+
+project.synth();
+",
+  "cdk8s/cdk8s-cli.projenrc.js": "const { TypeScriptLibraryProject, Semver } = require('projen');
+
+const common = require('./cdk8s.common');
+
+const project = new TypeScriptLibraryProject({
+  name: 'cdk8s-cli',
+  description: 'CDK for Kubernetes CLI',
+  bin: {
+    cdk8s: 'bin/cdk8s',
+  },
+  deps: [
+    'cdk8s@^0.0.0',
+    'codemaker',
+    \`constructs\`,
+    'fs-extra',
+    'jsii-srcmak',
+    'jsii-pacmak',
+    'sscaff',
+    'yaml',
+    'yargs',
+    'json2jsii',
+    'colors',
+
+    // add @types/node as a regular dependency since it's needed to during \\"import\\"
+    // to compile the generated jsii code.
+    '@types/node',
+  ],
+  devDeps: [
+    '@types/fs-extra',
+    '@types/json-schema',
+  ],
+  ...common.options,
+});
+
+project.eslint.addIgnorePattern('/templates/');
+project.jest.addIgnorePattern('/templates/');
+
+common.fixup(project);
+
+project.synth();
+",
+  "cdk8s/cdk8s.common.js": "exports.options = {
+  minNodeVersion: '10.17.0',
+  repository: 'https://github.com/awslabs/cdk8s.git',
+  authorName: 'Amazon Web Services',
+  authorUrl: 'https://aws.amazon.com',
+  authorOrganization: true,
+  buildWorkflow: false,
+  rebuildBot: false,
+  stability: 'experimental',
+  releaseWorkflow: false,
+  dependabot: false,
+  mergify: false,
+  compat: false,
+  dependabot: false,
+  pullRequestTemplate: false,
+  keywords: [
+    \\"cdk\\",
+    \\"kubernetes\\",
+    \\"k8s\\",
+    \\"constructs\\"
+  ]
+};
+
+// some common fixups for projects
+exports.fixup = project => {
+  // override the default \\"build\\" from projen because currently in this
+  // repo it means \\"compile\\"
+  project.setScript('build', 'yarn compile');
+
+  project.buildTask.reset();
+  project.buildTask.spawn(project.compileTask);
+
+  // // add \\"compile\\" after test because the test command deletes lib/ and we run tests *after* build in this repo.
+  project.addTestCommand('yarn compile');
+
+  // jsii-release is declared at the root level, we don't need it here.
+  project.deps.removeDependency('jsii-release');
+
+  // typescript is not semantically versionned and should remain on the same minor.
+  // https://github.com/microsoft/TypeScript/issues/14116
+  // TODO add this to projen.
+  project.devDependencies['typescript'] = project.devDependencies['typescript']
+
+  delete project.manifest.scripts.bump;
+  delete project.manifest.scripts.release;
+};
+",
+  "cdk8s/cdk8s.projenrc.js": "const { JsiiProject, Semver } = require('projen');
+
+const common = require('./cdk8s.common');
+
+const project = new JsiiProject({
+  name: 'cdk8s',
+  description: 'Cloud Development Kit for Kubernetes',
+  stability: common.options.stability,
+
+  // without this, the version of 'constructs' would need to be controlled
+  // from this file, since otherwise it would create a 0.0.0 dev dependency.
+  peerDependencyOptions: {
+    pinnedDevDependency: false,
+  },
+
+  ...common.options,
+
+  peerDeps: [
+    'constructs',
+  ],
+  bundledDeps: [
+    'yaml',
+    'json-stable-stringify',
+    'follow-redirects',
+    'fast-json-patch',
+  ],
+  devDeps: [
+    'constructs',
+    '@types/follow-redirects',
+    '@types/json-stable-stringify',
+    '@types/yaml',
+    'json-schema-to-typescript',
+  ],
+
+  // jsii configuration
+  java: {
+    javaPackage: 'org.cdk8s',
+    mavenGroupId: 'org.cdk8s',
+    mavenArtifactId: 'cdk8s',
+  },
+  python: {
+    distName: 'cdk8s',
+    module: 'cdk8s',
+  },
+  dotnet: {
+    dotNetNamespace: 'Org.Cdk8s',
+    packageId: 'Org.Cdk8s',
+  },
+});
+
+common.fixup(project);
+
+// _loadurl.js is written in javascript so we need to commit it and also copy it
+// after compilation to the \`lib/\` directory.
+project.gitignore.include('/src/_loadurl.js');
+project.addCompileCommand('cp src/_loadurl.js lib/');
+
+project.synth();
+",
+  "package.json": Object {
+    "//": "~~ Generated by projen. To modify, edit .projenrc.js and run \\"npx projen\\".",
+    "author": Object {
+      "email": "elad.benisrael@gmail.com",
+      "name": "Elad Ben-Israel",
+      "organization": false,
+    },
+    "awscdkio": Object {
+      "twitter": "emeshbi",
+    },
+    "bin": Object {},
+    "bundledDependencies": Array [],
+    "dependencies": Object {
+      "@aws-cdk/aws-apigateway": "^1.75.0",
+      "@aws-cdk/aws-cloudwatch": "^1.75.0",
+      "@aws-cdk/aws-cloudwatch-actions": "^1.75.0",
+      "@aws-cdk/aws-dynamodb": "^1.75.0",
+      "@aws-cdk/aws-ecs": "^1.75.0",
+      "@aws-cdk/aws-ecs-patterns": "^1.75.0",
+      "@aws-cdk/aws-elasticloadbalancingv2": "^1.75.0",
+      "@aws-cdk/aws-events": "^1.75.0",
+      "@aws-cdk/aws-events-targets": "^1.75.0",
+      "@aws-cdk/aws-lambda": "^1.75.0",
+      "@aws-cdk/aws-rds": "^1.75.0",
+      "@aws-cdk/aws-sns": "^1.75.0",
+      "@aws-cdk/aws-sns-subscriptions": "^1.75.0",
+      "@aws-cdk/aws-sqs": "^1.75.0",
+      "@aws-cdk/core": "^1.75.0",
+    },
+    "description": "Watching your CDK apps since 2019",
+    "devDependencies": Object {
+      "@aws-cdk/assert": "^1.75.0",
+      "@types/jest": "*",
+      "@types/node": "^14.0.0",
+      "@typescript-eslint/eslint-plugin": "^4.3.0",
+      "@typescript-eslint/parser": "^4.3.0",
+      "aws-sdk": "*",
+      "eslint": "*",
+      "eslint-import-resolver-node": "*",
+      "eslint-import-resolver-typescript": "*",
+      "eslint-plugin-import": "*",
+      "jest": "*",
+      "jest-junit": "^12",
+      "jsii": "*",
+      "jsii-diff": "*",
+      "jsii-docgen": "*",
+      "jsii-pacmak": "*",
+      "jsii-release": "*",
+      "json-schema": "*",
+      "projen": "^0.9.1",
+      "standard-version": "^9.0.0",
+      "ts-jest": "*",
+      "typescript": "^3.9.5",
+    },
+    "engines": Object {
+      "node": ">= 14.0.0",
+    },
+    "jest": Object {
+      "clearMocks": true,
+      "collectCoverage": true,
+      "coverageDirectory": "coverage",
+      "coveragePathIgnorePatterns": Array [
+        "/node_modules/",
+      ],
+      "globals": Object {
+        "ts-jest": Object {
+          "tsconfig": "tsconfig.jest.json",
+        },
+      },
+      "preset": "ts-jest",
+      "reporters": Array [
+        "default",
+        Array [
+          "jest-junit",
+          Object {
+            "outputDirectory": "test-reports",
+          },
+        ],
+      ],
+      "testMatch": Array [
+        "**/__tests__/**/*.ts?(x)",
+        "**/?(*.)+(spec|test).ts?(x)",
+      ],
+      "testPathIgnorePatterns": Array [
+        "/node_modules/",
+      ],
+    },
+    "jsii": Object {
+      "outdir": "dist",
+      "targets": Object {
+        "java": Object {
+          "maven": Object {
+            "artifactId": "cdk-watchful",
+            "groupId": "com.github.eladb",
+          },
+          "package": "com.github.eladb.watchful",
+        },
+        "python": Object {
+          "distName": "cdk-watchful",
+          "module": "cdk_watchful",
+        },
+      },
+      "tsc": Object {
+        "outDir": "lib",
+        "rootDir": "src",
+      },
+    },
+    "keywords": Array [
+      "cdk",
+      "cloudwatch",
+      "monitoring",
+    ],
+    "license": "Apache-2.0",
+    "main": "lib/index.js",
+    "name": "cdk-watchful",
+    "peerDependencies": Object {
+      "@aws-cdk/aws-apigateway": "^1.75.0",
+      "@aws-cdk/aws-cloudwatch": "^1.75.0",
+      "@aws-cdk/aws-cloudwatch-actions": "^1.75.0",
+      "@aws-cdk/aws-dynamodb": "^1.75.0",
+      "@aws-cdk/aws-ecs": "^1.75.0",
+      "@aws-cdk/aws-ecs-patterns": "^1.75.0",
+      "@aws-cdk/aws-elasticloadbalancingv2": "^1.75.0",
+      "@aws-cdk/aws-events": "^1.75.0",
+      "@aws-cdk/aws-events-targets": "^1.75.0",
+      "@aws-cdk/aws-lambda": "^1.75.0",
+      "@aws-cdk/aws-rds": "^1.75.0",
+      "@aws-cdk/aws-sns": "^1.75.0",
+      "@aws-cdk/aws-sns-subscriptions": "^1.75.0",
+      "@aws-cdk/aws-sqs": "^1.75.0",
+      "@aws-cdk/core": "^1.75.0",
+      "constructs": "^3.2.27",
+    },
+    "repository": Object {
+      "type": "git",
+      "url": "https://github.com/eladb/cdk-watchful.git",
+    },
+    "scripts": Object {
+      "build": "npx projen build",
+      "bump": "npx projen bump",
+      "clobber": "npx projen clobber",
+      "compat": "npx projen compat",
+      "compile": "npx projen compile",
+      "docgen": "npx projen docgen",
+      "eslint": "npx projen eslint",
+      "package": "npx projen package",
+      "projen": "npx projen",
+      "projen:upgrade": "npx projen projen:upgrade",
+      "release": "npx projen release",
+      "start": "npx projen start",
+      "test": "npx projen test",
+      "test:update": "npx projen test:update",
+      "test:watch": "npx projen test:watch",
+      "watch": "npx projen watch",
+    },
+    "stability": "stable",
+    "types": "lib/index.d.ts",
+    "version": "0.0.0",
+  },
+  "src/index.ts": "export class Hello {
+  public sayHello() {
+    return 'hello, world!';
+  }
+}",
+  "test/hello.test.ts": "import { Hello } from '../src';
+
+test('hello', () => {
+  expect(new Hello().sayHello()).toBe('hello, world!');
+});",
+  "tsconfig.jest.json": Object {
+    "compilerOptions": Object {
+      "alwaysStrict": true,
+      "declaration": true,
+      "experimentalDecorators": true,
+      "inlineSourceMap": true,
+      "inlineSources": true,
+      "lib": Array [
+        "es2018",
+      ],
+      "module": "CommonJS",
+      "noEmitOnError": false,
+      "noFallthroughCasesInSwitch": true,
+      "noImplicitAny": true,
+      "noImplicitReturns": true,
+      "noImplicitThis": true,
+      "noUnusedLocals": true,
+      "noUnusedParameters": true,
+      "resolveJsonModule": true,
+      "strict": true,
+      "strictNullChecks": true,
+      "strictPropertyInitialization": true,
+      "stripInternal": true,
+      "target": "ES2018",
+    },
+    "exclude": Array [
+      "node_modules",
+    ],
+    "include": Array [
+      ".projenrc.js",
+      "src/**/*.ts",
+      "test/**/*.ts",
+    ],
+  },
+  "version.json": Object {
+    "version": "0.0.0",
+  },
+}
+`;

--- a/test/gitpod.test.ts
+++ b/test/gitpod.test.ts
@@ -1,52 +1,37 @@
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import * as logging from '../src/logging';
-import { Project } from '../src/project';
-import { synthSnapshot } from './util';
+import { synthSnapshot, TestProject } from './util';
 
 // This is duplicated vs exported
 const GITPOD_FILE = '.gitpod.yml';
 
 logging.disable();
 
-let tempDir: string;
-beforeEach(() => {
-  tempDir = fs.mkdtempSync(path.join(__dirname, 'tmp.gitpod'));
-});
-
-afterEach(() => {
-  if (tempDir) {
-    fs.removeSync(tempDir);
-  }
-});
-
 describe('gitpod enable/disable', () => {
   test('given gitpod is false', () => {
-    const project = new Project({
-      outdir: tempDir,
+    const project = new TestProject({
       gitpod: false,
     });
 
     project.synth();
-    const filePath = path.join(tempDir, GITPOD_FILE);
+    const filePath = path.join(project.outdir, GITPOD_FILE);
     expect(fs.existsSync(filePath)).toBeFalsy();
   });
   test('given gitpod is true', () => {
-    const project = new Project({
-      outdir: tempDir,
+    const project = new TestProject({
       gitpod: true,
     });
 
     project.synth();
-    const filePath = path.join(tempDir, GITPOD_FILE);
+    const filePath = path.join(project.outdir, GITPOD_FILE);
     expect(fs.existsSync(filePath)).toBeTruthy();
   });
 });
 
 describe('gitpod image & file', () => {
   test('given an image', () => {
-    const project = new Project({
-      outdir: tempDir,
+    const project = new TestProject({
       gitpod: true,
     });
     project.gitpod?.addCustomDocker({ image: 'jsii/superchain' });
@@ -55,8 +40,7 @@ describe('gitpod image & file', () => {
     expect(snapshot).toContain('image: jsii/superchain');
   });
   test('given a docker file dep', () => {
-    const project = new Project({
-      outdir: tempDir,
+    const project = new TestProject({
       gitpod: true,
     });
     project.gitpod?.addCustomDocker({ file: '.gitpod.Dockerfile' });
@@ -69,8 +53,7 @@ describe('gitpod image & file', () => {
 
 describe('gitpod tasks', () => {
   test('given custom tasks', () => {
-    const project = new Project({
-      outdir: tempDir,
+    const project = new TestProject({
       gitpod: true,
     });
     project.gitpod?.addTasks({ command: 'text' });

--- a/test/integ.test.ts
+++ b/test/integ.test.ts
@@ -1,0 +1,25 @@
+import { join, dirname } from 'path';
+import { copySync } from 'fs-extra';
+import { glob } from 'glob';
+import { exec } from '../src/util';
+import { mkdtemp, directorySnapshot } from './util';
+
+const cli = require.resolve('../lib/cli');
+const samples = join(__dirname, 'integration');
+const files = glob.sync('*.projenrc.js', { cwd: samples });
+
+for (const projenrc of files) {
+  test(projenrc, () => {
+    const workdir = mkdtemp();
+    const base = join(samples, dirname(projenrc));
+    copySync(base, workdir, { recursive: true });
+    copySync(join(base, projenrc), join(workdir, '.projenrc.js'));
+    const command = [
+      process.execPath,
+      cli,
+      '--no-post',
+    ];
+    exec(command.join(' '), { cwd: workdir });
+    expect(directorySnapshot(workdir, { excludeGlobs: ['node_modules/**'] })).toMatchSnapshot();
+  });
+}

--- a/test/integration/cdk-watchful.projenrc.js
+++ b/test/integration/cdk-watchful.projenrc.js
@@ -1,0 +1,64 @@
+const { ConstructLibraryAws, Semver } = require('projen');
+
+const project = new ConstructLibraryAws({
+  name: 'cdk-watchful',
+  description: 'Watching your CDK apps since 2019',
+
+  authorName: 'Elad Ben-Israel',
+  authorEmail: 'elad.benisrael@gmail.com',
+  repository: 'https://github.com/eladb/cdk-watchful.git',
+  keywords: [
+    'cloudwatch',
+    'monitoring',
+  ],
+
+  catalog: {
+    twitter: 'emeshbi',
+  },
+
+  // creates PRs for projen upgrades
+  projenUpgradeSecret: 'PROJEN_GITHUB_TOKEN',
+
+  cdkVersion: '1.75.0',
+  cdkDependencies: [
+    '@aws-cdk/aws-apigateway',
+    '@aws-cdk/aws-cloudwatch',
+    '@aws-cdk/aws-cloudwatch-actions',
+    '@aws-cdk/aws-dynamodb',
+    '@aws-cdk/aws-ecs',
+    '@aws-cdk/aws-ecs-patterns',
+    '@aws-cdk/aws-elasticloadbalancingv2',
+    '@aws-cdk/aws-events',
+    '@aws-cdk/aws-events-targets',
+    '@aws-cdk/aws-lambda',
+    '@aws-cdk/aws-rds',
+    '@aws-cdk/aws-sns',
+    '@aws-cdk/aws-sns-subscriptions',
+    '@aws-cdk/aws-sqs',
+    '@aws-cdk/core',
+  ],
+
+  devDeps: [
+    'aws-sdk',
+  ],
+
+  // jsii publishing
+
+  java: {
+    javaPackage: 'com.github.eladb.watchful',
+    mavenGroupId: 'com.github.eladb',
+    mavenArtifactId: 'cdk-watchful',
+  },
+
+  python: {
+    distName: 'cdk-watchful',
+    module: 'cdk_watchful',
+  },
+
+  minNodeVersion: '14.0.0',
+});
+
+project.gitignore.exclude('.env', '.idea');
+project.gitignore.exclude('example/*.js', 'example/*.d.ts');
+
+project.synth();

--- a/test/integration/cdk8s/cdk8s-cli.projenrc.js
+++ b/test/integration/cdk8s/cdk8s-cli.projenrc.js
@@ -1,0 +1,40 @@
+const { TypeScriptLibraryProject, Semver } = require('projen');
+
+const common = require('./cdk8s.common');
+
+const project = new TypeScriptLibraryProject({
+  name: 'cdk8s-cli',
+  description: 'CDK for Kubernetes CLI',
+  bin: {
+    cdk8s: 'bin/cdk8s',
+  },
+  deps: [
+    'cdk8s@^0.0.0',
+    'codemaker',
+    `constructs`,
+    'fs-extra',
+    'jsii-srcmak',
+    'jsii-pacmak',
+    'sscaff',
+    'yaml',
+    'yargs',
+    'json2jsii',
+    'colors',
+
+    // add @types/node as a regular dependency since it's needed to during "import"
+    // to compile the generated jsii code.
+    '@types/node',
+  ],
+  devDeps: [
+    '@types/fs-extra',
+    '@types/json-schema',
+  ],
+  ...common.options,
+});
+
+project.eslint.addIgnorePattern('/templates/');
+project.jest.addIgnorePattern('/templates/');
+
+common.fixup(project);
+
+project.synth();

--- a/test/integration/cdk8s/cdk8s.common.js
+++ b/test/integration/cdk8s/cdk8s.common.js
@@ -1,0 +1,46 @@
+exports.options = {
+  minNodeVersion: '10.17.0',
+  repository: 'https://github.com/awslabs/cdk8s.git',
+  authorName: 'Amazon Web Services',
+  authorUrl: 'https://aws.amazon.com',
+  authorOrganization: true,
+  buildWorkflow: false,
+  rebuildBot: false,
+  stability: 'experimental',
+  releaseWorkflow: false,
+  dependabot: false,
+  mergify: false,
+  compat: false,
+  dependabot: false,
+  pullRequestTemplate: false,
+  keywords: [
+    "cdk",
+    "kubernetes",
+    "k8s",
+    "constructs"
+  ]
+};
+
+// some common fixups for projects
+exports.fixup = project => {
+  // override the default "build" from projen because currently in this
+  // repo it means "compile"
+  project.setScript('build', 'yarn compile');
+
+  project.buildTask.reset();
+  project.buildTask.spawn(project.compileTask);
+
+  // // add "compile" after test because the test command deletes lib/ and we run tests *after* build in this repo.
+  project.addTestCommand('yarn compile');
+
+  // jsii-release is declared at the root level, we don't need it here.
+  project.deps.removeDependency('jsii-release');
+
+  // typescript is not semantically versionned and should remain on the same minor.
+  // https://github.com/microsoft/TypeScript/issues/14116
+  // TODO add this to projen.
+  project.devDependencies['typescript'] = project.devDependencies['typescript']
+
+  delete project.manifest.scripts.bump;
+  delete project.manifest.scripts.release;
+};

--- a/test/integration/cdk8s/cdk8s.projenrc.js
+++ b/test/integration/cdk8s/cdk8s.projenrc.js
@@ -1,0 +1,58 @@
+const { JsiiProject, Semver } = require('projen');
+
+const common = require('./cdk8s.common');
+
+const project = new JsiiProject({
+  name: 'cdk8s',
+  description: 'Cloud Development Kit for Kubernetes',
+  stability: common.options.stability,
+
+  // without this, the version of 'constructs' would need to be controlled
+  // from this file, since otherwise it would create a 0.0.0 dev dependency.
+  peerDependencyOptions: {
+    pinnedDevDependency: false,
+  },
+
+  ...common.options,
+
+  peerDeps: [
+    'constructs',
+  ],
+  bundledDeps: [
+    'yaml',
+    'json-stable-stringify',
+    'follow-redirects',
+    'fast-json-patch',
+  ],
+  devDeps: [
+    'constructs',
+    '@types/follow-redirects',
+    '@types/json-stable-stringify',
+    '@types/yaml',
+    'json-schema-to-typescript',
+  ],
+
+  // jsii configuration
+  java: {
+    javaPackage: 'org.cdk8s',
+    mavenGroupId: 'org.cdk8s',
+    mavenArtifactId: 'cdk8s',
+  },
+  python: {
+    distName: 'cdk8s',
+    module: 'cdk8s',
+  },
+  dotnet: {
+    dotNetNamespace: 'Org.Cdk8s',
+    packageId: 'Org.Cdk8s',
+  },
+});
+
+common.fixup(project);
+
+// _loadurl.js is written in javascript so we need to commit it and also copy it
+// after compilation to the `lib/` directory.
+project.gitignore.include('/src/_loadurl.js');
+project.addCompileCommand('cp src/_loadurl.js lib/');
+
+project.synth();

--- a/test/jest.test.ts
+++ b/test/jest.test.ts
@@ -41,7 +41,7 @@ test('Node Project Jest Defaults Configured', () => {
   expect(project.jest?.config.clearMocks).toEqual(true);
   expect(project.jest?.config.collectCoverage).toEqual(true);
 
-  const snapshot = synthSnapshot(project, 'package.json');
+  const snapshot = synthSnapshot(project);
   expect(snapshot['package.json'].jest).toBeTruthy();
 
   const jest = snapshot['package.json'].jest;
@@ -66,7 +66,7 @@ test('Node Project Jest With Options Configured', () => {
     },
   });
 
-  const snapshot = synthSnapshot(project, 'package.json');
+  const snapshot = synthSnapshot(project);
   expect(snapshot['package.json'].jest).toBeTruthy();
 
   const jest = snapshot['package.json'].jest;
@@ -85,7 +85,7 @@ test('Typescript Project Jest Defaults Configured', () => {
     jest: true,
   });
 
-  const snapshot = synthSnapshot(project, 'tsconfig.jest.json');
+  const snapshot = synthSnapshot(project);
   const jestTypescriptConfig = snapshot['tsconfig.jest.json'];
 
   expect(jestTypescriptConfig.compilerOptions).toBeTruthy();
@@ -119,7 +119,7 @@ test('Typescript Project Jest With Compiler Options', () => {
     ...compilerOptions,
   };
 
-  const snapshot = synthSnapshot(project, 'tsconfig.jest.json');
+  const snapshot = synthSnapshot(project);
   const jestTypescriptConfig = snapshot['tsconfig.jest.json'];
 
   expect(jestTypescriptConfig.compilerOptions).toBeTruthy();

--- a/test/node-project.test.ts
+++ b/test/node-project.test.ts
@@ -14,7 +14,7 @@ test('license file is added by default', () => {
   });
 
   // THEN
-  expect(synthSnapshot(project, 'LICENSE').LICENSE).toContain('Apache License');
+  expect(synthSnapshot(project).LICENSE).toContain('Apache License');
 });
 
 test('license file is not added if licensed is false', () => {
@@ -28,8 +28,8 @@ test('license file is not added if licensed is false', () => {
   });
 
   // THEN
-  const snapshot = synthSnapshot(project, 'LICENSE', '.gitignore', 'package.json');
-  expect(Object.keys(snapshot).sort()).toEqual(['.gitignore', 'package.json'].sort());
+  const snapshot = synthSnapshot(project);
+  expect(snapshot.LICENSE).toBeUndefined();
   expect(snapshot['.gitignore']).not.toContain('LICENSE');
   expect(snapshot['package.json'].license).toEqual('UNLICENSED');
 });

--- a/test/pr-template.test.ts
+++ b/test/pr-template.test.ts
@@ -10,9 +10,7 @@ test('default', () => {
   project.github?.addPullRequestTemplate();
 
   // THEN
-  expect(synthSnapshot(project, PULL_REQUEST_TEMPLATE_FILE)).toStrictEqual({
-    '.github/pull_request_template.md': 'Fixes #',
-  });
+  expect(synthSnapshot(project)[PULL_REQUEST_TEMPLATE_FILE]).toStrictEqual('Fixes #');
 });
 
 test('custom content', () => {
@@ -28,12 +26,10 @@ test('custom content', () => {
   );
 
   // THEN
-  expect(synthSnapshot(project, PULL_REQUEST_TEMPLATE_FILE)).toStrictEqual({
-    '.github/pull_request_template.md': [
-      'hello',
-      'world',
-      '',
-      'foobar',
-    ].join('\n'),
-  });
+  expect(synthSnapshot(project)[PULL_REQUEST_TEMPLATE_FILE]).toStrictEqual([
+    'hello',
+    'world',
+    '',
+    'foobar',
+  ].join('\n'));
 });

--- a/test/vscode-launch-config.test.ts
+++ b/test/vscode-launch-config.test.ts
@@ -11,11 +11,9 @@ test('empty launch configuration', () => {
   project.vscode?.launchConfiguration;
 
   // THEN
-  expect(synthSnapshot(project, VSCODE_DEBUGGER_FILE)).toStrictEqual({
-    '.vscode/launch.json': {
-      version: '0.2.0',
-      configurations: [],
-    },
+  expect(synthSnapshot(project)[VSCODE_DEBUGGER_FILE]).toStrictEqual({
+    version: '0.2.0',
+    configurations: [],
   });
 });
 
@@ -35,20 +33,18 @@ test('adding a launch configuration entry', () => {
   });
 
   // THEN
-  expect(synthSnapshot(project, VSCODE_DEBUGGER_FILE)).toStrictEqual({
-    '.vscode/launch.json': {
-      version: '0.2.0',
-      configurations: [
-        {
-          type: 'node',
-          request: 'launch',
-          name: 'CDK Debugger',
-          skipFiles: ['<node_internals>/**'],
-          runtimeArgs: ['-r', './node_modules/ts-node/register/transpile-only'],
-          args: ['${workspaceFolder}/src/main.ts'],
-        },
-      ],
-    },
+  expect(synthSnapshot(project)[VSCODE_DEBUGGER_FILE]).toStrictEqual({
+    version: '0.2.0',
+    configurations: [
+      {
+        type: 'node',
+        request: 'launch',
+        name: 'CDK Debugger',
+        skipFiles: ['<node_internals>/**'],
+        runtimeArgs: ['-r', './node_modules/ts-node/register/transpile-only'],
+        args: ['${workspaceFolder}/src/main.ts'],
+      },
+    ],
   });
 });
 
@@ -88,37 +84,35 @@ test('adding multiple launch configuration entries', () => {
   });
 
   // THEN
-  expect(synthSnapshot(project, VSCODE_DEBUGGER_FILE)).toStrictEqual({
-    '.vscode/launch.json': {
-      version: '0.2.0',
-      configurations: [
-        {
-          type: 'node',
-          request: 'launch',
-          name: 'CDK Debugger',
-          skipFiles: ['<node_internals>/**'],
-          runtimeArgs: ['-r', './node_modules/ts-node/register/transpile-only'],
-          args: ['${workspaceFolder}/src/main.ts'],
-        },
-        {
-          type: 'node',
-          request: 'launch',
-          name: 'Launch Program',
-          skipFiles: ['<node_internals>/**'],
-          program: '${workspaceFolder}/lib/index.js',
-          preLaunchTask: 'tsc: build - tsconfig.json',
-          outFiles: ['${workspaceFolder}/lib/**/*.js'],
-          internalConsoleOptions: 'openOnSessionStart',
-        },
-        {
-          type: 'pwa-chrome',
-          request: 'launch',
-          name: 'Launch Chrome against localhost',
-          url: 'http://localhost:8080',
-          webRoot: '${workspaceFolder}',
-          debugServer: 4711,
-        },
-      ],
-    },
+  expect(synthSnapshot(project)[VSCODE_DEBUGGER_FILE]).toStrictEqual({
+    version: '0.2.0',
+    configurations: [
+      {
+        type: 'node',
+        request: 'launch',
+        name: 'CDK Debugger',
+        skipFiles: ['<node_internals>/**'],
+        runtimeArgs: ['-r', './node_modules/ts-node/register/transpile-only'],
+        args: ['${workspaceFolder}/src/main.ts'],
+      },
+      {
+        type: 'node',
+        request: 'launch',
+        name: 'Launch Program',
+        skipFiles: ['<node_internals>/**'],
+        program: '${workspaceFolder}/lib/index.js',
+        preLaunchTask: 'tsc: build - tsconfig.json',
+        outFiles: ['${workspaceFolder}/lib/**/*.js'],
+        internalConsoleOptions: 'openOnSessionStart',
+      },
+      {
+        type: 'pwa-chrome',
+        request: 'launch',
+        name: 'Launch Chrome against localhost',
+        url: 'http://localhost:8080',
+        webRoot: '${workspaceFolder}',
+        debugServer: 4711,
+      },
+    ],
   });
 });


### PR DESCRIPTION
Integration tests are a complete snapshot of the synthesis of real projects.

Ideally most of the coverage is achieved through unit tests, but this is a cheap way to capture unw

To add sample real projects, just add files with the `xxx.projenrc.js` extension under `test/integration`. If the file is in a subdirectory, the entire directory will be staged.

The `xxx.projenrc.js` file will be renamed `.projenrc.js` and the `projen` CLI will be executed. The resulting deep directory snapshot will be taken as a jest snapshot.
