### PR TITLE
fix(node): workflowBootstrapSteps not respected

### DIFF
--- a/API.md
+++ b/API.md
@@ -3013,7 +3013,7 @@ Name | Type | Description
 **buildTask**🔹 | <code>[tasks.Task](#projen-tasks-task)</code> | The task responsible for a full release build.
 **compileTask**🔹 | <code>[tasks.Task](#projen-tasks-task)</code> | Compiles the code.
 **entrypoint**⚠️ | <code>string</code> | <span></span>
-**installWorkflowSteps**🔹 | <code>Array<any></code> | <span></span>
+**installWorkflowSteps**🔹 | <code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code> | <span></span>
 **manifest**⚠️ | <code>any</code> | <span></span>
 **npmDistTag**⚠️ | <code>string</code> | <span></span>
 **npmRegistry**⚠️ | <code>string</code> | <span></span>

--- a/src/node-project.ts
+++ b/src/node-project.ts
@@ -393,10 +393,13 @@ export class NodeProject extends Project {
     return this.package.manifest;
   }
 
+  private readonly workflowBootstrapSteps: workflows.JobStep[];
+
   constructor(options: NodeProjectOptions) {
     super(options);
 
     this.package = new NodePackage(this, options);
+    this.workflowBootstrapSteps = options.workflowBootstrapSteps ?? [];
 
     this.runScriptCommand = (() => {
       switch (this.packageManager) {
@@ -752,8 +755,12 @@ export class NodeProject extends Project {
     this.package.addKeywords(...keywords);
   }
 
-  public get installWorkflowSteps(): any[] {
-    const install = new Array();
+  public get installWorkflowSteps(): workflows.JobStep[] {
+    const install = new Array<workflows.JobStep>();
+
+    // first run the workflow bootstrap steps
+    install.push(...this.workflowBootstrapSteps);
+
     if (this.nodeVersion) {
       install.push({
         name: 'Setup Node.js',
@@ -766,6 +773,7 @@ export class NodeProject extends Project {
       name: 'Install dependencies',
       run: this.package.installCommand,
     });
+
     return install;
   }
 


### PR DESCRIPTION
Include `workflowBootstrapSteps` in all workflows.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.