### PR TITLE
fix(deps): unable to create patch file in custom containers

### DIFF
--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -32,12 +32,12 @@ jobs:
       - name: Create Patch
         run: |-
           git add .
-          git diff --patch --staged > ${{ runner.temp }}/upgrade.patch
+          git diff --patch --staged > .upgrade.tmp.patch
       - name: Upload patch
         uses: actions/upload-artifact@v2
         with:
-          name: upgrade.patch
-          path: ${{ runner.temp }}/upgrade.patch
+          name: .upgrade.tmp.patch
+          path: .upgrade.tmp.patch
     container:
       image: jsii/superchain
   pr:
@@ -54,11 +54,11 @@ jobs:
       - name: Download patch
         uses: actions/download-artifact@v2
         with:
-          name: upgrade.patch
-          path: ${{ runner.temp }}
+          name: .upgrade.tmp.patch
+          path: .upgrade.tmp.patch
       - name: Apply patch
-        run: '[ -s ${{ runner.temp }}/upgrade.patch ] && git apply ${{ runner.temp
-          }}/upgrade.patch || echo "Empty patch. Skipping."'
+        run: '[ -s .upgrade.tmp.patch ] && git apply .upgrade.tmp.patch || echo "Empty
+          patch. Skipping."'
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@v3

--- a/src/__tests__/__snapshots__/integ.test.ts.snap
+++ b/src/__tests__/__snapshots__/integ.test.ts.snap
@@ -456,12 +456,12 @@ jobs:
       - name: Create Patch
         run: |-
           git add .
-          git diff --patch --staged > \${{ runner.temp }}/upgrade.patch
+          git diff --patch --staged > .upgrade.tmp.patch
       - name: Upload patch
         uses: actions/upload-artifact@v2
         with:
-          name: upgrade.patch
-          path: \${{ runner.temp }}/upgrade.patch
+          name: .upgrade.tmp.patch
+          path: .upgrade.tmp.patch
     container:
       image: jsii/superchain
   pr:
@@ -478,11 +478,11 @@ jobs:
       - name: Download patch
         uses: actions/download-artifact@v2
         with:
-          name: upgrade.patch
-          path: \${{ runner.temp }}
+          name: .upgrade.tmp.patch
+          path: .upgrade.tmp.patch
       - name: Apply patch
-        run: '[ -s \${{ runner.temp }}/upgrade.patch ] && git apply \${{ runner.temp
-          }}/upgrade.patch || echo \\"Empty patch. Skipping.\\"'
+        run: '[ -s .upgrade.tmp.patch ] && git apply .upgrade.tmp.patch || echo \\"Empty
+          patch. Skipping.\\"'
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@v3
@@ -563,12 +563,12 @@ jobs:
       - name: Create Patch
         run: |-
           git add .
-          git diff --patch --staged > \${{ runner.temp }}/upgrade.patch
+          git diff --patch --staged > .upgrade.tmp.patch
       - name: Upload patch
         uses: actions/upload-artifact@v2
         with:
-          name: upgrade.patch
-          path: \${{ runner.temp }}/upgrade.patch
+          name: .upgrade.tmp.patch
+          path: .upgrade.tmp.patch
     container:
       image: jsii/superchain
   pr:
@@ -585,11 +585,11 @@ jobs:
       - name: Download patch
         uses: actions/download-artifact@v2
         with:
-          name: upgrade.patch
-          path: \${{ runner.temp }}
+          name: .upgrade.tmp.patch
+          path: .upgrade.tmp.patch
       - name: Apply patch
-        run: '[ -s \${{ runner.temp }}/upgrade.patch ] && git apply \${{ runner.temp
-          }}/upgrade.patch || echo \\"Empty patch. Skipping.\\"'
+        run: '[ -s .upgrade.tmp.patch ] && git apply .upgrade.tmp.patch || echo \\"Empty
+          patch. Skipping.\\"'
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@v3
@@ -2072,12 +2072,12 @@ jobs:
       - name: Create Patch
         run: |-
           git add .
