### PR TITLE
fix(awscdk-lib): incorrect version of constructs used for CDK 2.0

### DIFF
--- a/API.md
+++ b/API.md
@@ -439,6 +439,7 @@ new AwsCdkConstructLibrary(options: AwsCdkConstructLibraryOptions)
   * **cdkDependenciesAsDeps** (<code>boolean</code>)  If this is enabled (default), all modules declared in `cdkDependencies` will be also added as normal `dependencies` (as well as `peerDependencies`). __*Default*__: true
   * **cdkTestDependencies** (<code>Array<string></code>)  AWS CDK modules required for testing. __*Optional*__
   * **cdkVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for CDK. __*Default*__: false
+  * **constructsVersion** (<code>string</code>)  Minimum target version of constructs being tested against. If not provided, the default value depends on the configured `cdkVersion`:. __*Optional*__
 
 
 
@@ -1088,6 +1089,7 @@ new ConstructLibraryAws(options: AwsCdkConstructLibraryOptions)
   * **cdkDependenciesAsDeps** (<code>boolean</code>)  If this is enabled (default), all modules declared in `cdkDependencies` will be also added as normal `dependencies` (as well as `peerDependencies`). __*Default*__: true
   * **cdkTestDependencies** (<code>Array<string></code>)  AWS CDK modules required for testing. __*Optional*__
   * **cdkVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for CDK. __*Default*__: false
+  * **constructsVersion** (<code>string</code>)  Minimum target version of constructs being tested against. If not provided, the default value depends on the configured `cdkVersion`:. __*Optional*__
 
 
 
@@ -7000,6 +7002,7 @@ Name | Type | Description
 **compat**?🔹 | <code>boolean</code> | Automatically run API compatibility test against the latest version published to npm after compilation.<br/>__*Default*__: false
 **compatIgnore**?🔹 | <code>string</code> | Name of the ignore file for API compatibility tests.<br/>__*Default*__: ".compatignore"
 **compileBeforeTest**?🔹 | <code>boolean</code> | Compile the code before running tests.<br/>__*Default*__: if `testdir` is under `src/**`, the default is `true`, otherwise the default is `false.
+**constructsVersion**?🔹 | <code>string</code> | Minimum target version of constructs being tested against. If not provided, the default value depends on the configured `cdkVersion`:.<br/>__*Optional*__
 **copyrightOwner**?🔹 | <code>string</code> | License copyright owner.<br/>__*Default*__: defaults to the value of authorName or "" if `authorName` is undefined.
 **copyrightPeriod**?🔹 | <code>string</code> | The copyright years to put in the LICENSE file.<br/>__*Default*__: current year
 **dependabot**?🔹 | <code>boolean</code> | Include dependabot configuration.<br/>__*Default*__: true
@@ -7361,6 +7364,7 @@ Name | Type | Description
 **compat**?⚠️ | <code>boolean</code> | Automatically run API compatibility test against the latest version published to npm after compilation.<br/>__*Default*__: false
 **compatIgnore**?⚠️ | <code>string</code> | Name of the ignore file for API compatibility tests.<br/>__*Default*__: ".compatignore"
 **compileBeforeTest**?⚠️ | <code>boolean</code> | Compile the code before running tests.<br/>__*Default*__: if `testdir` is under `src/**`, the default is `true`, otherwise the default is `false.
+**constructsVersion**?⚠️ | <code>string</code> | Minimum target version of constructs being tested against. If not provided, the default value depends on the configured `cdkVersion`:.<br/>__*Optional*__
 **copyrightOwner**?⚠️ | <code>string</code> | License copyright owner.<br/>__*Default*__: defaults to the value of authorName or "" if `authorName` is undefined.
 **copyrightPeriod**?⚠️ | <code>string</code> | The copyright years to put in the LICENSE file.<br/>__*Default*__: current year
 **dependabot**?⚠️ | <code>boolean</code> | Include dependabot configuration.<br/>__*Default*__: true

--- a/src/__tests__/__snapshots__/inventory.test.ts.snap
+++ b/src/__tests__/__snapshots__/inventory.test.ts.snap
@@ -1498,6 +1498,17 @@ Array [
         "type": "boolean",
       },
       Object {
+        "docs": "Minimum target version of constructs being tested against. If not provided, the default value depends on the configured \`cdkVersion\`:.",
+        "name": "constructsVersion",
+        "optional": true,
+        "parent": "AwsCdkConstructLibraryOptions",
+        "path": Array [
+          "constructsVersion",
+        ],
+        "switch": "constructs-version",
+        "type": "string",
+      },
+      Object {
         "default": "- defaults to the value of authorName or \\"\\" if \`authorName\` is undefined.",
         "docs": "License copyright owner.",
         "name": "copyrightOwner",

--- a/src/__tests__/__snapshots__/new.test.ts.snap
+++ b/src/__tests__/__snapshots__/new.test.ts.snap
@@ -137,6 +137,7 @@ const project = new AwsCdkConstructLibrary({
   // cdkDependenciesAsDeps: true,                                              /* If this is enabled (default), all modules declared in \`cdkDependencies\` will be also added as normal \`dependencies\` (as well as \`peerDependencies\`). */
   // cdkTestDependencies: undefined,                                           /* AWS CDK modules required for testing. */
   // cdkVersionPinning: false,                                                 /* Use pinned version instead of caret version for CDK. */
