### PR TITLE
fix(deps): SECURITY: CVE-2021-21306; force typedoc >= 2.0.0

### DIFF
--- a/src/typescript-typedoc.ts
+++ b/src/typescript-typedoc.ts
@@ -6,7 +6,7 @@ import { TypeScriptProject } from './typescript';
  */
 export class TypedocDocgen {
   constructor(project: TypeScriptProject) {
-    project.addDevDeps('typedoc');
+    project.addDevDeps('typedoc@^2');
 
     const docgen = project.addTask('docgen', {
       description: `Generate TypeScript API reference ${project.docsDirectory}`,


### PR DESCRIPTION
typedoc depends on marked which is what is actually vunlerable.
- https://github.com/TypeStrong/typedoc/commit/21fa828c7b62932a3666f67e961e569f1b6a1249

v2.0.0 includes the marked update to fix this.

Changes the 'docgen' flag to pull in typedocs@^2.

The default .projenrc.js config in projen/projen and that generated does
not enable this flag by default.

This can also be mitigated by setting `docgen: false` in .projenrc.js
if you are not in a position to upgrade.

https://nvd.nist.gov/vuln/detail/CVE-2021-21306
