### PR TITLE
chore: copy package.json to backup in order to create the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
         run: /bin/bash ./projen.bash bump
       - name: build
         run: /bin/bash ./projen.bash build
+      - name: Backup version file
+        run: cp -f package.json package.json.bak.json
       - name: Unbump
         run: /bin/bash ./projen.bash unbump
       - name: Anti-tamper check
@@ -43,8 +45,9 @@ jobs:
           github.ref }} | cut -f1)"
       - name: Create release
         if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        run: gh release create v$(node -p "require('./package.json').version") -F
-          .changelog.tmp.md -t v$(node -p "require('./package.json').version")
+        run: gh release create v$(node -p "require('./package.json.bak.json').version")
+          -F .changelog.tmp.md -t v$(node -p
+          "require('./package.json.bak.json').version")
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload artifact

--- a/src/__tests__/__snapshots__/integ.test.ts.snap
+++ b/src/__tests__/__snapshots__/integ.test.ts.snap
@@ -348,8 +348,9 @@ jobs:
           github.ref }} | cut -f1)\\"
       - name: Create release
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        run: gh release create v$(node -p \\"require('./package.json').version\\") -F
-          .changelog.tmp.md -t v$(node -p \\"require('./package.json').version\\")
+        run: gh release create v$(node -p \\"require('./package.json.bak.json').version\\")
+          -F .changelog.tmp.md -t v$(node -p
+          \\"require('./package.json.bak.json').version\\")
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
       - name: Upload artifact
@@ -4646,8 +4647,9 @@ jobs:
           github.ref }} | cut -f1)\\"
       - name: Create release
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        run: gh release create v$(node -p \\"require('./package.json').version\\") -F
-          .changelog.tmp.md -t v$(node -p \\"require('./package.json').version\\")
+        run: gh release create v$(node -p \\"require('./package.json.bak.json').version\\")
+          -F .changelog.tmp.md -t v$(node -p
+          \\"require('./package.json.bak.json').version\\")
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
       - name: Upload artifact

--- a/src/__tests__/__snapshots__/integ.test.ts.snap
+++ b/src/__tests__/__snapshots__/integ.test.ts.snap
@@ -336,6 +336,8 @@ jobs:
         run: npx projen bump
       - name: build
         run: npx projen build
+      - name: Backup version file
+        run: cp -f package.json package.json.bak.json
       - name: Unbump
         run: npx projen unbump
       - name: Anti-tamper check
@@ -4632,6 +4634,8 @@ jobs:
         run: npx projen bump
       - name: build
         run: npx projen build
+      - name: Backup version file
+        run: cp -f package.json package.json.bak.json
       - name: Unbump
         run: npx projen unbump
       - name: Anti-tamper check

--- a/src/__tests__/__snapshots__/jsii.test.ts.snap
+++ b/src/__tests__/__snapshots__/jsii.test.ts.snap
@@ -44,8 +44,9 @@ jobs:
           github.ref }} | cut -f1)\\"
       - name: Create release
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        run: gh release create v$(node -p \\"require('./package.json').version\\") -F
-          .changelog.tmp.md -t v$(node -p \\"require('./package.json').version\\")
+        run: gh release create v$(node -p \\"require('./package.json.bak.json').version\\")
+          -F .changelog.tmp.md -t v$(node -p
+          \\"require('./package.json.bak.json').version\\")
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
       - name: Upload artifact
@@ -146,8 +147,9 @@ jobs:
           github.ref }} | cut -f1)\\"
       - name: Create release
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        run: gh release create v$(node -p \\"require('./package.json').version\\") -F
-          .changelog.tmp.md -t v$(node -p \\"require('./package.json').version\\")
+        run: gh release create v$(node -p \\"require('./package.json.bak.json').version\\")
+          -F .changelog.tmp.md -t v$(node -p
+          \\"require('./package.json.bak.json').version\\")
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
       - name: Upload artifact

--- a/src/__tests__/__snapshots__/jsii.test.ts.snap
+++ b/src/__tests__/__snapshots__/jsii.test.ts.snap
@@ -32,6 +32,8 @@ jobs:
         run: npx projen bump
       - name: build
         run: npx projen build
+      - name: Backup version file
+        run: cp -f package.json package.json.bak.json
       - name: Unbump
         run: npx projen unbump
       - name: Anti-tamper check
@@ -132,6 +134,8 @@ jobs:
         run: npx projen bump
       - name: build
         run: npx projen build
+      - name: Backup version file
+        run: cp -f package.json package.json.bak.json
       - name: Unbump
         run: npx projen unbump
       - name: Anti-tamper check

--- a/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
@@ -101,6 +101,8 @@ jobs:
         run: npx projen bump
       - name: build
         run: npx projen build
+      - name: Backup version file
+        run: cp -f package.json package.json.bak.json
       - name: Unbump
         run: npx projen unbump
       - name: Anti-tamper check

--- a/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
@@ -113,8 +113,9 @@ jobs:
           github.ref }} | cut -f1)\\"
       - name: Create release
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        run: gh release create v$(node -p \\"require('./package.json').version\\") -F
-          .changelog.tmp.md -t v$(node -p \\"require('./package.json').version\\")
+        run: gh release create v$(node -p \\"require('./package.json.bak.json').version\\")
+          -F .changelog.tmp.md -t v$(node -p
+          \\"require('./package.json.bak.json').version\\")
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
       - name: Upload artifact

--- a/src/__tests__/web/__snapshots__/react-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-project.test.ts.snap
@@ -91,6 +91,8 @@ jobs:
         run: npx projen bump
       - name: build
         run: npx projen build
+      - name: Backup version file
+        run: cp -f package.json package.json.bak.json
       - name: Unbump
         run: npx projen unbump
       - name: Anti-tamper check

--- a/src/__tests__/web/__snapshots__/react-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-project.test.ts.snap
@@ -103,8 +103,9 @@ jobs:
           github.ref }} | cut -f1)\\"
       - name: Create release
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        run: gh release create v$(node -p \\"require('./package.json').version\\") -F
-          .changelog.tmp.md -t v$(node -p \\"require('./package.json').version\\")
+        run: gh release create v$(node -p \\"require('./package.json.bak.json').version\\")
+          -F .changelog.tmp.md -t v$(node -p
+          \\"require('./package.json.bak.json').version\\")
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
       - name: Upload artifact


### PR DESCRIPTION
In order to create the github release, we need to know the version number but since we are reverting it
to 0.0.0, we need to store the bumped version somewhere.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.