### PR TITLE
fix(jsii): `.projenrc.ts` accidentally relying on `tsconfig.json`

### DIFF
--- a/src/__tests__/__snapshots__/new.test.ts.snap
+++ b/src/__tests__/__snapshots__/new.test.ts.snap
@@ -422,7 +422,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "typedoc",
         "type": "build",
-        "version": "^0.20.35",
+        "version": "^0.21.4",
       },
       Object {
         "name": "typescript",
@@ -527,7 +527,7 @@ tsconfig.tsbuildinfo
         "name": "docgen",
         "steps": Array [
           Object {
-            "exec": "typedoc --out docs/",
+            "exec": "typedoc src --disableSources --out docs/",
           },
         ],
       },
@@ -951,7 +951,7 @@ project.synth();",
       "projen": "^999.999.999",
       "standard-version": "^9",
       "ts-jest": "*",
-      "typedoc": "^0.20.35",
+      "typedoc": "^0.21.4",
       "typescript": "^4.2.0",
     },
     "jest": Object {

--- a/src/typescript/projenrc.ts
+++ b/src/typescript/projenrc.ts
@@ -32,7 +32,11 @@ export class Projenrc extends Component {
     // specific task (if this task is not defined, projen falls back to
     // running "node .projenrc.js").
     project.addDevDeps('ts-node@^9');
-    project.addTask(TypeScriptProject.DEFAULT_TASK, { exec: `ts-node ${this.rcfile}` });
+
+    // use the --skip-project flag to ensure ts-node doesn't use the
+    // tsconfig.json settings intended for the project's source code
+    // see: https://github.com/projen/projen/issues/948
+    project.addTask(TypeScriptProject.DEFAULT_TASK, { exec: `ts-node --skip-project ${this.rcfile}` });
 
     this.generateProjenrc();
   }


### PR DESCRIPTION
Fixes #948 

Uses the `--skip-project` flag on `ts-node` to "Skip reading `tsconfig.json`". 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.