-          git diff --patch --staged > \${{ runner.temp }}/upgrade.patch
+          git diff --patch --staged > .upgrade.tmp.patch
       - name: Upload patch
         uses: actions/upload-artifact@v2
         with:
-          name: upgrade.patch
-          path: \${{ runner.temp }}/upgrade.patch
+          name: .upgrade.tmp.patch
+          path: .upgrade.tmp.patch
     container:
       image: jsii/superchain
   pr:
@@ -2093,11 +2093,11 @@ jobs:
       - name: Download patch
         uses: actions/download-artifact@v2
         with:
-          name: upgrade.patch
-          path: \${{ runner.temp }}
+          name: .upgrade.tmp.patch
+          path: .upgrade.tmp.patch
       - name: Apply patch
-        run: '[ -s \${{ runner.temp }}/upgrade.patch ] && git apply \${{ runner.temp
-          }}/upgrade.patch || echo \\"Empty patch. Skipping.\\"'
+        run: '[ -s .upgrade.tmp.patch ] && git apply .upgrade.tmp.patch || echo \\"Empty
+          patch. Skipping.\\"'
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@v3
@@ -3468,12 +3468,12 @@ jobs:
       - name: Create Patch
         run: |-
           git add .
-          git diff --patch --staged > \${{ runner.temp }}/upgrade.patch
+          git diff --patch --staged > .upgrade.tmp.patch
       - name: Upload patch
         uses: actions/upload-artifact@v2
         with:
-          name: upgrade.patch
-          path: \${{ runner.temp }}/upgrade.patch
+          name: .upgrade.tmp.patch
+          path: .upgrade.tmp.patch
   pr:
     name: Create Pull Request
     needs: upgrade
@@ -3487,11 +3487,11 @@ jobs:
       - name: Download patch
         uses: actions/download-artifact@v2
         with:
-          name: upgrade.patch
-          path: \${{ runner.temp }}
+          name: .upgrade.tmp.patch
+          path: .upgrade.tmp.patch
       - name: Apply patch
-        run: '[ -s \${{ runner.temp }}/upgrade.patch ] && git apply \${{ runner.temp
-          }}/upgrade.patch || echo \\"Empty patch. Skipping.\\"'
+        run: '[ -s .upgrade.tmp.patch ] && git apply .upgrade.tmp.patch || echo \\"Empty
+          patch. Skipping.\\"'
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@v3
@@ -4694,12 +4694,12 @@ jobs:
       - name: Create Patch
         run: |-
           git add .
-          git diff --patch --staged > \${{ runner.temp }}/upgrade.patch
+          git diff --patch --staged > .upgrade.tmp.patch
       - name: Upload patch
         uses: actions/upload-artifact@v2
         with:
-          name: upgrade.patch
-          path: \${{ runner.temp }}/upgrade.patch
+          name: .upgrade.tmp.patch
+          path: .upgrade.tmp.patch
   pr:
     name: Create Pull Request
     needs: upgrade
@@ -4714,11 +4714,11 @@ jobs:
       - name: Download patch
         uses: actions/download-artifact@v2
         with:
-          name: upgrade.patch
-          path: \${{ runner.temp }}
+          name: .upgrade.tmp.patch
+          path: .upgrade.tmp.patch
       - name: Apply patch
-        run: '[ -s \${{ runner.temp }}/upgrade.patch ] && git apply \${{ runner.temp
-          }}/upgrade.patch || echo \\"Empty patch. Skipping.\\"'
+        run: '[ -s .upgrade.tmp.patch ] && git apply .upgrade.tmp.patch || echo \\"Empty
+          patch. Skipping.\\"'
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@v3

--- a/src/__tests__/__snapshots__/upgrade-dependencies.test.ts.snap
+++ b/src/__tests__/__snapshots__/upgrade-dependencies.test.ts.snap
@@ -30,12 +30,12 @@ jobs:
       - name: Create Patch
         run: |-
           git add .
