### PR TITLE
fix(node): security vulnerability in rebuild-bot

### DIFF
--- a/.github/workflows/rebuild-bot.yml
+++ b/.github/workflows/rebuild-bot.yml
@@ -2,9 +2,6 @@
 
 name: rebuild-bot
 on:
-  issue_comment:
-    types:
-      - created
   workflow_dispatch: {}
 jobs:
   build:

--- a/src/__tests__/__snapshots__/integ.test.ts.snap
+++ b/src/__tests__/__snapshots__/integ.test.ts.snap
@@ -317,9 +317,6 @@ jobs:
 
 name: rebuild-bot
 on:
-  issue_comment:
-    types:
-      - created
   workflow_dispatch: {}
 jobs:
   build:
@@ -4206,9 +4203,6 @@ jobs:
 
 name: rebuild-bot
 on:
-  issue_comment:
-    types:
-      - created
   workflow_dispatch: {}
 jobs:
   build:


### PR DESCRIPTION
To address a security issue, the `@projen rebuild` workflow will no longer be triggered by a comment on the pull request. This commit removes the `issue_comment` trigger from rebuild-bot workflow so that this workflow can only be executed manually by administrators.

Additional details will be provided at a future date.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.