### PR TITLE
chore: update xmlbuilder2 dependency

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -101,6 +101,10 @@
       "type": "build"
     },
     {
+      "name": "@campionfellin/xmlbuilder2",
+      "type": "bundled"
+    },
+    {
       "name": "@iarna/toml",
       "type": "bundled"
     },
@@ -127,10 +131,6 @@
     },
     {
       "name": "semver",
-      "type": "bundled"
-    },
-    {
-      "name": "xmlbuilder2",
       "type": "bundled"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -29,7 +29,7 @@ const project = new JsiiProject({
     'inquirer',
     'chalk',
     '@iarna/toml',
-    'xmlbuilder2',
+    '@campionfellin/xmlbuilder2',
   ],
 
   devDeps: [

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "typescript": "^3.9.5"
   },
   "dependencies": {
+    "@campionfellin/xmlbuilder2": "^2.4.2",
     "@iarna/toml": "^2.2.5",
     "chalk": "^4.1.0",
     "decamelize": "^4.0.0",
@@ -69,11 +70,11 @@
     "glob": "^7",
     "inquirer": "^7.3.3",
     "semver": "^7.3.2",
-    "xmlbuilder2": "^2.4.0",
     "yaml": "^1.10.0",
     "yargs": "^16.2.0"
   },
   "bundledDependencies": [
+    "@campionfellin/xmlbuilder2",
     "@iarna/toml",
     "chalk",
     "decamelize",
@@ -81,7 +82,6 @@
     "glob",
     "inquirer",
     "semver",
-    "xmlbuilder2",
     "yaml",
     "yargs"
   ],

--- a/src/xmlfile.ts
+++ b/src/xmlfile.ts
@@ -1,4 +1,4 @@
-import { create as createxml } from 'xmlbuilder2';
+import { create as createxml } from '@campionfellin/xmlbuilder2';
 import { IResolver } from './file';
 import { ObjectFile, ObjectFileOptions } from './object-file';
 import { Project } from './project';

--- a/yarn.lock
+++ b/yarn.lock
@@ -277,6 +277,17 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@campionfellin/xmlbuilder2@^2.4.2":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@campionfellin/xmlbuilder2/-/xmlbuilder2-2.4.2.tgz#efa1e3763da83dc9f1b2ea25758921ec4b85be63"
+  integrity sha512-oKKxHbRC1ps2j0VCzQjrsW3BCI49q524YdWdA2x3WCQr2iheOgP/5VwhYBoHnY8SK7LTpJXLguyNR453dyE/Aw==
+  dependencies:
+    "@oozcitak/dom" "1.15.8"
+    "@oozcitak/infra" "1.0.8"
+    "@oozcitak/util" "8.3.8"
+    "@types/node" "*"
+    js-yaml "3.14.0"
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -677,11 +688,6 @@
   version "14.14.20"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.20.tgz#f7974863edd21d1f8a494a73e8e2b3658615c340"
   integrity sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A==
-
-"@types/node@14.6.2":
-  version "14.6.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.2.tgz#264b44c5a28dfa80198fc2f7b6d3c8a054b9491f"
-  integrity sha512-onlIwbaeqvZyniGPfdw/TEhKIh79pz66L1q06WUQqJLnAb6wbjvOtepLYTGHTqzdXgBYIE3ZdmqHDGsRsbBz7A==
 
 "@types/node@^10.17.0":
   version "10.17.55"
@@ -6108,17 +6114,6 @@ xml@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
   integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
-
-xmlbuilder2@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/xmlbuilder2/-/xmlbuilder2-2.4.0.tgz#fb6c5171bef1bcb984c88cfef5210e17b7b841cd"
-  integrity sha512-KrOVUGD65xTQ7ZA+GMQGdBSpe1Ufu5ylCQSYVk6QostySDkxPmAQ0WWIu7dR3JjLfVbF22RFQX7KyrZ6VTLcQg==
-  dependencies:
-    "@oozcitak/dom" "1.15.8"
-    "@oozcitak/infra" "1.0.8"
-    "@oozcitak/util" "8.3.8"
-    "@types/node" "14.6.2"
-    js-yaml "3.14.0"
 
 xmlbuilder@^15.1.1:
   version "15.1.1"


### PR DESCRIPTION
I am hoping that this will fix https://github.com/projen/projen/issues/498

You can see the diff between the current `xmlbuilder2` library and my fork of it here - 

https://github.com/oozcitak/xmlbuilder2/compare/master...campionfellin:master

Basically, just changing the dependency on `@types/node` from `14.6.2` to `*`


Signed-off-by: campionfellin <campionfellin@gmail.com>

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.