### PR TITLE
fix(node): subprojects fail to run "projen" as part of "build"

### DIFF
--- a/src/node-project.ts
+++ b/src/node-project.ts
@@ -477,7 +477,11 @@ export class NodeProject extends Project {
 
     // first, execute projen as the first thing during build
     if (options.projenDuringBuild ?? true) {
-      this.buildTask.exec(this.projenCommand);
+      // skip for sub-projects (i.e. "parent" is defined) since synthing the
+      // root project will include the subprojects.
+      if (!this.parent) {
+        this.buildTask.exec(this.projenCommand);
+      }
     }
 
     this.addLicense(options);


### PR DESCRIPTION
#658 added the execution of "projen" as part of the full-build task. This works for top-level projects
but fails in subprojects.

Conditionally skip this for subprojects.

Fixes #661

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.