### PR TITLE
fix(cli): false value for interactive flag gets ignored in start command

### DIFF
--- a/src/cli/cmds/start.ts
+++ b/src/cli/cmds/start.ts
@@ -7,7 +7,7 @@ class Command implements yargs.CommandModule {
   describe = 'Prints all project commands';
 
   public builder(args: yargs.Argv) {
-    return args.option('interactive', { alias: 'i', desc: 'Interactive menu', default: true });
+    return args.option('interactive', { type: 'boolean', alias: 'i', desc: 'Interactive menu', default: true });
   }
 
   async handler(opts: any) {


### PR DESCRIPTION
Fixes #771 

Interactive flag was missing boolean type. Without type, `npx projen start --interactive false` considers false as string and still runs in interactive mode.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.