### PR TITLE
feat(awscdk-app): CDK v2 support

### DIFF
--- a/API.md
+++ b/API.md
@@ -446,7 +446,7 @@ new AwsCdkConstructLibrary(options: AwsCdkConstructLibraryOptions)
   * **cdkDependenciesAsDeps** (<code>boolean</code>)  If this is enabled (default), all modules declared in `cdkDependencies` will be also added as normal `dependencies` (as well as `peerDependencies`). __*Default*__: true
   * **cdkTestDependencies** (<code>Array<string></code>)  AWS CDK modules required for testing. __*Optional*__
   * **cdkVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for CDK. __*Default*__: false
-  * **constructsVersion** (<code>string</code>)  Minimum target version of constructs being tested against. If not provided, the default value depends on the configured `cdkVersion`:. __*Optional*__
+  * **constructsVersion** (<code>string</code>)  Minimum target version of constructs being tested against. If not provided, the default value depends on the configured `cdkVersion`:. __*Default*__: When the default behavior is used, the dependency on `constructs` will only be added as a `peerDependency`. Otherwise, a `devDependency` will also be added, set to the exact version configrued here.
 
 
 
@@ -456,7 +456,8 @@ new AwsCdkConstructLibrary(options: AwsCdkConstructLibraryOptions)
 Name | Type | Description 
 -----|------|-------------
 **cdkDependenciesAsDeps**🔹 | <code>boolean</code> | Whether CDK dependencies are added as normal dependencies (and peer dependencies).
-**version**🔹 | <code>string</code> | The target CDK version for this library.
+**cdkVersion**🔹 | <code>string</code> | The target CDK version for this library.
+**version**⚠️ | <code>string</code> | <span></span>
 
 ### Methods
 
@@ -1108,7 +1109,7 @@ new ConstructLibraryAws(options: AwsCdkConstructLibraryOptions)
   * **cdkDependenciesAsDeps** (<code>boolean</code>)  If this is enabled (default), all modules declared in `cdkDependencies` will be also added as normal `dependencies` (as well as `peerDependencies`). __*Default*__: true
   * **cdkTestDependencies** (<code>Array<string></code>)  AWS CDK modules required for testing. __*Optional*__
   * **cdkVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for CDK. __*Default*__: false
-  * **constructsVersion** (<code>string</code>)  Minimum target version of constructs being tested against. If not provided, the default value depends on the configured `cdkVersion`:. __*Optional*__
+  * **constructsVersion** (<code>string</code>)  Minimum target version of constructs being tested against. If not provided, the default value depends on the configured `cdkVersion`:. __*Default*__: When the default behavior is used, the dependency on `constructs` will only be added as a `peerDependency`. Otherwise, a `devDependency` will also be added, set to the exact version configrued here.
 
 
 
