### PR TITLE
feat(cli): --version flag

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'path';
 import * as yargs from 'yargs';
-import { PROJEN_RC } from '../common';
+import { PROJEN_RC, PROJEN_VERSION } from '../common';
 import { TaskRuntime } from '../tasks';
 import { synth } from './synth';
 import { discoverTaskCommands } from './tasks';
@@ -21,8 +21,12 @@ async function main() {
   ya.option('watch', { type: 'boolean', default: false, desc: 'Keep running and resynthesize when projenrc changes', alias: 'w' });
   ya.options('debug', { type: 'boolean', default: false, desc: 'Debug logs' });
   ya.options('rc', { desc: 'path to .projenrc.js file', default: DEFAULT_RC, type: 'string' });
-  ya.version(false);
   ya.help();
+
+  // do not use the default yargs '--version' implementation since it is
+  // global by default (it appears on all subcommands)
+  ya.version(false);
+  ya.option('version', { type: 'boolean', description: 'Show version number', global: false });
 
   const args = ya.argv;
 
@@ -32,6 +36,10 @@ async function main() {
 
   // no command means synthesize
   if (args._.length === 0) {
+    if (args.version) {
+      console.log(PROJEN_VERSION);
+      process.exit(0);
+    }
     await synth(runtime, {
       post: args.post as boolean,
       watch: args.watch as boolean,


### PR DESCRIPTION
Fixes #497

`yargs` provides a built-in utility that shows the script's version and immediately exits when the user passes the `--version` flag. Unfortunately, we are using `--version` as an field in new project types (so a user can run `projen new java --version 1.2.3` and the version will be pre-filled in their `projenrc` file), which causes a conflict. Currently, `yargs` doesn't provide ways to customize where this `--version` utility is valid (see https://github.com/yargs/yargs/issues/1918), so to work around this I manually implemented the `--version` feature so it only activates if you run `projen` with no subcommands.

Now the current behavior is:

```
$ projen --help
projen [command]

Commands:
  projen new [PROJECT-TYPE] [OPTIONS]  Creates a new projen project
  projen start                         Prints all project commands

Options:
      --post     Run post-synthesis steps such as installing dependencies. Use
                 --no-post to skip                           [boolean] [default: true]
  -w, --watch    Keep running and resynthesize when projenrc changes
                                                            [boolean] [default: false]
      --debug    Debug logs                                 [boolean] [default: false]
      --rc       path to .projenrc.js file
                                           [string] [default: "/path/to/.projenrc.js"]
      --help     Show help                                                   [boolean]
      --version  Show version number                                         [boolean]

$ projen new --help
(help information, with no --version option available)

$ projen new java --help
(help information, with java-specific --version information shown)

$ projen new java --help
(help information, with python-specific --version information shown)
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.