### PR TITLE
fix(deps): SECURITY: CVE-2021-28918, aws-cdk < 1.95.2 include this dependency

### DIFF
--- a/src/__tests__/__snapshots__/inventory.test.ts.snap
+++ b/src/__tests__/__snapshots__/inventory.test.ts.snap
@@ -158,7 +158,7 @@ Array [
         "type": "unknown",
       },
       Object {
-        "default": "\\"1.73.0\\"",
+        "default": "\\"1.95.2\\"",
         "docs": "AWS CDK version to use.",
         "name": "cdkVersion",
         "parent": "AwsCdkTypeScriptAppOptions",
@@ -1380,7 +1380,7 @@ Array [
         "type": "unknown",
       },
       Object {
-        "default": "\\"1.73.0\\"",
+        "default": "\\"1.95.2\\"",
         "docs": "Minimum target version this library is tested against.",
         "name": "cdkVersion",
         "parent": "AwsCdkConstructLibraryOptions",

--- a/src/__tests__/__snapshots__/new.test.ts.snap
+++ b/src/__tests__/__snapshots__/new.test.ts.snap
@@ -4,7 +4,7 @@ exports[`projen new awscdk-app-ts 1`] = `
 "const { AwsCdkTypeScriptApp } = require('projen');
 
 const project = new AwsCdkTypeScriptApp({
-  cdkVersion: '1.73.0',
+  cdkVersion: '1.95.2',
   defaultReleaseBranch: 'main',
   jsiiFqn: \\"projen.AwsCdkTypeScriptApp\\",
   name: 'my-project',
@@ -123,7 +123,7 @@ exports[`projen new awscdk-construct 1`] = `
 const project = new AwsCdkConstructLibrary({
   author: 'My User Name',
   authorAddress: 'my@user.email.com',
-  cdkVersion: '1.73.0',
+  cdkVersion: '1.95.2',
   defaultReleaseBranch: 'main',
   jsiiFqn: \\"projen.AwsCdkConstructLibrary\\",
   name: 'my-project',

--- a/src/awscdk-app-ts.ts
+++ b/src/awscdk-app-ts.ts
@@ -23,7 +23,7 @@ export interface AwsCdkTypeScriptAppOptions extends TypeScriptProjectOptions {
   /**
    * AWS CDK version to use.
    *
-   * @default "1.73.0"
+   * @default "1.95.2"
    */
   readonly cdkVersion: string;
 

--- a/src/awscdk-construct.ts
+++ b/src/awscdk-construct.ts
@@ -7,7 +7,7 @@ export interface AwsCdkConstructLibraryOptions extends ConstructLibraryOptions {
   /**
    * Minimum target version this library is tested against.
    *
-   * @default "1.73.0"
+   * @default "1.95.2"
    */
   readonly cdkVersion: string;
 


### PR DESCRIPTION
https://github.com/aws/aws-cdk/releases/tag/v1.95.2
https://github.com/advisories/GHSA-pch5-whg9-qr2r

Changes awscdk-app-ts, awscdk-construct to DEFAULT to `1.95.2` for the `cdkVersion`
