### PR TITLE
fix(release): use posix path for changelog and bump file

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { posix } from 'path';
 import { Component } from './component';
 import { Project } from './project';
 import { Task } from './tasks';
@@ -41,8 +41,8 @@ export class Version extends Component {
   constructor(project: Project, options: VersionOptions) {
     super(project);
 
-    this.changelogFile = join(options.artifactsDirectory, 'changelog.md');
-    this.bumpFile = join(options.artifactsDirectory, 'version.txt');
+    this.changelogFile = posix.join(options.artifactsDirectory, 'changelog.md');
+    this.bumpFile = posix.join(options.artifactsDirectory, 'version.txt');
 
     const versionFile = options.versionFile;
 


### PR DESCRIPTION
When using projen on a windows machine on a project with the version component, the workflows and tasks contained `\` in their path, thus resulting in a difference between windows/not-windows synths. It also breaks the release script when running in github actions.

This PR forces the use of posix slashes for those files.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.