### PR TITLE
feat(jest): coverage text output and watch ignore patterns

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -45,6 +45,11 @@ const project = new JsiiProject({
   devContainer: true,
   // since this is projen, we need to always compile before we run
   projenCommand: '/bin/bash ./projen.bash',
+
+  // makes it very hard to iterate with jest --watch
+  jestOptions: {
+    coverageText: false
+  }
 });
 
 // this script is what we use as the projen command in this project

--- a/API.md
+++ b/API.md
@@ -1570,6 +1570,7 @@ new Jest(project: NodeProject, options?: JestOptions)
 * **project** (<code>[NodeProject](#projen-nodeproject)</code>)  *No description*
 * **options** (<code>[JestOptions](#projen-jestoptions)</code>)  *No description*
   * **coverage** (<code>boolean</code>)  Collect coverage. __*Default*__: true
+  * **coverageText** (<code>boolean</code>)  Include the `text` coverage reporter, which means that coverage summary is printed at the end of the jest execution. __*Default*__: true
   * **ignorePatterns** (<code>Array<string></code>)  Defines `testPathIgnorePatterns` and `coveragePathIgnorePatterns`. __*Default*__: ["/node_modules/"]
   * **jestConfig** (<code>[JestConfigOptions](#projen-jestconfigoptions)</code>)  *No description* __*Optional*__
   * **jestVersion** (<code>string</code>)  The version of jest to use. __*Default*__: installs the latest jest version
@@ -1637,6 +1638,19 @@ addTestMatch(pattern: string): void
 ```
 
 * **pattern** (<code>string</code>)  glob pattern to match for tests.
+
+
+
+
+#### addWatchIgnorePattern(pattern)🔹 <a id="projen-jest-addwatchignorepattern"></a>
+
+Adds a watch ignore pattern.
+
+```ts
+addWatchIgnorePattern(pattern: string): void
+```
+
+* **pattern** (<code>string</code>)  The pattern (regular expression).
 
 
 
@@ -6294,6 +6308,7 @@ Name | Type | Description
 Name | Type | Description 
 -----|------|-------------
 **coverage**?⚠️ | <code>boolean</code> | Collect coverage.<br/>__*Default*__: true
+**coverageText**?🔹 | <code>boolean</code> | Include the `text` coverage reporter, which means that coverage summary is printed at the end of the jest execution.<br/>__*Default*__: true
 **ignorePatterns**?⚠️ | <code>Array<string></code> | Defines `testPathIgnorePatterns` and `coveragePathIgnorePatterns`.<br/>__*Default*__: ["/node_modules/"]
 **jestConfig**?🔹 | <code>[JestConfigOptions](#projen-jestconfigoptions)</code> | __*Optional*__
 **jestVersion**?🔹 | <code>string</code> | The version of jest to use.<br/>__*Default*__: installs the latest jest version

--- a/package.json
+++ b/package.json
@@ -94,12 +94,21 @@
     ],
     "clearMocks": true,
     "collectCoverage": true,
+    "coverageReporters": [
+      "json",
+      "lcov",
+      "clover"
+    ],
     "coverageDirectory": "coverage",
     "coveragePathIgnorePatterns": [
       "/node_modules/"
     ],
     "testPathIgnorePatterns": [
       "/node_modules/"
+    ],
+    "watchPathIgnorePatterns": [
+      "/node_modules/",
+      "/src/"
     ],
     "reporters": [
       "default",

--- a/src/__tests__/__snapshots__/integ.test.ts.snap
+++ b/src/__tests__/__snapshots__/integ.test.ts.snap
@@ -1413,6 +1413,12 @@ project.synth();
       "coveragePathIgnorePatterns": Array [
         "/node_modules/",
       ],
+      "coverageReporters": Array [
+        "json",
+        "lcov",
+        "clover",
+        "text",
+      ],
       "globals": Object {
         "ts-jest": Object {
           "tsconfig": "tsconfig.jest.json",
@@ -1433,6 +1439,9 @@ project.synth();
         "**/?(*.)+(spec|test).ts?(x)",
       ],
       "testPathIgnorePatterns": Array [
+        "/node_modules/",
+      ],
+      "watchPathIgnorePatterns": Array [
         "/node_modules/",
       ],
     },
@@ -2698,6 +2707,12 @@ project.synth();
       "coveragePathIgnorePatterns": Array [
         "/node_modules/",
       ],
+      "coverageReporters": Array [
+        "json",
+        "lcov",
+        "clover",
+        "text",
+      ],
       "globals": Object {
         "ts-jest": Object {
           "tsconfig": "tsconfig.jest.json",
@@ -2718,6 +2733,9 @@ project.synth();
         "**/?(*.)+(spec|test).ts?(x)",
       ],
       "testPathIgnorePatterns": Array [
+        "/node_modules/",
+      ],
+      "watchPathIgnorePatterns": Array [
         "/node_modules/",
       ],
     },
@@ -3934,6 +3952,12 @@ project.synth();
         "/node_modules/",
         "/templates/",
       ],
+      "coverageReporters": Array [
+        "json",
+        "lcov",
+        "clover",
+        "text",
+      ],
       "globals": Object {
         "ts-jest": Object {
           "tsconfig": "tsconfig.jest.json",
@@ -3956,6 +3980,9 @@ project.synth();
       "testPathIgnorePatterns": Array [
         "/node_modules/",
         "/templates/",
+      ],
+      "watchPathIgnorePatterns": Array [
+        "/node_modules/",
       ],
     },
     "keywords": Array [
@@ -4733,6 +4760,12 @@ project.synth();
       "coveragePathIgnorePatterns": Array [
         "/node_modules/",
       ],
+      "coverageReporters": Array [
+        "json",
+        "lcov",
+        "clover",
+        "text",
+      ],
       "reporters": Array [
         "default",
         Array [
@@ -4747,6 +4780,9 @@ project.synth();
         "**/?(*.)+(spec|test).[tj]s?(x)",
       ],
       "testPathIgnorePatterns": Array [
+        "/node_modules/",
+      ],
+      "watchPathIgnorePatterns": Array [
         "/node_modules/",
       ],
     },

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -280,6 +280,7 @@ export class TypeScriptProject extends NodeProject {
       const srctest = this.testdir;
 
       this.jest.addTestMatch(`**/${libtest}/**/?(*.)+(spec|test).js?(x)`);
+      this.jest.addWatchIgnorePattern(`/${this.srcdir}/`);
 
       const resolveSnapshotPath = (test: string, ext: string) => {
         const fullpath = test.replace(libtest, srctest);


### PR DESCRIPTION
Allow disabling the text output option for jest coverage to improve test output readability. This is okay in case coverage is collected and calculated through some other form.

This change also adds a "watch ignore pattern" for `src/**` when tests are executed from `lib/`.

Enable this for projen.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.