### PR TITLE
feat(eslint): devdirs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,7 +27,7 @@
     "import/resolver": {
       "node": {},
       "typescript": {
-        "directory": "./tsconfig.json"
+        "project": "./tsconfig.jest.json"
       }
     }
   },
@@ -124,8 +124,8 @@
       "error",
       {
         "devDependencies": [
-          "**/build-tools/**",
-          "**/test/**"
+          "**/test/**",
+          "**/build-tools/**"
         ],
         "optionalDependencies": false,
         "peerDependencies": true

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -175,7 +175,7 @@
       "description": "Runs eslint against the codebase",
       "steps": [
         {
-          "exec": "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test .projenrc.js"
+          "exec": "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools .projenrc.js"
         }
       ]
     },

--- a/API.md
+++ b/API.md
@@ -1216,10 +1216,11 @@ new Eslint(project: NodeProject, options: EslintOptions)
 
 * **project** (<code>[NodeProject](#projen-nodeproject)</code>)  *No description*
 * **options** (<code>[EslintOptions](#projen-eslintoptions)</code>)  *No description*
-  * **dirs** (<code>Array<string></code>)  Directories with source files to lint (e.g. [ "src", "test" ]). 
-  * **fileExtensions** (<code>Array<string></code>)  File types that should be linted (e.g. [ ".js", ".ts" ]). 
-  * **tsconfigPath** (<code>string</code>)  *No description* 
+  * **dirs** (<code>Array<string></code>)  Directories with source files to lint (e.g. [ "src" ]). 
+  * **devdirs** (<code>Array<string></code>)  Directories with source files that include tests and build tools. __*Default*__: []
+  * **fileExtensions** (<code>Array<string></code>)  File types that should be linted (e.g. [ ".js", ".ts" ]). __*Default*__: [".ts"]
   * **ignorePatterns** (<code>Array<string></code>)  List of file patterns that should not be linted, using the same syntax as .gitignore patterns. __*Default*__: [ '*.js', '*.d.ts', 'node_modules/', '*.generated.ts', 'coverage' ]
+  * **tsconfigPath** (<code>string</code>)  Path to `tsconfig.json` which should be used by eslint. __*Default*__: "./tsconfig.json"
 
 
 
@@ -5724,10 +5725,11 @@ Name | Type | Description
 
 Name | Type | Description 
 -----|------|-------------
-**dirs**🔹 | <code>Array<string></code> | Directories with source files to lint (e.g. [ "src", "test" ]).
-**fileExtensions**🔹 | <code>Array<string></code> | File types that should be linted (e.g. [ ".js", ".ts" ]).
-**tsconfigPath**🔹 | <code>string</code> | <span></span>
+**dirs**🔹 | <code>Array<string></code> | Directories with source files to lint (e.g. [ "src" ]).
+**devdirs**?🔹 | <code>Array<string></code> | Directories with source files that include tests and build tools.<br/>__*Default*__: []
+**fileExtensions**?🔹 | <code>Array<string></code> | File types that should be linted (e.g. [ ".js", ".ts" ]).<br/>__*Default*__: [".ts"]
 **ignorePatterns**?🔹 | <code>Array<string></code> | List of file patterns that should not be linted, using the same syntax as .gitignore patterns.<br/>__*Default*__: [ '*.js', '*.d.ts', 'node_modules/', '*.generated.ts', 'coverage' ]
+**tsconfigPath**?🔹 | <code>string</code> | Path to `tsconfig.json` which should be used by eslint.<br/>__*Default*__: "./tsconfig.json"
 
 
 

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -256,7 +256,8 @@ export class TypeScriptProject extends NodeProject {
     if (options.eslint ?? true) {
       this.eslint = new Eslint(this, {
         tsconfigPath: `./${eslintTsConfig}`,
-        dirs: [this.srcdir, this.testdir],
+        dirs: [this.srcdir],
+        devdirs: [this.testdir, 'build-tools'],
         fileExtensions: ['.ts', '.tsx'],
         ...options.eslintOptions,
       });

--- a/test/__snapshots__/eslint.test.ts.snap
+++ b/test/__snapshots__/eslint.test.ts.snap
@@ -226,7 +226,7 @@ Object {
     "import/resolver": Object {
       "node": Object {},
       "typescript": Object {
-        "directory": "./tsconfig.json",
+        "project": "./tsconfig.json",
       },
     },
   },

--- a/test/__snapshots__/eslint.test.ts.snap
+++ b/test/__snapshots__/eslint.test.ts.snap
@@ -1,0 +1,234 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`devdirs 1`] = `
+Object {
+  "env": Object {
+    "jest": true,
+    "node": true,
+  },
+  "extends": Array [
+    "plugin:import/typescript",
+  ],
+  "ignorePatterns": Array [
+    "*.js",
+    "!.projenrc.js",
+    "*.d.ts",
+    "node_modules/",
+    "*.generated.ts",
+    "coverage",
+  ],
+  "overrides": Array [
+    Object {
+      "files": Array [
+        ".projenrc.js",
+      ],
+      "rules": Object {
+        "@typescript-eslint/no-require-imports": "off",
+        "import/no-extraneous-dependencies": "off",
+      },
+    },
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": Object {
+    "ecmaVersion": 2018,
+    "project": "./tsconfig.json",
+    "sourceType": "module",
+  },
+  "plugins": Array [
+    "@typescript-eslint",
+    "import",
+  ],
+  "root": true,
+  "rules": Object {
+    "@typescript-eslint/indent": Array [
+      "error",
+      2,
+    ],
+    "@typescript-eslint/member-delimiter-style": Array [
+      "error",
+    ],
+    "@typescript-eslint/member-ordering": Array [
+      "error",
+      Object {
+        "default": Array [
+          "public-static-field",
+          "public-static-method",
+          "protected-static-field",
+          "protected-static-method",
+          "private-static-field",
+          "private-static-method",
+          "field",
+          "constructor",
+          "method",
+        ],
+      },
+    ],
+    "@typescript-eslint/no-floating-promises": Array [
+      "error",
+    ],
+    "@typescript-eslint/no-require-imports": Array [
+      "error",
+    ],
+    "@typescript-eslint/no-shadow": Array [
+      "error",
+    ],
+    "@typescript-eslint/return-await": Array [
+      "error",
+    ],
+    "array-bracket-newline": Array [
+      "error",
+      "consistent",
+    ],
+    "array-bracket-spacing": Array [
+      "error",
+      "never",
+    ],
+    "brace-style": Array [
+      "error",
+      "1tbs",
+      Object {
+        "allowSingleLine": true,
+      },
+    ],
+    "comma-dangle": Array [
+      "error",
+      "always-multiline",
+    ],
+    "comma-spacing": Array [
+      "error",
+      Object {
+        "after": true,
+        "before": false,
+      },
+    ],
+    "curly": Array [
+      "error",
+      "multi-line",
+      "consistent",
+    ],
+    "dot-notation": Array [
+      "error",
+    ],
+    "import/no-extraneous-dependencies": Array [
+      "error",
+      Object {
+        "devDependencies": Array [
+          "**/foo/**",
+          "**/bar/**",
+        ],
+        "optionalDependencies": false,
+        "peerDependencies": true,
+      },
+    ],
+    "import/no-unresolved": Array [
+      "error",
+    ],
+    "import/order": Array [
+      "warn",
+      Object {
+        "alphabetize": Object {
+          "caseInsensitive": true,
+          "order": "asc",
+        },
+        "groups": Array [
+          "builtin",
+          "external",
+        ],
+      },
+    ],
+    "indent": Array [
+      "off",
+    ],
+    "key-spacing": Array [
+      "error",
+    ],
+    "keyword-spacing": Array [
+      "error",
+    ],
+    "max-len": Array [
+      "error",
+      Object {
+        "code": 150,
+        "ignoreComments": true,
+        "ignoreRegExpLiterals": true,
+        "ignoreStrings": true,
+        "ignoreTemplateLiterals": true,
+        "ignoreUrls": true,
+      },
+    ],
+    "no-bitwise": Array [
+      "error",
+    ],
+    "no-duplicate-imports": Array [
+      "error",
+    ],
+    "no-multi-spaces": Array [
+      "error",
+      Object {
+        "ignoreEOLComments": false,
+      },
+    ],
+    "no-multiple-empty-lines": Array [
+      "error",
+    ],
+    "no-return-await": Array [
+      "off",
+    ],
+    "no-shadow": Array [
+      "off",
+    ],
+    "no-trailing-spaces": Array [
+      "error",
+    ],
+    "object-curly-newline": Array [
+      "error",
+      Object {
+        "consistent": true,
+        "multiline": true,
+      },
+    ],
+    "object-curly-spacing": Array [
+      "error",
+      "always",
+    ],
+    "object-property-newline": Array [
+      "error",
+      Object {
+        "allowAllPropertiesOnSameLine": true,
+      },
+    ],
+    "quote-props": Array [
+      "error",
+      "consistent-as-needed",
+    ],
+    "quotes": Array [
+      "error",
+      "single",
+      Object {
+        "avoidEscape": true,
+      },
+    ],
+    "semi": Array [
+      "error",
+      "always",
+    ],
+    "space-before-blocks": Array [
+      "error",
+    ],
+  },
+  "settings": Object {
+    "import/parsers": Object {
+      "@typescript-eslint/parser": Array [
+        ".ts",
+        ".tsx",
+      ],
+    },
+    "import/resolver": Object {
+      "node": Object {},
+      "typescript": Object {
+        "directory": "./tsconfig.json",
+      },
+    },
+  },
+}
+`;

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -114,8 +114,8 @@ Object {
         "error",
         Object {
           "devDependencies": Array [
-            "**/build-tools/**",
             "**/test/**",
+            "**/build-tools/**",
           ],
           "optionalDependencies": false,
           "peerDependencies": true,
@@ -227,7 +227,7 @@ Object {
       "import/resolver": Object {
         "node": Object {},
         "typescript": Object {
-          "directory": "./tsconfig.json",
+          "directory": "./tsconfig.jest.json",
         },
       },
     },
@@ -962,7 +962,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "eslint",
         "steps": Array [
           Object {
-            "exec": "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test .projenrc.js",
+            "exec": "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools .projenrc.js",
           },
         ],
       },
@@ -1673,8 +1673,8 @@ Object {
         "error",
         Object {
           "devDependencies": Array [
-            "**/build-tools/**",
             "**/test/**",
+            "**/build-tools/**",
           ],
           "optionalDependencies": false,
           "peerDependencies": true,
@@ -1786,7 +1786,7 @@ Object {
       "import/resolver": Object {
         "node": Object {},
         "typescript": Object {
-          "directory": "./tsconfig.json",
+          "directory": "./tsconfig.jest.json",
         },
       },
     },
@@ -2108,7 +2108,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "eslint",
         "steps": Array [
           Object {
-            "exec": "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test .projenrc.js",
+            "exec": "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools .projenrc.js",
           },
         ],
       },
@@ -2949,8 +2949,8 @@ Object {
         "error",
         Object {
           "devDependencies": Array [
-            "**/build-tools/**",
             "**/test/**",
+            "**/build-tools/**",
           ],
           "optionalDependencies": false,
           "peerDependencies": true,
@@ -3062,7 +3062,7 @@ Object {
       "import/resolver": Object {
         "node": Object {},
         "typescript": Object {
-          "directory": "./tsconfig.json",
+          "directory": "./tsconfig.jest.json",
         },
       },
     },
@@ -3353,7 +3353,7 @@ dist
         "name": "eslint",
         "steps": Array [
           Object {
-            "exec": "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test .projenrc.js",
+            "exec": "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools .projenrc.js",
           },
         ],
       },

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -227,7 +227,7 @@ Object {
       "import/resolver": Object {
         "node": Object {},
         "typescript": Object {
-          "directory": "./tsconfig.jest.json",
+          "project": "./tsconfig.jest.json",
         },
       },
     },
@@ -1786,7 +1786,7 @@ Object {
       "import/resolver": Object {
         "node": Object {},
         "typescript": Object {
-          "directory": "./tsconfig.jest.json",
+          "project": "./tsconfig.jest.json",
         },
       },
     },
@@ -3062,7 +3062,7 @@ Object {
       "import/resolver": Object {
         "node": Object {},
         "typescript": Object {
-          "directory": "./tsconfig.jest.json",
+          "project": "./tsconfig.jest.json",
         },
       },
     },

--- a/test/eslint.test.ts
+++ b/test/eslint.test.ts
@@ -1,0 +1,16 @@
+import { Eslint, NodeProject } from '../src';
+import { mkdtemp, synthSnapshot } from './util';
+
+test('devdirs', () => {
+  // GIVEN
+  const project = new NodeProject({ outdir: mkdtemp(), name: 'test' });
+
+  // WHEN
+  new Eslint(project, {
+    devdirs: ['foo', 'bar'],
+    dirs: ['mysrc'],
+  });
+
+  // THEN
+  expect(synthSnapshot(project)['.eslintrc.json']).toMatchSnapshot();
+});


### PR DESCRIPTION
Allow specifying `devdirs` which is a list of directories that should be linted but also allow importing deps from `devDependencies`.

Previously these were hard-coded to `test` and `build-tools`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.