### PR TITLE
feat: auto-merge

### DIFF
--- a/API.md
+++ b/API.md
@@ -37,7 +37,7 @@ Name|Description
 [Version](#projen-version)|*No description*
 [YamlFile](#projen-yamlfile)|*No description*
 [deps.Dependencies](#projen-deps-dependencies)|The `Dependencies` component is responsible to track the list of dependencies a project has, and then used by project types as the model for rendering project-specific dependency manifests such as the dependencies section `package.json` files.
-[github.AutoMerge](#projen-github-automerge)|*No description*
+[github.AutoMerge](#projen-github-automerge)|Sets up mergify to merging approved pull requests.
 [github.Dependabot](#projen-github-dependabot)|Defines dependabot configuration for node projects.
 [github.GitHub](#projen-github-github)|*No description*
 [github.GithubWorkflow](#projen-github-githubworkflow)|*No description*
@@ -2191,6 +2191,7 @@ Name | Type | Description
 **testCompileTask**🔹 | <code>[tasks.Task](#projen-tasks-task)</code> | Compiles the test code.
 **testTask**🔹 | <code>[tasks.Task](#projen-tasks-task)</code> | Tests the code.
 **testdir**🔹 | <code>string</code> | The directory in which tests reside.
+**autoMerge**?🔹 | <code>[github.AutoMerge](#projen-github-automerge)</code> | Automatic PR merges.<br/>__*Optional*__
 **buildWorkflow**?🔹 | <code>[github.GithubWorkflow](#projen-github-githubworkflow)</code> | The PR build GitHub workflow.<br/>__*Optional*__
 **buildWorkflowJobId**?🔹 | <code>string</code> | __*Optional*__
 **jest**?🔹 | <code>[Jest](#projen-jest)</code> | The Jest configuration (if enabled).<br/>__*Optional*__
@@ -3395,7 +3396,13 @@ removeDependency(name: string, type?: DependencyType): void
 
 ## class AutoMerge 🔹 <a id="projen-github-automerge"></a>
 
+Sets up mergify to merging approved pull requests.
 
+If `buildJob` is specified, the specified GitHub workflow job ID is required
+to succeed in order for the PR to be merged.
+
+`approvedReviews` specified the number of code review approvals required for
+the PR to be merged.
 
 __Submodule__: github
 
@@ -3412,8 +3419,9 @@ new github.AutoMerge(project: Project, options?: AutoMergeOptions)
 
 * **project** (<code>[Project](#projen-project)</code>)  *No description*
 * **options** (<code>[github.AutoMergeOptions](#projen-github-automergeoptions)</code>)  *No description*
+  * **approvedReviews** (<code>number</code>)  Number of approved code reviews. __*Default*__: 1
   * **autoMergeLabel** (<code>string</code>)  Automatically merge PRs that build successfully and have this label. __*Default*__: "auto-merge"
-  * **buildJobId** (<code>string</code>)  The GitHub job ID of the build workflow. __*Optional*__
+  * **buildJob** (<code>string</code>)  The GitHub job ID of the build workflow. __*Optional*__
 
 
 
@@ -6469,8 +6477,9 @@ Name | Type | Description
 
 Name | Type | Description 
 -----|------|-------------
+**approvedReviews**?🔹 | <code>number</code> | Number of approved code reviews.<br/>__*Default*__: 1
 **autoMergeLabel**?🔹 | <code>string</code> | Automatically merge PRs that build successfully and have this label.<br/>__*Default*__: "auto-merge"
-**buildJobId**?🔹 | <code>string</code> | The GitHub job ID of the build workflow.<br/>__*Optional*__
+**buildJob**?🔹 | <code>string</code> | The GitHub job ID of the build workflow.<br/>__*Optional*__
 
 
 

--- a/API.md
+++ b/API.md
@@ -37,6 +37,7 @@ Name|Description
 [Version](#projen-version)|*No description*
 [YamlFile](#projen-yamlfile)|*No description*
 [deps.Dependencies](#projen-deps-dependencies)|The `Dependencies` component is responsible to track the list of dependencies a project has, and then used by project types as the model for rendering project-specific dependency manifests such as the dependencies section `package.json` files.
+[github.AutoMerge](#projen-github-automerge)|*No description*
 [github.Dependabot](#projen-github-dependabot)|Defines dependabot configuration for node projects.
 [github.GitHub](#projen-github-github)|*No description*
 [github.GithubWorkflow](#projen-github-githubworkflow)|*No description*
@@ -113,6 +114,7 @@ Name|Description
 [YamlFileOptions](#projen-yamlfileoptions)|*No description*
 [deps.Dependency](#projen-deps-dependency)|*No description*
 [deps.DepsManifest](#projen-deps-depsmanifest)|*No description*
+[github.AutoMergeOptions](#projen-github-automergeoptions)|*No description*
 [github.DependabotIgnore](#projen-github-dependabotignore)|You can use the `ignore` option to customize which dependencies are updated.
 [github.DependabotOptions](#projen-github-dependabotoptions)|*No description*
 [github.MergifyOptions](#projen-github-mergifyoptions)|*No description*
@@ -2193,7 +2195,6 @@ Name | Type | Description
 **buildWorkflowJobId**?🔹 | <code>string</code> | __*Optional*__
 **jest**?🔹 | <code>[Jest](#projen-jest)</code> | The Jest configuration (if enabled).<br/>__*Optional*__
 **maxNodeVersion**?🔹 | <code>string</code> | Maximum node version required by this pacakge.<br/>__*Optional*__
-**mergify**?🔹 | <code>[github.Mergify](#projen-github-mergify)</code> | Mergify behavior.<br/>__*Optional*__
 **minNodeVersion**?🔹 | <code>string</code> | Minimum node.js version required by this package.<br/>__*Optional*__
 **npmignore**?🔹 | <code>[IgnoreFile](#projen-ignorefile)</code> | The .npmignore file.<br/>__*Optional*__
 **releaseWorkflow**?🔹 | <code>[github.GithubWorkflow](#projen-github-githubworkflow)</code> | The release GitHub workflow.<br/>__*Optional*__
@@ -3389,6 +3390,39 @@ removeDependency(name: string, type?: DependencyType): void
 
 
 
+
+
+
+## class AutoMerge 🔹 <a id="projen-github-automerge"></a>
+
+
+
+__Submodule__: github
+
+__Extends__: [Component](#projen-component)
+
+### Initializer
+
+
+
+
+```ts
+new github.AutoMerge(project: Project, options?: AutoMergeOptions)
+```
+
+* **project** (<code>[Project](#projen-project)</code>)  *No description*
+* **options** (<code>[github.AutoMergeOptions](#projen-github-automergeoptions)</code>)  *No description*
+  * **autoMergeLabel** (<code>string</code>)  Automatically merge PRs that build successfully and have this label. __*Default*__: "auto-merge"
+  * **buildJobId** (<code>string</code>)  The GitHub job ID of the build workflow. __*Optional*__
+
+
+
+### Properties
+
+
+Name | Type | Description 
+-----|------|-------------
+**autoMergeLabel**🔹 | <code>string</code> | <span></span>
 
 
 
@@ -6423,6 +6457,20 @@ Name | Type | Description
 Name | Type | Description 
 -----|------|-------------
 **dependencies**🔹 | <code>Array<[deps.Dependency](#projen-deps-dependency)></code> | All dependencies of this module.
+
+
+
+## struct AutoMergeOptions 🔹 <a id="projen-github-automergeoptions"></a>
+
+
+
+
+
+
+Name | Type | Description 
+-----|------|-------------
+**autoMergeLabel**?🔹 | <code>string</code> | Automatically merge PRs that build successfully and have this label.<br/>__*Default*__: "auto-merge"
+**buildJobId**?🔹 | <code>string</code> | The GitHub job ID of the build workflow.<br/>__*Optional*__
 
 
 

--- a/src/github/auto-merge.ts
+++ b/src/github/auto-merge.ts
@@ -1,0 +1,86 @@
+import { Component } from '../component';
+import { Project } from '../project';
+
+export interface AutoMergeOptions {
+  /**
+   * The GitHub job ID of the build workflow.
+   */
+  readonly buildJob?: string;
+
+  /**
+   * Number of approved code reviews.
+   * @default 1
+   */
+  readonly approvedReviews?: number;
+
+  /**
+   * Automatically merge PRs that build successfully and have this label.
+   *
+   * To disable, set this value to an empty string.
+   *
+   * @default "auto-merge"
+   */
+  readonly autoMergeLabel?: string;
+}
+
+/**
+ * Sets up mergify to merging approved pull requests.
+ *
+ * If `buildJob` is specified, the specified GitHub workflow job ID is required
+ * to succeed in order for the PR to be merged.
+ *
+ * `approvedReviews` specified the number of code review approvals required for
+ * the PR to be merged.
+ */
+export class AutoMerge extends Component {
+  public readonly autoMergeLabel: string;
+
+  constructor(project: Project, options: AutoMergeOptions = { }) {
+    super(project);
+
+    const successfulBuild = options.buildJob
+      ? [`status-success=${options.buildJob}`]
+      : [];
+
+    const mergeAction = {
+      merge: {
+      // squash all commits into a single commit when merging
+        method: 'squash',
+
+        // use PR title+body as the commit message
+        commit_message: 'title+body',
+
+        // update PR branch so it's up-to-date before merging
+        strict: 'smart',
+        strict_method: 'merge',
+      },
+
+      delete_head_branch: { },
+    };
+
+    const approvedReviews = options.approvedReviews ?? 1;
+
+    project.github?.addMergifyRules({
+      name: 'Automatic merge on approval and successful build',
+      actions: mergeAction,
+      conditions: [
+        `#approved-reviews-by>=${approvedReviews}`,
+        ...successfulBuild,
+      ],
+    });
+
+    // empty string means disabled.
+    const autoMergeLabel = options.autoMergeLabel ?? 'auto-merge';;
+    this.autoMergeLabel = autoMergeLabel;
+    if (this.autoMergeLabel) {
+      project.github?.addMergifyRules({
+        name: `Automatic merge PRs with ${autoMergeLabel} label upon successful build`,
+        actions: mergeAction,
+        conditions: [
+          `label=${autoMergeLabel}`,
+          ...successfulBuild,
+        ],
+      });
+    }
+  }
+}

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -5,3 +5,4 @@ export * from './workflows';
 export * from './mergify';
 export * from './pr-template';
 export * from './mergify';
+export * from './auto-merge';

--- a/src/node-project.ts
+++ b/src/node-project.ts
@@ -1,7 +1,8 @@
 import { PROJEN_RC, PROJEN_VERSION } from './common';
 import { GithubWorkflow } from './github';
+import { AutoMerge } from './github/auto-merge';
 import { DependabotOptions } from './github/dependabot';
-import { Mergify, MergifyOptions } from './github/mergify';
+import { MergifyOptions } from './github/mergify';
 import { IgnoreFile } from './ignore-file';
 import { Jest, JestOptions } from './jest';
 import { License } from './license';
@@ -333,11 +334,6 @@ export class NodeProject extends Project {
   public readonly npmignore?: IgnoreFile;
 
   /**
-   * Mergify behavior.
-   */
-  public readonly mergify?: Mergify;
-
-  /**
    * @deprecated use `package.allowLibraryDependencies`
    */
   public get allowLibraryDependencies(): boolean { return this.package.allowLibraryDependencies; }
@@ -642,51 +638,11 @@ export class NodeProject extends Project {
       }
     }
 
-
-    let autoMergeLabel;
-
+    let autoMerge;
     if (options.mergify ?? true) {
-      const successfulBuild = this.buildWorkflow
-        ? [`status-success=${this.buildWorkflowJobId}`]
-        : [];
-
-      const mergeAction = {
-        merge: {
-          // squash all commits into a single commit when merging
-          method: 'squash',
-
-          // use PR title+body as the commit message
-          commit_message: 'title+body',
-
-          // update PR branch so it's up-to-date before merging
-          strict: 'smart',
-          strict_method: 'merge',
-        },
-
-        delete_head_branch: { },
-      };
-
-      this.github?.addMergifyRules({
-        name: 'Automatic merge on approval and successful build',
-        actions: mergeAction,
-        conditions: [
-          '#approved-reviews-by>=1',
-          ...successfulBuild,
-        ],
+      autoMerge = new AutoMerge(this, {
+        autoMergeLabel: options.mergifyAutoMergeLabel,
       });
-
-      // empty string means disabled.
-      autoMergeLabel = options.mergifyAutoMergeLabel ?? 'auto-merge';
-      if (autoMergeLabel !== '') {
-        this.github?.addMergifyRules({
-          name: `Automatic merge PRs with ${autoMergeLabel} label upon successful build`,
-          actions: mergeAction,
-          conditions: [
-            `label=${autoMergeLabel}`,
-            ...successfulBuild,
-          ],
-        });
-      }
 
       this.npmignore?.exclude('/.mergify.yml');
     }
@@ -699,7 +655,7 @@ export class NodeProject extends Project {
     new ProjenUpgrade(this, {
       autoUpgradeSecret: options.projenUpgradeSecret,
       autoUpgradeSchedule: options.projenUpgradeSchedule,
-      labels: (projenAutoMerge && autoMergeLabel) ? [autoMergeLabel] : [],
+      labels: (projenAutoMerge && autoMerge?.autoMergeLabel) ? [autoMerge.autoMergeLabel] : [],
     });
 
     if (options.pullRequestTemplate ?? true) {

--- a/src/node-project.ts
+++ b/src/node-project.ts
@@ -642,6 +642,7 @@ export class NodeProject extends Project {
     if (options.mergify ?? true) {
       autoMerge = new AutoMerge(this, {
         autoMergeLabel: options.mergifyAutoMergeLabel,
+        buildJob: this.buildWorkflowJobId,
       });
 
       this.npmignore?.exclude('/.mergify.yml');

--- a/src/node-project.ts
+++ b/src/node-project.ts
@@ -363,6 +363,11 @@ export class NodeProject extends Project {
    */
   public readonly buildTask: Task;
 
+  /**
+   * Automatic PR merges.
+   */
+  public readonly autoMerge?: AutoMerge;
+
   private readonly _version: Version;
 
   /**
@@ -638,9 +643,8 @@ export class NodeProject extends Project {
       }
     }
 
-    let autoMerge;
     if (options.mergify ?? true) {
-      autoMerge = new AutoMerge(this, {
+      this.autoMerge = new AutoMerge(this, {
         autoMergeLabel: options.mergifyAutoMergeLabel,
         buildJob: this.buildWorkflowJobId,
       });
@@ -656,7 +660,9 @@ export class NodeProject extends Project {
     new ProjenUpgrade(this, {
       autoUpgradeSecret: options.projenUpgradeSecret,
       autoUpgradeSchedule: options.projenUpgradeSchedule,
-      labels: (projenAutoMerge && autoMerge?.autoMergeLabel) ? [autoMerge.autoMergeLabel] : [],
+      labels: (projenAutoMerge && this.autoMerge?.autoMergeLabel)
+        ? [this.autoMerge.autoMergeLabel]
+        : [],
     });
 
     if (options.pullRequestTemplate ?? true) {

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -556,6 +556,7 @@ pull_request_rules:
       delete_head_branch: {}
     conditions:
       - \\"#approved-reviews-by>=1\\"
+      - status-success=build
   - name: Automatic merge PRs with auto-merge label upon successful build
     actions:
       merge:
@@ -566,6 +567,7 @@ pull_request_rules:
       delete_head_branch: {}
     conditions:
       - label=auto-merge
+      - status-success=build
   - name: Merge pull requests from dependabot if CI passes
     conditions:
       - author=dependabot[bot]

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -556,7 +556,6 @@ pull_request_rules:
       delete_head_branch: {}
     conditions:
       - \\"#approved-reviews-by>=1\\"
-      - status-success=build
   - name: Automatic merge PRs with auto-merge label upon successful build
     actions:
       merge:
@@ -567,7 +566,6 @@ pull_request_rules:
       delete_head_branch: {}
     conditions:
       - label=auto-merge
-      - status-success=build
   - name: Merge pull requests from dependabot if CI passes
     conditions:
       - author=dependabot[bot]


### PR DESCRIPTION
Extract a `github.AutoMerge` component from `NodeProject`. This component will set up mergify to merge approved pull requests which pass CI builds.
