### PR TITLE
fix: "yarn link projen" is broken

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,24 +69,26 @@ When your local version of projen builds successfully, you can test it to create
 a new project by going into another directory and invoking the binary directly:
 
 ```console
-$ pwd
-/path/to/projen
-$ cd ..
-$ mkdir testing
-$ cd testing
-$ ../projen/bin/projen new <project-type>
+$ cd /path/to/local/projen
+$ yarn link
+$ cd/
+
+# existing project
+$ cd /my/other/project
+$ yarn link projen
+
+# new project
+$ mkdir /my/new/project
+$ cd /my/new/project
+$ /path/to/local/projen/bin/projen new TYPE
+$ yarn link projen # !IMPORTANT
 ```
 
-Running `npx projen` in an existing projen-based project will by default run the
-version of projen that is installed by npm, so to override this and synthesize
-using your locally built projen, run:
+From now on, running `npx projen` (or `pj`) in this directory will use the local
+development version of projen instead of the latest one from npm.
 
 ```console
-$ pwd
-/path/to/root/of/some/project
-$ rm -rf node_modules/projen && ../path/to/projen/bin/projen
-Synthesizing project ...
-...
+$ yarn unlink projen
 ```
 
 ### Version bumping

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,20 +68,30 @@ and formatting errors whenever possible while saving a document.
 When your local version of projen builds successfully, you can test it to create
 a new project by going into another directory and invoking the binary directly:
 
+First, tell yarn to create a link from your local development copy:
+
 ```console
 $ cd /path/to/local/projen
 $ yarn link
-$ cd/
+```
 
-# existing project
-$ cd /my/other/project
-$ yarn link projen
+Now, to create new projects:
 
-# new project
+```console
 $ mkdir /my/new/project
 $ cd /my/new/project
-$ /path/to/local/projen/bin/projen new TYPE
-$ yarn link projen # !IMPORTANT
+$ yarn link projen
+$ npx projen new TYPE
+$ yarn link projen # <-- important to run this again
+```
+
+If you already have an existing project and you want to test a new projen
+feature against it:
+
+```console
+$ cd /my/other/project
+$ yarn link projen
+$ npx projen
 ```
 
 From now on, running `npx projen` (or `pj`) in this directory will use the local

--- a/src/__tests__/__snapshots__/integ.test.ts.snap
+++ b/src/__tests__/__snapshots__/integ.test.ts.snap
@@ -706,7 +706,6 @@ tsconfig.tsbuildinfo
       Object {
         "name": "projen",
         "type": "build",
-        "version": "^999.999.999",
       },
       Object {
         "name": "standard-version",
@@ -1427,7 +1426,7 @@ project.synth();
       "jsii-pacmak": "*",
       "json-schema": "*",
       "npm-check-updates": "^11",
-      "projen": "^999.999.999",
+      "projen": "*",
       "standard-version": "^9",
       "ts-jest": "*",
       "typescript": "*",
@@ -2133,7 +2132,6 @@ tsconfig.tsbuildinfo
       Object {
         "name": "projen",
         "type": "build",
-        "version": "^999.999.999",
       },
       Object {
         "name": "ts-jest",
@@ -2836,7 +2834,7 @@ project.synth();
       "json-schema": "*",
       "json-schema-to-typescript": "*",
       "npm-check-updates": "^11",
-      "projen": "^999.999.999",
+      "projen": "*",
       "ts-jest": "*",
       "typescript": "*",
     },
@@ -3498,7 +3496,6 @@ tsconfig.tsbuildinfo
       Object {
         "name": "projen",
         "type": "build",
-        "version": "^999.999.999",
       },
       Object {
         "name": "ts-jest",
@@ -4192,7 +4189,7 @@ project.synth();
       "jest-junit": "^12",
       "json-schema": "*",
       "npm-check-updates": "^11",
-      "projen": "^999.999.999",
+      "projen": "*",
       "ts-jest": "*",
       "typescript": "*",
     },
@@ -4696,7 +4693,6 @@ junit.xml
       Object {
         "name": "projen",
         "type": "build",
-        "version": "^999.999.999",
       },
       Object {
         "name": "standard-version",
@@ -5112,7 +5108,7 @@ project.synth();
       "jest": "*",
       "jest-junit": "^12",
       "npm-check-updates": "^11",
-      "projen": "^999.999.999",
+      "projen": "*",
       "standard-version": "^9",
     },
     "jest": Object {

--- a/src/__tests__/util.ts
+++ b/src/__tests__/util.ts
@@ -164,7 +164,7 @@ export function sanitizeOutput(dir: string) {
   const depsPath = path.join(dir, '.projen', 'deps.json');
   const deps = fs.readJsonSync(depsPath);
   for (const dep of deps.dependencies) {
-    if (dep.name === 'projen') {
+    if (dep.name === 'projen' && dep.version) {
       dep.version = dep.version.replace(/\d+\.\d+\.\d+/, '999.999.999');
     }
   }

--- a/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
@@ -307,7 +307,6 @@ pull_request_rules:
       Object {
         "name": "projen",
         "type": "build",
-        "version": "^1.2.3",
       },
       Object {
         "name": "standard-version",
@@ -717,7 +716,7 @@ pull_request_rules:
     },
     "devDependencies": Object {
       "npm-check-updates": "^11",
-      "projen": "^1.2.3",
+      "projen": "*",
       "standard-version": "^9",
     },
     "engines": Object {

--- a/src/__tests__/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -276,7 +276,6 @@ tsconfig.tsbuildinfo
       Object {
         "name": "projen",
         "type": "build",
-        "version": "^1.2.3",
       },
       Object {
         "name": "typescript",
@@ -682,7 +681,7 @@ tsconfig.tsbuildinfo
       "@types/react": "*",
       "@types/react-dom": "*",
       "npm-check-updates": "^11",
-      "projen": "^1.2.3",
+      "projen": "*",
       "typescript": "*",
     },
     "engines": Object {

--- a/src/__tests__/web/__snapshots__/react-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-project.test.ts.snap
@@ -301,7 +301,6 @@ pull_request_rules:
       Object {
         "name": "projen",
         "type": "build",
-        "version": "^1.2.3",
       },
       Object {
         "name": "standard-version",
@@ -700,7 +699,7 @@ pull_request_rules:
       "@testing-library/react": "*",
       "@testing-library/user-event": "*",
       "npm-check-updates": "^11",
-      "projen": "^1.2.3",
+      "projen": "*",
       "standard-version": "^9",
     },
     "eslintConfig": Object {

--- a/src/__tests__/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-ts-project.test.ts.snap
@@ -278,7 +278,6 @@ tsconfig.tsbuildinfo
       Object {
         "name": "projen",
         "type": "build",
-        "version": "^1.2.3",
       },
       Object {
         "name": "typescript",
@@ -668,7 +667,7 @@ tsconfig.tsbuildinfo
       "@types/react": "*",
       "@types/react-dom": "*",
       "npm-check-updates": "^11",
-      "projen": "^1.2.3",
+      "projen": "*",
       "typescript": "^4.0.3",
     },
     "eslintConfig": Object {

--- a/src/__tests__/web/nextjs-project.test.ts
+++ b/src/__tests__/web/nextjs-project.test.ts
@@ -23,7 +23,6 @@ class TestNextJsProject extends NextJsProject {
       outdir: mkdtemp(),
       logging: { level: LogLevel.OFF },
       defaultReleaseBranch: 'main',
-      projenVersion: '^1.2.3',
     });
   }
 }

--- a/src/__tests__/web/nextjs-ts-project.test.ts
+++ b/src/__tests__/web/nextjs-ts-project.test.ts
@@ -23,7 +23,6 @@ class TestNextJsTypeScriptProject extends NextJsTypeScriptProject {
       outdir: mkdtemp(),
       logging: { level: LogLevel.OFF },
       defaultReleaseBranch: 'main',
-      projenVersion: '^1.2.3',
     });
   }
 }

--- a/src/__tests__/web/react-project.test.ts
+++ b/src/__tests__/web/react-project.test.ts
@@ -57,7 +57,6 @@ class TestReactProject extends ReactProject {
       outdir: mkdtemp(),
       logging: { level: LogLevel.OFF },
       defaultReleaseBranch: 'main',
-      projenVersion: '^1.2.3',
     });
   }
 }

