### PR TITLE
fix(--watch): watches only root .projenrc

### DIFF
--- a/src/cli/synth.ts
+++ b/src/cli/synth.ts
@@ -85,12 +85,8 @@ export async function synth(runtime: TaskRuntime, options: SynthOptions) {
   }
 
   function watchLoop() {
-    if (!fs.existsSync(rcfile)) {
-      throw new Error(`--watch is only supported for projects with "${rcfile}"`);
-    }
-
-    logging.info(`Watching for changes in ${rcfile}...`);
-    const watch = fs.watch(rcfile);
+    logging.info(`Watching for changes in ${workdir}...`);
+    const watch = fs.watch(workdir, { recursive: true });
     watch.on('change', () => {
       process.stdout.write('\x1Bc'); // clear screen
       watch.close();


### PR DESCRIPTION
If the project uses multiple files for projenrc, or non-javascript, then watch would not capture
any changes.

This change simply watches all changes in the project directory. This might have performance issues
for very large projects, so we may need to introduce some filters later.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.