### PR TITLE
fix(node): dependabot builds always fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,11 +31,15 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           directory: coverage
-      - name: Commit and push changes (if any)
-        run: 'git diff --exit-code || (git add . && git commit -m "chore: self mutation"
-          && git push origin HEAD:${{ github.event.pull_request.head.ref }})'
-      - if: ${{ github.repository == github.event.pull_request.head.repo.full_name }}
-        name: Update status check
+      - name: Check for changes
+        id: git_diff
+        run: git diff --exit-code || echo "::set-output name=has_changes::true"
+      - if: steps.git_diff.outputs.has_changes
+        name: Commit and push changes (if changed)
+        run: 'git add . && git commit -m "chore: self mutation" && git push origin
+          HEAD:${{ github.event.pull_request.head.ref }}'
+      - if: steps.git_diff.outputs.has_changes
+        name: Update status check (if changed)
         run: gh api -X POST /repos/${{ github.event.pull_request.head.repo.full_name
           }}/check-runs -F name="build" -F head_sha="$(git rev-parse HEAD)" -F
           status="completed" -F conclusion="success"

--- a/src/__tests__/__snapshots__/integ.test.ts.snap
+++ b/src/__tests__/__snapshots__/integ.test.ts.snap
@@ -293,11 +293,15 @@ jobs:
           git config user.email \\"github-actions@github.com\\"
       - name: Build
         run: npx projen build
-      - name: Commit and push changes (if any)
-        run: 'git diff --exit-code || (git add . && git commit -m \\"chore: self mutation\\"
-          && git push origin HEAD:\${{ github.event.pull_request.head.ref }})'
-      - if: \${{ github.repository == github.event.pull_request.head.repo.full_name }}
-        name: Update status check
+      - name: Check for changes
+        id: git_diff
+        run: git diff --exit-code || echo \\"::set-output name=has_changes::true\\"
+      - if: steps.git_diff.outputs.has_changes
+        name: Commit and push changes (if changed)
+        run: 'git add . && git commit -m \\"chore: self mutation\\" && git push origin
+          HEAD:\${{ github.event.pull_request.head.ref }}'
+      - if: steps.git_diff.outputs.has_changes
+        name: Update status check (if changed)
         run: gh api -X POST /repos/\${{ github.event.pull_request.head.repo.full_name
           }}/check-runs -F name=\\"build\\" -F head_sha=\\"$(git rev-parse HEAD)\\" -F
           status=\\"completed\\" -F conclusion=\\"success\\"
@@ -4233,11 +4237,15 @@ jobs:
           git config user.email \\"github-actions@github.com\\"
       - name: Build
         run: npx projen build
-      - name: Commit and push changes (if any)
-        run: 'git diff --exit-code || (git add . && git commit -m \\"chore: self mutation\\"
-          && git push origin HEAD:\${{ github.event.pull_request.head.ref }})'
-      - if: \${{ github.repository == github.event.pull_request.head.repo.full_name }}
-        name: Update status check
+      - name: Check for changes
+        id: git_diff
+        run: git diff --exit-code || echo \\"::set-output name=has_changes::true\\"
+      - if: steps.git_diff.outputs.has_changes
+        name: Commit and push changes (if changed)
+        run: 'git add . && git commit -m \\"chore: self mutation\\" && git push origin
+          HEAD:\${{ github.event.pull_request.head.ref }}'
+      - if: steps.git_diff.outputs.has_changes
+        name: Update status check (if changed)
         run: gh api -X POST /repos/\${{ github.event.pull_request.head.repo.full_name
           }}/check-runs -F name=\\"build\\" -F head_sha=\\"$(git rev-parse HEAD)\\" -F
           status=\\"completed\\" -F conclusion=\\"success\\"

--- a/src/__tests__/__snapshots__/node-project.test.ts.snap
+++ b/src/__tests__/__snapshots__/node-project.test.ts.snap
@@ -24,15 +24,21 @@ git config user.email \\"github-actions@github.com\\"",
     "run": "npx projen build",
   },
   Object {
-    "name": "Commit and push changes (if any)",
-    "run": "git diff --exit-code || (git add . && git commit -m \\"chore: self mutation\\" && git push origin HEAD:\${{ github.event.pull_request.head.ref }})",
+    "id": "git_diff",
+    "name": "Check for changes",
+    "run": "git diff --exit-code || echo \\"::set-output name=has_changes::true\\"",
+  },
+  Object {
+    "if": "steps.git_diff.outputs.has_changes",
+    "name": "Commit and push changes (if changed)",
+    "run": "git add . && git commit -m \\"chore: self mutation\\" && git push origin HEAD:\${{ github.event.pull_request.head.ref }}",
   },
   Object {
     "env": Object {
       "GITHUB_TOKEN": "\${{ secrets.GITHUB_TOKEN }}",
     },
-    "if": "\${{ github.repository == github.event.pull_request.head.repo.full_name }}",
-    "name": "Update status check",
+    "if": "steps.git_diff.outputs.has_changes",
+    "name": "Update status check (if changed)",
     "run": "gh api -X POST /repos/\${{ github.event.pull_request.head.repo.full_name }}/check-runs -F name=\\"build\\" -F head_sha=\\"$(git rev-parse HEAD)\\" -F status=\\"completed\\" -F conclusion=\\"success\\"",
   },
 ]

