### PR TITLE
feat(awscdk-construct): cdkDependenciesAsDeps

### DIFF
--- a/API.md
+++ b/API.md
@@ -431,7 +431,7 @@ new AwsCdkConstructLibrary(options: AwsCdkConstructLibraryOptions)
 
 Name | Type | Description 
 -----|------|-------------
-**cdkDependenciesAsDeps**🔹 | <code>boolean</code> | Wether to add `cdkDependencies` to `dependencies`.
+**cdkDependenciesAsDeps**🔹 | <code>boolean</code> | Whether CDK dependencies are added as normal dependencies (and peer dependencies).
 **version**🔹 | <code>string</code> | The target CDK version for this library.
 
 ### Methods

--- a/API.md
+++ b/API.md
@@ -420,6 +420,7 @@ new AwsCdkConstructLibrary(options: AwsCdkConstructLibraryOptions)
   * **cdkVersion** (<code>string</code>)  Minimum target version this library is tested against. 
   * **cdkAssert** (<code>boolean</code>)  Install the @aws-cdk/assert library? __*Default*__: true
   * **cdkDependencies** (<code>Array<string></code>)  Which AWS CDK modules (those that start with "@aws-cdk/") does this library require when consumed? __*Optional*__
+  * **cdkDependenciesAsDeps** (<code>boolean</code>)  If this is enabled (default), all modules declared in `cdkDependencies` will be also added as normal `dependencies` (as well as `peerDependencies`). __*Default*__: true
   * **cdkTestDependencies** (<code>Array<string></code>)  AWS CDK modules required for testing. __*Optional*__
   * **cdkVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for CDK. __*Default*__: false
 
@@ -430,6 +431,7 @@ new AwsCdkConstructLibrary(options: AwsCdkConstructLibraryOptions)
 
 Name | Type | Description 
 -----|------|-------------
+**cdkDependenciesAsDeps**🔹 | <code>boolean</code> | Wether to add `cdkDependencies` to `dependencies`.
 **version**🔹 | <code>string</code> | The target CDK version for this library.
 
 ### Methods
@@ -439,12 +441,13 @@ Name | Type | Description
 
 Adds CDK modules as runtime dependencies.
 
-Modules are currently added with a caret CDK version both as "dependencies"
+Modules are currently by default added with a caret CDK version both as "dependencies"
 and "peerDependencies". This is because currently npm would not
 automatically install peer dependencies that are not declared as concerete
 dependencies by the consumer, so this is a little npm "hack" so that
 consumers will not need to depend on them directly if they don't interact
 with them.
