### PR TITLE
fix(deps): deps workflow fails due to patchfile going into the wrong directory

### DIFF
--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -55,7 +55,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: .upgrade.tmp.patch
-          path: .upgrade.tmp.patch
       - name: Apply patch
         run: '[ -s .upgrade.tmp.patch ] && git apply .upgrade.tmp.patch || echo "Empty
           patch. Skipping."'

--- a/src/__tests__/__snapshots__/integ.test.ts.snap
+++ b/src/__tests__/__snapshots__/integ.test.ts.snap
@@ -479,7 +479,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: .upgrade.tmp.patch
-          path: .upgrade.tmp.patch
       - name: Apply patch
         run: '[ -s .upgrade.tmp.patch ] && git apply .upgrade.tmp.patch || echo \\"Empty
           patch. Skipping.\\"'
@@ -586,7 +585,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: .upgrade.tmp.patch
-          path: .upgrade.tmp.patch
       - name: Apply patch
         run: '[ -s .upgrade.tmp.patch ] && git apply .upgrade.tmp.patch || echo \\"Empty
           patch. Skipping.\\"'
@@ -2094,7 +2092,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: .upgrade.tmp.patch
-          path: .upgrade.tmp.patch
       - name: Apply patch
         run: '[ -s .upgrade.tmp.patch ] && git apply .upgrade.tmp.patch || echo \\"Empty
           patch. Skipping.\\"'
@@ -3488,7 +3485,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: .upgrade.tmp.patch
-          path: .upgrade.tmp.patch
       - name: Apply patch
         run: '[ -s .upgrade.tmp.patch ] && git apply .upgrade.tmp.patch || echo \\"Empty
           patch. Skipping.\\"'
@@ -4715,7 +4711,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: .upgrade.tmp.patch
-          path: .upgrade.tmp.patch
       - name: Apply patch
         run: '[ -s .upgrade.tmp.patch ] && git apply .upgrade.tmp.patch || echo \\"Empty
           patch. Skipping.\\"'

--- a/src/__tests__/__snapshots__/upgrade-dependencies.test.ts.snap
+++ b/src/__tests__/__snapshots__/upgrade-dependencies.test.ts.snap
@@ -51,7 +51,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: .upgrade.tmp.patch
-          path: .upgrade.tmp.patch
       - name: Apply patch
         run: '[ -s .upgrade.tmp.patch ] && git apply .upgrade.tmp.patch || echo \\"Empty
           patch. Skipping.\\"'
@@ -155,7 +154,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: .upgrade.tmp.patch
-          path: .upgrade.tmp.patch
       - name: Apply patch
         run: '[ -s .upgrade.tmp.patch ] && git apply .upgrade.tmp.patch || echo \\"Empty
           patch. Skipping.\\"'

--- a/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
@@ -179,7 +179,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: .upgrade.tmp.patch
-          path: .upgrade.tmp.patch
       - name: Apply patch
         run: '[ -s .upgrade.tmp.patch ] && git apply .upgrade.tmp.patch || echo \\"Empty
           patch. Skipping.\\"'

--- a/src/__tests__/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -120,7 +120,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: .upgrade.tmp.patch
-          path: .upgrade.tmp.patch
       - name: Apply patch
         run: '[ -s .upgrade.tmp.patch ] && git apply .upgrade.tmp.patch || echo \\"Empty
           patch. Skipping.\\"'

--- a/src/__tests__/web/__snapshots__/react-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-project.test.ts.snap
@@ -165,7 +165,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: .upgrade.tmp.patch
-          path: .upgrade.tmp.patch
       - name: Apply patch
         run: '[ -s .upgrade.tmp.patch ] && git apply .upgrade.tmp.patch || echo \\"Empty
           patch. Skipping.\\"'

--- a/src/__tests__/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-ts-project.test.ts.snap
@@ -110,7 +110,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: .upgrade.tmp.patch
-          path: .upgrade.tmp.patch
       - name: Apply patch
         run: '[ -s .upgrade.tmp.patch ] && git apply .upgrade.tmp.patch || echo \\"Empty
           patch. Skipping.\\"'

--- a/src/upgrade-dependencies.ts
+++ b/src/upgrade-dependencies.ts
@@ -260,7 +260,7 @@ export class UpgradeDependencies extends Component {
       {
         name: 'Download patch',
         uses: 'actions/download-artifact@v2',
-        with: { name: upgrade.patchFile, path: upgrade.patchFile },
+        with: { name: upgrade.patchFile },
       },
       {
         name: 'Apply patch',


### PR DESCRIPTION
The `download-artifact` action should not use `path`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.