### PR TITLE
fix(release): unable to upload all files to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,6 @@ jobs:
         if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}
         run: gh release create v$(node -p "require('./package.json').version") -F
           changelog.tmp.md -t v$(node -p "require('./package.json').version")
-          ./dist/*/**
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Unbump

--- a/src/__tests__/__snapshots__/integ.test.ts.snap
+++ b/src/__tests__/__snapshots__/integ.test.ts.snap
@@ -358,7 +358,6 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         run: gh release create v$(node -p \\"require('./package.json').version\\") -F
           changelog.tmp.md -t v$(node -p \\"require('./package.json').version\\")
-          ./dist/*/**
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
       - name: Unbump
@@ -4207,7 +4206,6 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         run: gh release create v$(node -p \\"require('./package.json').version\\") -F
           changelog.tmp.md -t v$(node -p \\"require('./package.json').version\\")
-          ./dist/*/**
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
       - name: Unbump

--- a/src/__tests__/__snapshots__/jsii.test.ts.snap
+++ b/src/__tests__/__snapshots__/jsii.test.ts.snap
@@ -44,7 +44,6 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         run: gh release create v$(node -p \\"require('./package.json').version\\") -F
           changelog.tmp.md -t v$(node -p \\"require('./package.json').version\\")
-          ./dist/*/**
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
       - name: Unbump
@@ -145,7 +144,6 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         run: gh release create v$(node -p \\"require('./package.json').version\\") -F
           changelog.tmp.md -t v$(node -p \\"require('./package.json').version\\")
-          ./dist/*/**
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
       - name: Unbump

--- a/src/node-project.ts
+++ b/src/node-project.ts
@@ -626,7 +626,6 @@ export class NodeProject extends Project {
           `gh release create ${getVersion}`,
           `-F ${this._version.changelogFile}`,
           `-t ${getVersion}`,
-          `./${artifactDirectory}/*/**`,
         ].join(' '),
         env: {
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}',


### PR DESCRIPTION
Since `dist/` may contain a large number of files (esp. for java), we decided to disable this feature for now.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.