+See `cdkDependenciesAsDeps` for changing the default behavior.
 
 ```ts
 addCdkDependencies(...deps: string[]): void
@@ -914,6 +917,7 @@ new ConstructLibraryAws(options: AwsCdkConstructLibraryOptions)
   * **cdkVersion** (<code>string</code>)  Minimum target version this library is tested against. 
   * **cdkAssert** (<code>boolean</code>)  Install the @aws-cdk/assert library? __*Default*__: true
   * **cdkDependencies** (<code>Array<string></code>)  Which AWS CDK modules (those that start with "@aws-cdk/") does this library require when consumed? __*Optional*__
+  * **cdkDependenciesAsDeps** (<code>boolean</code>)  If this is enabled (default), all modules declared in `cdkDependencies` will be also added as normal `dependencies` (as well as `peerDependencies`). __*Default*__: true
   * **cdkTestDependencies** (<code>Array<string></code>)  AWS CDK modules required for testing. __*Optional*__
   * **cdkVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for CDK. __*Default*__: false
 
@@ -6672,6 +6676,7 @@ Name | Type | Description
 **catalog**?🔹 | <code>[Catalog](#projen-catalog)</code> | Libraries will be picked up by the construct catalog when they are published to npm as jsii modules and will be published under:.<br/>__*Default*__: new version will be announced
 **cdkAssert**?🔹 | <code>boolean</code> | Install the @aws-cdk/assert library?<br/>__*Default*__: true
 **cdkDependencies**?🔹 | <code>Array<string></code> | Which AWS CDK modules (those that start with "@aws-cdk/") does this library require when consumed?<br/>__*Optional*__
+**cdkDependenciesAsDeps**?🔹 | <code>boolean</code> | If this is enabled (default), all modules declared in `cdkDependencies` will be also added as normal `dependencies` (as well as `peerDependencies`).<br/>__*Default*__: true
 **cdkTestDependencies**?🔹 | <code>Array<string></code> | AWS CDK modules required for testing.<br/>__*Optional*__
 **cdkVersionPinning**?🔹 | <code>boolean</code> | Use pinned version instead of caret version for CDK.<br/>__*Default*__: false
 **clobber**?🔹 | <code>boolean</code> | Add a `clobber` task which resets the repo to origin.<br/>__*Default*__: true
@@ -6909,6 +6914,7 @@ Name | Type | Description
 **catalog**?⚠️ | <code>[Catalog](#projen-catalog)</code> | Libraries will be picked up by the construct catalog when they are published to npm as jsii modules and will be published under:.<br/>__*Default*__: new version will be announced
 **cdkAssert**?⚠️ | <code>boolean</code> | Install the @aws-cdk/assert library?<br/>__*Default*__: true
 **cdkDependencies**?⚠️ | <code>Array<string></code> | Which AWS CDK modules (those that start with "@aws-cdk/") does this library require when consumed?<br/>__*Optional*__
+**cdkDependenciesAsDeps**?⚠️ | <code>boolean</code> | If this is enabled (default), all modules declared in `cdkDependencies` will be also added as normal `dependencies` (as well as `peerDependencies`).<br/>__*Default*__: true
 **cdkTestDependencies**?⚠️ | <code>Array<string></code> | AWS CDK modules required for testing.<br/>__*Optional*__
 **cdkVersionPinning**?⚠️ | <code>boolean</code> | Use pinned version instead of caret version for CDK.<br/>__*Default*__: false
 **clobber**?⚠️ | <code>boolean</code> | Add a `clobber` task which resets the repo to origin.<br/>__*Default*__: true

--- a/src/__tests__/__snapshots__/inventory.test.ts.snap
+++ b/src/__tests__/__snapshots__/inventory.test.ts.snap
@@ -1357,6 +1357,18 @@ Array [
         "type": "unknown",
       },
       Object {
+        "default": "true",
+        "docs": "If this is enabled (default), all modules declared in \`cdkDependencies\` will be also added as normal \`dependencies\` (as well as \`peerDependencies\`).",
+        "name": "cdkDependenciesAsDeps",
+        "optional": true,
+        "parent": "AwsCdkConstructLibraryOptions",
+        "path": Array [
+          "cdkDependenciesAsDeps",
+        ],
+        "switch": "cdk-dependencies-as-deps",
+        "type": "boolean",
+      },
+      Object {
         "docs": "AWS CDK modules required for testing.",
         "name": "cdkTestDependencies",
         "optional": true,

--- a/src/__tests__/__snapshots__/new.test.ts.snap
+++ b/src/__tests__/__snapshots__/new.test.ts.snap
@@ -132,6 +132,7 @@ const project = new AwsCdkConstructLibrary({
   /* AwsCdkConstructLibraryOptions */
   // cdkAssert: true,                                                          /* Install the @aws-cdk/assert library? */
   // cdkDependencies: undefined,                                               /* Which AWS CDK modules (those that start with \\"@aws-cdk/\\") does this library require when consumed? */
+  // cdkDependenciesAsDeps: true,                                              /* If this is enabled (default), all modules declared in \`cdkDependencies\` will be also added as normal \`dependencies\` (as well as \`peerDependencies\`). */
   // cdkTestDependencies: undefined,                                           /* AWS CDK modules required for testing. */
   // cdkVersionPinning: false,                                                 /* Use pinned version instead of caret version for CDK. */
 

--- a/src/awscdk-construct.ts
+++ b/src/awscdk-construct.ts
@@ -30,9 +30,10 @@ export interface AwsCdkConstructLibraryOptions extends ConstructLibraryOptions {
   /**
    * If this is enabled (default), all modules declared in `cdkDependencies` will be also added as normal `dependencies` (as well as `peerDependencies`).
    *
-   * This is to ensure that downstream consumers actually have your cdk Dependencies installed
-   * when using npm < 7 or yarn, since theese don't install peerDependencies by default.
-   * If `false` `cdkDependencies` will be added to `devDependencies` to ensure they are present during development.
+   * This is to ensure that downstream consumers actually have your CDK dependencies installed
+   * when using npm < 7 or yarn, 
+where peer dependencies are not automatically installed. 
+   * If this is disabled, `cdkDependencies` will be added to `devDependencies` to ensure they are present during development.
    *
    * @default true
    */

--- a/src/awscdk-construct.ts
+++ b/src/awscdk-construct.ts
@@ -28,12 +28,13 @@ export interface AwsCdkConstructLibraryOptions extends ConstructLibraryOptions {
   readonly cdkDependencies?: string[];
 
   /**
-   * If this is enabled (default), all modules declared in `cdkDependencies` will be also added as normal `dependencies` (as well as `peerDependencies`).
+   * If this is enabled (default), all modules declared in `cdkDependencies` will be also added as
+   * normal `dependencies` (as well as `peerDependencies`).
    *
    * This is to ensure that downstream consumers actually have your CDK dependencies installed
-   * when using npm < 7 or yarn, 
-where peer dependencies are not automatically installed. 
-   * If this is disabled, `cdkDependencies` will be added to `devDependencies` to ensure they are present during development.
+   * when using npm < 7 or yarn, where peer dependencies are not automatically installed.
+   * If this is disabled, `cdkDependencies` will be added to `devDependencies` to ensure
+   * they are present during development.
    *
    * @default true
    */
@@ -125,7 +126,7 @@ export class AwsCdkConstructLibrary extends ConstructLibrary {
   public readonly version: string;
 
   /**
-   * Wether to add `cdkDependencies` to `dependencies`.
+   * Whether CDK dependencies are added as normal dependencies (and peer dependencies).
    */
   public readonly cdkDependenciesAsDeps: boolean
 

--- a/src/awscdk-construct.ts
+++ b/src/awscdk-construct.ts
@@ -28,6 +28,17 @@ export interface AwsCdkConstructLibraryOptions extends ConstructLibraryOptions {
   readonly cdkDependencies?: string[];
 
   /**
+   * If this is enabled (default), all modules declared in `cdkDependencies` will be also added as normal `dependencies` (as well as `peerDependencies`).
+   *
+   * This is to ensure that downstream consumers actually have your cdk Dependencies installed
+   * when using npm < 7 or yarn, since theese don't install peerDependencies by default.
+   * If `false` `cdkDependencies` will be added to `devDependencies` to ensure they are present during development.
+   *
+   * @default true
+   */
+  readonly cdkDependenciesAsDeps?: boolean;
+
+  /**
    * Install the @aws-cdk/assert library?
    * @default true
    */
@@ -112,6 +123,11 @@ export class AwsCdkConstructLibrary extends ConstructLibrary {
    */
   public readonly version: string;
 
+  /**
+   * Wether to add `cdkDependencies` to `dependencies`.
+   */
+  public readonly cdkDependenciesAsDeps: boolean
+
   constructor(options: AwsCdkConstructLibraryOptions) {
     super({
       ...options,
@@ -121,6 +137,7 @@ export class AwsCdkConstructLibrary extends ConstructLibrary {
     });
 
     this.version = options.cdkVersionPinning ? options.cdkVersion : `^${options.cdkVersion}`;
+    this.cdkDependenciesAsDeps = options.cdkDependenciesAsDeps ?? true;
 
     this.addPeerDeps('constructs@^3.2.27');
 
@@ -135,19 +152,25 @@ export class AwsCdkConstructLibrary extends ConstructLibrary {
   /**
    * Adds CDK modules as runtime dependencies.
    *
-   * Modules are currently added with a caret CDK version both as "dependencies"
+   * Modules are currently by default added with a caret CDK version both as "dependencies"
    * and "peerDependencies". This is because currently npm would not
    * automatically install peer dependencies that are not declared as concerete
    * dependencies by the consumer, so this is a little npm "hack" so that
    * consumers will not need to depend on them directly if they don't interact
    * with them.
+   * See `cdkDependenciesAsDeps` for changing the default behavior.
    *
    * @param deps names of cdk modules (e.g. `@aws-cdk/aws-lambda`).
    */
   public addCdkDependencies(...deps: string[]) {
     // this ugliness will go away in cdk v2.0
     this.addPeerDeps(...deps.map(m => this.formatModuleSpec(m)));
-    this.addDeps(...deps.map(m => this.formatModuleSpec(m)));
+
+    if (this.cdkDependenciesAsDeps) {
+      this.addDeps(...deps.map(m => this.formatModuleSpec(m)));
+    } else {
+      this.addDevDeps(...deps.map(m => this.formatModuleSpec(m)));
+    }
   }
 
   /**


### PR DESCRIPTION
Allows disabling the default behavior in which CDK dependencies are also added as normal dependencies (and not just peer dependencies).

Resolves #577

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.