### PR TITLE
fix(java): corrupted java directory name

### DIFF
--- a/src/__tests__/java/__snapshots__/maven.test.ts.snap
+++ b/src/__tests__/java/__snapshots__/maven.test.ts.snap
@@ -320,7 +320,7 @@ public class Main {
     System.out.println(\\"Hello, world!\\");
   }
 }",
-  "src/test/java/o/r/g/a/c/m/e/MyTest.java": "package org.acme;
+  "src/test/java/org.acme/MyTest.java": "package org.acme;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/__tests__/java/__snapshots__/maven.test.ts.snap
+++ b/src/__tests__/java/__snapshots__/maven.test.ts.snap
@@ -320,7 +320,7 @@ public class Main {
     System.out.println(\\"Hello, world!\\");
   }
 }",
-  "src/test/java/org.acme/MyTest.java": "package org.acme;
+  "src/test/java/org/acme/MyTest.java": "package org.acme;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/java/junit.ts
+++ b/src/java/junit.ts
@@ -50,7 +50,7 @@ export class Junit extends Component {
     });
 
     const javaPackage = options.sampleJavaPackage ?? 'org.acme';
-    new SampleDir(project, join(TESTDIR, ...javaPackage), {
+    new SampleDir(project, join(TESTDIR, javaPackage), {
       files: {
         'MyTest.java': [
           `package ${javaPackage};`,

--- a/src/java/junit.ts
+++ b/src/java/junit.ts
@@ -50,7 +50,7 @@ export class Junit extends Component {
     });
 
     const javaPackage = options.sampleJavaPackage ?? 'org.acme';
-    new SampleDir(project, join(TESTDIR, javaPackage), {
+    new SampleDir(project, join(TESTDIR, ...javaPackage.split('.')), {
       files: {
         'MyTest.java': [
           `package ${javaPackage};`,

--- a/src/java/junit.ts
+++ b/src/java/junit.ts
@@ -50,7 +50,8 @@ export class Junit extends Component {
     });
 
     const javaPackage = options.sampleJavaPackage ?? 'org.acme';
-    new SampleDir(project, join(TESTDIR, ...javaPackage.split('.')), {
+    const javaPackagePath = javaPackage.split('.');
+    new SampleDir(project, join(TESTDIR, ...javaPackagePath), {
       files: {
         'MyTest.java': [
           `package ${javaPackage};`,


### PR DESCRIPTION
## Summary

This PR removes the usage of `...` causing the package name to be split into its characters when being processed by `path.join`. This would create `src/test/java/o/r/g/a/c/m/e` from `org.acme` in the sample package. 

Screenshot: 


<img width="1369" alt="Screenshot 2021-01-06 at 20 33 15" src="https://user-images.githubusercontent.com/39558817/103813270-1daea780-5060-11eb-9955-8b14c6d1bd9b.png">

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.