+  // constructsVersion: undefined,                                             /* Minimum target version of constructs being tested against. If not provided, the default value depends on the configured \`cdkVersion\`:. */
 
   /* ConstructLibraryOptions */
   // catalog: undefined,                                                       /* Libraries will be picked up by the construct catalog when they are published to npm as jsii modules and will be published under:. */

--- a/src/__tests__/awscdk-construct.test.ts
+++ b/src/__tests__/awscdk-construct.test.ts
@@ -1,0 +1,83 @@
+import { AwsCdkConstructLibrary, AwsCdkConstructLibraryOptions } from '../awscdk-construct';
+import { LogLevel } from '../logger';
+import { NpmAccess } from '../node-package';
+import { mkdtemp, synthSnapshot } from './util';
+
+describe('constructs dependency selection', () => {
+  test('user-selected', () => {
+    // GIVEN
+    const project = new TestProject({ cdkVersion: '1.100.0', constructsVersion: '42.1337.0-ultimate.∞' });
+
+    // WHEN
+    const snapshot = synthSnapshot(project);
+
+    // THEN
+    expect(snapshot['package.json']?.peerDependencies?.constructs).toBe('^42.1337.0-ultimate.∞');
+    expect(snapshot['package.json']?.devDependencies?.constructs).toBe('42.1337.0-ultimate.∞');
+    expect(snapshot['package.json']?.dependencies?.constructs).toBeUndefined();
+  });
+
+
+  test('for cdk 1.x', () => {
+    // GIVEN
+    const project = new TestProject({ cdkVersion: '1.100.0' });
+
+    // WHEN
+    const snapshot = synthSnapshot(project);
+
+    // THEN
+    expect(snapshot['package.json']?.peerDependencies?.constructs).toMatch(/^\^3\./);
+    expect(snapshot['package.json']?.devDependencies?.constructs).toBeUndefined();
+    expect(snapshot['package.json']?.dependencies?.constructs).toBeUndefined();
+  });
+
+  test('for cdk 2.x', () => {
+    // GIVEN
+    const project = new TestProject({ cdkVersion: '2.0.0-alpha.5' });
+
+    // WHEN
+    const snapshot = synthSnapshot(project);
+
+    // THEN
+    expect(snapshot['package.json']?.peerDependencies?.constructs).toMatch(/^\^10./);
+    expect(snapshot['package.json']?.devDependencies?.constructs).toBeUndefined();
+    expect(snapshot['package.json']?.dependencies?.constructs).toBeUndefined();
+  });
+
+  test('for cdk 3.x (does not exist yet)', () => {
+    // GIVEN
+    const project = new TestProject({ cdkVersion: '3.1337.42' });
+
+    // WHEN
+    const snapshot = synthSnapshot(project);
+
+    // THEN
+    expect(snapshot['package.json']?.peerDependencies?.constructs).toBe('*');
+    expect(snapshot['package.json']?.devDependencies?.constructs).toBeUndefined();
+    expect(snapshot['package.json']?.dependencies?.constructs).toBeUndefined();
+  });
+});
+
+const defaultOptions = {
+  author: 'Nobody',
+  authorAddress: 'nobody@nowhere.com',
+  clobber: false,
+  defaultReleaseBranch: 'main',
+  jest: false,
+  name: 'test-project',
+  npmAccess: NpmAccess.PUBLIC,
+  repositoryUrl: 'https://github.com/projen/projen.git',
+} as const;
+
+class TestProject extends AwsCdkConstructLibrary {
+  constructor(options: Omit<AwsCdkConstructLibraryOptions, keyof typeof defaultOptions>) {
+    super({
+      outdir: mkdtemp(),
+      logging: {
+        level: LogLevel.OFF,
+      },
+      ...defaultOptions,
+      ...options,
+    });
+  }
+}

