### PR TITLE
fix: Normal npm module lookup

### DIFF
--- a/src/inventory.ts
+++ b/src/inventory.ts
@@ -121,7 +121,10 @@ function discoverJsiiTypes(...moduleDirs: string[]) {
     // this will also end-up in the projen module and add the projen types
     if (manifest.dependencies) {
       for (const dependency of Object.keys(manifest.dependencies)) {
-        const nestedDependencyFolder = path.join(dir, 'node_modules', dependency);
+        const nestedDependencyFolder = path.dirname(require.resolve(`${dependency}/package.json`, {
+          paths: [dir],
+        }));
+
         if (fs.existsSync(nestedDependencyFolder)) {
           discoverJsii(nestedDependencyFolder);
         }


### PR DESCRIPTION
Small additional PR for module lookup with the following structure:

```
feat projen project -> common company projen project -> projen
```

The common company project can be installed in different places by npm/yarn based on external conditions. The previous code solved one situation but it is possible that the module is not found. This happens for instance when initiating a project within a monorepo with hoisting

With this change we rely on the node resolution system to find all nested projects.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.