### PR TITLE
fix: output to STDOUT crashes jsii languages

### DIFF
--- a/src/project.ts
+++ b/src/project.ts
@@ -162,6 +162,9 @@ export class Project {
   private readonly excludeFromCleanup: string[];
 
   constructor(options: ProjectOptions) {
+    // https://github.com/aws/jsii/issues/2406
+    process.stdout.write = (...args: any) => process.stderr.write.apply(process.stderr, args);
+
     this.name = options.name;
     this.parent = options.parent;
     this.excludeFromCleanup = [];

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,7 +8,7 @@ const decamelize = require('decamelize');
 export function exec(command: string, options?: child_process.ExecSyncOptions) {
   logging.verbose(command);
   return child_process.execSync(command, {
-    stdio: ['inherit', 'inherit', 'pipe'],
+    stdio: ['inherit', process.stderr, 'pipe'],
     ...options,
   });
 }


### PR DESCRIPTION
See https://github.com/aws/jsii/issues/2406 for details.

Until this is resolved in jsii, we bluntly hook `process.stdout.write()` and redirect the stream to STDERR. We do the same thing when we `exec()` shell commands.

NOTE: the task runtime still inherits STDOUT, so this applies only to logs coming from libraries.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.