### PR TITLE
fix(node): tags may be pushed without a bump commit

### DIFF
--- a/.github/workflows/rebuild-bot.yml
+++ b/.github/workflows/rebuild-bot.yml
@@ -51,7 +51,11 @@ jobs:
         run: /bin/bash ./projen.bash build
       - name: Commit changes
         run: 'git commit -am "chore: update generated files"'
-      - name: Push changes
+      - name: Push commits
+        run: git push origin $BRANCH
+        env:
+          BRANCH: ${{ steps.query_pull_request.outputs.branch }}
+      - name: Push tags
         run: git push --follow-tags origin $BRANCH
         env:
           BRANCH: ${{ steps.query_pull_request.outputs.branch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,11 @@ jobs:
           directory: coverage
       - name: Anti-tamper check
         run: git diff --exit-code
-      - name: Push changes
+      - name: Push commits
+        run: git push origin $BRANCH
+        env:
+          BRANCH: ${{ github.ref }}
+      - name: Push tags
         run: git push --follow-tags origin $BRANCH
         env:
           BRANCH: ${{ github.ref }}

--- a/src/__tests__/__snapshots__/integ.test.ts.snap
+++ b/src/__tests__/__snapshots__/integ.test.ts.snap
@@ -366,7 +366,11 @@ jobs:
         run: npx projen build
       - name: Commit changes
         run: 'git commit -am \\"chore: update generated files\\"'
-      - name: Push changes
+      - name: Push commits
+        run: git push origin $BRANCH
+        env:
+          BRANCH: \${{ steps.query_pull_request.outputs.branch }}
+      - name: Push tags
         run: git push --follow-tags origin $BRANCH
         env:
           BRANCH: \${{ steps.query_pull_request.outputs.branch }}
@@ -414,7 +418,11 @@ jobs:
         run: npx projen build
       - name: Anti-tamper check
         run: git diff --exit-code
-      - name: Push changes
+      - name: Push commits
+        run: git push origin $BRANCH
+        env:
+          BRANCH: \${{ github.ref }}
+      - name: Push tags
         run: git push --follow-tags origin $BRANCH
         env:
           BRANCH: \${{ github.ref }}
@@ -4276,7 +4284,11 @@ jobs:
         run: npx projen build
       - name: Commit changes
         run: 'git commit -am \\"chore: update generated files\\"'
-      - name: Push changes
+      - name: Push commits
+        run: git push origin $BRANCH
+        env:
+          BRANCH: \${{ steps.query_pull_request.outputs.branch }}
+      - name: Push tags
         run: git push --follow-tags origin $BRANCH
         env:
           BRANCH: \${{ steps.query_pull_request.outputs.branch }}
@@ -4320,7 +4332,11 @@ jobs:
         run: npx projen build
       - name: Anti-tamper check
         run: git diff --exit-code
-      - name: Push changes
+      - name: Push commits
+        run: git push origin $BRANCH
+        env:
+          BRANCH: \${{ github.ref }}
+      - name: Push tags
         run: git push --follow-tags origin $BRANCH
         env:
           BRANCH: \${{ github.ref }}

--- a/src/__tests__/__snapshots__/jsii.test.ts.snap
+++ b/src/__tests__/__snapshots__/jsii.test.ts.snap
@@ -35,7 +35,11 @@ jobs:
         run: npx projen build
       - name: Anti-tamper check
         run: git diff --exit-code
-      - name: Push changes
+      - name: Push commits
+        run: git push origin $BRANCH
+        env:
+          BRANCH: \${{ github.ref }}
+      - name: Push tags
         run: git push --follow-tags origin $BRANCH
         env:
           BRANCH: \${{ github.ref }}
@@ -123,7 +127,11 @@ jobs:
         run: npx projen build
       - name: Anti-tamper check
         run: git diff --exit-code
-      - name: Push changes
+      - name: Push commits
+        run: git push origin $BRANCH
+        env:
+          BRANCH: \${{ github.ref }}
+      - name: Push tags
         run: git push --follow-tags origin $BRANCH
         env:
           BRANCH: \${{ github.ref }}

--- a/src/node-project.ts
+++ b/src/node-project.ts
@@ -903,13 +903,26 @@ export class NodeProject extends Project {
       run: `git commit -am "${options.commit}"`,
     }];
 
-    const pushChanges = !options.pushBranch ? [] : [{
-      name: 'Push changes',
-      run: 'git push --follow-tags origin $BRANCH',
-      env: {
-        BRANCH: options.pushBranch,
+    const pushChanges = !options.pushBranch ? [] : [
+      {
+        name: 'Push commits',
+        run: 'git push origin $BRANCH',
+        env: {
+          BRANCH: options.pushBranch,
+        },
       },
-    }];
+
+      // push tags only after we've managed to push our commits in order to
+      // avoid tags being pushed but commits being rejected due to new commits
+      // see https://github.com/projen/projen/issues/553
+      {
+        name: 'Push tags',
+        run: 'git push --follow-tags origin $BRANCH',
+        env: {
+          BRANCH: options.pushBranch,
+        },
+      },
+    ];
 
     const job: any = {
       'runs-on': 'ubuntu-latest',


### PR DESCRIPTION
When multiple commits are pushed to the main branch at once (for whatever reason), the release workflow will try to push both the new tag and the bump commit. In such a case, the tag will be pushed but the commit will fail, which means the repo is in a corrupted state (from a bump perspective).

This change fixes the broken transaction issue by pushing the tag only after the bump commit has been pushed.

The implication is that only the latest release (in the series of commits) will succeed. Ideally we'd want to cancel the release workflow (instead of failing it), but this will be done in a future change.

Fixes #553

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.