### PR TITLE
fix: #904 allow overwrite of tasks

### DIFF
--- a/src/tasks/tasks.ts
+++ b/src/tasks/tasks.ts
@@ -51,9 +51,6 @@ export class Tasks extends Component {
    */
   public addTask(name: string, options: TaskOptions = {}) {
     const task = new Task(name, options);
-    if (this._tasks[name]) {
-      throw new Error(`A task with the name ${name} already exists. To override it, call removeTask first and then create the new task.`);
-    }
     this._tasks[name] = task;
     return task;
   }


### PR DESCRIPTION
This PR allows for tasks to be overwritten: without this, a task may not be changed without removing the whole of the DAG of dependent tasks and the task itself, then adding the change, then replacing the whole of the DAG.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.