### PR TITLE
fix(release): publishing jobs fail when new commits are pushed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      latest_commit: ${{ steps.git_remote.outputs.latest_commit }}
     env:
       CI: "true"
     steps:
@@ -54,6 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
@@ -74,6 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
@@ -96,6 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2

--- a/API.md
+++ b/API.md
@@ -5517,6 +5517,7 @@ new github.TaskWorkflow(github: GitHub, options: TaskWorkflowOptions)
   * **container** (<code>[github.workflows.ContainerOptions](#projen-github-workflows-containeroptions)</code>)  *No description* __*Default*__: default image
   * **env** (<code>Map<string, string></code>)  Workflow environment variables. __*Default*__: {}
   * **jobId** (<code>string</code>)  The primary job id. __*Default*__: "build"
+  * **outputs** (<code>Map<string, [github.workflows.JobStepOutput](#projen-github-workflows-jobstepoutput)></code>)  Mapping of job output names to values/expressions. __*Default*__: {}
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Actions to run after the main build step. __*Default*__: not set
   * **preBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to run before the main build step. __*Default*__: not set
   * **preCheckoutSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Initial steps to run before the source code checkout. __*Default*__: not set
@@ -6629,6 +6630,7 @@ new release.Publisher(project: Project, options: PublisherOptions)
 * **options** (<code>[release.PublisherOptions](#projen-release-publisheroptions)</code>)  *No description*
   * **artifactName** (<code>string</code>)  The name of the artifact to download (e.g. `dist`). 
   * **buildJobId** (<code>string</code>)  The job ID that produces the build artifacts. 
+  * **condition** (<code>string</code>)  A GitHub workflow expression used as a condition for publishers. __*Default*__: no condition
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement for `jsii-release`. __*Default*__: "latest"
 
 
@@ -6641,6 +6643,7 @@ Name | Type | Description
 **artifactName**🔹 | <code>string</code> | <span></span>
 **buildJobId**🔹 | <code>string</code> | <span></span>
 **jsiiReleaseVersion**🔹 | <code>string</code> | <span></span>
+**condition**?🔹 | <code>string</code> | __*Optional*__
 
 ### Methods
 
@@ -10953,6 +10956,7 @@ Name | Type | Description
 **container**?🔹 | <code>[github.workflows.ContainerOptions](#projen-github-workflows-containeroptions)</code> | __*Default*__: default image
 **env**?🔹 | <code>Map<string, string></code> | Workflow environment variables.<br/>__*Default*__: {}
 **jobId**?🔹 | <code>string</code> | The primary job id.<br/>__*Default*__: "build"
+**outputs**?🔹 | <code>Map<string, [github.workflows.JobStepOutput](#projen-github-workflows-jobstepoutput)></code> | Mapping of job output names to values/expressions.<br/>__*Default*__: {}
 **postBuildSteps**?🔹 | <code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code> | Actions to run after the main build step.<br/>__*Default*__: not set
 **preBuildSteps**?🔹 | <code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code> | Steps to run before the main build step.<br/>__*Default*__: not set
 **preCheckoutSteps**?🔹 | <code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code> | Initial steps to run before the source code checkout.<br/>__*Default*__: not set
@@ -11585,6 +11589,7 @@ Name | Type | Description
 -----|------|-------------
 **artifactName**🔹 | <code>string</code> | The name of the artifact to download (e.g. `dist`).
 **buildJobId**🔹 | <code>string</code> | The job ID that produces the build artifacts.
+**condition**?🔹 | <code>string</code> | A GitHub workflow expression used as a condition for publishers.<br/>__*Default*__: no condition
 **jsiiReleaseVersion**?🔹 | <code>string</code> | Version requirement for `jsii-release`.<br/>__*Default*__: "latest"
 
 

--- a/src/__tests__/__snapshots__/integ.test.ts.snap
+++ b/src/__tests__/__snapshots__/integ.test.ts.snap
@@ -325,6 +325,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      latest_commit: \${{ steps.git_remote.outputs.latest_commit }}
     env:
       CI: \\"true\\"
     steps:
@@ -368,6 +370,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
@@ -388,6 +391,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
@@ -410,6 +414,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
@@ -4612,6 +4617,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      latest_commit: \${{ steps.git_remote.outputs.latest_commit }}
     env:
       CI: \\"true\\"
     steps:

--- a/src/__tests__/__snapshots__/jsii.test.ts.snap
+++ b/src/__tests__/__snapshots__/jsii.test.ts.snap
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      latest_commit: \${{ steps.git_remote.outputs.latest_commit }}
     env:
       CI: \\"true\\"
     steps:
@@ -53,6 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
@@ -73,6 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
@@ -107,6 +111,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      latest_commit: \${{ steps.git_remote.outputs.latest_commit }}
     env:
       CI: \\"true\\"
     steps:
@@ -146,6 +152,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
@@ -166,6 +173,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2

--- a/src/__tests__/release/__snapshots__/release.test.ts.snap
+++ b/src/__tests__/release/__snapshots__/release.test.ts.snap
@@ -26,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      latest_commit: \${{ steps.git_remote.outputs.latest_commit }}
     env:
       CI: \\"true\\"
     steps:
@@ -69,6 +71,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      latest_commit: \${{ steps.git_remote.outputs.latest_commit }}
     env:
       CI: \\"true\\"
     steps:
@@ -112,6 +116,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      latest_commit: \${{ steps.git_remote.outputs.latest_commit }}
     env:
       CI: \\"true\\"
     steps:
@@ -328,6 +334,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      latest_commit: \${{ steps.git_remote.outputs.latest_commit }}
     env:
       CI: \\"true\\"
     steps:
@@ -363,6 +371,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
@@ -395,6 +404,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      latest_commit: \${{ steps.git_remote.outputs.latest_commit }}
     env:
       CI: \\"true\\"
     steps:
@@ -430,6 +441,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
@@ -621,6 +633,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      latest_commit: \${{ steps.git_remote.outputs.latest_commit }}
     env:
       CI: \\"true\\"
     steps:
@@ -657,6 +671,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+    if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
@@ -808,6 +823,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      latest_commit: \${{ steps.git_remote.outputs.latest_commit }}
     env:
       CI: \\"true\\"
     steps:
@@ -929,6 +946,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      latest_commit: \${{ steps.git_remote.outputs.latest_commit }}
     env:
       CI: \\"true\\"
     steps:
@@ -1081,6 +1100,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      latest_commit: \${{ steps.git_remote.outputs.latest_commit }}
     env:
       CI: \\"true\\"
     steps:
@@ -1220,6 +1241,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      latest_commit: \${{ steps.git_remote.outputs.latest_commit }}
     env:
       CI: \\"true\\"
     steps:
@@ -1255,6 +1278,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
@@ -1275,6 +1299,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
@@ -1297,6 +1322,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
@@ -1315,6 +1341,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
@@ -1333,6 +1360,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    if: needs.release.outputs.latest_commit == github.sha
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
@@ -1508,6 +1536,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      latest_commit: \${{ steps.git_remote.outputs.latest_commit }}
     env:
       CI: \\"true\\"
     steps:
@@ -1551,6 +1581,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      latest_commit: \${{ steps.git_remote.outputs.latest_commit }}
     env:
       CI: \\"true\\"
     steps:
@@ -1594,6 +1626,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      latest_commit: \${{ steps.git_remote.outputs.latest_commit }}
     env:
       CI: \\"true\\"
     steps:
@@ -1810,6 +1844,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      latest_commit: \${{ steps.git_remote.outputs.latest_commit }}
     env:
       CI: \\"true\\"
     steps:

--- a/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
@@ -91,6 +91,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      latest_commit: \${{ steps.git_remote.outputs.latest_commit }}
     env:
       CI: \\"true\\"
     steps:

--- a/src/__tests__/web/__snapshots__/react-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-project.test.ts.snap
@@ -85,6 +85,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      latest_commit: \${{ steps.git_remote.outputs.latest_commit }}
     env:
       CI: \\"true\\"
     steps:

--- a/src/github/task-workflow.ts
+++ b/src/github/task-workflow.ts
@@ -1,7 +1,7 @@
 import { Task } from '../tasks';
 import { GitHub } from './github';
 import { GithubWorkflow } from './workflows';
-import { ContainerOptions, Job, JobPermissions, JobStep, Triggers } from './workflows-model';
+import { ContainerOptions, Job, JobPermissions, JobStep, JobStepOutput, Triggers } from './workflows-model';
 
 const DEFAULT_JOB_ID = 'build';
 const UBUNTU_LATEST = 'ubuntu-latest';
@@ -87,6 +87,13 @@ export interface TaskWorkflowOptions {
    * Permissions for the build job.
    */
   readonly permissions: JobPermissions;
+
+  /**
+   * Mapping of job output names to values/expressions.
+   *
+   * @default {}
+   */
+  readonly outputs?: { [name: string]: JobStepOutput };
 }
 
 /**
@@ -139,6 +146,7 @@ export class TaskWorkflow extends GithubWorkflow {
       env: options.env,
       permissions: options.permissions,
       if: options.condition,
+      outputs: options.outputs,
       steps: [
         ...preCheckoutSteps,
 

--- a/src/release/publisher.ts
+++ b/src/release/publisher.ts
@@ -17,6 +17,13 @@ export interface PublisherOptions {
   readonly buildJobId: string;
 
   /**
+   * A GitHub workflow expression used as a condition for publishers.
+   *
+   * @default - no condition
+   */
+  readonly condition?: string;
+
+  /**
    * The name of the artifact to download (e.g. `dist`).
    *
    * The artifact is expected to include a subdirectory for each release target:
@@ -44,6 +51,7 @@ export class Publisher extends Component {
   public readonly buildJobId: string;
   public readonly artifactName: string;
   public readonly jsiiReleaseVersion: string;
+  public readonly condition?: string;
 
   // the jobs to add to the release workflow
   private readonly jobs: { [name: string]: workflows.Job } = {};
@@ -54,6 +62,7 @@ export class Publisher extends Component {
     this.buildJobId = options.buildJobId;
     this.artifactName = options.artifactName;
     this.jsiiReleaseVersion = options.jsiiReleaseVersion ?? JSII_RELEASE_VERSION;
+    this.condition = options.condition;
   }
 
   /**
@@ -207,6 +216,7 @@ export class Publisher extends Component {
     return {
       name: `Release to ${opts.name}`,
       permissions: opts.permissions ? opts.permissions : { contents: JobPermission.READ },
+      if: this.condition,
       needs: [this.buildJobId],
       runsOn: 'ubuntu-latest',
       container: {


### PR DESCRIPTION
When new commits are pushed to the release branch, the release job will not upload the artifact but the publisher jobs will still execute (and fail, because there is no artifact).

This change adds a job condition that will only execute the publishing jobs if we are indeed releasing the latest commit. Otherwise, the publishers will be skipped and the workflow will not fail.

Fixes #723

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.