### PR TITLE
chore: bump fails if there is already a tag

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -42,7 +42,7 @@
           "exec": "git -c \"versionsort.suffix=-\" tag --sort=\"-version:refname\" --list \"v*\" | head -n1 > .version.tmp.json"
         },
         {
-          "exec": "[ \"$(cat .version.tmp.json)\" == \"\" ] && echo \"v0.1.0\" > .version.tmp.json"
+          "exec": "if [ \"$(cat .version.tmp.json)\" == \"\" ]; then echo \"v0.1.0\" > .version.tmp.json; fi"
         },
         {
           "exec": "standard-version"

--- a/src/__tests__/__snapshots__/integ.test.ts.snap
+++ b/src/__tests__/__snapshots__/integ.test.ts.snap
@@ -855,7 +855,7 @@ tsconfig.tsbuildinfo
             "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list \\"v*\\" | head -n1 > .version.tmp.json",
           },
           Object {
-            "exec": "[ \\"$(cat .version.tmp.json)\\" == \\"\\" ] && echo \\"v0.1.0\\" > .version.tmp.json",
+            "exec": "if [ \\"$(cat .version.tmp.json)\\" == \\"\\" ]; then echo \\"v0.1.0\\" > .version.tmp.json; fi",
           },
           Object {
             "exec": "standard-version",
@@ -2047,7 +2047,7 @@ tsconfig.tsbuildinfo
             "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list \\"v*\\" | head -n1 > .version.tmp.json",
           },
           Object {
-            "exec": "[ \\"$(cat .version.tmp.json)\\" == \\"\\" ] && echo \\"v0.1.0\\" > .version.tmp.json",
+            "exec": "if [ \\"$(cat .version.tmp.json)\\" == \\"\\" ]; then echo \\"v0.1.0\\" > .version.tmp.json; fi",
           },
           Object {
             "exec": "standard-version",
@@ -3367,7 +3367,7 @@ tsconfig.tsbuildinfo
             "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list \\"v*\\" | head -n1 > .version.tmp.json",
           },
           Object {
-            "exec": "[ \\"$(cat .version.tmp.json)\\" == \\"\\" ] && echo \\"v0.1.0\\" > .version.tmp.json",
+            "exec": "if [ \\"$(cat .version.tmp.json)\\" == \\"\\" ]; then echo \\"v0.1.0\\" > .version.tmp.json; fi",
           },
           Object {
             "exec": "standard-version",
@@ -4458,7 +4458,7 @@ junit.xml
             "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list \\"v*\\" | head -n1 > .version.tmp.json",
           },
           Object {
-            "exec": "[ \\"$(cat .version.tmp.json)\\" == \\"\\" ] && echo \\"v0.1.0\\" > .version.tmp.json",
+            "exec": "if [ \\"$(cat .version.tmp.json)\\" == \\"\\" ]; then echo \\"v0.1.0\\" > .version.tmp.json; fi",
           },
           Object {
             "exec": "standard-version",

--- a/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
@@ -283,7 +283,7 @@ pull_request_rules:
             "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list \\"v*\\" | head -n1 > .version.tmp.json",
           },
           Object {
-            "exec": "[ \\"$(cat .version.tmp.json)\\" == \\"\\" ] && echo \\"v0.1.0\\" > .version.tmp.json",
+            "exec": "if [ \\"$(cat .version.tmp.json)\\" == \\"\\" ]; then echo \\"v0.1.0\\" > .version.tmp.json; fi",
           },
           Object {
             "exec": "standard-version",

--- a/src/__tests__/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -261,7 +261,7 @@ tsconfig.tsbuildinfo
             "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list \\"v*\\" | head -n1 > .version.tmp.json",
           },
           Object {
-            "exec": "[ \\"$(cat .version.tmp.json)\\" == \\"\\" ] && echo \\"v0.1.0\\" > .version.tmp.json",
+            "exec": "if [ \\"$(cat .version.tmp.json)\\" == \\"\\" ]; then echo \\"v0.1.0\\" > .version.tmp.json; fi",
           },
           Object {
             "exec": "standard-version",

--- a/src/__tests__/web/__snapshots__/react-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-project.test.ts.snap
@@ -274,7 +274,7 @@ pull_request_rules:
             "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list \\"v*\\" | head -n1 > .version.tmp.json",
           },
           Object {
-            "exec": "[ \\"$(cat .version.tmp.json)\\" == \\"\\" ] && echo \\"v0.1.0\\" > .version.tmp.json",
+            "exec": "if [ \\"$(cat .version.tmp.json)\\" == \\"\\" ]; then echo \\"v0.1.0\\" > .version.tmp.json; fi",
           },
           Object {
             "exec": "standard-version",

--- a/src/__tests__/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-ts-project.test.ts.snap
@@ -265,7 +265,7 @@ tsconfig.tsbuildinfo
             "exec": "git -c \\"versionsort.suffix=-\\" tag --sort=\\"-version:refname\\" --list \\"v*\\" | head -n1 > .version.tmp.json",
           },
           Object {
-            "exec": "[ \\"$(cat .version.tmp.json)\\" == \\"\\" ] && echo \\"v0.1.0\\" > .version.tmp.json",
+            "exec": "if [ \\"$(cat .version.tmp.json)\\" == \\"\\" ]; then echo \\"v0.1.0\\" > .version.tmp.json; fi",
           },
           Object {
             "exec": "standard-version",

--- a/src/version.ts
+++ b/src/version.ts
@@ -49,7 +49,7 @@ export class Version extends Component {
     const initialVersion = options.initialVersion ?? 'v0.1.0';
 
     this.bumpTask.exec(`${listGitTags} | head -n1 > ${versionFile}`);
-    this.bumpTask.exec(`[ "$(cat ${versionFile})" == "" ] && echo "${initialVersion}" > ${versionFile}`);
+    this.bumpTask.exec(`if [ "$(cat ${versionFile})" == "" ]; then echo "${initialVersion}" > ${versionFile}; fi`);
     this.bumpTask.exec('standard-version');
 
     this.unbumpTask = project.addTask('unbump', {


### PR DESCRIPTION
Fix #787 which tested if a version was not found, but then if there _was_ a version, it failed. AHHH!

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.