### PR TITLE
feat: add line endings to json files

### DIFF
--- a/src/json.ts
+++ b/src/json.ts
@@ -43,6 +43,6 @@ export class JsonFile extends ObjectFile implements IMarkableFile {
       sanitized['//'] = JsonFile.PROJEN_MARKER;
     }
 
-    return JSON.stringify(sanitized, undefined, 2);
+    return `${JSON.stringify(sanitized, undefined, 2)}\n'`;
   }
 }


### PR DESCRIPTION
Adds a line ending to the JSON files. Without those, git diffs may look strange, linting programs may complain, and other tools like npm or yarn may cause inconsistencies.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.