### PR TITLE
feat: upgrade default @types/node to v12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.2.0
         with:
-          node-version: 10.17.0
+          node-version: 12.19.16
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Set git identity

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.2.0
         with:
-          node-version: 12.19.16
+          node-version: 12.19.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Set git identity

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.2.0
         with:
-          node-version: 12.19.16
+          node-version: 12.19.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.2.0
         with:
-          node-version: 10.17.0
+          node-version: 12.19.16
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Release

--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.2.0
         with:
-          node-version: 10.17.0
+          node-version: 12.19.16
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.2.0
         with:
-          node-version: 12.19.16
+          node-version: 12.19.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "@types/node",
-      "version": "^12.19.16",
+      "version": "^12.19.0",
       "type": "build"
     },
     {

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "@types/node",
-      "version": "^10.17.0",
+      "version": "^12.19.16",
       "type": "build"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -41,7 +41,7 @@ const project = new JsiiProject({
 
   projenDevDependency: false, // because I am projen
   releaseToNpm: true,
-  minNodeVersion: '12.19.16',
+  minNodeVersion: '12.19.0',
   codeCov: true,
   defaultReleaseBranch: 'main',
   gitpod: true,

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -41,7 +41,7 @@ const project = new JsiiProject({
 
   projenDevDependency: false, // because I am projen
   releaseToNpm: true,
-  minNodeVersion: '10.17.0',
+  minNodeVersion: '12.19.16',
   codeCov: true,
   defaultReleaseBranch: 'main',
   gitpod: true,

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/glob": "^7.1.3",
     "@types/ini": "^1.3.30",
     "@types/jest": "^26.0.23",
-    "@types/node": "^12.19.16",
+    "@types/node": "^12.19.0",
     "@types/semver": "^7.3.6",
     "@types/yargs": "^15.0.14",
     "@typescript-eslint/eslint-plugin": "^4.28.1",
@@ -91,7 +91,7 @@
     "yargs"
   ],
   "engines": {
-    "node": ">= 12.19.16"
+    "node": ">= 12.19.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/glob": "^7.1.3",
     "@types/ini": "^1.3.30",
     "@types/jest": "^26.0.23",
-    "@types/node": "^10.17.0",
+    "@types/node": "^12.19.16",
     "@types/semver": "^7.3.6",
     "@types/yargs": "^15.0.14",
     "@typescript-eslint/eslint-plugin": "^4.28.1",
@@ -91,7 +91,7 @@
     "yargs"
   ],
   "engines": {
-    "node": ">= 10.17.0"
+    "node": ">= 12.19.16"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/src/__tests__/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-ts-project.test.ts.snap
@@ -304,7 +304,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^10.17.0",
+        "version": "^12.19.16",
       },
       Object {
         "name": "@types/react",
@@ -700,7 +700,7 @@ tsconfig.tsbuildinfo
       "@testing-library/react": "*",
       "@testing-library/user-event": "*",
       "@types/jest": "*",
-      "@types/node": "^10.17.0",
+      "@types/node": "^12.19.16",
       "@types/react": "*",
       "@types/react-dom": "*",
       "npm-check-updates": "^11",

--- a/src/__tests__/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-ts-project.test.ts.snap
@@ -304,7 +304,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^12.19.16",
+        "version": "^12.19.0",
       },
       Object {
         "name": "@types/react",
@@ -700,7 +700,7 @@ tsconfig.tsbuildinfo
       "@testing-library/react": "*",
       "@testing-library/user-event": "*",
       "@types/jest": "*",
-      "@types/node": "^12.19.16",
+      "@types/node": "^12.19.0",
       "@types/react": "*",
       "@types/react-dom": "*",
       "npm-check-updates": "^11",

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -393,7 +393,7 @@ export class TypeScriptProject extends NodeProject {
 
     this.addDevDeps(
       `typescript${tsver}`,
-      `@types/node@^${this.package.minNodeVersion ?? '10.17.0'}`, // install the minimum version to ensure compatibility
+      `@types/node@^${this.package.minNodeVersion ?? '12.19.16'}`, // install the minimum version to ensure compatibility
     );
 
     // generate sample code in `src` and `lib` if these directories are empty or non-existent.

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -393,7 +393,7 @@ export class TypeScriptProject extends NodeProject {
 
     this.addDevDeps(
       `typescript${tsver}`,
-      `@types/node@^${this.package.minNodeVersion ?? '12.19.16'}`, // install the minimum version to ensure compatibility
+      `@types/node@^${this.package.minNodeVersion ?? '12.19.0'}`, // install the minimum version to ensure compatibility
     );
 
     // generate sample code in `src` and `lib` if these directories are empty or non-existent.

--- a/yarn.lock
+++ b/yarn.lock
@@ -796,7 +796,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.0.0.tgz#067a6c49dc7a5c2412a505628e26902ae967bf6f"
   integrity sha512-TmCW5HoZ2o2/z2EYi109jLqIaPIi9y/lc2LmDCWzuCi35bcaQ+OtUh6nwBiFK7SOu25FAU5+YKdqFZUwtqGSdg==
 
-"@types/node@^12.19.16":
+"@types/node@^12.19.0":
   version "12.20.15"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.15.tgz#10ee6a6a3f971966fddfa3f6e89ef7a73ec622df"
   integrity sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -796,10 +796,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.0.0.tgz#067a6c49dc7a5c2412a505628e26902ae967bf6f"
   integrity sha512-TmCW5HoZ2o2/z2EYi109jLqIaPIi9y/lc2LmDCWzuCi35bcaQ+OtUh6nwBiFK7SOu25FAU5+YKdqFZUwtqGSdg==
 
-"@types/node@^10.17.0":
-  version "10.17.60"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
-  integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
+"@types/node@^12.19.16":
+  version "12.20.15"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.15.tgz#10ee6a6a3f971966fddfa3f6e89ef7a73ec622df"
+  integrity sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
Node v10 is [no longer being supported](https://nodejs.org/en/about/releases/), so this PR updates the default version of @types/node vended in TypeScript projects to v12, as well as the minNodeVersion used by projen itself to v12.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.