### PR TITLE
fix(docgen): add additional args to typedoc and update version

### DIFF
--- a/src/typescript-typedoc.ts
+++ b/src/typescript-typedoc.ts
@@ -5,11 +5,11 @@ import { TypeScriptProject } from './typescript';
  */
 export class TypedocDocgen {
   constructor(project: TypeScriptProject) {
-    project.addDevDeps('typedoc@^0.20.35');
+    project.addDevDeps('typedoc@^0.21.4');
 
     const docgen = project.addTask('docgen', {
       description: `Generate TypeScript API reference ${project.docsDirectory}`,
-      exec: 'typedoc --out ' + project.docsDirectory,
+      exec: `typedoc ${project.srcdir} --disableSources --out ${project.docsDirectory}`,
     });
 
     project.buildTask.spawn(docgen);


### PR DESCRIPTION
I'm not sure that this was working for anyone else, but typedoc requires an entrypoint of some sort to be passed in. It also seemed reasonable to update the version of typedoc (the issue was present in both versions) so that it can support typescript 4.3.

As an opinioned change, I added the `disableSources` flag as well. Without that flag, typedoc generates links to the source in the html with a SHA that will be constantly changing. While a nice feature, it causes very noisy diffs.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.