--- a/src/__tests__/util.ts
+++ b/src/__tests__/util.ts
@@ -43,8 +43,29 @@ export interface SynthOutput {
   [filePath: string]: any;
 }
 
+const autoRemove = new Set<string>();
+
+// Hook to automatically remove temporary directories without needing each
+// place to actually handle this specifically.
+afterAll((done) => {
+  // Array.from used to get a copy, so we can safely remove from the set
+  for (const dir of Array.from(autoRemove)) {
+    try {
+      // Note - fs-extra.removeSync is idempotent, so we're safe if the
+      // directory has already been cleaned up before we get there!
+      fs.removeSync(dir);
+    } catch (e) {
+      done.fail(e);
+    }
+    autoRemove.delete(dir);
+  }
+  done();
+});
+
 export function mkdtemp() {
-  return removeAtExit(fs.mkdtempSync(path.join(os.tmpdir(), 'projen-test-')));
+  const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'projen-test-'));
+  autoRemove.add(tmpdir);
+  return tmpdir;
 }
 
 export function synthSnapshot(project: Project): any {
@@ -106,21 +127,4 @@ export function directorySnapshot(root: string, options: DirectorySnapshotOption
   }
 
   return output;
-}
-
-const cleanUpDirectories = new Set<string>();
-function removeAtExit(directory: string): string {
-  if (cleanUpDirectories.size === 0) {
-    process.once('exit', () => {
-      for (const dir of cleanUpDirectories) {
-        try {
-          fs.removeSync(dir);
-        } catch {
-          // IGNORE: It's unsafe to do much else during `exit`, unfortunately.
-        }
-      }
-    });
-  }
-  cleanUpDirectories.add(directory);
-  return directory;
 }

--- a/src/awscdk-construct.ts
+++ b/src/awscdk-construct.ts
@@ -16,7 +16,7 @@ export interface AwsCdkConstructLibraryOptions extends ConstructLibraryOptions {
    * the default value depends on the configured `cdkVersion`:
    *
    * - For CDK 1.x, the default is "3.2.27"
-   * - For CDK 2.x, the default is "10.0.0"
+   * - For CDK 2.x, the default is "10.0.5"
    * - Otherwise, the default is "*"
    *
    * When the default behavior is used, the dependency on `constructs` will only
@@ -163,7 +163,7 @@ export class AwsCdkConstructLibrary extends ConstructLibrary {
       this.addPeerDeps('constructs@^3.2.27');
     } else if (options.cdkVersion.startsWith('2.')) {
       // CDK 2.x is built on constructs 10.x
-      this.addPeerDeps('constructs@^10.0.0');
+      this.addPeerDeps('constructs@^10.0.5');
     } else {
       // Otherwise, let the user manage which version they use
       this.addPeerDeps('constructs');


### PR DESCRIPTION
CDK 2.0 pre-releases depend on constructs@10, and not constructs@3. This
selects the version of constructs to be registered based on the CDK major
version being used.

Additionally, a new `constructsVersion` option enables user-defined
versions to be used instead of the default/inferred version.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.