### PR TITLE
fix(jsii): error if docgen is explicitly enabled

### DIFF
--- a/src/__tests__/jsii.test.ts
+++ b/src/__tests__/jsii.test.ts
@@ -277,6 +277,20 @@ describe('publish to go', () => {
   });
 });
 
+test('docgen: true should just work', () => {
+  const project = new TestJsiiProject({
+    author: 'My name',
+    name: 'testproject',
+    authorAddress: 'https://foo.bar',
+    defaultReleaseBranch: 'main',
+    repositoryUrl: 'https://github.com/foo/bar.git',
+    docgen: true,
+  });
+
+  const output = synthSnapshot(project);
+  expect(output['.projen/tasks.json'].tasks.docgen.steps[0].exec).toStrictEqual('jsii-docgen');
+});
+
 class TestJsiiProject extends JsiiProject {
   constructor(options: JsiiProjectOptions) {
     super({

--- a/src/__tests__/util.ts
+++ b/src/__tests__/util.ts
@@ -80,6 +80,11 @@ export function mkdtemp() {
  * files so that the snapshots are human readable.
  */
 export function synthSnapshot(project: Project): any {
+  // defensive: verify that "outdir" is actually in a temporary directory
+  if (!path.resolve(project.outdir).startsWith(os.tmpdir())) {
+    throw new Error('Trying to capture a snapshot of a project outside of tmpdir, which implies this test might corrupt an existing project');
+  }
+
   const synthed = Symbol.for('synthed');
   if (synthed in project) {
     throw new Error('duplicate synth()');

--- a/src/jsii-project.ts
+++ b/src/jsii-project.ts
@@ -152,6 +152,7 @@ export class JsiiProject extends TypeScriptProject {
       releaseWorkflowSetupSteps: options.releaseWorkflowSetupSteps,
       releaseToNpm: false, // we have a jsii release workflow
       disableTsconfig: true, // jsii generates its own tsconfig.json
+      docgen: false, // we use jsii-docgen here so disable typescript docgen
     });
 
     const srcdir = this.srcdir;


### PR DESCRIPTION
Disable `docgen` when calling `super()` since `JsiiProject` uses `jsii-docgen` instead of
the normal TypeScript docgen tooling.

Fixes #960

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.