### PR TITLE
fix(nextjs): projen marker causes NextJS build warning

### DIFF
--- a/src/web/postcss.ts
+++ b/src/web/postcss.ts
@@ -43,7 +43,7 @@ export class PostCss {
       project.addDeps('tailwindcss', 'autoprefixer');
     }
 
-    this.file = new JsonFile(project, this.fileName, { obj: config });
+    this.file = new JsonFile(project, this.fileName, { obj: config, marker: false });
 
     project.npmignore?.exclude(`/${this.fileName}`);
   }


### PR DESCRIPTION
Fixes issue mentioned by @pgollucci 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.