### PR TITLE
fix(bump): invalid version selected for multiple tags

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -39,7 +39,7 @@
       "description": "Bumps version based on latest git tag and generates a changelog entry",
       "steps": [
         {
-          "exec": "git describe --tags --match=\"v*\" --first-parent --abbrev=0 > .version.tmp.json"
+          "exec": "git -c \"versionsort.suffix=-\" tag --sort=\"-version:refname\" --list \"v*\" | head -n1 > .version.tmp.json"
         },
         {
           "exec": "standard-version"

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -39,7 +39,7 @@
       "description": "Bumps version based on latest git tag and generates a changelog entry",
       "steps": [
         {
-          "exec": "git -c \"versionsort.suffix=-\" tag --sort=\"-version:refname\" --list \"v*\" | head -n1 > .version.tmp.json"
+          "exec": "git -c \"versionsort.suffix=-\" tag --sort=\"-version:refname\" --list=\"v*\" | head -n1 > .version.tmp.json"
         },
         {
           "exec": "standard-version"

--- a/src/__tests__/__snapshots__/integ.test.ts.snap
+++ b/src/__tests__/__snapshots__/integ.test.ts.snap
@@ -848,7 +848,7 @@ tsconfig.tsbuildinfo
         "name": "bump",
         "steps": Array [
           Object {
-            "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list \\"v*\\" | head -n1 > .version.tmp.json",
+            "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list=\\"v*\\" | head -n1 > .version.tmp.json",
           },
           Object {
             "exec": "standard-version",
@@ -2037,7 +2037,7 @@ tsconfig.tsbuildinfo
         "name": "bump",
         "steps": Array [
           Object {
-            "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list \\"v*\\" | head -n1 > .version.tmp.json",
+            "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list=\\"v*\\" | head -n1 > .version.tmp.json",
           },
           Object {
             "exec": "standard-version",
@@ -3354,7 +3354,7 @@ tsconfig.tsbuildinfo
         "name": "bump",
         "steps": Array [
           Object {
-            "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list \\"v*\\" | head -n1 > .version.tmp.json",
+            "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list=\\"v*\\" | head -n1 > .version.tmp.json",
           },
           Object {
             "exec": "standard-version",
@@ -4438,7 +4438,7 @@ junit.xml
         "name": "bump",
         "steps": Array [
           Object {
-            "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list \\"v*\\" | head -n1 > .version.tmp.json",
+            "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list=\\"v*\\" | head -n1 > .version.tmp.json",
           },
           Object {
             "exec": "standard-version",

--- a/src/__tests__/__snapshots__/integ.test.ts.snap
+++ b/src/__tests__/__snapshots__/integ.test.ts.snap
@@ -847,7 +847,7 @@ junit.xml
         "name": "bump",
         "steps": Array [
           Object {
-            "exec": "git describe --tags --match=\\"v*\\" --first-parent --abbrev=0 > .version.tmp.json",
+            "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list \\"v*\\" | head -n1 > .version.tmp.json",
           },
           Object {
             "exec": "standard-version",
@@ -2035,7 +2035,7 @@ junit.xml
         "name": "bump",
         "steps": Array [
           Object {
-            "exec": "git describe --tags --match=\\"v*\\" --first-parent --abbrev=0 > .version.tmp.json",
+            "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list \\"v*\\" | head -n1 > .version.tmp.json",
           },
           Object {
             "exec": "standard-version",
@@ -3351,7 +3351,7 @@ junit.xml
         "name": "bump",
         "steps": Array [
           Object {
-            "exec": "git describe --tags --match=\\"v*\\" --first-parent --abbrev=0 > .version.tmp.json",
+            "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list \\"v*\\" | head -n1 > .version.tmp.json",
           },
           Object {
             "exec": "standard-version",
@@ -4435,7 +4435,7 @@ junit.xml
         "name": "bump",
         "steps": Array [
           Object {
-            "exec": "git describe --tags --match=\\"v*\\" --first-parent --abbrev=0 > .version.tmp.json",
+            "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list \\"v*\\" | head -n1 > .version.tmp.json",
           },
           Object {
             "exec": "standard-version",

--- a/src/__tests__/__snapshots__/new.test.ts.snap
+++ b/src/__tests__/__snapshots__/new.test.ts.snap
@@ -591,7 +591,7 @@ appsync/
       "json-schema": "^0.3.0",
       "projen": "^0.3.178",
       "standard-version": "^9.0.0",
-      "ts-jest": "^26.5.5",
+      "ts-jest": "^26.5.6",
       "ts-node": "^9.1.1",
       "typescript": "^3.9.5",
     },

--- a/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
@@ -276,7 +276,7 @@ pull_request_rules:
         "name": "bump",
         "steps": Array [
           Object {
-            "exec": "git describe --tags --match=\\"v*\\" --first-parent --abbrev=0 > .version.tmp.json",
+            "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list \\"v*\\" | head -n1 > .version.tmp.json",
           },
           Object {
             "exec": "standard-version",

--- a/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
@@ -276,7 +276,7 @@ pull_request_rules:
         "name": "bump",
         "steps": Array [
           Object {
-            "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list \\"v*\\" | head -n1 > .version.tmp.json",
+            "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list=\\"v*\\" | head -n1 > .version.tmp.json",
           },
           Object {
             "exec": "standard-version",

--- a/src/__tests__/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -254,7 +254,7 @@ tsconfig.tsbuildinfo
         "name": "bump",
         "steps": Array [
           Object {
-            "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list \\"v*\\" | head -n1 > .version.tmp.json",
+            "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list=\\"v*\\" | head -n1 > .version.tmp.json",
           },
           Object {
             "exec": "standard-version",

--- a/src/__tests__/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -253,7 +253,7 @@ dist
         "name": "bump",
         "steps": Array [
           Object {
-            "exec": "git describe --tags --match=\\"v*\\" --first-parent --abbrev=0 > .version.tmp.json",
+            "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list \\"v*\\" | head -n1 > .version.tmp.json",
           },
           Object {
             "exec": "standard-version",

--- a/src/__tests__/web/__snapshots__/react-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-project.test.ts.snap
@@ -267,7 +267,7 @@ pull_request_rules:
         "name": "bump",
         "steps": Array [
           Object {
-            "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list \\"v*\\" | head -n1 > .version.tmp.json",
+            "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list=\\"v*\\" | head -n1 > .version.tmp.json",
           },
           Object {
             "exec": "standard-version",

--- a/src/__tests__/web/__snapshots__/react-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-project.test.ts.snap
@@ -267,7 +267,7 @@ pull_request_rules:
         "name": "bump",
         "steps": Array [
           Object {
-            "exec": "git describe --tags --match=\\"v*\\" --first-parent --abbrev=0 > .version.tmp.json",
+            "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list \\"v*\\" | head -n1 > .version.tmp.json",
           },
           Object {
             "exec": "standard-version",

--- a/src/__tests__/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-ts-project.test.ts.snap
@@ -257,7 +257,7 @@ dist
         "name": "bump",
         "steps": Array [
           Object {
-            "exec": "git describe --tags --match=\\"v*\\" --first-parent --abbrev=0 > .version.tmp.json",
+            "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list \\"v*\\" | head -n1 > .version.tmp.json",
           },
           Object {
             "exec": "standard-version",

--- a/src/__tests__/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-ts-project.test.ts.snap
@@ -258,7 +258,7 @@ tsconfig.tsbuildinfo
         "name": "bump",
         "steps": Array [
           Object {
-            "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list \\"v*\\" | head -n1 > .version.tmp.json",
+            "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list=\\"v*\\" | head -n1 > .version.tmp.json",
           },
           Object {
             "exec": "standard-version",

--- a/src/version.ts
+++ b/src/version.ts
@@ -31,7 +31,7 @@ export class Version extends Component {
       '-c "versionsort.suffix=-"', // makes sure pre-release versions are listed after the primary version
       'tag',
       '--sort="-version:refname"', // sort as versions and not lexicographically
-      '--list "v*"', // only tags that start with "v"
+      '--list="v*"', // only tags that start with "v"
     ].join(' ');
 
     this.bumpTask.exec(`${listGitTags} | head -n1 > ${versionFile}`);

--- a/src/version.ts
+++ b/src/version.ts
@@ -26,10 +26,15 @@ export class Version extends Component {
       condition: changesSinceLastRelease,
     });
 
-    // the default for "standard-version" is to find a tag across the entire
-    // repository but we want to select the last tag accessible from the
-    // *current branch*.
-    this.bumpTask.exec(`git describe --tags --match="v*" --first-parent --abbrev=0 > ${versionFile}`);
+    const listGitTags = [
+      'git',
+      '-c "versionsort.suffix=-"', // makes sure pre-release versions are listed after the primary version
+      'tag',
+      '--sort="-version:refname"', // sort as versions and not lexicographically
+      '--list "v*"', // only tags that start with "v"
+    ].join(' ');
+
+    this.bumpTask.exec(`${listGitTags} | head -n1 > ${versionFile}`);
     this.bumpTask.exec('standard-version');
 
     this.unbumpTask = project.addTask('unbump', {


### PR DESCRIPTION
If there are multiple version tags on the same commit, `git describe` would return the first tag which is lexicographically first. This is not what we want, so we now use `git tag` with a `version:refname` sort order in order to query the repo for the latest version (for real).

Fixes #762

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.