--- a/src/__tests__/web/react-ts-project.test.ts
+++ b/src/__tests__/web/react-ts-project.test.ts
@@ -16,7 +16,6 @@ class TestReactTypeScriptProject extends ReactTypeScriptProject {
       outdir: mkdtemp(),
       logging: { level: LogLevel.OFF },
       defaultReleaseBranch: 'main',
-      projenVersion: '^1.2.3',
     });
   }
 }

--- a/src/node-package.ts
+++ b/src/node-package.ts
@@ -1,6 +1,6 @@
-import { join, resolve } from 'path';
+import { join } from 'path';
 import { parse as urlparse } from 'url';
-import { accessSync, constants, existsSync, lstatSync, readdirSync, readJsonSync, unlinkSync } from 'fs-extra';
+import { accessSync, constants, existsSync, readdirSync, readJsonSync } from 'fs-extra';
 import * as semver from 'semver';
 import { resolve as resolveJson } from './_resolve';
 import { Component } from './component';
@@ -672,15 +672,6 @@ export class NodePackage extends Component {
     super.postSynthesize();
 
     const outdir = this.project.outdir;
-
-    // now we run `yarn install`, but before we do that, remove the
-    // `node_modules/projen` symlink so that yarn won't hate us.
-    const projenModule = resolve('node_modules', 'projen');
-    try {
-      if (lstatSync(projenModule).isSymbolicLink()) {
-        unlinkSync(projenModule);
-      }
-    } catch (e) { }
 
     exec(this.renderInstallCommand(this.isAutomatedBuild), { cwd: outdir });
 

--- a/src/node-project.ts
+++ b/src/node-project.ts
@@ -1,4 +1,4 @@
-import { PROJEN_DIR, PROJEN_RC, PROJEN_VERSION } from './common';
+import { PROJEN_DIR, PROJEN_RC } from './common';
 import { AutoMerge, DependabotOptions, GithubWorkflow, workflows } from './github';
 import { MergifyOptions } from './github/mergify';
 import { JobPermission } from './github/workflows-model';
@@ -506,8 +506,8 @@ export class NodeProject extends Project {
 
     const projen = options.projenDevDependency ?? true;
     if (projen) {
-      const projenVersion = options.projenVersion ?? `^${PROJEN_VERSION}`;
-      this.addDevDeps(`projen@${projenVersion}`);
+      const postfix = options.projenVersion ? `@${options.projenVersion}` : '';
+      this.addDevDeps(`projen${postfix}`);
     }
 
     if (!options.defaultReleaseBranch) {


### PR DESCRIPTION
By default, do not pin projen to the CLI version and let the dependency manager maintain the version. This also has the affect of enabling normal use of `yarn link`.
Update CONTRIBUTING to describe the local test workflow.

Fixes #151

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.