### PR TITLE
chore: do not use “projen publish:xxx” in publish jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,10 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: /bin/bash ./projen.bash publish:npm
+        run: npx -p jsii-release@latest jsii-release-npm
         env:
+          NPM_DIST_TAG: latest
+          NPM_REGISTRY: registry.npmjs.org
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     container:
       image: jsii/superchain
@@ -79,7 +81,7 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: /bin/bash ./projen.bash publish:maven
+        run: npx -p jsii-release@latest jsii-release-maven
         env:
           MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           MAVEN_GPG_PRIVATE_KEY_PASSPHRASE: ${{ secrets.MAVEN_GPG_PRIVATE_KEY_PASSPHRASE }}
@@ -101,7 +103,7 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: /bin/bash ./projen.bash publish:pypi
+        run: npx -p jsii-release@latest jsii-release-pypi
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}

--- a/src/__tests__/__snapshots__/integ.test.ts.snap
+++ b/src/__tests__/__snapshots__/integ.test.ts.snap
@@ -375,8 +375,10 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: npx projen publish:npm
+        run: npx -p jsii-release@latest jsii-release-npm
         env:
+          NPM_DIST_TAG: latest
+          NPM_REGISTRY: registry.npmjs.org
           NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
     container:
       image: jsii/superchain
@@ -393,7 +395,7 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: npx projen publish:maven
+        run: npx -p jsii-release@latest jsii-release-maven
         env:
           MAVEN_GPG_PRIVATE_KEY: \${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           MAVEN_GPG_PRIVATE_KEY_PASSPHRASE: \${{ secrets.MAVEN_GPG_PRIVATE_KEY_PASSPHRASE }}
@@ -415,7 +417,7 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: npx projen publish:pypi
+        run: npx -p jsii-release@latest jsii-release-pypi
         env:
           TWINE_USERNAME: \${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: \${{ secrets.TWINE_PASSWORD }}

--- a/src/__tests__/__snapshots__/jsii.test.ts.snap
+++ b/src/__tests__/__snapshots__/jsii.test.ts.snap
@@ -60,8 +60,10 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: npx projen publish:npm
+        run: npx -p jsii-release@latest jsii-release-npm
         env:
+          NPM_DIST_TAG: latest
+          NPM_REGISTRY: registry.npmjs.org
           NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
     container:
       image: jsii/superchain
@@ -78,8 +80,13 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: npx projen publish:go
+        run: npx -p jsii-release@latest jsii-release-golang
         env:
+          GITHUB_REPO: github.com/foo/bar
+          GIT_BRANCH: custom-branch
+          GIT_USER_NAME: custom user
+          GIT_USER_EMAIL: custom@email.com
+          GIT_COMMIT_MESSAGE: custom commit message
           GITHUB_TOKEN: \${{ secrets.CUSTOM_SECRET }}
     container:
       image: jsii/superchain
@@ -146,8 +153,10 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: npx projen publish:npm
+        run: npx -p jsii-release@latest jsii-release-npm
         env:
+          NPM_DIST_TAG: latest
+          NPM_REGISTRY: registry.npmjs.org
           NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
     container:
       image: jsii/superchain
@@ -164,8 +173,10 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: npx projen publish:go
+        run: npx -p jsii-release@latest jsii-release-golang
         env:
+          GIT_USER_NAME: GitHub Actions
+          GIT_USER_EMAIL: github-actions@github.com
           GITHUB_TOKEN: \${{ secrets.GO_GITHUB_TOKEN }}
     container:
       image: jsii/superchain

--- a/src/__tests__/jsii.test.ts
+++ b/src/__tests__/jsii.test.ts
@@ -69,6 +69,11 @@ describe('maven repository options', () => {
       ],
       steps: [{ exec: 'npx -p jsii-release@latest jsii-release-maven' }],
     });
+
+    const workflow = outdir['.github/workflows/release.yml'];
+    expect(workflow).toContain('run: npx -p jsii-release@latest jsii-release-maven');
+    expect(workflow).not.toContainEqual('MAVEN_SERVER_ID');
+    expect(workflow).not.toContainEqual('MAVEN_REPOSITORY_URL');
   });
 
   test('use nexus repo new endpoint', () => {
@@ -104,6 +109,12 @@ describe('maven repository options', () => {
       ],
       steps: [{ exec: 'npx -p jsii-release@latest jsii-release-maven' }],
     });
+
+    const workflow = outdir['.github/workflows/release.yml'];
+    expect(workflow).toContain('run: npx -p jsii-release@latest jsii-release-maven');
+    expect(workflow).toContain('MAVEN_ENDPOINT: https://s01.oss.sonatype.org');
+    expect(workflow).not.toContainEqual('MAVEN_SERVER_ID');
+    expect(workflow).not.toContainEqual('MAVEN_REPOSITORY_URL');
   });
 
   test('use github as repository', () => {
@@ -141,6 +152,10 @@ describe('maven repository options', () => {
       ],
       steps: [{ exec: 'npx -p jsii-release@latest jsii-release-maven' }],
     });
+
+    const workflow = outdir['.github/workflows/release.yml'];
+    expect(workflow).toContain('MAVEN_SERVER_ID: github');
+    expect(workflow).toContain('MAVEN_REPOSITORY_URL: https://maven.pkg.github.com/eladb');
   });
 });
 

