### PR TITLE
fix: unbump fails since tag is not created

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -51,9 +51,6 @@
       "steps": [
         {
           "exec": "standard-version -r 0.0.0"
-        },
-        {
-          "exec": "git tag -d v0.0.0"
         }
       ]
     },

--- a/src/__tests__/__snapshots__/integ.test.ts.snap
+++ b/src/__tests__/__snapshots__/integ.test.ts.snap
@@ -985,9 +985,6 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
           Object {
             "exec": "standard-version -r 0.0.0",
           },
-          Object {
-            "exec": "git tag -d v0.0.0",
-          },
         ],
       },
       "watch": Object {
@@ -2148,9 +2145,6 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "steps": Array [
           Object {
             "exec": "standard-version -r 0.0.0",
-          },
-          Object {
-            "exec": "git tag -d v0.0.0",
           },
         ],
       },
@@ -3415,9 +3409,6 @@ junit.xml
           Object {
             "exec": "standard-version -r 0.0.0",
           },
-          Object {
-            "exec": "git tag -d v0.0.0",
-          },
         ],
       },
       "watch": Object {
@@ -4412,9 +4403,6 @@ junit.xml
         "steps": Array [
           Object {
             "exec": "standard-version -r 0.0.0",
-          },
-          Object {
-            "exec": "git tag -d v0.0.0",
           },
         ],
       },

--- a/src/version.ts
+++ b/src/version.ts
@@ -32,8 +32,6 @@ export class Version extends Component {
       exec: 'standard-version -r 0.0.0',
     });
 
-    this.unbumpTask.exec('git tag -d v0.0.0');
-
     project.addDevDeps(
       'standard-version@^9',
     );


### PR DESCRIPTION
We updated the configuration of standard-version to skip tagging (since the tag is created by the github release), so there is no need to delete the `v0.0.0` tag after we unbump anymore.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.