### PR TITLE
fix: honor mergify: false when dependabot: true

### DIFF
--- a/src/node-project.ts
+++ b/src/node-project.ts
@@ -709,10 +709,10 @@ export class NodeProject extends Project {
       });
 
       this.npmignore?.exclude('/.mergify.yml');
-    }
 
-    if (options.dependabot ?? true) {
-      this.github?.addDependabot(options.dependabotOptions);
+      if (options.dependabot ?? true) {
+        this.github?.addDependabot(options.dependabotOptions);
+      }
     }
 
     const projenAutoMerge = options.projenUpgradeAutoMerge ?? true;


### PR DESCRIPTION
Fixes: https://github.com/projen/projen/issues/696

Its perfectably legit to have dependabot on but not mergify, or
mergify to not be involved in that flow.

I will add a test, but am I blind, I don't see _any_ dependabot, mergify
tests??