-          git diff --patch --staged > \${{ runner.temp }}/upgrade.patch
+          git diff --patch --staged > .upgrade.tmp.patch
       - name: Upload patch
         uses: actions/upload-artifact@v2
         with:
-          name: upgrade.patch
-          path: \${{ runner.temp }}/upgrade.patch
+          name: .upgrade.tmp.patch
+          path: .upgrade.tmp.patch
   pr:
     name: Create Pull Request
     needs: upgrade
@@ -50,11 +50,11 @@ jobs:
       - name: Download patch
         uses: actions/download-artifact@v2
         with:
-          name: upgrade.patch
-          path: \${{ runner.temp }}
+          name: .upgrade.tmp.patch
+          path: .upgrade.tmp.patch
       - name: Apply patch
-        run: '[ -s \${{ runner.temp }}/upgrade.patch ] && git apply \${{ runner.temp
-          }}/upgrade.patch || echo \\"Empty patch. Skipping.\\"'
+        run: '[ -s .upgrade.tmp.patch ] && git apply .upgrade.tmp.patch || echo \\"Empty
+          patch. Skipping.\\"'
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@v3
@@ -134,12 +134,12 @@ jobs:
       - name: Create Patch
         run: |-
           git add .
-          git diff --patch --staged > \${{ runner.temp }}/upgrade.patch
+          git diff --patch --staged > .upgrade.tmp.patch
       - name: Upload patch
         uses: actions/upload-artifact@v2
         with:
-          name: upgrade.patch
-          path: \${{ runner.temp }}/upgrade.patch
+          name: .upgrade.tmp.patch
+          path: .upgrade.tmp.patch
   pr:
     name: Create Pull Request
     needs: upgrade
@@ -154,11 +154,11 @@ jobs:
       - name: Download patch
         uses: actions/download-artifact@v2
         with:
-          name: upgrade.patch
-          path: \${{ runner.temp }}
+          name: .upgrade.tmp.patch
+          path: .upgrade.tmp.patch
       - name: Apply patch
-        run: '[ -s \${{ runner.temp }}/upgrade.patch ] && git apply \${{ runner.temp
-          }}/upgrade.patch || echo \\"Empty patch. Skipping.\\"'
+        run: '[ -s .upgrade.tmp.patch ] && git apply .upgrade.tmp.patch || echo \\"Empty
+          patch. Skipping.\\"'
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@v3

--- a/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
@@ -158,12 +158,12 @@ jobs:
       - name: Create Patch
         run: |-
           git add .
-          git diff --patch --staged > \${{ runner.temp }}/upgrade.patch
+          git diff --patch --staged > .upgrade.tmp.patch
       - name: Upload patch
         uses: actions/upload-artifact@v2
         with:
-          name: upgrade.patch
-          path: \${{ runner.temp }}/upgrade.patch
+          name: .upgrade.tmp.patch
+          path: .upgrade.tmp.patch
   pr:
     name: Create Pull Request
     needs: upgrade
@@ -178,11 +178,11 @@ jobs:
       - name: Download patch
         uses: actions/download-artifact@v2
         with:
-          name: upgrade.patch
-          path: \${{ runner.temp }}
+          name: .upgrade.tmp.patch
+          path: .upgrade.tmp.patch
       - name: Apply patch
-        run: '[ -s \${{ runner.temp }}/upgrade.patch ] && git apply \${{ runner.temp
-          }}/upgrade.patch || echo \\"Empty patch. Skipping.\\"'
+        run: '[ -s .upgrade.tmp.patch ] && git apply .upgrade.tmp.patch || echo \\"Empty
+          patch. Skipping.\\"'
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@v3

--- a/src/__tests__/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -99,12 +99,12 @@ jobs:
       - name: Create Patch
         run: |-
           git add .
