### PR TITLE
feat(deps): use projen token for deps workflow if defined

### DIFF
--- a/src/__tests__/__snapshots__/integ.test.ts.snap
+++ b/src/__tests__/__snapshots__/integ.test.ts.snap
@@ -487,7 +487,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@v3
         with:
-          token: \${{ secrets.GITHUB_TOKEN }}
+          token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: >-
             chore(deps): upgrade dependencies
 

--- a/src/node-project.ts
+++ b/src/node-project.ts
@@ -637,6 +637,8 @@ export class NodeProject extends Project {
       ? DependenciesUpgradeMechanism.dependabot()
       : DependenciesUpgradeMechanism.githubWorkflow({
         workflowOptions: options.workflowContainerImage ? {
+          // if projen secret is defined, use it (otherwise default to GITHUB_TOKEN).
+          secret: options.projenUpgradeSecret,
           container: {
             image: options.workflowContainerImage,
           },


### PR DESCRIPTION
If `projenUpgradeSecret` is defined, use it for the normal dependency upgrade workflow and not just for the projen upgrade workflow. This is useful if dep changes require workflow changes

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.