--- a/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
@@ -60,11 +60,15 @@ jobs:
           git config user.email \\"github-actions@github.com\\"
       - name: Build
         run: npx projen build
-      - name: Commit and push changes (if any)
-        run: 'git diff --exit-code || (git add . && git commit -m \\"chore: self mutation\\"
-          && git push origin HEAD:\${{ github.event.pull_request.head.ref }})'
-      - if: \${{ github.repository == github.event.pull_request.head.repo.full_name }}
-        name: Update status check
+      - name: Check for changes
+        id: git_diff
+        run: git diff --exit-code || echo \\"::set-output name=has_changes::true\\"
+      - if: steps.git_diff.outputs.has_changes
+        name: Commit and push changes (if changed)
+        run: 'git add . && git commit -m \\"chore: self mutation\\" && git push origin
+          HEAD:\${{ github.event.pull_request.head.ref }}'
+      - if: steps.git_diff.outputs.has_changes
+        name: Update status check (if changed)
         run: gh api -X POST /repos/\${{ github.event.pull_request.head.repo.full_name
           }}/check-runs -F name=\\"build\\" -F head_sha=\\"$(git rev-parse HEAD)\\" -F
           status=\\"completed\\" -F conclusion=\\"success\\"

--- a/src/__tests__/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -61,11 +61,15 @@ jobs:
           git config user.email \\"github-actions@github.com\\"
       - name: Build
         run: npx projen build
-      - name: Commit and push changes (if any)
-        run: 'git diff --exit-code || (git add . && git commit -m \\"chore: self mutation\\"
-          && git push origin HEAD:\${{ github.event.pull_request.head.ref }})'
-      - if: \${{ github.repository == github.event.pull_request.head.repo.full_name }}
-        name: Update status check
+      - name: Check for changes
+        id: git_diff
+        run: git diff --exit-code || echo \\"::set-output name=has_changes::true\\"
+      - if: steps.git_diff.outputs.has_changes
+        name: Commit and push changes (if changed)
+        run: 'git add . && git commit -m \\"chore: self mutation\\" && git push origin
+          HEAD:\${{ github.event.pull_request.head.ref }}'
+      - if: steps.git_diff.outputs.has_changes
+        name: Update status check (if changed)
         run: gh api -X POST /repos/\${{ github.event.pull_request.head.repo.full_name
           }}/check-runs -F name=\\"build\\" -F head_sha=\\"$(git rev-parse HEAD)\\" -F
           status=\\"completed\\" -F conclusion=\\"success\\"

--- a/src/__tests__/web/__snapshots__/react-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-project.test.ts.snap
@@ -54,11 +54,15 @@ jobs:
           git config user.email \\"github-actions@github.com\\"
       - name: Build
         run: npx projen build
-      - name: Commit and push changes (if any)
-        run: 'git diff --exit-code || (git add . && git commit -m \\"chore: self mutation\\"
-          && git push origin HEAD:\${{ github.event.pull_request.head.ref }})'
-      - if: \${{ github.repository == github.event.pull_request.head.repo.full_name }}
-        name: Update status check
+      - name: Check for changes
+        id: git_diff
+        run: git diff --exit-code || echo \\"::set-output name=has_changes::true\\"
+      - if: steps.git_diff.outputs.has_changes
+        name: Commit and push changes (if changed)
+        run: 'git add . && git commit -m \\"chore: self mutation\\" && git push origin
+          HEAD:\${{ github.event.pull_request.head.ref }}'
+      - if: steps.git_diff.outputs.has_changes
+        name: Update status check (if changed)
         run: gh api -X POST /repos/\${{ github.event.pull_request.head.repo.full_name
           }}/check-runs -F name=\\"build\\" -F head_sha=\\"$(git rev-parse HEAD)\\" -F
           status=\\"completed\\" -F conclusion=\\"success\\"

--- a/src/__tests__/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-ts-project.test.ts.snap
@@ -55,11 +55,15 @@ jobs:
           git config user.email \\"github-actions@github.com\\"
       - name: Build
         run: npx projen build
-      - name: Commit and push changes (if any)
-        run: 'git diff --exit-code || (git add . && git commit -m \\"chore: self mutation\\"
-          && git push origin HEAD:\${{ github.event.pull_request.head.ref }})'
-      - if: \${{ github.repository == github.event.pull_request.head.repo.full_name }}
-        name: Update status check
+      - name: Check for changes
+        id: git_diff
+        run: git diff --exit-code || echo \\"::set-output name=has_changes::true\\"
+      - if: steps.git_diff.outputs.has_changes
+        name: Commit and push changes (if changed)
+        run: 'git add . && git commit -m \\"chore: self mutation\\" && git push origin
+          HEAD:\${{ github.event.pull_request.head.ref }}'
+      - if: steps.git_diff.outputs.has_changes
+        name: Update status check (if changed)
         run: gh api -X POST /repos/\${{ github.event.pull_request.head.repo.full_name
           }}/check-runs -F name=\\"build\\" -F head_sha=\\"$(git rev-parse HEAD)\\" -F
           status=\\"completed\\" -F conclusion=\\"success\\"


### PR DESCRIPTION
Add a condition that will only update status check if the build actually resulted in changes to the repo. This condition is added both for the "commit & push" step and the "update status" step. This means that we no longer
need the condition that only updates status checks if the PR is from a non-fork because if the push would have failed anyway and we would not get there at all.

Fixes #760

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.