### PR TITLE
fix(release): typescript release is broken due to missing files

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -291,6 +291,9 @@
       },
       "steps": [
         {
+          "exec": "rm -fr dist"
+        },
+        {
           "spawn": "bump"
         },
         {

--- a/src/__tests__/__snapshots__/integ.test.ts.snap
+++ b/src/__tests__/__snapshots__/integ.test.ts.snap
@@ -1095,6 +1095,9 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "release",
         "steps": Array [
           Object {
+            "exec": "rm -fr dist",
+          },
+          Object {
             "spawn": "bump",
           },
           Object {
@@ -3786,9 +3789,6 @@ tsconfig.tsbuildinfo
         "name": "package",
         "steps": Array [
           Object {
-            "exec": "rm -fr dist",
-          },
-          Object {
             "exec": "mkdir -p dist/js",
           },
           Object {
@@ -4964,6 +4964,9 @@ junit.xml
         },
         "name": "release",
         "steps": Array [
+          Object {
+            "exec": "rm -fr dist",
+          },
           Object {
             "spawn": "bump",
           },

--- a/src/__tests__/release/__snapshots__/release.test.ts.snap
+++ b/src/__tests__/release/__snapshots__/release.test.ts.snap
@@ -217,6 +217,9 @@ node_modules/
         "name": "release",
         "steps": Array [
           Object {
+            "exec": "rm -fr dist",
+          },
+          Object {
             "spawn": "bump",
           },
           Object {
@@ -239,6 +242,9 @@ node_modules/
         "name": "release:10.x",
         "steps": Array [
           Object {
+            "exec": "rm -fr dist",
+          },
+          Object {
             "spawn": "bump",
           },
           Object {
@@ -260,6 +266,9 @@ node_modules/
         },
         "name": "release:2.x",
         "steps": Array [
+          Object {
+            "exec": "rm -fr dist",
+          },
           Object {
             "spawn": "bump",
           },
@@ -527,6 +536,9 @@ node_modules/
         "name": "release",
         "steps": Array [
           Object {
+            "exec": "rm -fr dist",
+          },
+          Object {
             "spawn": "bump",
           },
           Object {
@@ -548,6 +560,9 @@ node_modules/
         },
         "name": "release:foo",
         "steps": Array [
+          Object {
+            "exec": "rm -fr dist",
+          },
           Object {
             "spawn": "bump",
           },
@@ -743,6 +758,9 @@ node_modules/
         "name": "release",
         "steps": Array [
           Object {
+            "exec": "rm -fr dist",
+          },
+          Object {
             "spawn": "bump",
           },
           Object {
@@ -852,6 +870,9 @@ Object {
       },
       "name": "release",
       "steps": Array [
+        Object {
+          "exec": "rm -fr dist",
+        },
         Object {
           "spawn": "bump",
         },
@@ -1010,6 +1031,9 @@ node_modules/
         "name": "release",
         "steps": Array [
           Object {
+            "exec": "rm -fr dist",
+          },
+          Object {
             "spawn": "bump",
           },
           Object {
@@ -1122,6 +1146,9 @@ Object {
       "name": "release",
       "steps": Array [
         Object {
+          "exec": "rm -fr dist",
+        },
+        Object {
           "spawn": "bump",
         },
         Object {
@@ -1144,6 +1171,9 @@ Object {
       },
       "name": "release:10.x",
       "steps": Array [
+        Object {
+          "exec": "rm -fr dist",
+        },
         Object {
           "spawn": "bump",
         },
@@ -1418,6 +1448,9 @@ Object {
       "name": "release",
       "steps": Array [
         Object {
+          "exec": "rm -fr dist",
+        },
+        Object {
           "spawn": "bump",
         },
         Object {
@@ -1666,6 +1699,9 @@ node_modules/
         "name": "release",
         "steps": Array [
           Object {
+            "exec": "rm -fr dist",
+          },
+          Object {
             "spawn": "bump",
           },
           Object {
@@ -1687,6 +1723,9 @@ node_modules/
         },
         "name": "release:3.x",
         "steps": Array [
+          Object {
+            "exec": "rm -fr dist",
+          },
           Object {
             "spawn": "bump",
           },
@@ -1710,6 +1749,9 @@ node_modules/
         },
         "name": "release:next",
         "steps": Array [
+          Object {
+            "exec": "rm -fr dist",
+          },
           Object {
             "spawn": "bump",
           },
@@ -1870,6 +1912,9 @@ node_modules/
         },
         "name": "release:10.x",
         "steps": Array [
+          Object {
+            "exec": "rm -fr dist",
+          },
           Object {
             "spawn": "bump",
           },

--- a/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
@@ -446,6 +446,9 @@ pull_request_rules:
         "name": "release",
         "steps": Array [
           Object {
+            "exec": "rm -fr dist",
+          },
+          Object {
             "spawn": "bump",
           },
           Object {

--- a/src/__tests__/web/__snapshots__/react-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-project.test.ts.snap
@@ -433,6 +433,9 @@ pull_request_rules:
         "name": "release",
         "steps": Array [
           Object {
+            "exec": "rm -fr dist",
+          },
+          Object {
             "spawn": "bump",
           },
           Object {

--- a/src/release/release.ts
+++ b/src/release/release.ts
@@ -141,7 +141,7 @@ export class Release extends Component {
    */
   public readonly publisher: Publisher;
 
-  private readonly task: Task;
+  private readonly buildTask: Task;
   private readonly version: Version;
   private readonly postBuildSteps: workflows.JobStep[];
   private readonly antitamper: boolean;
@@ -162,7 +162,7 @@ export class Release extends Component {
       throw new Error('"releaseBranches" is no longer an array. See type annotations');
     }
 
-    this.task = options.task;
+    this.buildTask = options.task;
     this.preBuildSteps = options.releaseWorkflowSetupSteps ?? [];
     this.postBuildSteps = options.postBuildSteps ?? [];
     this.antitamper = options.antitamper ?? true;
@@ -281,8 +281,9 @@ export class Release extends Component {
       env,
     });
 
+    releaseTask.exec(`rm -fr ${this.artifactDirectory}`);
     releaseTask.spawn(this.version.bumpTask);
-    releaseTask.spawn(this.task);
+    releaseTask.spawn(this.buildTask);
     releaseTask.spawn(this.version.unbumpTask);
 
     // anti-tamper check (fails if there were changes to committed files)

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -216,7 +216,6 @@ export class TypeScriptProject extends NodeProject {
         description: 'Create an npm tarball',
       });
 
-      this.packageTask.exec('rm -fr dist');
       this.packageTask.exec('mkdir -p dist/js');
       this.packageTask.exec(`${this.package.packageManager} pack`);
       this.packageTask.exec('mv *.tgz dist/js/');


### PR DESCRIPTION
The `package` task for TypeScript deletes the `dist` directory before it runs. This conflicts with the release task that was introduced in #917 which emitted `version.txt` and `changelog.md` into `dist` for later consumption when the GitHub release is created.

To address this, we moved to cleanup of `dist` from the `package` to the `release` task.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.