### PR TITLE
feat(cli): do not show cli help on errors

### DIFF
--- a/src/__tests__/__snapshots__/new.test.ts.snap
+++ b/src/__tests__/__snapshots__/new.test.ts.snap
@@ -242,6 +242,7 @@ Object {
 /.github/pull_request_template.md          	linguist-generated
 /.github/workflows/build.yml               	linguist-generated
 /.github/workflows/release.yml             	linguist-generated
+/.github/workflows/stale.yml               	linguist-generated
 /.github/workflows/upgrade-dependencies.yml	linguist-generated
 /.gitignore                                	linguist-generated
 /.gitpod.yml                               	linguist-generated
@@ -291,6 +292,7 @@ yarn-error.log*
 !/.github/pull_request_template.md
 !/.github/workflows/build.yml
 !/.github/workflows/release.yml
+!/.github/workflows/stale.yml
 !/.github/workflows/upgrade-dependencies.yml
 !/.gitpod.yml
 !/.mergify.yml
@@ -510,7 +512,7 @@ tsconfig.tsbuildinfo
         "name": "compile",
         "steps": Array [
           Object {
-            "exec": "tsc",
+            "exec": "tsc --build",
           },
         ],
       },
@@ -672,7 +674,7 @@ tsconfig.tsbuildinfo
         "name": "watch",
         "steps": Array [
           Object {
-            "exec": "tsc -w",
+            "exec": "tsc --build -w",
           },
         ],
       },

--- a/src/__tests__/util.ts
+++ b/src/__tests__/util.ts
@@ -43,7 +43,7 @@ export function execProjenCLI(workdir: string, args: string[] = []) {
     ...args,
   ];
 
