### PR TITLE
feat: expand TypeScrtiptConfigOptions

### DIFF
--- a/API.md
+++ b/API.md
@@ -10255,6 +10255,8 @@ Name | Type | Description
 **noImplicitAny**?🔹 | <code>boolean</code> | In some cases where no type annotations are present, TypeScript will fall back to a type of any for a variable when it cannot infer the type.<br/>__*Default*__: true
 **noImplicitReturns**?🔹 | <code>boolean</code> | When enabled, TypeScript will check all code paths in a function to ensure they return a value.<br/>__*Default*__: true
 **noImplicitThis**?🔹 | <code>boolean</code> | Raise error on ‘this’ expressions with an implied ‘any’ type.<br/>__*Default*__: true
+**noPropertyAccessFromIndexSignature**?🔹 | <code>boolean</code> | Raise error on use of the dot syntax to access fields which are not defined.<br/>__*Default*__: true
+**noUncheckedIndexedAccess**?🔹 | <code>boolean</code> | Raise error when accessing indexes on objects with unknown keys defined in index signatures.<br/>__*Default*__: true
 **noUnusedLocals**?🔹 | <code>boolean</code> | Report errors on unused local variables.<br/>__*Default*__: true
 **noUnusedParameters**?🔹 | <code>boolean</code> | Report errors on unused parameters in functions.<br/>__*Default*__: true
 **outDir**?🔹 | <code>string</code> | Output directory for the compiled files.<br/>__*Optional*__

--- a/src/typescript-config.ts
+++ b/src/typescript-config.ts
@@ -232,6 +232,20 @@ export interface TypeScriptCompilerOptions {
   readonly noImplicitThis?: boolean;
 
   /**
+   * Raise error on use of the dot syntax to access fields which are not defined.
+   *
+   * @default true
+   */
+  readonly noPropertyAccessFromIndexSignature?: boolean;
+
+  /**
+   * Raise error when accessing indexes on objects with unknown keys defined in index signatures.
+   *
+   * @default true
+   */
+  readonly noUncheckedIndexedAccess?: boolean;
+
+  /**
    * Report errors on unused local variables.
    *
    * @default true


### PR DESCRIPTION
Added new compiler options available in TypeScript 4.1 and 4.2

Specifically added flags for [noUncheckedIndexAccess](https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess) and [noPropertyAccessFromIndexSignature](https://www.typescriptlang.org/tsconfig#noPropertyAccessFromIndexSignature) to users to adopt these checks.

Default has been set to true as defaults seemed to align with "stricter" configuration generally.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.