--- a/src/__tests__/release/__snapshots__/release.test.ts.snap
+++ b/src/__tests__/release/__snapshots__/release.test.ts.snap
@@ -361,7 +361,7 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: projen publish:pypi
+        run: npx -p jsii-release@latest jsii-release-pypi
         env:
           TWINE_USERNAME: \${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: \${{ secrets.TWINE_PASSWORD }}
@@ -428,7 +428,7 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: projen publish:pypi
+        run: npx -p jsii-release@latest jsii-release-pypi
         env:
           TWINE_USERNAME: \${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: \${{ secrets.TWINE_PASSWORD }}
@@ -649,8 +649,9 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: projen publish:npm
+        run: npx -p jsii-release@latest jsii-release-npm
         env:
+          NPM_REGISTRY: npm.pkg.github.com
           NPM_TOKEN: \${{ secrets.GITHUB_TOKEN }}
     container:
       image: jsii/superchain
@@ -1231,8 +1232,10 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: projen publish:go
+        run: npx -p jsii-release@latest jsii-release-golang
         env:
+          GIT_USER_NAME: GitHub Actions
+          GIT_USER_EMAIL: github-actions@github.com
           GITHUB_TOKEN: \${{ secrets.GO_GITHUB_TOKEN }}
     container:
       image: jsii/superchain
@@ -1249,7 +1252,7 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: projen publish:maven
+        run: npx -p jsii-release@latest jsii-release-maven
         env:
           MAVEN_GPG_PRIVATE_KEY: \${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           MAVEN_GPG_PRIVATE_KEY_PASSPHRASE: \${{ secrets.MAVEN_GPG_PRIVATE_KEY_PASSPHRASE }}
@@ -1271,7 +1274,7 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: projen publish:npm
+        run: npx -p jsii-release@latest jsii-release-npm
         env:
           NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
     container:
@@ -1289,7 +1292,7 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: projen publish:nuget
+        run: npx -p jsii-release@latest jsii-release-nuget
         env:
           NUGET_API_KEY: \${{ secrets.NUGET_API_KEY }}
     container:
@@ -1307,7 +1310,7 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: projen publish:pypi
+        run: npx -p jsii-release@latest jsii-release-pypi
         env:
           TWINE_USERNAME: \${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: \${{ secrets.TWINE_PASSWORD }}


### PR DESCRIPTION
Since the publish job does not checkout the sources, we cannot really use projen tasks there. Instead, just emit the actual command and environment into the workflow. Not a huge deal.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.