### PR TITLE
fix(node): workflows fail if repo is in restricted mode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      contents: write
     env:
       CI: "true"
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      statuses: write
+      checks: write
       contents: write
     env:
       CI: "true"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       CI: "true"
       RELEASE: "true"
@@ -59,6 +61,8 @@ jobs:
     name: Release to NPM
     needs: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
@@ -77,6 +81,8 @@ jobs:
     name: Release to Maven
     needs: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
@@ -97,6 +103,8 @@ jobs:
     name: Release to PyPi
     needs: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2

--- a/src/__tests__/__snapshots__/integ.test.ts.snap
+++ b/src/__tests__/__snapshots__/integ.test.ts.snap
@@ -262,7 +262,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      statuses: write
+      checks: write
       contents: write
     env:
       CI: \\"true\\"
@@ -4594,7 +4594,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      statuses: write
+      checks: write
       contents: write
     env:
       CI: \\"true\\"

--- a/src/__tests__/__snapshots__/integ.test.ts.snap
+++ b/src/__tests__/__snapshots__/integ.test.ts.snap
@@ -261,6 +261,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      contents: write
     env:
       CI: \\"true\\"
     steps:
@@ -309,6 +312,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       CI: \\"true\\"
       RELEASE: \\"true\\"
@@ -359,6 +364,8 @@ jobs:
     name: Release to NPM
     needs: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
@@ -377,6 +384,8 @@ jobs:
     name: Release to Maven
     needs: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
@@ -397,6 +406,8 @@ jobs:
     name: Release to PyPi
     needs: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
@@ -4582,6 +4593,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      contents: write
     env:
       CI: \\"true\\"
     steps:
@@ -4624,6 +4638,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       CI: \\"true\\"
       RELEASE: \\"true\\"

--- a/src/__tests__/__snapshots__/jsii.test.ts.snap
+++ b/src/__tests__/__snapshots__/jsii.test.ts.snap
@@ -12,6 +12,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       CI: \\"true\\"
       RELEASE: \\"true\\"
@@ -58,6 +60,8 @@ jobs:
     name: Release to NPM
     needs: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
@@ -76,6 +80,8 @@ jobs:
     name: Release to Go
     needs: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
@@ -108,6 +114,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       CI: \\"true\\"
       RELEASE: \\"true\\"
@@ -154,6 +162,8 @@ jobs:
     name: Release to NPM
     needs: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
@@ -172,6 +182,8 @@ jobs:
     name: Release to Go
     needs: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2

--- a/src/__tests__/node-project.test.ts
+++ b/src/__tests__/node-project.test.ts
@@ -1,6 +1,7 @@
 import * as yaml from 'yaml';
 import { NodeProject, NodeProjectOptions, LogLevel } from '..';
 import { DependencyType } from '../deps';
+import { JobPermission } from '../github/workflows-model';
 import * as logging from '../logging';
 import { NodePackage, NpmAccess } from '../node-package';
 import { DependenciesUpgradeMechanism } from '../node-project';
