### PR TITLE
feat: allow users to customize the publisher workflow image

### DIFF
--- a/API.md
+++ b/API.md
@@ -3163,7 +3163,7 @@ new Publisher(project: Project, options: PublisherOptions)
   * **buildJobId** (<code>string</code>)  The job ID that produces the build artifacts. 
   * **workflow** (<code>[github.GithubWorkflow](#projen-github-githubworkflow)</code>)  The github workflow to add release jobs to. 
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement for `jsii-release`. __*Default*__: "latest"
-  * **workflowContainerImage** (<code>string</code>)  Container image to use for GitHub workflows. __*Default*__: 'jsii/superchain'
+  * **workflowImage** (<code>string</code>)  Container image to use for GitHub workflows. __*Default*__: 'jsii/superchain'
 
 
 
@@ -3176,7 +3176,7 @@ Name | Type | Description
 **buildJobId**🔹 | <code>string</code> | <span></span>
 **jsiiReleaseVersion**🔹 | <code>string</code> | <span></span>
 **workflow**🔹 | <code>[github.GithubWorkflow](#projen-github-githubworkflow)</code> | <span></span>
-**workflowContainerImage**🔹 | <code>string</code> | <span></span>
+**workflowImage**🔹 | <code>string</code> | <span></span>
 
 ### Methods
 
@@ -8308,7 +8308,7 @@ Name | Type | Description
 **buildJobId**🔹 | <code>string</code> | The job ID that produces the build artifacts.
 **workflow**🔹 | <code>[github.GithubWorkflow](#projen-github-githubworkflow)</code> | The github workflow to add release jobs to.
 **jsiiReleaseVersion**?🔹 | <code>string</code> | Version requirement for `jsii-release`.<br/>__*Default*__: "latest"
-**workflowContainerImage**?🔹 | <code>string</code> | Container image to use for GitHub workflows.<br/>__*Default*__: 'jsii/superchain'
+**workflowImage**?🔹 | <code>string</code> | Container image to use for GitHub workflows.<br/>__*Default*__: 'jsii/superchain'
 
 
 

--- a/API.md
+++ b/API.md
@@ -3163,6 +3163,7 @@ new Publisher(project: Project, options: PublisherOptions)
   * **buildJobId** (<code>string</code>)  The job ID that produces the build artifacts. 
   * **workflow** (<code>[github.GithubWorkflow](#projen-github-githubworkflow)</code>)  The github workflow to add release jobs to. 
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement for `jsii-release`. __*Default*__: "latest"
+  * **workflowContainerImage** (<code>string</code>)  Container image to use for GitHub workflows. __*Default*__: 'jsii/superchain'
 
 
 
@@ -3175,6 +3176,7 @@ Name | Type | Description
 **buildJobId**🔹 | <code>string</code> | <span></span>
 **jsiiReleaseVersion**🔹 | <code>string</code> | <span></span>
 **workflow**🔹 | <code>[github.GithubWorkflow](#projen-github-githubworkflow)</code> | <span></span>
+**workflowContainerImage**🔹 | <code>string</code> | <span></span>
 
 ### Methods
 
@@ -8306,6 +8308,7 @@ Name | Type | Description
 **buildJobId**🔹 | <code>string</code> | The job ID that produces the build artifacts.
 **workflow**🔹 | <code>[github.GithubWorkflow](#projen-github-githubworkflow)</code> | The github workflow to add release jobs to.
 **jsiiReleaseVersion**?🔹 | <code>string</code> | Version requirement for `jsii-release`.<br/>__*Default*__: "latest"
+**workflowContainerImage**?🔹 | <code>string</code> | Container image to use for GitHub workflows.<br/>__*Default*__: 'jsii/superchain'
 
 
 

--- a/src/__tests__/node-project.test.ts
+++ b/src/__tests__/node-project.test.ts
@@ -304,6 +304,19 @@ test('buildWorkflowMutable will push changes to PR branches', () => {
   expect(workflow.jobs.build.steps).toMatchSnapshot();
 });
 
+test('workflowContainerImage propagates to the release workflow', () => {
+  // WHEN
+  const project = new TestNodeProject({
+    workflowContainerImage: 'some-other-workflow-image',
+    releaseToNpm: true,
+  });
+
+  // THEN
+  const workflowYaml = synthSnapshot(project)['.github/workflows/release.yml'];
+  const workflow = yaml.parse(workflowYaml);
+  expect(workflow.jobs.release_npm.container.image).toEqual('some-other-workflow-image');
+});
+
 function packageJson(project: Project) {
   return synthSnapshot(project)['package.json'];
 }

--- a/src/__tests__/node-project.test.ts
+++ b/src/__tests__/node-project.test.ts
@@ -307,7 +307,7 @@ test('buildWorkflowMutable will push changes to PR branches', () => {
 test('workflowImage propagates to the release workflow', () => {
   // WHEN
   const project = new TestNodeProject({
-    workflowContainerImage: 'some-other-workflow-image',
+    workflowImage: 'some-other-workflow-image',
     releaseToNpm: true,
   });
 

--- a/src/__tests__/node-project.test.ts
+++ b/src/__tests__/node-project.test.ts
@@ -304,7 +304,7 @@ test('buildWorkflowMutable will push changes to PR branches', () => {
   expect(workflow.jobs.build.steps).toMatchSnapshot();
 });
 
-test('workflowContainerImage propagates to the release workflow', () => {
+test('workflowImage propagates to the release workflow', () => {
   // WHEN
   const project = new TestNodeProject({
     workflowContainerImage: 'some-other-workflow-image',

--- a/src/node-project.ts
+++ b/src/node-project.ts
@@ -612,7 +612,7 @@ export class NodeProject extends Project {
         artifactName: artifactDirectory,
         buildJobId,
         jsiiReleaseVersion: options.jsiiReleaseVersion,
-        workflowContainerImage: options.workflowContainerImage,
+        workflowImage: options.workflowContainerImage,
       });
 
       if (options.releaseToNpm ?? false) {

--- a/src/node-project.ts
+++ b/src/node-project.ts
@@ -612,6 +612,7 @@ export class NodeProject extends Project {
         artifactName: artifactDirectory,
         buildJobId,
         jsiiReleaseVersion: options.jsiiReleaseVersion,
+        workflowContainerImage: options.workflowContainerImage,
       });
 
       if (options.releaseToNpm ?? false) {

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -18,7 +18,7 @@ export interface PublisherOptions {
    *
    * @default - 'jsii/superchain'
    */
-  readonly workflowContainerImage?: string;
+  readonly workflowImage?: string;
 
   /**
    * The job ID that produces the build artifacts. All publish jobs will take a dependency on this job.
@@ -54,7 +54,7 @@ export class Publisher extends Component {
   public readonly buildJobId: string;
   public readonly artifactName: string;
   public readonly jsiiReleaseVersion: string;
-  public readonly workflowContainerImage: string;
+  public readonly workflowImage: string;
 
   constructor(project: Project, options: PublisherOptions) {
     super(project);
@@ -62,7 +62,7 @@ export class Publisher extends Component {
     this.workflow = options.workflow;
     this.buildJobId = options.buildJobId;
     this.artifactName = options.artifactName;
-    this.workflowContainerImage = options.workflowContainerImage ?? 'jsii/superchain';
+    this.workflowImage = options.workflowImage ?? 'jsii/superchain';
     this.jsiiReleaseVersion = options.jsiiReleaseVersion ?? JSII_RELEASE_VERSION;
   }
 
@@ -78,7 +78,7 @@ export class Publisher extends Component {
         'needs': this.buildJobId,
         'runs-on': 'ubuntu-latest',
         'container': {
-          image: this.workflowContainerImage,
+          image: this.workflowImage,
         },
         'steps': [
           this.renderDownloadArtifactStep(),

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -14,6 +14,13 @@ export interface PublisherOptions {
   readonly workflow: GithubWorkflow;
 
   /**
+   * Container image to use for GitHub workflows.
+   *
+   * @default - 'jsii/superchain'
+   */
+  readonly workflowContainerImage?: string;
+
+  /**
    * The job ID that produces the build artifacts. All publish jobs will take a dependency on this job.
    */
   readonly buildJobId: string;
@@ -47,6 +54,7 @@ export class Publisher extends Component {
   public readonly buildJobId: string;
   public readonly artifactName: string;
   public readonly jsiiReleaseVersion: string;
+  public readonly workflowContainerImage: string;
 
   constructor(project: Project, options: PublisherOptions) {
     super(project);
@@ -54,6 +62,7 @@ export class Publisher extends Component {
     this.workflow = options.workflow;
     this.buildJobId = options.buildJobId;
     this.artifactName = options.artifactName;
+    this.workflowContainerImage = options.workflowContainerImage ?? 'jsii/superchain';
     this.jsiiReleaseVersion = options.jsiiReleaseVersion ?? JSII_RELEASE_VERSION;
   }
 
@@ -69,7 +78,7 @@ export class Publisher extends Component {
         'needs': this.buildJobId,
         'runs-on': 'ubuntu-latest',
         'container': {
-          image: 'jsii/superchain',
+          image: this.workflowContainerImage,
         },
         'steps': [
           this.renderDownloadArtifactStep(),


### PR DESCRIPTION
This PR allows the user to customize the release workflow image as it was previously hard-coded.

#639 prompted this PR as I needed a short-term workaround for the `jsii/superchain` regression.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.