### PR TITLE
fix(upgrade): projen upgrade workflow never upgrades projen

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -146,6 +146,9 @@
           "exec": "npm-check-updates --upgrade --target=minor --reject='projen'"
         },
         {
+          "exec": "yarn install --check-files"
+        },
+        {
           "exec": "/bin/bash ./projen.bash"
         }
       ]

--- a/API.md
+++ b/API.md
@@ -2674,6 +2674,7 @@ Name | Type | Description
 -----|------|-------------
 **allowLibraryDependencies**🔹 | <code>boolean</code> | Allow project to take library dependencies.
 **entrypoint**🔹 | <code>string</code> | The module's entrypoint (e.g. `lib/index.js`).
+**installAndUpdateLockfileCommand**🔹 | <code>string</code> | Renders `yarn install` or `npm install` with lockfile update (not frozen).
 **installCommand**🔹 | <code>string</code> | Returns the command to execute in order to install all dependencies (always frozen).
 **manifest**⚠️ | <code>any</code> | <span></span>
 **npmAccess**🔹 | <code>[NpmAccess](#projen-npmaccess)</code> | npm package access level.

--- a/src/__tests__/__snapshots__/integ.test.ts.snap
+++ b/src/__tests__/__snapshots__/integ.test.ts.snap
@@ -1175,6 +1175,9 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
             "exec": "npm-check-updates --upgrade --target=minor --reject='projen'",
           },
           Object {
+            "exec": "yarn install --check-files",
+          },
+          Object {
             "exec": "npx projen",
           },
         ],
@@ -1187,6 +1190,9 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "steps": Array [
           Object {
             "exec": "npm-check-updates --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "yarn install --check-files",
           },
           Object {
             "exec": "npx projen",
@@ -2478,6 +2484,9 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
             "exec": "npm-check-updates --upgrade --target=minor --reject='projen'",
           },
           Object {
+            "exec": "yarn install --check-files",
+          },
+          Object {
             "exec": "npx projen",
           },
         ],
@@ -2490,6 +2499,9 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "steps": Array [
           Object {
             "exec": "npm-check-updates --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "yarn install --check-files",
           },
           Object {
             "exec": "npx projen",
@@ -3884,6 +3896,9 @@ tsconfig.tsbuildinfo
             "exec": "npm-check-updates --upgrade --target=minor --reject='projen'",
           },
           Object {
+            "exec": "yarn install --check-files",
+          },
+          Object {
             "exec": "npx projen",
           },
         ],
@@ -3896,6 +3911,9 @@ tsconfig.tsbuildinfo
         "steps": Array [
           Object {
             "exec": "npm-check-updates --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "yarn install --check-files",
           },
           Object {
             "exec": "npx projen",
@@ -5023,6 +5041,9 @@ junit.xml
             "exec": "npm-check-updates --upgrade --target=minor --reject='projen'",
           },
           Object {
+            "exec": "pnpm i",
+          },
+          Object {
             "exec": "npx projen",
           },
         ],
@@ -5035,6 +5056,9 @@ junit.xml
         "steps": Array [
           Object {
             "exec": "npm-check-updates --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "pnpm i",
           },
           Object {
             "exec": "npx projen",

--- a/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
@@ -461,6 +461,9 @@ pull_request_rules:
             "exec": "npm-check-updates --upgrade --target=minor --reject='projen'",
           },
           Object {
+            "exec": "yarn install --check-files",
+          },
+          Object {
             "exec": "npx projen",
           },
         ],
@@ -473,6 +476,9 @@ pull_request_rules:
         "steps": Array [
           Object {
             "exec": "npm-check-updates --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "yarn install --check-files",
           },
           Object {
             "exec": "npx projen",

--- a/src/__tests__/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -442,6 +442,9 @@ tsconfig.tsbuildinfo
             "exec": "npm-check-updates --upgrade --target=minor --reject='projen'",
           },
           Object {
+            "exec": "yarn install --check-files",
+          },
+          Object {
             "exec": "npx projen",
           },
         ],
@@ -454,6 +457,9 @@ tsconfig.tsbuildinfo
         "steps": Array [
           Object {
             "exec": "npm-check-updates --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "yarn install --check-files",
           },
           Object {
             "exec": "npx projen",

--- a/src/__tests__/web/__snapshots__/react-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-project.test.ts.snap
@@ -428,6 +428,9 @@ pull_request_rules:
             "exec": "npm-check-updates --upgrade --target=minor --reject='projen'",
           },
           Object {
+            "exec": "yarn install --check-files",
+          },
+          Object {
             "exec": "npx projen",
           },
         ],
@@ -440,6 +443,9 @@ pull_request_rules:
         "steps": Array [
           Object {
             "exec": "npm-check-updates --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "yarn install --check-files",
           },
           Object {
             "exec": "npx projen",

--- a/src/__tests__/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-ts-project.test.ts.snap
@@ -417,6 +417,9 @@ tsconfig.tsbuildinfo
             "exec": "npm-check-updates --upgrade --target=minor --reject='projen'",
           },
           Object {
+            "exec": "yarn install --check-files",
+          },
+          Object {
             "exec": "npx projen",
           },
         ],
@@ -429,6 +432,9 @@ tsconfig.tsbuildinfo
         "steps": Array [
           Object {
             "exec": "npm-check-updates --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "yarn install --check-files",
           },
           Object {
             "exec": "npx projen",

--- a/src/node-package.ts
+++ b/src/node-package.ts
@@ -622,6 +622,13 @@ export class NodePackage extends Component {
     return this.renderInstallCommand(true);
   }
 
+  /**
+   * Renders `yarn install` or `npm install` with lockfile update (not frozen)
+   */
+  public get installAndUpdateLockfileCommand() {
+    return this.renderInstallCommand(false);
+  }
+
   // ---------------------------------------------------------------------------------------
 
   public preSynthesize() {

--- a/src/upgrade-dependencies.ts
+++ b/src/upgrade-dependencies.ts
@@ -122,6 +122,11 @@ export class UpgradeDependencies extends Component {
     }
 
     task.exec(ncuCommand.join(' '));
+
+    // run "yarn/npm install" to update the lockfile and install any deps (such as projen)
+    task.exec(this._project.package.installAndUpdateLockfileCommand);
+
+    // run "projen" to give projen a chance to update dependencies (it will also run "yarn install")
     task.exec(this._project.projenCommand);
 
     return task;


### PR DESCRIPTION
Run `yarn install` immediately after `ncu` in order to make sure we get the correct version of `projen` before we actually run it.

Fixes #809

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.