### PR TITLE
feat: add conditional operators for mergify rule

### DIFF
--- a/API.md
+++ b/API.md
@@ -175,6 +175,7 @@ Name|Description
 [github.DependabotIgnore](#projen-github-dependabotignore)|You can use the `ignore` option to customize which dependencies are updated.
 [github.DependabotOptions](#projen-github-dependabotoptions)|*No description*
 [github.GitHubOptions](#projen-github-githuboptions)|*No description*
+[github.MergifyConditionalOperator](#projen-github-mergifyconditionaloperator)|The Mergify conditional operators that can be used are: `or` and `and`.
 [github.MergifyOptions](#projen-github-mergifyoptions)|*No description*
 [github.MergifyRule](#projen-github-mergifyrule)|*No description*
 [github.PullRequestTemplateOptions](#projen-github-pullrequesttemplateoptions)|Options for `PullRequestTemplate`.
@@ -5369,9 +5370,9 @@ addRule(rule: MergifyRule): void
 ```
 
 * **rule** (<code>[github.MergifyRule](#projen-github-mergifyrule)</code>)  *No description*
-  * **actions** (<code>Map<string, any></code>)  *No description* 
-  * **conditions** (<code>Array<string></code>)  *No description* 
-  * **name** (<code>string</code>)  *No description* 
+  * **actions** (<code>Map<string, any></code>)  A dictionary made of Actions that will be executed on the matching pull requests. 
+  * **conditions** (<code>Array<string &#124; [github.MergifyConditionalOperator](#projen-github-mergifyconditionaloperator)></code>)  A list of Conditions string that must match against the pull request for the rule to be applied. 
+  * **name** (<code>string</code>)  The name of the rule. 
 
 
 
@@ -10542,6 +10543,22 @@ Name | Type | Description
 
 
 
+## struct MergifyConditionalOperator 🔹 <a id="projen-github-mergifyconditionaloperator"></a>
+
+
+The Mergify conditional operators that can be used are: `or` and `and`.
+
+Note: The number of nested conditions is limited to 3.
+
+
+
+Name | Type | Description 
+-----|------|-------------
+**and**?🔹 | <code>Array<string &#124; [github.MergifyConditionalOperator](#projen-github-mergifyconditionaloperator)></code> | __*Optional*__
+**or**?🔹 | <code>Array<string &#124; [github.MergifyConditionalOperator](#projen-github-mergifyconditionaloperator)></code> | __*Optional*__
+
+
+
 ## struct MergifyOptions 🔹 <a id="projen-github-mergifyoptions"></a>
 
 
@@ -10564,9 +10581,9 @@ Name | Type | Description
 
 Name | Type | Description 
 -----|------|-------------
-**actions**🔹 | <code>Map<string, any></code> | <span></span>
-**conditions**🔹 | <code>Array<string></code> | <span></span>
-**name**🔹 | <code>string</code> | <span></span>
+**actions**🔹 | <code>Map<string, any></code> | A dictionary made of Actions that will be executed on the matching pull requests.
+**conditions**🔹 | <code>Array<string &#124; [github.MergifyConditionalOperator](#projen-github-mergifyconditionaloperator)></code> | A list of Conditions string that must match against the pull request for the rule to be applied.
+**name**🔹 | <code>string</code> | The name of the rule.
 
 
 

--- a/src/github/mergify.ts
+++ b/src/github/mergify.ts
@@ -2,9 +2,34 @@ import { Component } from '../component';
 import { YamlFile } from '../yaml';
 import { GitHub } from './github';
 
+/**
+ * The Mergify conditional operators that can be used are: `or` and `and`.
+ * Note: The number of nested conditions is limited to 3.
+ */
+export interface MergifyConditionalOperator {
+  readonly or?: MergifyCondition[];
+  readonly and?: MergifyCondition[];
+}
+
+export type MergifyCondition = string | MergifyConditionalOperator;
+
 export interface MergifyRule {
+  /**
+   * The name of the rule. This is not used by the engine directly,
+   * but is used when reporting information about a rule.
+   */
   readonly name: string;
-  readonly conditions: string[];
+  /**
+   * A list of Conditions string that must match against the
+   * pull request for the rule to be applied.
+   * @see https://docs.mergify.io/conditions/#combining-conditions-with-operators
+   */
+  readonly conditions: MergifyCondition[];
+  /**
+   * A dictionary made of Actions that will be executed on the
+   * matching pull requests.
+   * @see https://docs.mergify.io/actions/#actions
+   */
   readonly actions: { [action: string]: any };
 }
 

--- a/src/github/mergify.ts
+++ b/src/github/mergify.ts
@@ -5,6 +5,7 @@ import { GitHub } from './github';
 /**
  * The Mergify conditional operators that can be used are: `or` and `and`.
  * Note: The number of nested conditions is limited to 3.
+ * @see https://docs.mergify.io/conditions/#combining-conditions-with-operators
  */
 export interface MergifyConditionalOperator {
   readonly or?: MergifyCondition[];
@@ -22,7 +23,7 @@ export interface MergifyRule {
   /**
    * A list of Conditions string that must match against the
    * pull request for the rule to be applied.
-   * @see https://docs.mergify.io/conditions/#combining-conditions-with-operators
+   * @see https://docs.mergify.io/conditions/#conditions
    */
   readonly conditions: MergifyCondition[];
   /**


### PR DESCRIPTION
According to Mergify documentation [here](https://docs.mergify.io/conditions/#conditions), Projen interface is missing the conditional operators so that the configuration can be simplified. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.