@@ -7151,7 +7152,7 @@ Name | Type | Description
 **compat**?🔹 | <code>boolean</code> | Automatically run API compatibility test against the latest version published to npm after compilation.<br/>__*Default*__: false
 **compatIgnore**?🔹 | <code>string</code> | Name of the ignore file for API compatibility tests.<br/>__*Default*__: ".compatignore"
 **compileBeforeTest**?🔹 | <code>boolean</code> | Compile the code before running tests.<br/>__*Default*__: if `testdir` is under `src/**`, the default is `true`, otherwise the default is `false.
-**constructsVersion**?🔹 | <code>string</code> | Minimum target version of constructs being tested against. If not provided, the default value depends on the configured `cdkVersion`:.<br/>__*Optional*__
+**constructsVersion**?🔹 | <code>string</code> | Minimum target version of constructs being tested against. If not provided, the default value depends on the configured `cdkVersion`:.<br/>__*Default*__: When the default behavior is used, the dependency on `constructs` will only be added as a `peerDependency`. Otherwise, a `devDependency` will also be added, set to the exact version configrued here.
 **copyrightOwner**?🔹 | <code>string</code> | License copyright owner.<br/>__*Default*__: defaults to the value of authorName or "" if `authorName` is undefined.
 **copyrightPeriod**?🔹 | <code>string</code> | The copyright years to put in the LICENSE file.<br/>__*Default*__: current year
 **dependabot**?🔹 | <code>boolean</code> | Include dependabot configuration.<br/>__*Default*__: true
@@ -7522,7 +7523,7 @@ Name | Type | Description
 **compat**?⚠️ | <code>boolean</code> | Automatically run API compatibility test against the latest version published to npm after compilation.<br/>__*Default*__: false
 **compatIgnore**?⚠️ | <code>string</code> | Name of the ignore file for API compatibility tests.<br/>__*Default*__: ".compatignore"
 **compileBeforeTest**?⚠️ | <code>boolean</code> | Compile the code before running tests.<br/>__*Default*__: if `testdir` is under `src/**`, the default is `true`, otherwise the default is `false.
-**constructsVersion**?⚠️ | <code>string</code> | Minimum target version of constructs being tested against. If not provided, the default value depends on the configured `cdkVersion`:.<br/>__*Optional*__
+**constructsVersion**?⚠️ | <code>string</code> | Minimum target version of constructs being tested against. If not provided, the default value depends on the configured `cdkVersion`:.<br/>__*Default*__: When the default behavior is used, the dependency on `constructs` will only be added as a `peerDependency`. Otherwise, a `devDependency` will also be added, set to the exact version configrued here.
 **copyrightOwner**?⚠️ | <code>string</code> | License copyright owner.<br/>__*Default*__: defaults to the value of authorName or "" if `authorName` is undefined.
 **copyrightPeriod**?⚠️ | <code>string</code> | The copyright years to put in the LICENSE file.<br/>__*Default*__: current year
 **dependabot**?⚠️ | <code>boolean</code> | Include dependabot configuration.<br/>__*Default*__: true

--- a/src/__tests__/__snapshots__/inventory.test.ts.snap
+++ b/src/__tests__/__snapshots__/inventory.test.ts.snap
@@ -1534,6 +1534,9 @@ Array [
         "type": "boolean",
       },
       Object {
+        "default": "- When the default behavior is used, the dependency on \`constructs\` will only
+be added as a \`peerDependency\`. Otherwise, a \`devDependency\` will also be
+added, set to the exact version configrued here.",
         "docs": "Minimum target version of constructs being tested against. If not provided, the default value depends on the configured \`cdkVersion\`:.",
         "name": "constructsVersion",
         "optional": true,

--- a/src/__tests__/awscdk-app.test.ts
+++ b/src/__tests__/awscdk-app.test.ts
@@ -1,0 +1,20 @@
+import { AwsCdkTypeScriptApp } from '../awscdk-app-ts';
+import { mkdtemp, synthSnapshot } from './util';
+
+describe('cdkVersion is >= 2.0.0', () => {
+  test('use "aws-cdk-lib" the constructs at ^10.0.5', () => {
+    const project = new AwsCdkTypeScriptApp({
+      outdir: mkdtemp(),
+      cdkVersion: '2.0.0-rc.1',
+      defaultReleaseBranch: 'main',
+      name: 'test',
+    });
+    const snap = synthSnapshot(project);
+    expect(snap['package.json'].dependencies).toStrictEqual({
+      '@aws-cdk/assert': '^2.0.0-rc.1',
+      'aws-cdk-lib': '^2.0.0-rc.1',
+      'constructs': '^10.0.5',
+    });
+    expect(snap['src/main.ts'].indexOf('import { App, Stack, StackProps } from \'aws-cdk-lib\'')).not.toEqual(-1);
+  });
+});

--- a/src/awscdk-construct.ts
+++ b/src/awscdk-construct.ts
@@ -1,3 +1,4 @@
+import * as semver from 'semver';
 import { ConstructLibrary, ConstructLibraryOptions } from './construct-lib';
 
 /**
@@ -19,7 +20,7 @@ export interface AwsCdkConstructLibraryOptions extends ConstructLibraryOptions {
    * - For CDK 2.x, the default is "10.0.5"
    * - Otherwise, the default is "*"
    *
-   * When the default behavior is used, the dependency on `constructs` will only
+   * @default - When the default behavior is used, the dependency on `constructs` will only
    * be added as a `peerDependency`. Otherwise, a `devDependency` will also be
    * added, set to the exact version configrued here.
    */
@@ -137,7 +138,7 @@ export class AwsCdkConstructLibrary extends ConstructLibrary {
   /**
    * The target CDK version for this library.
    */
-  public readonly version: string;
+  public readonly cdkVersion: string;
 
   /**
    * Whether CDK dependencies are added as normal dependencies (and peer dependencies).
@@ -152,16 +153,17 @@ export class AwsCdkConstructLibrary extends ConstructLibrary {
       },
     });
 
-    this.version = options.cdkVersionPinning ? options.cdkVersion : `^${options.cdkVersion}`;
+    this.cdkVersion = options.cdkVersionPinning ? options.cdkVersion : `^${options.cdkVersion}`;
     this.cdkDependenciesAsDeps = options.cdkDependenciesAsDeps ?? true;
 
+    const cdkMajorVersion = semver.minVersion(this.cdkVersion)?.major ?? 1;
     if (options.constructsVersion) {
       this.addPeerDeps(`constructs@^${options.constructsVersion}`);
       this.addDevDeps(`constructs@${options.constructsVersion}`);
-    } else if (options.cdkVersion.startsWith('1.')) {
+    } else if (cdkMajorVersion === 1) {
       // CDK 1.x is built on constructs 3.x
       this.addPeerDeps('constructs@^3.2.27');
-    } else if (options.cdkVersion.startsWith('2.')) {
+    } else if (cdkMajorVersion == 2) {
       // CDK 2.x is built on constructs 10.x
       this.addPeerDeps('constructs@^10.0.5');
     } else {
@@ -175,6 +177,13 @@ export class AwsCdkConstructLibrary extends ConstructLibrary {
 
     this.addCdkDependencies(...options.cdkDependencies ?? []);
     this.addCdkTestDependencies(...options.cdkTestDependencies ?? []);
+  }
+
+  /**
+   * @deprecated use `cdkVersion`
+   */
+  public get version() {
+    return this.cdkVersion;
   }
 
   /**
@@ -211,7 +220,7 @@ export class AwsCdkConstructLibrary extends ConstructLibrary {
   }
 
   private formatModuleSpec(module: string): string {
-    return `${module}@${this.version}`;
+    return `${module}@${this.cdkVersion}`;
   }
 }
 


### PR DESCRIPTION
If `cdkVersion` is set to a version above 2.0.0, the project will use `aws-cdk-lib`, `constructs@^10` and the initial sample code will also be compatible with 2.0.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.