-  return exec(command.map(x => `"${x}"`).join(' '), { cwd: workdir, stdio: 'inherit' });
+  return exec(command.map(x => `"${x}"`).join(' '), { cwd: workdir });
 }
 
 export interface SynthOutput {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,6 +16,7 @@ async function main() {
 
   ya.recommendCommands();
   ya.strictCommands();
+  ya.showHelpOnFail(false);
   ya.wrap(yargs.terminalWidth());
   ya.option('post', { type: 'boolean', default: true, desc: 'Run post-synthesis steps such as installing dependencies. Use --no-post to skip' });
   ya.option('watch', { type: 'boolean', default: false, desc: 'Keep running and resynthesize when projenrc changes', alias: 'w' });

--- a/src/cli/macros.ts
+++ b/src/cli/macros.ts
@@ -1,23 +1,23 @@
 import * as path from 'path';
 import { execOrUndefined, formatAsPythonModule } from '../util';
 
-export function tryProcessMacro(macro: string) {
+export function tryProcessMacro(cwd: string, macro: string) {
   if (!macro.startsWith('$')) { return undefined; }
 
-  const basedir = path.basename(process.cwd());
+  const basedir = path.basename(cwd);
 
   switch (macro) {
     case '$BASEDIR': return basedir;
     case '$GIT_REMOTE':
-      const origin = execOrUndefined('git remote get-url origin');
+      const origin = execOrUndefined('git remote get-url origin', { cwd });
       if (origin) {
         return origin;
       }
-      const slug = getFromGitConfig('github.user') ?? resolveEmail().split('@')[0];
+      const slug = getFromGitConfig(cwd, 'github.user') ?? resolveEmail(cwd).split('@')[0];
       return `https://github.com/${slug}/${basedir}.git`;
 
-    case '$GIT_USER_NAME': return getFromGitConfig('user.name') ?? 'user';
-    case '$GIT_USER_EMAIL': return resolveEmail();
+    case '$GIT_USER_NAME': return getFromGitConfig(cwd, 'user.name') ?? 'user';
+    case '$GIT_USER_EMAIL': return resolveEmail(cwd);
     case '$PYTHON_MODULE_NAME': return formatAsPythonModule(basedir);
   }
 
@@ -28,11 +28,11 @@ export function tryProcessMacro(macro: string) {
  * Returns a value from git config. Searches local and then global git config.
  * @param key the config key
  */
-function getFromGitConfig(key: string): string | undefined {
-  return execOrUndefined(`git config --get --includes ${key}`)
-    ?? execOrUndefined(`git config --get --global --includes ${key}`);
+function getFromGitConfig(cwd: string, key: string): string | undefined {
+  return execOrUndefined(`git config --get --includes ${key}`, { cwd })
+    ?? execOrUndefined(`git config --get --global --includes ${key}`, { cwd });
 }
 
-function resolveEmail(): string {
-  return getFromGitConfig('user.email') ?? 'user@domain.com';
+function resolveEmail(cwd: string): string {
+  return getFromGitConfig(cwd, 'user.email') ?? 'user@domain.com';
 }

--- a/src/release/bump-version.ts
+++ b/src/release/bump-version.ts
@@ -1,7 +1,7 @@
 import { join } from 'path';
 import { pathExists, readFile, remove, writeFile } from 'fs-extra';
 import * as logging from '../logging';
-import { execCapture } from '../util';
+import { exec, execCapture } from '../util';
 
 export interface BumpOptions {
   /**
@@ -118,8 +118,7 @@ export async function bump(cwd: string, options: BumpOptions) {
     cmd.push('--first-release');
   }
 
-  // use execCapture so that STDOUT wont pollute our output
-  execCapture(cmd.join(' '), { cwd });
+  exec(cmd.join(' '), { cwd });
 
   await remove(rcfile);
 

--- a/src/release/bump-version.ts
+++ b/src/release/bump-version.ts
@@ -118,7 +118,8 @@ export async function bump(cwd: string, options: BumpOptions) {
     cmd.push('--first-release');
   }
 
-  execCapture(cmd.join(' '), { stdio: 'inherit', cwd });
+  // use execCapture so that STDOUT wont pollute our output
+  execCapture(cmd.join(' '), { cwd });
 
   await remove(rcfile);
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,31 +5,35 @@ import * as logging from './logging';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const decamelize = require('decamelize');
 
-export function exec(command: string, options?: { cwd?: string }): void {
+export function exec(command: string, options: { cwd: string }): void {
   logging.verbose(command);
   child_process.execSync(command, {
     stdio: ['inherit', process.stderr, 'pipe'], // "pipe" for STDERR means it appears in exceptions
-    ...options,
+    cwd: options.cwd,
   });
 }
 
 /**
  * Executes command and returns STDOUT. If the command fails (non-zero), throws an error.
  */
-export function execCapture(command: string, options?: child_process.ExecSyncOptions) {
+export function execCapture(command: string, options: { cwd: string }) {
   logging.verbose(command);
   return child_process.execSync(command, {
-    stdio: ['inherit', 'pipe', 'inherit'],
-    ...options,
+    stdio: ['inherit', 'pipe', 'pipe'], // "pipe" for STDERR means it appears in exceptions
+    cwd: options.cwd,
   });
 }
 
 /**
  * Executes `command` and returns its value or undefined if the command failed.
  */
-export function execOrUndefined(command: string, options?: child_process.ExecSyncOptions): string | undefined {
+export function execOrUndefined(command: string, options: { cwd: string }): string | undefined {
   try {
-    const value = child_process.execSync(command, { stdio: ['inherit', 'pipe', 'ignore'], ...options }).toString('utf-8').trim();
+    const value = child_process.execSync(command, {
+      stdio: ['inherit', 'pipe', 'pipe'], // "pipe" for STDERR means it appears in exceptions
+      cwd: options.cwd,
+    }).toString('utf-8').trim();
+
     if (!value) { return undefined; } // an empty string is the same as undefined
     return value;
   } catch {

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,10 +5,16 @@ import * as logging from './logging';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const decamelize = require('decamelize');
 
+const MAX_BUFFER = 10 * 1024 * 1024;
+
+/**
+ * Executes a command with STDOUT > STDERR.
+ */
 export function exec(command: string, options: { cwd: string }): void {
   logging.verbose(command);
   child_process.execSync(command, {
     stdio: ['inherit', process.stderr, 'pipe'], // "pipe" for STDERR means it appears in exceptions
+    maxBuffer: MAX_BUFFER,
     cwd: options.cwd,
   });
 }
@@ -20,6 +26,7 @@ export function execCapture(command: string, options: { cwd: string }) {
   logging.verbose(command);
   return child_process.execSync(command, {
     stdio: ['inherit', 'pipe', 'pipe'], // "pipe" for STDERR means it appears in exceptions
+    maxBuffer: MAX_BUFFER,
     cwd: options.cwd,
   });
 }
@@ -31,6 +38,7 @@ export function execOrUndefined(command: string, options: { cwd: string }): stri
   try {
     const value = child_process.execSync(command, {
       stdio: ['inherit', 'pipe', 'pipe'], // "pipe" for STDERR means it appears in exceptions
+      maxBuffer: MAX_BUFFER,
       cwd: options.cwd,
     }).toString('utf-8').trim();
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,10 +5,10 @@ import * as logging from './logging';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const decamelize = require('decamelize');
 
-export function exec(command: string, options?: child_process.ExecSyncOptions) {
+export function exec(command: string, options?: { cwd?: string }): void {
   logging.verbose(command);
-  return child_process.execSync(command, {
-    stdio: ['inherit', process.stderr, 'pipe'],
+  child_process.execSync(command, {
+    stdio: ['inherit', process.stderr, 'pipe'], // "pipe" for STDERR means it appears in exceptions
     ...options,
   });
 }


### PR DESCRIPTION
Also, enforce that `exec()` always pipes STDERR so that it is included in exception messages.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.