### PR TITLE
feat(jest/typescript): `test:compile` task

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -46,11 +46,24 @@
         }
       ]
     },
+    "test:compile": {
+      "name": "test:compile",
+      "category": "10.test",
+      "description": "compiles the test code",
+      "steps": [
+        {
+          "exec": "tsc --noEmit --project tsconfig.jest.json"
+        }
+      ]
+    },
     "test": {
       "name": "test",
       "category": "10.test",
       "description": "Run tests",
       "steps": [
+        {
+          "spawn": "test:compile"
+        },
         {
           "exec": "jest --passWithNoTests --all --updateSnapshot"
         },

--- a/API.md
+++ b/API.md
@@ -1888,6 +1888,7 @@ Name | Type | Description
 **packageManager**🔹 | <code>[NodePackageManager](#projen-nodepackagemanager)</code> | The package manager to use.
 **projenCommand**🔹 | <code>string</code> | The command to use in order to run the projen CLI.
 **runScriptCommand**🔹 | <code>string</code> | The command to use to run scripts (e.g. `yarn run` or `npm run` depends on the package manager).
+**testCompileTask**🔹 | <code>[tasks.Task](#projen-tasks-task)</code> | Compiles the test code.
 **testTask**🔹 | <code>[tasks.Task](#projen-tasks-task)</code> | Tests the code.
 **testdir**🔹 | <code>string</code> | The directory in which tests reside.
 **buildWorkflow**?🔹 | <code>[github.GithubWorkflow](#projen-github-githubworkflow)</code> | The PR build GitHub workflow.<br/>__*Optional*__

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "start": "/bin/bash ./projen.bash start",
     "clobber": "/bin/bash ./projen.bash clobber",
     "compile": "/bin/bash ./projen.bash compile",
+    "test:compile": "/bin/bash ./projen.bash test:compile",
     "test": "/bin/bash ./projen.bash test",
     "build": "/bin/bash ./projen.bash build",
     "bump": "/bin/bash ./projen.bash bump",

--- a/src/node-project.ts
+++ b/src/node-project.ts
@@ -628,6 +628,11 @@ export class NodeProject extends Project {
   public readonly testTask: Task;
 
   /**
+   * Compiles the test code.
+   */
+  public readonly testCompileTask: Task;
+
+  /**
    * The task responsible for a full release build. It spawns: compile + test + release + package
    */
   public readonly buildTask: Task;
@@ -735,10 +740,17 @@ export class NodeProject extends Project {
       category: TaskCategory.BUILD,
     });
 
+    this.testCompileTask = this.addTask('test:compile', {
+      description: 'compiles the test code',
+      category: TaskCategory.TEST,
+    });
+
     this.testTask = this.addTask('test', {
       description: 'Run tests',
       category: TaskCategory.TEST,
     });
+
+    this.testTask.spawn(this.testCompileTask);
 
     this.buildTask = this.addTask('build', {
       description: 'Full release build (test+compile)',

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -237,8 +237,6 @@ export class TypeScriptProject extends NodeProject {
         compilerOptions: compilerOptionDefaults,
       });
 
-      // const tsconfig = new TypescriptConfig(this, );
-
       eslintTsConfig = tsconfig.fileName;
 
       // if we test before compilation, remove the lib/ directory before running
@@ -248,6 +246,9 @@ export class TypeScriptProject extends NodeProject {
         // test code does not take a dependency on "lib" and instead on "src".
         this.testTask.prepend(`rm -fr ${this.libdir}/`);
       }
+
+      // compile test code
+      this.testCompileTask.exec(`tsc --noEmit --project ${tsconfig.fileName}`);
     }
 
     if (options.eslint ?? true) {

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -752,10 +752,23 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
             "exec": "rm -fr lib/",
           },
           Object {
+            "spawn": "test:compile",
+          },
+          Object {
             "exec": "jest --passWithNoTests --all --updateSnapshot",
           },
           Object {
             "spawn": "eslint",
+          },
+        ],
+      },
+      "test:compile": Object {
+        "category": "10.test",
+        "description": "compiles the test code",
+        "name": "test:compile",
+        "steps": Array [
+          Object {
+            "exec": "tsc --noEmit --project tsconfig.jest.json",
           },
         ],
       },
@@ -1440,6 +1453,7 @@ project.synth();
       "release": "npx projen release",
       "start": "npx projen start",
       "test": "npx projen test",
+      "test:compile": "npx projen test:compile",
       "test:update": "npx projen test:update",
       "test:watch": "npx projen test:watch",
       "watch": "npx projen watch",


### PR DESCRIPTION
jest does not perform any type-checking, so tests can pass but the code would have compilation errors.

This commit adds a test `test:compile` which runs `tsc --no-emit` against the test/** directory.

The task is spawned before running jest.

