### PR TITLE
fix: projen new not working with some of the new discovery changes

### DIFF
--- a/src/__tests__/__snapshots__/new.test.ts.snap
+++ b/src/__tests__/__snapshots__/new.test.ts.snap
@@ -1,5 +1,963 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`projen new --from external 1`] = `
+Object {
+  ".eslintrc.json": Object {
+    "env": Object {
+      "jest": true,
+      "node": true,
+    },
+    "extends": Array [
+      "plugin:import/typescript",
+    ],
+    "ignorePatterns": Array [
+      "*.js",
+      "*.d.ts",
+      "node_modules/",
+      "*.generated.ts",
+      "coverage",
+    ],
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": Object {
+      "ecmaVersion": 2018,
+      "project": "./tsconfig.jest.json",
+      "sourceType": "module",
+    },
+    "plugins": Array [
+      "@typescript-eslint",
+      "import",
+    ],
+    "root": true,
+    "rules": Object {
+      "@typescript-eslint/indent": Array [
+        "error",
+        2,
+      ],
+      "@typescript-eslint/member-delimiter-style": Array [
+        "error",
+      ],
+      "@typescript-eslint/member-ordering": Array [
+        "error",
+        Object {
+          "default": Array [
+            "public-static-field",
+            "public-static-method",
+            "protected-static-field",
+            "protected-static-method",
+            "private-static-field",
+            "private-static-method",
+            "field",
+            "constructor",
+            "method",
+          ],
+        },
+      ],
+      "@typescript-eslint/no-floating-promises": Array [
+        "error",
+      ],
+      "@typescript-eslint/no-require-imports": Array [
+        "error",
+      ],
+      "@typescript-eslint/no-shadow": Array [
+        "error",
+      ],
+      "@typescript-eslint/return-await": Array [
+        "error",
+      ],
+      "array-bracket-newline": Array [
+        "error",
+        "consistent",
+      ],
+      "array-bracket-spacing": Array [
+        "error",
+        "never",
+      ],
+      "brace-style": Array [
+        "error",
+        "1tbs",
+        Object {
+          "allowSingleLine": true,
+        },
+      ],
+      "comma-dangle": Array [
+        "error",
+        "always-multiline",
+      ],
+      "comma-spacing": Array [
+        "error",
+        Object {
+          "after": true,
+          "before": false,
+        },
+      ],
+      "curly": Array [
+        "error",
+        "multi-line",
+        "consistent",
+      ],
+      "dot-notation": Array [
+        "error",
+      ],
+      "import/no-extraneous-dependencies": Array [
+        "error",
+        Object {
+          "devDependencies": Array [
+            "**/build-tools/**",
+            "**/test/**",
+          ],
+          "optionalDependencies": false,
+          "peerDependencies": true,
+        },
+      ],
+      "import/no-unresolved": Array [
+        "error",
+      ],
+      "import/order": Array [
+        "warn",
+        Object {
+          "alphabetize": Object {
+            "caseInsensitive": true,
+            "order": "asc",
+          },
+          "groups": Array [
+            "builtin",
+            "external",
+          ],
+        },
+      ],
+      "indent": Array [
+        "off",
+      ],
+      "key-spacing": Array [
+        "error",
+      ],
+      "keyword-spacing": Array [
+        "error",
+      ],
+      "max-len": Array [
+        "error",
+        Object {
+          "code": 150,
+          "ignoreComments": true,
+          "ignoreRegExpLiterals": true,
+          "ignoreStrings": true,
+          "ignoreTemplateLiterals": true,
+          "ignoreUrls": true,
+        },
+      ],
+      "no-bitwise": Array [
+        "error",
+      ],
+      "no-duplicate-imports": Array [
+        "error",
+      ],
+      "no-multi-spaces": Array [
+        "error",
+        Object {
+          "ignoreEOLComments": false,
+        },
+      ],
+      "no-multiple-empty-lines": Array [
+        "error",
+      ],
+      "no-return-await": Array [
+        "off",
+      ],
+      "no-shadow": Array [
+        "off",
+      ],
+      "no-trailing-spaces": Array [
+        "error",
+      ],
+      "object-curly-newline": Array [
+        "error",
+        Object {
+          "consistent": true,
+          "multiline": true,
+        },
+      ],
+      "object-curly-spacing": Array [
+        "error",
+        "always",
+      ],
+      "object-property-newline": Array [
+        "error",
+        Object {
+          "allowAllPropertiesOnSameLine": true,
+        },
+      ],
+      "quote-props": Array [
+        "error",
+        "consistent-as-needed",
+      ],
+      "quotes": Array [
+        "error",
+        "single",
+        Object {
+          "avoidEscape": true,
+        },
+      ],
+      "semi": Array [
+        "error",
+        "always",
+      ],
+      "space-before-blocks": Array [
+        "error",
+      ],
+    },
+    "settings": Object {
+      "import/parsers": Object {
+        "@typescript-eslint/parser": Array [
+          ".ts",
+          ".tsx",
+        ],
+      },
+      "import/resolver": Object {
+        "node": Object {},
+        "typescript": Object {
+          "directory": "./tsconfig.json",
+        },
+      },
+    },
+  },
+  ".gitignore": "# ~~ Generated by projen. To modify, edit .projenrc.js and run \\"npx projen\\".
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+# Diagnostic reports (https://nodejs.org/api/report.html)
+report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+# Directory for instrumented libs generated by jscoverage/JSCover
+lib-cov
+# Coverage directory used by tools like istanbul
+coverage
+*.lcov
+# nyc test coverage
+.nyc_output
+# Compiled binary addons (https://nodejs.org/api/addons.html)
+build/Release
+# Dependency directories
+node_modules/
+jspm_packages/
+# TypeScript cache
+*.tsbuildinfo
+# Optional eslint cache
+.eslintcache
+# Output of 'npm pack'
+*.tgz
+# Yarn Integrity file
+.yarn-integrity
+# parcel-bundler cache (https://parceljs.org/)
+.cache
+# jest-junit artifacts
+/test-reports/
+junit.xml
+/coverage
+/lib
+/dist
+cdk.out/
+.cdk.staging/
+.parcel-cache/
+appsync/
+!/package.json
+!/.npmignore
+!/LICENSE
+!/.projenrc.js
+!version.json
+!/.versionrc.json
+!/test
+!/.github/workflows/build.yml
+!/.mergify.yml
+!/.github/dependabot.yml
+!/.github/pull_request_template.md
+!/tsconfig.json
+!/src
+!/tsconfig.jest.json
+!/.eslintrc.json
+!/cdk.json",
+  ".mergify.yml": "# ~~ Generated by projen. To modify, edit .projenrc.js and run \\"npx projen\\".
+
+pull_request_rules:
+  - name: Automatic merge on approval and successful build
+    actions:
+      merge:
+        method: squash
+        commit_message: title+body
+        strict: smart
+        strict_method: merge
+      delete_head_branch: {}
+    conditions:
+      - \\"#approved-reviews-by>=1\\"
+      - status-success=build
+  - name: Automatic merge PRs with auto-merge label upon successful build
+    actions:
+      merge:
+        method: squash
+        commit_message: title+body
+        strict: smart
+        strict_method: merge
+      delete_head_branch: {}
+    conditions:
+      - label=auto-merge
+      - status-success=build
+  - name: Merge pull requests from dependabot if CI passes
+    conditions:
+      - author=dependabot[bot]
+      - status-success=build
+    actions:
+      merge:
+        method: merge
+        commit_message: title+body
+",
+  ".npmignore": "# ~~ Generated by projen. To modify, edit .projenrc.js and run \\"npx projen\\".
+/.projenrc.js
+/.versionrc.json
+/coverage
+/test
+/.mergify.yml
+/tsconfig.json
+/src
+dist
+/tsconfig.json
+/.github
+/.vscode
+/.idea
+/.projenrc.js
+/tsconfig.jest.json
+/.eslintrc.json
+cdk.out/
+.cdk.staging/
+appsync/
+!/lib
+!/lib/**/*.js
+!/lib/**/*.d.ts",
+  ".versionrc.json": Object {
+    "bumpFiles": Array [
+      Object {
+        "filename": "version.json",
+        "type": "json",
+      },
+    ],
+    "commitAll": true,
+    "packageFiles": Array [
+      Object {
+        "filename": "version.json",
+        "type": "json",
+      },
+    ],
+    "scripts": Object {
+      "postbump": "yarn run projen && git add .",
+    },
+  },
+  "LICENSE": "                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      \\"License\\" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      \\"Licensor\\" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      \\"Legal Entity\\" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      \\"control\\" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      \\"You\\" (or \\"Your\\") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      \\"Source\\" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      \\"Object\\" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      \\"Work\\" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      \\"Derivative Works\\" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      \\"Contribution\\" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, \\"submitted\\"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as \\"Not a Contribution.\\"
+
+      \\"Contributor\\" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a \\"NOTICE\\" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an \\"AS IS\\" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets \\"[]\\"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same \\"printed page\\" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021 
+
+   Licensed under the Apache License, Version 2.0 (the \\"License\\");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an \\"AS IS\\" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+",
+  "README.md": "# my project",
+  "cdk.json": Object {
+    "app": "npx ts-node --prefer-ts-exts src/main.ts",
+  },
+  "package.json": Object {
+    "//": "~~ Generated by projen. To modify, edit .projenrc.js and run \\"npx projen\\".",
+    "bin": Object {},
+    "bundledDependencies": Array [],
+    "dependencies": Object {
+      "@aws-cdk/assert": "^1.95.2",
+      "@aws-cdk/aws-appsync": "^1.95.2",
+      "@aws-cdk/aws-cognito": "^1.95.2",
+      "@aws-cdk/aws-dynamodb": "^1.95.2",
+      "@aws-cdk/core": "^1.95.2",
+      "aws-cdk-appsync-transformer": "^1.63.0-rc.3",
+    },
+    "devDependencies": Object {
+      "@types/jest": "^26.0.23",
+      "@types/node": "^10.17.0",
+      "@typescript-eslint/eslint-plugin": "^4.3.0",
+      "@typescript-eslint/parser": "^4.3.0",
+      "aws-cdk": "^1.95.2",
+      "cdk-appsync-project": "^1.0.4",
+      "eslint": "^7.25.0",
+      "eslint-import-resolver-node": "^0.3.4",
+      "eslint-import-resolver-typescript": "^2.4.0",
+      "eslint-plugin-import": "^2.22.1",
+      "jest": "^26.6.3",
+      "jest-junit": "^12",
+      "json-schema": "^0.3.0",
+      "projen": "^0.3.178",
+      "standard-version": "^9.0.0",
+      "ts-jest": "^26.5.5",
+      "ts-node": "^9.1.1",
+      "typescript": "^3.9.5",
+    },
+    "jest": Object {
+      "clearMocks": true,
+      "collectCoverage": true,
+      "coverageDirectory": "coverage",
+      "coveragePathIgnorePatterns": Array [
+        "/node_modules/",
+      ],
+      "globals": Object {
+        "ts-jest": Object {
+          "tsconfig": "tsconfig.jest.json",
+        },
+      },
+      "preset": "ts-jest",
+      "reporters": Array [
+        "default",
+        Array [
+          "jest-junit",
+          Object {
+            "outputDirectory": "test-reports",
+          },
+        ],
+      ],
+      "testMatch": Array [
+        "**/__tests__/**/*.ts?(x)",
+        "**/?(*.)+(spec|test).ts?(x)",
+      ],
+      "testPathIgnorePatterns": Array [
+        "/node_modules/",
+      ],
+    },
+    "keywords": Array [],
+    "license": "Apache-2.0",
+    "name": "my-project",
+    "peerDependencies": Object {},
+    "scripts": Object {
+      "build": "yarn run test && yarn run compile && yarn run synth",
+      "bump": "yarn run --silent no-changes || standard-version",
+      "cdk": "cdk",
+      "compile": "true",
+      "deploy": "cdk deploy",
+      "destroy": "cdk destroy",
+      "diff": "cdk diff",
+      "eslint": "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test",
+      "no-changes": "(git log --oneline -1 | grep -q \\"chore(release):\\") && echo \\"No changes to release.\\"",
+      "projen": "node .projenrc.js",
+      "projen:upgrade": "yarn upgrade -L projen && CI=\\"\\" yarn projen",
+      "release": "yarn run --silent no-changes || (yarn run bump && git push --follow-tags origin main)",
+      "start": "npx projen start -i",
+      "synth": "cdk synth",
+      "test": "rm -fr lib/ && jest --passWithNoTests --updateSnapshot && yarn run eslint",
+      "test:update": "jest --updateSnapshot",
+      "test:watch": "jest --watch",
+    },
+    "start": Object {
+      "build": Object {
+        "category": 0,
+        "command": "yarn run build",
+        "desc": "Full release build (test+compile)",
+      },
+      "bump": Object {
+        "category": 2,
+        "command": "yarn run bump",
+        "desc": "Commits a bump to the package version based on conventional commits",
+      },
+      "compile": Object {
+        "category": 0,
+        "command": "yarn run compile",
+        "desc": "Only compile",
+      },
+      "deploy": Object {
+        "category": 2,
+        "command": "yarn run deploy",
+        "desc": "Deploys your cdk app to the AWS cloud",
+      },
+      "destroy": Object {
+        "category": 2,
+        "command": "yarn run destroy",
+        "desc": "Destroys your cdk app in the AWS cloud",
+      },
+      "eslint": Object {
+        "category": 1,
+        "command": "yarn run eslint",
+        "desc": "Runs eslint against the codebase",
+      },
+      "projen": Object {
+        "category": 3,
+        "command": "yarn run projen",
+        "desc": "Synthesize project configuration from .projenrc.js",
+      },
+      "projen:upgrade": Object {
+        "category": 3,
+        "command": "yarn run projen:upgrade",
+        "desc": "upgrades projen to the latest version",
+      },
+      "release": Object {
+        "category": 2,
+        "command": "yarn run release",
+        "desc": "Bumps version & push to main",
+      },
+      "start": Object {
+        "command": "yarn run start",
+        "desc": "Shows this menu",
+      },
+      "synth": Object {
+        "category": 0,
+        "command": "yarn run synth",
+        "desc": "Synthesizes your cdk app into cdk.out (part of \\"yarn build\\")",
+      },
+      "test": Object {
+        "category": 1,
+        "command": "yarn run test",
+        "desc": "Run tests",
+      },
+      "test:watch": Object {
+        "category": 1,
+        "command": "yarn run test:watch",
+        "desc": "Run jest in watch mode",
+      },
+      "watch": Object {
+        "category": 0,
+        "command": "yarn run watch",
+        "desc": "Watch & compile in the background",
+      },
+    },
+    "version": "0.0.0",
+  },
+  "schema.graphql": "# This is a sample generated schema
+type Customer @model
+    @auth(rules: [
+        { allow: groups, groups: [\\"Admins\\"] },
+        { allow: private, provider: iam, operations: [read, update] }
+    ]) {
+        id: ID!
+        firstName: String!
+        lastName: String!
+        active: Boolean!
+        address: String!
+}
+
+type Product @model
+    @auth(rules: [
+        { allow: groups, groups: [\\"Admins\\"] },
+        { allow: public, provider: iam, operations: [read] }
+    ]) {
+        id: ID!
+        name: String!
+        description: String!
+        price: String!
+        active: Boolean!
+        added: AWSDateTime!
+        orders: [Order] @connection
+}
+
+type Order @model
+    @key(fields: [\\"id\\", \\"productID\\"]) {
+        id: ID!
+        productID: ID!
+        total: String!
+        ordered: AWSDateTime!
+}
+
+# Demonstrate the FUNCTION resolvers
+type User @model(queries: null, mutations: null, subscriptions: null)
+    @auth(rules: [
+        { allow: groups, groups: [\\"Admins\\"] },
+        { allow: owner, ownerField: \\"sub\\" },
+        { allow: private, provider: iam, operations: [create, update] }
+    ]) {
+    id: ID!
+    enabled: Boolean!
+    status: String!
+    email: String!
+    name: String!
+    email_verified: String
+    phone_number: String
+    phone_number_verified: String
+}
+
+type UserConnection {
+    items: [User]
+}
+
+input CreateUserInput {
+    email: String!
+    name: String!
+}
+
+input UpdateUserInput {
+    id: ID!
+    email: String
+    name: String
+    number: String
+}
+
+# Demonstrate the FUNCTION resolvers
+type Query {
+  listUsers: UserConnection @function(name: \\"currently-unused\\")
+  getUser(id: ID!): User @function(name: \\"currently-unused\\")
+}
+
+type Mutation {
+  createUser(input: CreateUserInput!): User @function(name: \\"currently-unused\\")
+  updateUser(input: UpdateUserInput!): User @function(name: \\"currently-unused\\")
+}",
+  "src/main.ts": "import { App, Construct, Stack, StackProps } from '@aws-cdk/core';
+import { UserPool, UserPoolClient, VerificationEmailStyle } from '@aws-cdk/aws-cognito';
+import { AuthorizationType, UserPoolDefaultAction } from '@aws-cdk/aws-appsync';
+
+import { AppSyncTransformer } from 'aws-cdk-appsync-transformer';
+
+export class MyStack extends Stack {
+  public userPool: UserPool;
+  public api: AppSyncTransformer
+
+  constructor(scope: Construct, id: string, props: StackProps = {}) {
+    super(scope, id, props);
+
+    this.userPool = new UserPool(this, 'cognito', {
+      autoVerify: {
+        email: true,
+        phone: false
+      },
+      selfSignUpEnabled: true,
+      signInAliases: {
+        email: true
+      },
+      standardAttributes: {
+        email: {
+          mutable: true,
+          required: true
+        },
+      },
+      userVerification: {
+        emailSubject: 'Verify your email',
+        emailBody: 'Hello {username}! Your verification code is {####}',
+        emailStyle: VerificationEmailStyle.CODE,
+      }
+    });
+
+    const userpoolWebClient = new UserPoolClient(this, 'cognito-user-pool-client', {
+      userPool: this.userPool,
+      generateSecret: false,
+      authFlows: {
+        userPassword: true,
+        refreshToken: true
+      }
+    })
+
+    this.api = new AppSyncTransformer(this, 'appsync-api', {
+      schemaPath: './schema.graphql',
+      apiName: 'my-cool-api',
+      authorizationConfig: {
+        defaultAuthorization: {
+          authorizationType: AuthorizationType.USER_POOL,
+          userPoolConfig: {
+            userPool: this.userPool,
+            appIdClientRegex: userpoolWebClient.userPoolClientId,
+            defaultAction: UserPoolDefaultAction.ALLOW
+          }
+        }
+      }
+    })
+  }
+}
+
+// for development, use account/region from cdk cli
+const devEnv = {
+  account: process.env.CDK_DEFAULT_ACCOUNT,
+  region: process.env.CDK_DEFAULT_REGION,
+};
+
+const app = new App();
+
+new MyStack(app, 'my-stack-dev', { env: devEnv });
+// new MyStack(app, 'my-stack-prod', { env: prodEnv });
+
+app.synth();",
+  "test/main.test.ts": "import '@aws-cdk/assert/jest';
+import { MyStack } from '../src/main'
+import { App } from '@aws-cdk/core';
+
+test('Snapshot', () => {
+  const app = new App();
+  const stack = new MyStack(app, 'test');
+
+  expect(stack).toHaveResource('AWS::Cognito::UserPool');
+  expect(stack.api.nestedAppsyncStack).toHaveResource('AWS::AppSync::GraphQLApi');
+});",
+  "tsconfig.jest.json": Object {
+    "compilerOptions": Object {
+      "alwaysStrict": true,
+      "declaration": true,
+      "experimentalDecorators": true,
+      "inlineSourceMap": true,
+      "inlineSources": true,
+      "lib": Array [
+        "es2018",
+      ],
+      "module": "CommonJS",
+      "noEmitOnError": false,
+      "noFallthroughCasesInSwitch": true,
+      "noImplicitAny": true,
+      "noImplicitReturns": true,
+      "noImplicitThis": true,
+      "noUnusedLocals": true,
+      "noUnusedParameters": true,
+      "resolveJsonModule": true,
+      "strict": true,
+      "strictNullChecks": true,
+      "strictPropertyInitialization": true,
+      "stripInternal": true,
+      "target": "ES2018",
+    },
+    "exclude": Array [
+      "node_modules",
+    ],
+    "include": Array [
+      "src/**/*.ts",
+      "test/**/*.ts",
+    ],
+  },
+  "tsconfig.json": Object {
+    "compilerOptions": Object {
+      "alwaysStrict": true,
+      "declaration": true,
+      "experimentalDecorators": true,
+      "inlineSourceMap": true,
+      "inlineSources": true,
+      "lib": Array [
+        "es2018",
+      ],
+      "module": "CommonJS",
+      "noEmitOnError": false,
+      "noFallthroughCasesInSwitch": true,
+      "noImplicitAny": true,
+      "noImplicitReturns": true,
+      "noImplicitThis": true,
+      "noUnusedLocals": true,
+      "noUnusedParameters": true,
+      "outDir": "lib",
+      "resolveJsonModule": true,
+      "rootDir": "src",
+      "strict": true,
+      "strictNullChecks": true,
+      "strictPropertyInitialization": true,
+      "stripInternal": true,
+      "target": "ES2018",
+    },
+    "exclude": Array [
+      "node_modules",
+      "lib",
+      "cdk.out",
+    ],
+    "include": Array [
+      "src/**/*.ts",
+    ],
+  },
+  "version.json": Object {
+    "version": "0.0.0",
+  },
+}
+`;
+
 exports[`projen new awscdk-app-ts 1`] = `
 Object {
   ".projenrc.js": "const { AwsCdkTypeScriptApp } = require('projen');

--- a/src/__tests__/new.test.ts
+++ b/src/__tests__/new.test.ts
@@ -40,6 +40,31 @@ test('post-synthesis option disabled', () => {
   expect(synthSnapshot(project)['.postsynth']).toBeUndefined();
 });
 
+test('projen new --from external', () => {
+  const outdir = mkdtemp();
+  try {
+    const projectdir = createProjectDir(outdir);
+
+    // execute `projen new --from cdk-appsync-project` in the project directory
+    execProjenCLI(projectdir, ['new', '--from', 'cdk-appsync-project']);
+
+    // compare generated .projenrc.js to the snapshot
+    const actual = directorySnapshot(projectdir, {
+      excludeGlobs: [
+        '.git/**',
+        '.github/**',
+        'node_modules/**',
+        'yarn.lock',
+      ],
+    });
+
+    expect(actual).toMatchSnapshot();
+    expect(actual['schema.graphql']).toBeDefined();
+  } finally {
+    removeSync(outdir);
+  }
+});
+
 function createProjectDir(workdir: string) {
   // create project under "my-project" so that basedir is deterministic
   const projectdir = join(workdir, 'my-project');

--- a/src/inventory.ts
+++ b/src/inventory.ts
@@ -116,8 +116,15 @@ export function discover(...moduleDirs: string[]) {
 
 export function resolveProjectType(projectFqn: string) {
   const manifest = readJsiiManifest(projectFqn);
+
   const jsii: JsiiTypes = {};
   for (const [fqn, type] of Object.entries(manifest.types as JsiiTypes)) {
+    jsii[fqn] = type;
+  }
+
+  // Read Projen JSII types
+  const projenManifest = readJsiiManifest('projen');
+  for (const [fqn, type] of Object.entries(projenManifest.types as JsiiTypes)) {
     jsii[fqn] = type;
   }
 


### PR DESCRIPTION
Fixes #748 

* Fixed the discovery of external types when resolving the project
* Fixed the `newProjectFromModule` directory handling
* Added a unit test for testing external packages - currently points to one of my packages because that's the one I had on hand

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.