### PR TITLE
fix(cli): error when the given task doesn't exist

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,6 +16,7 @@ async function main() {
   discoverTaskCommands(runtime, ya);
 
   ya.recommendCommands();
+  ya.strictCommands();
   ya.wrap(yargs.terminalWidth());
   ya.option('post', { type: 'boolean', default: true, desc: 'Run post-synthesis steps such as installing dependencies. Use --no-post to skip' });
   ya.options('debug', { type: 'boolean', default: false, desc: 'Debug logs' });


### PR DESCRIPTION
Closes #484

When you run a task that doesn't exist, it will now raise an error, showing the CLI help printout and the message "Unknown command: foobar" with the error code 1.

Existing functionality that I verified as left intact:
- if the invalid task name is similar to an existing task name, the CLI will still show the error message "Did you mean <name>?" (this is existing behavior provided by yargs)
- providing no task still runs the 'default' synthesis task

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.