-          git diff --patch --staged > \${{ runner.temp }}/upgrade.patch
+          git diff --patch --staged > .upgrade.tmp.patch
       - name: Upload patch
         uses: actions/upload-artifact@v2
         with:
-          name: upgrade.patch
-          path: \${{ runner.temp }}/upgrade.patch
+          name: .upgrade.tmp.patch
+          path: .upgrade.tmp.patch
   pr:
     name: Create Pull Request
     needs: upgrade
@@ -119,11 +119,11 @@ jobs:
       - name: Download patch
         uses: actions/download-artifact@v2
         with:
-          name: upgrade.patch
-          path: \${{ runner.temp }}
+          name: .upgrade.tmp.patch
+          path: .upgrade.tmp.patch
       - name: Apply patch
-        run: '[ -s \${{ runner.temp }}/upgrade.patch ] && git apply \${{ runner.temp
-          }}/upgrade.patch || echo \\"Empty patch. Skipping.\\"'
+        run: '[ -s .upgrade.tmp.patch ] && git apply .upgrade.tmp.patch || echo \\"Empty
+          patch. Skipping.\\"'
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@v3

--- a/src/__tests__/web/__snapshots__/react-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-project.test.ts.snap
@@ -144,12 +144,12 @@ jobs:
       - name: Create Patch
         run: |-
           git add .
-          git diff --patch --staged > \${{ runner.temp }}/upgrade.patch
+          git diff --patch --staged > .upgrade.tmp.patch
       - name: Upload patch
         uses: actions/upload-artifact@v2
         with:
-          name: upgrade.patch
-          path: \${{ runner.temp }}/upgrade.patch
+          name: .upgrade.tmp.patch
+          path: .upgrade.tmp.patch
   pr:
     name: Create Pull Request
     needs: upgrade
@@ -164,11 +164,11 @@ jobs:
       - name: Download patch
         uses: actions/download-artifact@v2
         with:
-          name: upgrade.patch
-          path: \${{ runner.temp }}
+          name: .upgrade.tmp.patch
+          path: .upgrade.tmp.patch
       - name: Apply patch
-        run: '[ -s \${{ runner.temp }}/upgrade.patch ] && git apply \${{ runner.temp
-          }}/upgrade.patch || echo \\"Empty patch. Skipping.\\"'
+        run: '[ -s .upgrade.tmp.patch ] && git apply .upgrade.tmp.patch || echo \\"Empty
+          patch. Skipping.\\"'
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@v3

--- a/src/__tests__/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-ts-project.test.ts.snap
@@ -89,12 +89,12 @@ jobs:
       - name: Create Patch
         run: |-
           git add .
-          git diff --patch --staged > \${{ runner.temp }}/upgrade.patch
+          git diff --patch --staged > .upgrade.tmp.patch
       - name: Upload patch
         uses: actions/upload-artifact@v2
         with:
-          name: upgrade.patch
-          path: \${{ runner.temp }}/upgrade.patch
+          name: .upgrade.tmp.patch
+          path: .upgrade.tmp.patch
   pr:
     name: Create Pull Request
     needs: upgrade
@@ -109,11 +109,11 @@ jobs:
       - name: Download patch
         uses: actions/download-artifact@v2
         with:
-          name: upgrade.patch
-          path: \${{ runner.temp }}
+          name: .upgrade.tmp.patch
+          path: .upgrade.tmp.patch
       - name: Apply patch
-        run: '[ -s \${{ runner.temp }}/upgrade.patch ] && git apply \${{ runner.temp
-          }}/upgrade.patch || echo \\"Empty patch. Skipping.\\"'
+        run: '[ -s .upgrade.tmp.patch ] && git apply .upgrade.tmp.patch || echo \\"Empty
+          patch. Skipping.\\"'
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
Sometimes, the `runner.tmp` directory does not exist (e.g. when a custom container is used). Instead, just create it under cwd.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.