### PR TITLE
feat(python): pipenv support

### DIFF
--- a/API.md
+++ b/API.md
@@ -56,6 +56,8 @@ Name|Description
 [java.Pom](#projen-java-pom)|A Project Object Model or POM is the fundamental unit of work in Maven.
 [java.Projenrc](#projen-java-projenrc)|Allows writing projenrc files in java.
 [python.Pip](#projen-python-pip)|Manages dependencies using a requirements.txt file and the pip CLI tool.
+[python.Pipenv](#projen-python-pipenv)|Manage project dependencies and virtual environments through the Pipenv CLI tool.
+[python.PipenvPipfile](#projen-python-pipenvpipfile)|Represents configuration of a Pipfile file for a Pipenv project.
 [python.Poetry](#projen-python-poetry)|Manage project dependencies, virtual environments, and packaging through the poetry CLI tool.
 [python.PoetryPyproject](#projen-python-poetrypyproject)|Represents configuration of a pyproject.toml file for a Poetry project.
 [python.Pytest](#projen-python-pytest)|*No description*
@@ -168,6 +170,9 @@ Name|Description
 [java.ProjenrcCommonOptions](#projen-java-projenrccommonoptions)|Options for `Projenrc`.
 [java.ProjenrcOptions](#projen-java-projenrcoptions)|*No description*
 [python.PipOptions](#projen-python-pipoptions)|Options for pip.
+[python.PipenvOptions](#projen-python-pipenvoptions)|*No description*
+[python.PipenvPipfileOptions](#projen-python-pipenvpipfileoptions)|*No description*
+[python.PipenvPipfileOptionsWithoutDeps](#projen-python-pipenvpipfileoptionswithoutdeps)|*No description*
 [python.PoetryPyprojectOptions](#projen-python-poetrypyprojectoptions)|*No description*
 [python.PoetryPyprojectOptionsWithoutDeps](#projen-python-poetrypyprojectoptionswithoutdeps)|*No description*
 [python.PytestOptions](#projen-python-pytestoptions)|*No description*
@@ -4933,6 +4938,126 @@ installDependencies(): void
 
 
 
+## class Pipenv 🔹 <a id="projen-python-pipenv"></a>
+
+Manage project dependencies and virtual environments through the Pipenv CLI tool.
+
+__Implements__: [python.IPythonDeps](#projen-python-ipythondeps), [python.IPythonEnv](#projen-python-ipythonenv)
+__Submodule__: python
+
+__Extends__: [Component](#projen-component)
+
+### Initializer
+
+
+
+
+```ts
+new python.Pipenv(project: PythonProject, options: PipenvOptions)
+```
+
+* **project** (<code>[python.PythonProject](#projen-python-pythonproject)</code>)  *No description*
+* **options** (<code>[python.PipenvOptions](#projen-python-pipenvoptions)</code>)  *No description*
+  * **pipfileOptions** (<code>[python.PipenvPipfileOptionsWithoutDeps](#projen-python-pipenvpipfileoptionswithoutdeps)</code>)  Options to pass through to the Pipfile. __*Optional*__
+
+
+
+### Properties
+
+
+Name | Type | Description 
+-----|------|-------------
+**installTask**🔹 | <code>[tasks.Task](#projen-tasks-task)</code> | A task that installs and updates dependencies.
+
+### Methods
+
+
+#### addDependency(spec)🔹 <a id="projen-python-pipenv-adddependency"></a>
+
+Adds a runtime dependency.
+
+```ts
+addDependency(spec: string): void
+```
+
+* **spec** (<code>string</code>)  Format `<module>@<semver>`.
+
+
+
+
+#### addDevDependency(spec)🔹 <a id="projen-python-pipenv-adddevdependency"></a>
+
+Adds a dev dependency.
+
+```ts
+addDevDependency(spec: string): void
+```
+
+* **spec** (<code>string</code>)  Format `<module>@<semver>`.
+
+
+
+
+#### installDependencies()🔹 <a id="projen-python-pipenv-installdependencies"></a>
+
+Installs dependencies (called during post-synthesis).
+
+```ts
+installDependencies(): void
+```
+
+
+
+
+
+#### setupEnvironment()🔹 <a id="projen-python-pipenv-setupenvironment"></a>
+
+Initializes the virtual environment if it doesn't exist (called during post-synthesis).
+
+```ts
+setupEnvironment(): void
+```
+
+
+
+
+
+
+
+## class PipenvPipfile 🔹 <a id="projen-python-pipenvpipfile"></a>
+
+Represents configuration of a Pipfile file for a Pipenv project.
+
+__Submodule__: python
+
+__Extends__: [Component](#projen-component)
+
+### Initializer
+
+
+
+
+```ts
+new python.PipenvPipfile(project: PythonProject, options: PipenvPipfileOptions)
+```
+
+* **project** (<code>[python.PythonProject](#projen-python-pythonproject)</code>)  *No description*
+* **options** (<code>[python.PipenvPipfileOptions](#projen-python-pipenvpipfileoptions)</code>)  *No description*
+  * **pythonVersion** (<code>string</code>)  Version of python for Pipenv to use. __*Default*__: "3"
+  * **dependencies** (<code>Map<string, any></code>)  A list of dependencies for the project. __*Optional*__
+  * **devDependencies** (<code>Map<string, any></code>)  A list of development dependencies for the project. __*Optional*__
+
+
+
+### Properties
+
+
+Name | Type | Description 
+-----|------|-------------
+**file**🔹 | <code>[TomlFile](#projen-tomlfile)</code> | <span></span>
+
+
+
 ## class Poetry 🔹 <a id="projen-python-poetry"></a>
 
 Manage project dependencies, virtual environments, and packaging through the poetry CLI tool.
@@ -5154,6 +5279,8 @@ new python.PythonProject(options: PythonProjectOptions)
   * **deps** (<code>Array<string></code>)  List of runtime dependencies for this project. __*Default*__: []
   * **devDeps** (<code>Array<string></code>)  List of dev dependencies for this project. __*Default*__: []
   * **pip** (<code>boolean</code>)  Use pip with a requirements.txt file to track project dependencies. __*Default*__: true
+  * **pipenv** (<code>boolean</code>)  Use pipenv to manage your project dependencies and virtual environment. __*Default*__: false
+  * **pipenvOptions** (<code>[python.PipenvOptions](#projen-python-pipenvoptions)</code>)  pipenv options. __*Default*__: defaults
   * **poetry** (<code>boolean</code>)  Use poetry to manage your project dependencies, virtual environment, and (optional) packaging/publishing. __*Default*__: false
   * **pytest** (<code>boolean</code>)  Include pytest tests. __*Default*__: true
   * **pytestOptions** (<code>[python.PytestOptions](#projen-python-pytestoptions)</code>)  pytest options. __*Default*__: defaults
@@ -9057,7 +9184,7 @@ Name | Type | Description
 
 ## interface IPythonDeps 🔹 <a id="projen-python-ipythondeps"></a>
 
-__Implemented by__: [python.Pip](#projen-python-pip), [python.Poetry](#projen-python-poetry)
+__Implemented by__: [python.Pip](#projen-python-pip), [python.Pipenv](#projen-python-pipenv), [python.Poetry](#projen-python-poetry)
 
 
 
@@ -9113,7 +9240,7 @@ installDependencies(): void
 
 ## interface IPythonEnv 🔹 <a id="projen-python-ipythonenv"></a>
 
-__Implemented by__: [python.Poetry](#projen-python-poetry), [python.Venv](#projen-python-venv)
+__Implemented by__: [python.Pipenv](#projen-python-pipenv), [python.Poetry](#projen-python-poetry), [python.Venv](#projen-python-venv)
 
 
 ### Methods
@@ -9153,6 +9280,47 @@ Name | Type | Description
 
 
 Options for pip.
+
+
+## struct PipenvOptions 🔹 <a id="projen-python-pipenvoptions"></a>
+
+
+
+
+
+
+Name | Type | Description 
+-----|------|-------------
+**pipfileOptions**?🔹 | <code>[python.PipenvPipfileOptionsWithoutDeps](#projen-python-pipenvpipfileoptionswithoutdeps)</code> | Options to pass through to the Pipfile.<br/>__*Optional*__
+
+
+
+## struct PipenvPipfileOptions 🔹 <a id="projen-python-pipenvpipfileoptions"></a>
+
+
+
+
+
+
+Name | Type | Description 
+-----|------|-------------
+**dependencies**?🔹 | <code>Map<string, any></code> | A list of dependencies for the project.<br/>__*Optional*__
+**devDependencies**?🔹 | <code>Map<string, any></code> | A list of development dependencies for the project.<br/>__*Optional*__
+**pythonVersion**?🔹 | <code>string</code> | Version of python for Pipenv to use.<br/>__*Default*__: "3"
+
+
+
+## struct PipenvPipfileOptionsWithoutDeps 🔹 <a id="projen-python-pipenvpipfileoptionswithoutdeps"></a>
+
+
+
+
+
+
+Name | Type | Description 
+-----|------|-------------
+**pythonVersion**?🔹 | <code>string</code> | Version of python for Pipenv to use.<br/>__*Default*__: "3"
+
 
 
 ## struct PoetryPyprojectOptions 🔹 <a id="projen-python-poetrypyprojectoptions"></a>
@@ -9277,6 +9445,8 @@ Name | Type | Description
 **outdir**?🔹 | <code>string</code> | The root directory of the project.<br/>__*Default*__: "."
 **parent**?🔹 | <code>[Project](#projen-project)</code> | The parent project, if this project is part of a bigger project.<br/>__*Optional*__
 **pip**?🔹 | <code>boolean</code> | Use pip with a requirements.txt file to track project dependencies.<br/>__*Default*__: true
+**pipenv**?🔹 | <code>boolean</code> | Use pipenv to manage your project dependencies and virtual environment.<br/>__*Default*__: false
+**pipenvOptions**?🔹 | <code>[python.PipenvOptions](#projen-python-pipenvoptions)</code> | pipenv options.<br/>__*Default*__: defaults
 **poetry**?🔹 | <code>boolean</code> | Use poetry to manage your project dependencies, virtual environment, and (optional) packaging/publishing.<br/>__*Default*__: false
 **poetryOptions**?🔹 | <code>[python.PoetryPyprojectOptionsWithoutDeps](#projen-python-poetrypyprojectoptionswithoutdeps)</code> | Additional options to set for poetry if using poetry.<br/>__*Optional*__
 **projectType**?🔹 | <code>[ProjectType](#projen-projecttype)</code> | Which type of project this is (library/app).<br/>__*Default*__: ProjectType.UNKNOWN

--- a/docs/python.md
+++ b/docs/python.md
@@ -63,7 +63,7 @@ requirements. See the list below:
 - venv: environment manager
 - setuptools: packaging manager
 - poetry: dependency, environment, and packaging manager
-- pipenv (TBD): dependency and environment manager
+- pipenv: dependency and environment manager
 - conda (TBD): dependency and environment manager
 
 By default, pip, and venv will be used, along with setuptools if the project is a library:

--- a/src/__tests__/__snapshots__/inventory.test.ts.snap
+++ b/src/__tests__/__snapshots__/inventory.test.ts.snap
@@ -8257,6 +8257,30 @@ Array [
       },
       Object {
         "default": "false",
+        "docs": "Use pipenv to manage your project dependencies and virtual environment.",
+        "name": "pipenv",
+        "optional": true,
+        "parent": "PythonProjectOptions",
+        "path": Array [
+          "pipenv",
+        ],
+        "switch": "pipenv",
+        "type": "boolean",
+      },
+      Object {
+        "default": "- defaults",
+        "docs": "pipenv options.",
+        "name": "pipenvOptions",
+        "optional": true,
+        "parent": "PythonProjectOptions",
+        "path": Array [
+          "pipenvOptions",
+        ],
+        "switch": "pipenv-options",
+        "type": "PipenvOptions",
+      },
+      Object {
+        "default": "false",
         "docs": "Use poetry to manage your project dependencies, virtual environment, and (optional) packaging/publishing.",
         "name": "poetry",
         "optional": true,

--- a/src/__tests__/__snapshots__/new.test.ts.snap
+++ b/src/__tests__/__snapshots__/new.test.ts.snap
@@ -860,6 +860,8 @@ const project = new python.PythonProject({
   // deps: [],                             /* List of runtime dependencies for this project. */
   // devDeps: [],                          /* List of dev dependencies for this project. */
   // pip: true,                            /* Use pip with a requirements.txt file to track project dependencies. */
+  // pipenv: false,                        /* Use pipenv to manage your project dependencies and virtual environment. */
+  // pipenvOptions: undefined,             /* pipenv options. */
   // poetry: false,                        /* Use poetry to manage your project dependencies, virtual environment, and (optional) packaging/publishing. */
   // pytest: true,                         /* Include pytest tests. */
   // pytestOptions: undefined,             /* pytest options. */

--- a/src/__tests__/python/pipenv.test.ts
+++ b/src/__tests__/python/pipenv.test.ts
@@ -1,0 +1,37 @@
+import { synthSnapshot } from '../util';
+import { TestPythonProject } from './util';
+
+test('pipenv enabled', () => {
+  const p = new TestPythonProject({
+    venv: false,
+    pip: false,
+    pipenv: true,
+    deps: ['requests@*'],
+  });
+
+  const snapshot = synthSnapshot(p);
+  expect(snapshot.Pipfile).toContain('[[source]]');
+  expect(snapshot.Pipfile).toContain('[packages]');
+  expect(snapshot.Pipfile).toContain('[dev-packages]');
+  expect(snapshot.Pipfile).toContain('python_version = \"3\"');
+});
+
+test('pipenv custom python version', () => {
+  const p = new TestPythonProject({
+    venv: false,
+    pip: false,
+    pipenv: true,
+    deps: ['requests@*'],
+    pipenvOptions: {
+      pipfileOptions: {
+        pythonVersion: '3.9',
+      },
+    },
+  });
+
+  const snapshot = synthSnapshot(p);
+  expect(snapshot.Pipfile).toContain('[[source]]');
+  expect(snapshot.Pipfile).toContain('[packages]');
+  expect(snapshot.Pipfile).toContain('[dev-packages]');
+  expect(snapshot.Pipfile).toContain('python_version = \"3.9\"');
+});

--- a/src/__tests__/python/poetry.test.ts
+++ b/src/__tests__/python/poetry.test.ts
@@ -1,6 +1,5 @@
-import { LogLevel } from '../../logger';
-import { PythonProject, PythonProjectOptions } from '../../python';
-import { mkdtemp, synthSnapshot } from '../util';
+import { synthSnapshot } from '../util';
+import { TestPythonProject } from './util';
 
 test('poetry enabled', () => {
   const p = new TestPythonProject({
@@ -24,20 +23,3 @@ test('poetry enabled', () => {
   expect(snapshot['pyproject.toml']).toContain('Apache-2.0');
   expect(snapshot['pyproject.toml']).toContain('Development Status :: 4 - Beta');
 });
-
-class TestPythonProject extends PythonProject {
-  constructor(options: Partial<PythonProjectOptions> = { }) {
-    super({
-      ...options,
-      clobber: false,
-      name: 'test-python-project',
-      moduleName: 'test_python_project',
-      authorName: 'First Last',
-      authorEmail: 'email@example.com',
-      version: '0.1.0',
-      outdir: mkdtemp(),
-      logging: { level: LogLevel.OFF },
-      jsiiFqn: 'projen.python.PythonProject',
-    });
-  }
-}

--- a/src/__tests__/python/python-project.test.ts
+++ b/src/__tests__/python/python-project.test.ts
@@ -1,6 +1,5 @@
-import { LogLevel } from '../../logger';
-import { PythonProject, PythonProjectOptions } from '../../python';
-import { mkdtemp, synthSnapshot } from '../util';
+import { synthSnapshot } from '../util';
+import { TestPythonProject } from './util';
 
 test('defaults', () => {
   const p = new TestPythonProject();
@@ -46,19 +45,3 @@ test('pytest maxfailures', () => {
   expect(synthSnapshot(p)['.projen/tasks.json'].tasks.test.steps[0].exec).toContain('--maxfail=3');
 });
 
-class TestPythonProject extends PythonProject {
-  constructor(options: Partial<PythonProjectOptions> = { }) {
-    super({
-      ...options,
-      clobber: false,
-      name: 'test-python-project',
-      moduleName: 'test_python_project',
-      authorName: 'First Last',
-      authorEmail: 'email@example.com',
-      version: '0.1.0',
-      outdir: mkdtemp(),
-      logging: { level: LogLevel.OFF },
-      jsiiFqn: 'projen.python.PythonProject',
-    });
-  }
-}

--- a/src/__tests__/python/util.ts
+++ b/src/__tests__/python/util.ts
@@ -1,0 +1,20 @@
+import { LogLevel } from '../../logger';
+import { PythonProject, PythonProjectOptions } from '../../python';
+import { mkdtemp } from '../util';
+
+export class TestPythonProject extends PythonProject {
+  constructor(options: Partial<PythonProjectOptions> = {}) {
+    super({
+      ...options,
+      clobber: false,
+      name: 'test-python-project',
+      moduleName: 'test_python_project',
+      authorName: 'First Last',
+      authorEmail: 'email@example.com',
+      version: '0.1.0',
+      outdir: mkdtemp(),
+      logging: { level: LogLevel.OFF },
+      jsiiFqn: 'projen.python.PythonProject',
+    });
+  }
+}

--- a/src/python/index.ts
+++ b/src/python/index.ts
@@ -1,4 +1,5 @@
 export * from './pip';
+export * from './pipenv';
 export * from './poetry';
 export * from './pytest';
 export * from './python-env';

--- a/src/python/pipenv.ts
+++ b/src/python/pipenv.ts
@@ -1,0 +1,162 @@
+import { Component } from '../component';
+import { DependencyType } from '../deps';
+import { Task, TaskCategory } from '../tasks';
+import { TomlFile } from '../toml';
+import { exec, execOrUndefined } from '../util';
+import { IPythonDeps } from './python-deps';
+import { IPythonEnv } from './python-env';
+import { PythonProject } from './python-project';
+
+
+export interface PipenvOptions {
+  /**
+   * Options to pass through to the Pipfile
+   */
+  readonly pipfileOptions?: PipenvPipfileOptionsWithoutDeps;
+}
+/**
+ * Manage project dependencies and virtual environments through the
+ * Pipenv CLI tool.
+ */
+export class Pipenv extends Component implements IPythonDeps, IPythonEnv {
+  public readonly installTask: Task;
+
+
+  constructor(project: PythonProject, options: PipenvOptions) {
+    super(project);
+
+    this.installTask = project.addTask('install', {
+      description: 'Install and upgrade dependencies',
+      category: TaskCategory.BUILD,
+      exec: 'pipenv update',
+    });
+
+    this.project.tasks.addEnvironment('VIRTUAL_ENV', '$(pipenv --venv)');
+    this.project.tasks.addEnvironment('PATH', '$(echo $(pipenv --venv)/bin:$PATH)');
+
+    new PipenvPipfile(project, {
+      ...options.pipfileOptions,
+      dependencies: () => this.synthDependencies(),
+      devDependencies: () => this.synthDevDependencies(),
+    });
+  }
+
+  private synthDependencies() {
+    const dependencies: { [key: string]: any } = {};
+    for (const pkg of this.project.deps.all) {
+      if (pkg.type === DependencyType.RUNTIME) {
+        dependencies[pkg.name] = pkg.version;
+      }
+    }
+    return dependencies;
+  }
+
+  private synthDevDependencies() {
+    const dependencies: { [key: string]: any } = {};
+    for (const pkg of this.project.deps.all) {
+      if ([DependencyType.DEVENV].includes(pkg.type)) {
+        dependencies[pkg.name] = pkg.version;
+      }
+    }
+    return dependencies;
+  }
+
+  /**
+   * Adds a runtime dependency.
+   *
+   * @param spec Format `<module>@<semver>`
+   */
+  public addDependency(spec: string): void {
+    this.project.deps.addDependency(spec, DependencyType.RUNTIME);
+  }
+
+  /**
+   * Adds a dev dependency.
+   *
+   * @param spec Format `<module>@<semver>`
+   */
+  public addDevDependency(spec: string): void {
+    this.project.deps.addDependency(spec, DependencyType.DEVENV);
+  }
+
+  /**
+   * Initializes the virtual environment if it doesn't exist (called during post-synthesis).
+   */
+  public setupEnvironment(): void {
+    const result = execOrUndefined('which pipenv', { cwd: this.project.outdir });
+    if (!result) {
+      this.project.logger.info('Unable to setup an environment since pipenv is not installed. Please install pipenv (https://pipenv.pypa.io/en/latest/install/) or use a different component for managing environments such as \'venv\'.');
+    }
+
+    let envPath = execOrUndefined('pipenv --venv', { cwd: this.project.outdir });
+    if (!envPath) {
+      this.project.logger.info('Setting up a virtual environment...');
+      exec('pipenv --three', { cwd: this.project.outdir });
+      envPath = execOrUndefined('pipenv --venv', { cwd: this.project.outdir });
+      this.project.logger.info(`Environment successfully created (located in ${envPath}}).`);
+    }
+  }
+
+  /**
+   * Installs dependencies (called during post-synthesis).
+   */
+  public installDependencies() {
+    this.project.logger.info('Installing dependencies...');
+    exec(this.installTask.toShellCommand(), { cwd: this.project.outdir });
+  }
+}
+
+export interface PipenvPipfileOptionsWithoutDeps {
+  /**
+   * Version of python for Pipenv to use
+   *
+   * @default "3"
+   */
+  readonly pythonVersion?: string;
+}
+
+export interface PipenvPipfileOptions extends PipenvPipfileOptionsWithoutDeps {
+  /**
+   * A list of dependencies for the project.
+   *
+   * @example { requests: "^2.13.0" }
+   */
+  readonly dependencies?: { [key: string]: any };
+
+  /**
+   * A list of development dependencies for the project.
+   *
+   * @example { requests: "^2.13.0" }
+   */
+  readonly devDependencies?: { [key: string]: any };
+}
+
+/**
+ * Represents configuration of a Pipfile file for a Pipenv project.
+ *
+ * @see https://github.com/pypa/pipfile
+ */
+export class PipenvPipfile extends Component {
+  public readonly file: TomlFile;
+
+  constructor(project: PythonProject, options: PipenvPipfileOptions) {
+    super(project);
+
+    this.file = new TomlFile(project, 'Pipfile', {
+      marker: true,
+      omitEmpty: false,
+      obj: {
+        'source': [{
+          name: 'pypi',
+          url: 'https://pypi.python.org/simple',
+          verify_ssl: true,
+        }],
+        'packages': options.dependencies,
+        'dev-packages': options.devDependencies,
+        'requires': {
+          python_version: options.pythonVersion ?? '3',
+        },
+      },
+    });
+  }
+}

--- a/src/python/python-project.ts
+++ b/src/python/python-project.ts
@@ -1,5 +1,6 @@
 import { Project, ProjectOptions, ProjectType } from '../project';
 import { Pip } from './pip';
+import { Pipenv, PipenvOptions } from './pipenv';
 import { Poetry } from './poetry';
 import { Pytest, PytestOptions } from './pytest';
 import { IPythonDeps } from './python-deps';
@@ -88,6 +89,19 @@ export interface PythonProjectOptions extends ProjectOptions, PythonPackagingOpt
    * @default false
    */
   readonly poetry?: boolean;
+
+  /**
+   * Use pipenv to manage your project dependencies and virtual environment
+   *
+   * @default false
+   */
+  readonly pipenv?: boolean;
+
+  /**
+   * pipenv options
+   * @default - defaults
+   */
+  readonly pipenvOptions?: PipenvOptions;
 
   // -- optional components --
 
@@ -183,10 +197,13 @@ export class PythonProject extends Project {
     //   this.envManager = this.depsManager;
     // }
 
-    // if (options.pipenv ?? false) {
-    //   this.depsManager = new Pipenv(this, options);
-    //   this.envManager = this.depsManager;
-    // }
+    if (options.pipenv ?? false) {
+      const pipenv = new Pipenv(this, {
+        ...options.pipenvOptions,
+      });
+      this.depsManager = pipenv;
+      this.envManager = pipenv;
+    }
 
     if (options.poetry ?? false) {
       const poetry = new Poetry(this, {
@@ -219,11 +236,11 @@ export class PythonProject extends Project {
       throw new Error('At least one tool must be chosen for managing packaging (setuptools or poetry).');
     }
 
-    if (Number(options.venv ?? true) + Number(options.poetry ?? false) > 1) {
+    if (Number(options.venv ?? true) + Number(options.poetry ?? false) + Number(options.pipenv ?? false) > 1) {
       throw new Error('More than one component has been chosen for managing the environment (venv, conda, pipenv, or poetry)');
     }
 
-    if (Number(options.pip ?? true) + Number(options.poetry ?? false) > 1) {
+    if (Number(options.pip ?? true) + Number(options.poetry ?? false) + Number(options.pipenv ?? false) > 1) {
       throw new Error('More than one component has been chosen for managing dependencies (pip, conda, pipenv, or poetry)');
     }
 


### PR DESCRIPTION
This PR adds the ability for python projects to use Pipenv to manage virtual environments and dependencies. I also cleaned up a bit of duplicate code in the python tests.
Alongside the unit tests, I've tested this PR out locally by creating a small python project managed by projen.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.