### PR TITLE
fix(cleanup): some projen synthesized files are left orphaned

### DIFF
--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -15,7 +15,7 @@ export function cleanup(dir: string, exclude: string[]) {
 }
 
 function findGeneratedFiles(dir: string, exclude: string[]) {
-  const ignore = [...readGitIgnore(dir), 'node_modules/**', ...exclude];
+  const ignore = [...readGitIgnore(dir), 'node_modules/**', ...exclude, '.git/**'];
 
   const files = glob.sync('**', {
     ignore,
@@ -47,7 +47,9 @@ function readGitIgnore(dir: string) {
 
   return fs.readFileSync(filepath, 'utf-8')
     .split('\n')
+    .filter(x => x?.trim() !== '')
     .filter(x => !x.startsWith('#') && !x.startsWith('!'))
+    .map(x => x.replace(/^\//, '')) // remove "/" prefix
     .map(x => `${x}\n${x}/**`)
     .join('\n')
     .split('\n');


### PR DESCRIPTION
The code that parses gitignore had some issues that caused some files not to be located by projen's cleanup command.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.