@@ -330,6 +331,9 @@ test('extend github release workflow', () => {
 
   project.releaseWorkflow?.addJobs({
     publish_docker_hub: {
+      permissions: {
+        contents: JobPermission.READ,
+      },
       runsOn: 'ubuntu-latest',
       env: {
         CI: 'true',

--- a/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
@@ -28,6 +28,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      contents: write
     env:
       CI: \\"true\\"
     steps:
@@ -74,6 +77,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       CI: \\"true\\"
       RELEASE: \\"true\\"

--- a/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
@@ -29,7 +29,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      statuses: write
+      checks: write
       contents: write
     env:
       CI: \\"true\\"

--- a/src/__tests__/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -30,7 +30,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      statuses: write
+      checks: write
       contents: write
     env:
       CI: \\"true\\"

--- a/src/__tests__/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -29,6 +29,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      contents: write
     env:
       CI: \\"true\\"
     steps:

--- a/src/__tests__/web/__snapshots__/react-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-project.test.ts.snap
@@ -27,7 +27,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      statuses: write
+      checks: write
       contents: write
     env:
       CI: \\"true\\"

--- a/src/__tests__/web/__snapshots__/react-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-project.test.ts.snap
@@ -26,6 +26,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      contents: write
     env:
       CI: \\"true\\"
     steps:
@@ -68,6 +71,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       CI: \\"true\\"
       RELEASE: \\"true\\"

--- a/src/__tests__/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-ts-project.test.ts.snap
@@ -27,6 +27,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      contents: write
     env:
       CI: \\"true\\"
     steps:

--- a/src/__tests__/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-ts-project.test.ts.snap
@@ -28,7 +28,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      statuses: write
+      checks: write
       contents: write
     env:
       CI: \\"true\\"

--- a/src/github/workflows-model.ts
+++ b/src/github/workflows-model.ts
@@ -38,13 +38,19 @@ export interface Job {
   readonly needs?: string[];
 
   /**
-   * You can modify the default permissions granted to the GITHUB_TOKEN,
-   * adding or removing access as required, so that you only allow the minimum
-   * required access.
+   * You can modify the default permissions granted to the GITHUB_TOKEN, adding
+   * or removing access as required, so that you only allow the minimum required
+   * access.
+   *
+   * Use `{ contents: READ }` if your job only needs to clone code.
+   *
+   * This is intentionally a required field since it is required in order to
+   * allow workflows to run in GitHub repositories with restricted default
+   * access.
    *
    * @see https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token
    */
-  readonly permissions?: JobPermissions;
+  readonly permissions: JobPermissions;
 
   /**
    * The environment that the job references. All environment protection rules

--- a/src/github/workflows.ts
+++ b/src/github/workflows.ts
@@ -31,6 +31,14 @@ export class GithubWorkflow extends Component {
   }
 
   public addJobs(jobs: Record<string, workflows.Job>) {
+    // verify that job has a "permissions" statement to ensure workflow can
+    // operate in repos with default tokens set to readonly
+    for (const [id, job] of Object.entries(jobs)) {
+      if (!job.permissions) {
+        throw new Error(`${id}: all workflow jobs must have a "permissions" clause to ensure workflow can operate in restricted repositories`);
+      }
+    }
+
     this.jobs = {
       ...this.jobs,
       ...jobs,

--- a/src/node-project.ts
+++ b/src/node-project.ts
@@ -1,6 +1,7 @@
 import { PROJEN_DIR, PROJEN_RC, PROJEN_VERSION } from './common';
 import { AutoMerge, DependabotOptions, GithubWorkflow, workflows } from './github';
 import { MergifyOptions } from './github/mergify';
+import { JobPermission } from './github/workflows-model';
 import { IgnoreFile } from './ignore-file';
 import { Projenrc, ProjenrcOptions } from './javascript/projenrc';
 import { Jest, JestOptions } from './jest';
@@ -630,7 +631,10 @@ export class NodeProject extends Project {
         trigger: {
           pull_request: { },
         },
-
+        permissions: {
+          statuses: JobPermission.WRITE,
+          contents: JobPermission.WRITE,
+        },
         checkoutWith: mutableBuilds ? {
           ref: branch,
           repository: repo,
@@ -714,6 +718,9 @@ export class NodeProject extends Project {
         trigger,
         env: {
           RELEASE: 'true',
+        },
+        permissions: {
+          contents: JobPermission.WRITE,
         },
         preBuildSteps: [
           {
@@ -1067,6 +1074,7 @@ export class NodeProject extends Project {
         CI: 'true', // will cause `NodeProject` to execute `yarn install` with `--frozen-lockfile`
         ...options.env ?? {},
       },
+      permissions: options.permissions,
       ...condition,
       steps: [
         ...preCheckoutSteps,
@@ -1207,6 +1215,11 @@ interface NodeBuildWorkflowOptions {
    * @default {}
    */
   readonly env?: { [name: string]: string };
+
+  /**
+   * Permissions for the build job.
+   */
+  readonly permissions: workflows.JobPermissions;
 }
 
 export interface NodeWorkflowSteps {

--- a/src/node-project.ts
+++ b/src/node-project.ts
@@ -632,7 +632,7 @@ export class NodeProject extends Project {
           pull_request: { },
         },
         permissions: {
-          statuses: JobPermission.WRITE,
+          checks: JobPermission.WRITE,
           contents: JobPermission.WRITE,
         },
         checkoutWith: mutableBuilds ? {

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -1,5 +1,6 @@
 import { Component } from './component';
 import { GithubWorkflow } from './github';
+import { JobPermission } from './github/workflows-model';
 import { Project } from './project';
 
 const JSII_RELEASE_VERSION = 'latest';
@@ -65,6 +66,7 @@ export class Publisher extends Component {
     const npmTokenSecret = options.npmTokenSecret ?? 'NPM_TOKEN';
     this.workflow.addJobs({
       release_npm: {
+        permissions: { contents: JobPermission.READ },
         name: 'Release to NPM',
         needs: [this.buildJobId],
         runsOn: 'ubuntu-latest',
@@ -96,6 +98,7 @@ export class Publisher extends Component {
     this.workflow.addJobs({
       release_nuget: {
         name: 'Release to Nuget',
+        permissions: { contents: JobPermission.READ },
         needs: [this.buildJobId],
         runsOn: 'ubuntu-latest',
         container: {
@@ -129,6 +132,7 @@ export class Publisher extends Component {
     this.workflow.addJobs({
       release_maven: {
         name: 'Release to Maven',
+        permissions: { contents: JobPermission.READ },
         needs: [this.buildJobId],
         runsOn: 'ubuntu-latest',
         container: {
@@ -165,6 +169,7 @@ export class Publisher extends Component {
     this.workflow.addJobs({
       release_pypi: {
         name: 'Release to PyPi',
+        permissions: { contents: JobPermission.READ },
         needs: [this.buildJobId],
         runsOn: 'ubuntu-latest',
         container: {
@@ -195,6 +200,7 @@ export class Publisher extends Component {
     this.workflow.addJobs({
       release_golang: {
         name: 'Release to Go',
+        permissions: { contents: JobPermission.READ },
         needs: [this.buildJobId],
         runsOn: 'ubuntu-latest',
         container: {


### PR DESCRIPTION
Make "permissions" a required property when defining a job to ensure workflows explicitly state their desired permissions. This allows them to run in GitHub repos that are configured in restricted mode.

Note that setting "write" permissions on the workflow does not mean that forks will get elevated access. Forks will always be restricted to "read" permissions according to [GitHub documentation] and manual validation.

Fixes #807

[GitHub documentation]: https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.