### PR TITLE
#452 Fix broken Windows shell commands by running through shx.

### DIFF
--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -197,10 +197,11 @@ export class TypeScriptProject extends NodeProject {
         category: TaskCategory.RELEASE,
       });
 
-      this.packageTask.exec('rm -fr dist');
-      this.packageTask.exec('mkdir -p dist/js');
+      this.addDevDeps('shx');
+      this.packageTask.exec('shx rm -fr dist');
+      this.packageTask.exec('shx mkdir -p dist/js');
       this.packageTask.exec(`${this.package.packageManager} pack`);
-      this.packageTask.exec('mv *.tgz dist/js/');
+      this.packageTask.exec('shx mv *.tgz dist/js/');
 
       this.buildTask.spawn(this.packageTask);
     }
@@ -327,7 +328,7 @@ export class TypeScriptProject extends NodeProject {
       if (!compileBeforeTest) {
         // make sure to delete "lib" *before* running tests to ensure that
         // test code does not take a dependency on "lib" and instead on "src".
-        this.testTask.prependExec(`rm -fr ${this.libdir}/`);
+        this.testTask.prependExec(`shx rm -fr ${this.libdir}/`);
       }
 
       // compile test code


### PR DESCRIPTION
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

[shx](https://github.com/shelljs/shx) is added as a dev dependency in order for it to be available for use in scripts. Linux script commnds (e.g. `rm -fr ...`) are modified to run through `shx` in order to be supported on Windows.
