### PR TITLE
feat(jsii): Golang support (without publishing yet)

### DIFF
--- a/API.md
+++ b/API.md
@@ -102,6 +102,7 @@ Name|Description
 [JestConfigOptions](#projen-jestconfigoptions)|*No description*
 [JestOptions](#projen-jestoptions)|*No description*
 [JsiiDotNetTarget](#projen-jsiidotnettarget)|*No description*
+[JsiiGoTarget](#projen-jsiigotarget)|Go target configuration.
 [JsiiJavaTarget](#projen-jsiijavatarget)|*No description*
 [JsiiProjectOptions](#projen-jsiiprojectoptions)|*No description*
 [JsiiPythonTarget](#projen-jsiipythontarget)|*No description*
@@ -374,6 +375,7 @@ new AwsCdkConstructLibrary(options: AwsCdkConstructLibraryOptions)
   * **dotnet** (<code>[JsiiDotNetTarget](#projen-jsiidotnettarget)</code>)  *No description* __*Optional*__
   * **eslint** (<code>boolean</code>)  Install eslint. __*Default*__: true
   * **eslintOptions** (<code>[EslintOptions](#projen-eslintoptions)</code>)  Eslint options. __*Default*__: opinionated default options
+  * **publishToGo** (<code>[JsiiGoTarget](#projen-jsiigotarget)</code>)  Publish Go bindings to a git repository. __*Default*__: no publishing
   * **publishToMaven** (<code>[JsiiJavaTarget](#projen-jsiijavatarget)</code>)  Publish to maven. __*Default*__: no publishing
   * **publishToNuget** (<code>[JsiiDotNetTarget](#projen-jsiidotnettarget)</code>)  Publish to NuGet. __*Default*__: no publishing
   * **publishToPypi** (<code>[JsiiPythonTarget](#projen-jsiipythontarget)</code>)  Publish to pypi. __*Default*__: no publishing
@@ -745,6 +747,7 @@ new ConstructLibrary(options: ConstructLibraryOptions)
   * **dotnet** (<code>[JsiiDotNetTarget](#projen-jsiidotnettarget)</code>)  *No description* __*Optional*__
   * **eslint** (<code>boolean</code>)  Install eslint. __*Default*__: true
   * **eslintOptions** (<code>[EslintOptions](#projen-eslintoptions)</code>)  Eslint options. __*Default*__: opinionated default options
+  * **publishToGo** (<code>[JsiiGoTarget](#projen-jsiigotarget)</code>)  Publish Go bindings to a git repository. __*Default*__: no publishing
   * **publishToMaven** (<code>[JsiiJavaTarget](#projen-jsiijavatarget)</code>)  Publish to maven. __*Default*__: no publishing
   * **publishToNuget** (<code>[JsiiDotNetTarget](#projen-jsiidotnettarget)</code>)  Publish to NuGet. __*Default*__: no publishing
   * **publishToPypi** (<code>[JsiiPythonTarget](#projen-jsiipythontarget)</code>)  Publish to pypi. __*Default*__: no publishing
@@ -856,6 +859,7 @@ new ConstructLibraryAws(options: AwsCdkConstructLibraryOptions)
   * **dotnet** (<code>[JsiiDotNetTarget](#projen-jsiidotnettarget)</code>)  *No description* __*Optional*__
   * **eslint** (<code>boolean</code>)  Install eslint. __*Default*__: true
   * **eslintOptions** (<code>[EslintOptions](#projen-eslintoptions)</code>)  Eslint options. __*Default*__: opinionated default options
+  * **publishToGo** (<code>[JsiiGoTarget](#projen-jsiigotarget)</code>)  Publish Go bindings to a git repository. __*Default*__: no publishing
   * **publishToMaven** (<code>[JsiiJavaTarget](#projen-jsiijavatarget)</code>)  Publish to maven. __*Default*__: no publishing
   * **publishToNuget** (<code>[JsiiDotNetTarget](#projen-jsiidotnettarget)</code>)  Publish to NuGet. __*Default*__: no publishing
   * **publishToPypi** (<code>[JsiiPythonTarget](#projen-jsiipythontarget)</code>)  Publish to pypi. __*Default*__: no publishing
@@ -976,6 +980,7 @@ new ConstructLibraryCdk8s(options: ConstructLibraryCdk8sOptions)
   * **dotnet** (<code>[JsiiDotNetTarget](#projen-jsiidotnettarget)</code>)  *No description* __*Optional*__
   * **eslint** (<code>boolean</code>)  Install eslint. __*Default*__: true
   * **eslintOptions** (<code>[EslintOptions](#projen-eslintoptions)</code>)  Eslint options. __*Default*__: opinionated default options
+  * **publishToGo** (<code>[JsiiGoTarget](#projen-jsiigotarget)</code>)  Publish Go bindings to a git repository. __*Default*__: no publishing
   * **publishToMaven** (<code>[JsiiJavaTarget](#projen-jsiijavatarget)</code>)  Publish to maven. __*Default*__: no publishing
   * **publishToNuget** (<code>[JsiiDotNetTarget](#projen-jsiidotnettarget)</code>)  Publish to NuGet. __*Default*__: no publishing
   * **publishToPypi** (<code>[JsiiPythonTarget](#projen-jsiipythontarget)</code>)  Publish to pypi. __*Default*__: no publishing
@@ -1860,6 +1865,7 @@ new JsiiProject(options: JsiiProjectOptions)
   * **dotnet** (<code>[JsiiDotNetTarget](#projen-jsiidotnettarget)</code>)  *No description* __*Optional*__
   * **eslint** (<code>boolean</code>)  Install eslint. __*Default*__: true
   * **eslintOptions** (<code>[EslintOptions](#projen-eslintoptions)</code>)  Eslint options. __*Default*__: opinionated default options
+  * **publishToGo** (<code>[JsiiGoTarget](#projen-jsiigotarget)</code>)  Publish Go bindings to a git repository. __*Default*__: no publishing
   * **publishToMaven** (<code>[JsiiJavaTarget](#projen-jsiijavatarget)</code>)  Publish to maven. __*Default*__: no publishing
   * **publishToNuget** (<code>[JsiiDotNetTarget](#projen-jsiidotnettarget)</code>)  Publish to NuGet. __*Default*__: no publishing
   * **publishToPypi** (<code>[JsiiPythonTarget](#projen-jsiipythontarget)</code>)  Publish to pypi. __*Default*__: no publishing
@@ -5953,6 +5959,7 @@ Name | Type | Description
 **projenUpgradeSchedule**?🔹 | <code>Array<string></code> | Customize the projenUpgrade schedule in cron expression.<br/>__*Default*__: [ "0 6 * * *" ]
 **projenUpgradeSecret**?🔹 | <code>string</code> | Periodically submits a pull request for projen upgrades (executes `yarn projen:upgrade`).<br/>__*Default*__: no automatic projen upgrade pull requests
 **projenVersion**?🔹 | <code>[Semver](#projen-semver)</code> | Version of projen to install.<br/>__*Default*__: Semver.latest()
+**publishToGo**?🔹 | <code>[JsiiGoTarget](#projen-jsiigotarget)</code> | Publish Go bindings to a git repository.<br/>__*Default*__: no publishing
 **publishToMaven**?🔹 | <code>[JsiiJavaTarget](#projen-jsiijavatarget)</code> | Publish to maven.<br/>__*Default*__: no publishing
 **publishToNuget**?🔹 | <code>[JsiiDotNetTarget](#projen-jsiidotnettarget)</code> | Publish to NuGet.<br/>__*Default*__: no publishing
 **publishToPypi**?🔹 | <code>[JsiiPythonTarget](#projen-jsiipythontarget)</code> | Publish to pypi.<br/>__*Default*__: no publishing
@@ -6183,6 +6190,7 @@ Name | Type | Description
 **projenUpgradeSchedule**?⚠️ | <code>Array<string></code> | Customize the projenUpgrade schedule in cron expression.<br/>__*Default*__: [ "0 6 * * *" ]
 **projenUpgradeSecret**?⚠️ | <code>string</code> | Periodically submits a pull request for projen upgrades (executes `yarn projen:upgrade`).<br/>__*Default*__: no automatic projen upgrade pull requests
 **projenVersion**?⚠️ | <code>[Semver](#projen-semver)</code> | Version of projen to install.<br/>__*Default*__: Semver.latest()
+**publishToGo**?⚠️ | <code>[JsiiGoTarget](#projen-jsiigotarget)</code> | Publish Go bindings to a git repository.<br/>__*Default*__: no publishing
 **publishToMaven**?⚠️ | <code>[JsiiJavaTarget](#projen-jsiijavatarget)</code> | Publish to maven.<br/>__*Default*__: no publishing
 **publishToNuget**?⚠️ | <code>[JsiiDotNetTarget](#projen-jsiidotnettarget)</code> | Publish to NuGet.<br/>__*Default*__: no publishing
 **publishToPypi**?⚠️ | <code>[JsiiPythonTarget](#projen-jsiipythontarget)</code> | Publish to pypi.<br/>__*Default*__: no publishing
@@ -6287,6 +6295,7 @@ Name | Type | Description
 **projenUpgradeSchedule**?🔹 | <code>Array<string></code> | Customize the projenUpgrade schedule in cron expression.<br/>__*Default*__: [ "0 6 * * *" ]
 **projenUpgradeSecret**?🔹 | <code>string</code> | Periodically submits a pull request for projen upgrades (executes `yarn projen:upgrade`).<br/>__*Default*__: no automatic projen upgrade pull requests
 **projenVersion**?🔹 | <code>[Semver](#projen-semver)</code> | Version of projen to install.<br/>__*Default*__: Semver.latest()
+**publishToGo**?🔹 | <code>[JsiiGoTarget](#projen-jsiigotarget)</code> | Publish Go bindings to a git repository.<br/>__*Default*__: no publishing
 **publishToMaven**?🔹 | <code>[JsiiJavaTarget](#projen-jsiijavatarget)</code> | Publish to maven.<br/>__*Default*__: no publishing
 **publishToNuget**?🔹 | <code>[JsiiDotNetTarget](#projen-jsiidotnettarget)</code> | Publish to NuGet.<br/>__*Default*__: no publishing
 **publishToPypi**?🔹 | <code>[JsiiPythonTarget](#projen-jsiipythontarget)</code> | Publish to pypi.<br/>__*Default*__: no publishing
@@ -6390,6 +6399,7 @@ Name | Type | Description
 **projenUpgradeSchedule**?🔹 | <code>Array<string></code> | Customize the projenUpgrade schedule in cron expression.<br/>__*Default*__: [ "0 6 * * *" ]
 **projenUpgradeSecret**?🔹 | <code>string</code> | Periodically submits a pull request for projen upgrades (executes `yarn projen:upgrade`).<br/>__*Default*__: no automatic projen upgrade pull requests
 **projenVersion**?🔹 | <code>[Semver](#projen-semver)</code> | Version of projen to install.<br/>__*Default*__: Semver.latest()
+**publishToGo**?🔹 | <code>[JsiiGoTarget](#projen-jsiigotarget)</code> | Publish Go bindings to a git repository.<br/>__*Default*__: no publishing
 **publishToMaven**?🔹 | <code>[JsiiJavaTarget](#projen-jsiijavatarget)</code> | Publish to maven.<br/>__*Default*__: no publishing
 **publishToNuget**?🔹 | <code>[JsiiDotNetTarget](#projen-jsiidotnettarget)</code> | Publish to NuGet.<br/>__*Default*__: no publishing
 **publishToPypi**?🔹 | <code>[JsiiPythonTarget](#projen-jsiipythontarget)</code> | Publish to pypi.<br/>__*Default*__: no publishing
@@ -6981,6 +6991,19 @@ Name | Type | Description
 
 
 
+## struct JsiiGoTarget 🔹 <a id="projen-jsiigotarget"></a>
+
+
+Go target configuration.
+
+
+
+Name | Type | Description 
+-----|------|-------------
+**moduleName**🔹 | <code>string</code> | The name of the target go module.
+
+
+
 ## struct JsiiJavaTarget 🔹 <a id="projen-jsiijavatarget"></a>
 
 
@@ -7075,6 +7098,7 @@ Name | Type | Description
 **projenUpgradeSchedule**?🔹 | <code>Array<string></code> | Customize the projenUpgrade schedule in cron expression.<br/>__*Default*__: [ "0 6 * * *" ]
 **projenUpgradeSecret**?🔹 | <code>string</code> | Periodically submits a pull request for projen upgrades (executes `yarn projen:upgrade`).<br/>__*Default*__: no automatic projen upgrade pull requests
 **projenVersion**?🔹 | <code>[Semver](#projen-semver)</code> | Version of projen to install.<br/>__*Default*__: Semver.latest()
+**publishToGo**?🔹 | <code>[JsiiGoTarget](#projen-jsiigotarget)</code> | Publish Go bindings to a git repository.<br/>__*Default*__: no publishing
 **publishToMaven**?🔹 | <code>[JsiiJavaTarget](#projen-jsiijavatarget)</code> | Publish to maven.<br/>__*Default*__: no publishing
 **publishToNuget**?🔹 | <code>[JsiiDotNetTarget](#projen-jsiidotnettarget)</code> | Publish to NuGet.<br/>__*Default*__: no publishing
 **publishToPypi**?🔹 | <code>[JsiiPythonTarget](#projen-jsiipythontarget)</code> | Publish to pypi.<br/>__*Default*__: no publishing

--- a/src/__tests__/__snapshots__/inventory.test.ts.snap
+++ b/src/__tests__/__snapshots__/inventory.test.ts.snap
@@ -2009,6 +2009,18 @@ Array [
       },
       Object {
         "default": "- no publishing",
+        "docs": "Publish Go bindings to a git repository.",
+        "name": "publishToGo",
+        "optional": true,
+        "parent": "JsiiProjectOptions",
+        "path": Array [
+          "publishToGo",
+        ],
+        "switch": "publish-to-go",
+        "type": "JsiiGoTarget",
+      },
+      Object {
+        "default": "- no publishing",
         "docs": "Publish to maven.",
         "name": "publishToMaven",
         "optional": true,
@@ -3097,6 +3109,18 @@ Array [
         ],
         "switch": "projen-version",
         "type": "Semver",
+      },
+      Object {
+        "default": "- no publishing",
+        "docs": "Publish Go bindings to a git repository.",
+        "name": "publishToGo",
+        "optional": true,
+        "parent": "JsiiProjectOptions",
+        "path": Array [
+          "publishToGo",
+        ],
+        "switch": "publish-to-go",
+        "type": "JsiiGoTarget",
       },
       Object {
         "default": "- no publishing",
@@ -4490,6 +4514,18 @@ Array [
         ],
         "switch": "projen-version",
         "type": "Semver",
+      },
+      Object {
+        "default": "- no publishing",
+        "docs": "Publish Go bindings to a git repository.",
+        "name": "publishToGo",
+        "optional": true,
+        "parent": "JsiiProjectOptions",
+        "path": Array [
+          "publishToGo",
+        ],
+        "switch": "publish-to-go",
+        "type": "JsiiGoTarget",
       },
       Object {
         "default": "- no publishing",

--- a/src/__tests__/__snapshots__/new.test.ts.snap
+++ b/src/__tests__/__snapshots__/new.test.ts.snap
@@ -141,6 +141,7 @@ const project = new AwsCdkConstructLibrary({
   // docgen: true,                                                             /* Automatically generate API.md from jsii. */
   // eslint: true,                                                             /* Install eslint. */
   // eslintOptions: undefined,                                                 /* Eslint options. */
+  // publishToGo: undefined,                                                   /* Publish Go bindings to a git repository. */
   // publishToMaven: undefined,                                                /* Publish to maven. */
   // publishToNuget: undefined,                                                /* Publish to NuGet. */
   // publishToPypi: undefined,                                                 /* Publish to pypi. */
@@ -250,6 +251,7 @@ const project = new ConstructLibraryCdk8s({
   // docgen: true,                                                             /* Automatically generate API.md from jsii. */
   // eslint: true,                                                             /* Install eslint. */
   // eslintOptions: undefined,                                                 /* Eslint options. */
+  // publishToGo: undefined,                                                   /* Publish Go bindings to a git repository. */
   // publishToMaven: undefined,                                                /* Publish to maven. */
   // publishToNuget: undefined,                                                /* Publish to NuGet. */
   // publishToPypi: undefined,                                                 /* Publish to pypi. */
@@ -398,6 +400,7 @@ const project = new JsiiProject({
   // docgen: true,                                                             /* Automatically generate API.md from jsii. */
   // eslint: true,                                                             /* Install eslint. */
   // eslintOptions: undefined,                                                 /* Eslint options. */
+  // publishToGo: undefined,                                                   /* Publish Go bindings to a git repository. */
   // publishToMaven: undefined,                                                /* Publish to maven. */
   // publishToNuget: undefined,                                                /* Publish to NuGet. */
   // publishToPypi: undefined,                                                 /* Publish to pypi. */

--- a/src/__tests__/jsii.test.ts
+++ b/src/__tests__/jsii.test.ts
@@ -90,3 +90,24 @@ describe('maven repository options', () => {
   });
 });
 
+test('publish to go', () => {
+  const project = new JsiiProject({
+    authorAddress: 'https://foo.bar',
+    authorUrl: 'https://foo.bar',
+    repositoryUrl: 'https://github.com/foo/bar.git',
+    author: 'My Name',
+    outdir: mkdtemp(),
+    name: 'testproject',
+    publishToGo: {
+      moduleName: 'github.com/foo/bar',
+    },
+  });
+
+  const targets = synthSnapshot(project)['package.json'].jsii.targets;
+  expect(targets).toStrictEqual({
+    go: {
+      moduleName: 'github.com/foo/bar',
+    },
+  });
+});
+

--- a/src/jsii-project.ts
+++ b/src/jsii-project.ts
@@ -46,6 +46,12 @@ export interface JsiiProjectOptions extends NodeProjectOptions {
   readonly publishToPypi?: JsiiPythonTarget;
 
   /**
+   * Publish Go bindings to a git repository.
+   * @default - no publishing
+   */
+  readonly publishToGo?: JsiiGoTarget;
+
+  /**
    * @deprecated use `publishToPyPi`
    */
   readonly python?: JsiiPythonTarget;
@@ -137,6 +143,19 @@ export interface JsiiPythonTarget {
 export interface JsiiDotNetTarget {
   readonly dotNetNamespace: string;
   readonly packageId: string;
+}
+
+/**
+ * Go target configuration
+ */
+export interface JsiiGoTarget {
+  /**
+   * The name of the target go module.
+   *
+   * @example github.com/owner/repo
+   * @example github.com/owner/repo/subdir
+   */
+  readonly moduleName: string;
 }
 
 /**
@@ -253,6 +272,16 @@ export class JsiiProject extends TypeScriptProject {
       };
 
       this.publishToNuget();
+      publishing = true;
+    }
+
+    const golang = options.publishToGo;
+    if (golang) {
+      targets.go = {
+        moduleName: golang.moduleName,
+      };
+
+      this.publishToGo();
       publishing = true;
     }
 
@@ -418,7 +447,43 @@ export class JsiiProject extends TypeScriptProject {
       },
     });
   }
+
+  private publishToGo() {
+    if (!this.releaseWorkflow) {
+      return;
+    }
+
+    // TODO: once jsii-release supports golang
+    // this.releaseWorkflow.addJobs({
+    //   release_golang: {
+    //     'name': 'Release to Go',
+    //     'needs': this.releaseWorkflowJobId,
+    //     'runs-on': 'ubuntu-latest',
+    //     'container': {
+    //       image: 'jsii/superchain',
+    //     },
+    //     'steps': [
+    //       {
+    //         name: 'Download build artifacts',
+    //         uses: 'actions/download-artifact@v1',
+    //         with: {
+    //           name: 'dist',
+    //         },
+    //       },
+    //       {
+    //         name: 'Release',
+    //         run: 'npx -p jsii-release jsii-release-golang',
+    //         env: {
+    //           // TODO
+    //         },
+    //       },
+    //     ],
+    //   },
+    // });
+  }
 }
+
+
 function parseAuthorAddress(options: JsiiProjectOptions) {
   let authorEmail = options.authorEmail;
   let authorUrl = options.authorUrl;


### PR DESCRIPTION
Adds `publishToGo` option to jsii projects which renders the `go` target in the jsii config. This will cause the build output to include a `dist/go` artifact that can then be published to a git repository.

Once `jsii-release` supports go, we need to add the relevant workflow steps to actually publish.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.