### PR TITLE
chore: remove duplicate unit test

### DIFF
--- a/src/__tests__/__snapshots__/new.test.ts.snap
+++ b/src/__tests__/__snapshots__/new.test.ts.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`--no-git wont create a git repository 1`] = `undefined`;
-
 exports[`can choose from one of multiple external project types 1`] = `
 Object {
   ".eslintrc.json": Object {

--- a/src/__tests__/new.test.ts
+++ b/src/__tests__/new.test.ts
@@ -161,15 +161,6 @@ describe('git', () => {
   });
 });
 
-test('--no-git wont create a git repository', () => {
-  withProjectDir(projectdir => {
-    execProjenCLI(projectdir, ['new', 'project', '--project-type', 'lib', '--projenrc-java', '--no-synth']);
-
-    const projenrc = directorySnapshot(projectdir)['src/test/java/projenrc.java'];
-    expect(projenrc).toMatchSnapshot();
-  }, { git: false });
-});
-
 function withProjectDir(code: (workdir: string) => void, options: { git?: boolean } = {}) {
   const outdir = mkdtemp();
   try {


### PR DESCRIPTION
This test doesn't seem to do what it claims since the --no-git flag isn't being passed in, and the description seems identical to the test immediately preceding it. It was probably added by accident.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.