### PR TITLE
fix(source-code): empty lines have trailing whitespace

### DIFF
--- a/src/__tests__/source-code.test.ts
+++ b/src/__tests__/source-code.test.ts
@@ -64,6 +64,6 @@ test('trailing whitespace is trimmed', () => {
   
   expect(synthSnapshot(project)['test.txt']).toStrictEqual([
     '',
-    '    hello, world.'
+    '        hello, world.'
   ].join('\n'));
 });

--- a/src/__tests__/source-code.test.ts
+++ b/src/__tests__/source-code.test.ts
@@ -51,3 +51,19 @@ test('indent', () => {
     'level0',
   ].join('\n'));
 });
+
+test('trailing whitespace is trimmed', () => {
+  const project = new TestProject();
+  const hello = new SourceCode(project, 'test.txt', { indent: 4 });
+  hello.open();
+  hello.line();
+  hello.open();
+  hello.line('hello, world.   ');
+  hello.close();
+  hello.close();
+  
+  expect(synthSnapshot(project)['test.txt']).toStrictEqual([
+    '',
+    '    hello, world.'
+  ].join('\n'));
+});

--- a/src/__tests__/source-code.test.ts
+++ b/src/__tests__/source-code.test.ts
@@ -61,9 +61,9 @@ test('trailing whitespace is trimmed', () => {
   hello.line('hello, world.   ');
   hello.close();
   hello.close();
-  
+
   expect(synthSnapshot(project)['test.txt']).toStrictEqual([
     '',
-    '        hello, world.'
+    '        hello, world.',
   ].join('\n'));
 });

--- a/src/source-code.ts
+++ b/src/source-code.ts
@@ -34,7 +34,7 @@ export class SourceCode extends Component {
   public line(code?: string) {
     const spaces: number = this.indent * this.indentLevel;
     const prefix = ' '.repeat(spaces);
-    this.file.addLine(prefix + (code ?? ''));
+    this.file.addLine((prefix + (code ?? '')).trimEnd());
   }
 
   /**


### PR DESCRIPTION
If `code.line()` is called inside a block, it will create a line with trailing whitespace which would fail linters. Call `.trimEnd()` to trim.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.