### PR TITLE
fix(release): github releases are broken due to missing --repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,8 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat
-          dist/version.txt)
+        run: gh release create v$(cat dist/version.txt) -R ${{ github.repository }} -F
+          dist/changelog.md -t v$(cat dist/version.txt)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   release_npm:

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -139,7 +139,7 @@
       ],
       "steps": [
         {
-          "exec": "gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat dist/version.txt)"
+          "exec": "gh release create v$(cat dist/version.txt) -R ${{ github.repository }} -F dist/changelog.md -t v$(cat dist/version.txt)"
         }
       ]
     },

--- a/src/__tests__/__snapshots__/integ.test.ts.snap
+++ b/src/__tests__/__snapshots__/integ.test.ts.snap
@@ -372,8 +372,8 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat
-          dist/version.txt)
+        run: gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F
+          dist/changelog.md -t v$(cat dist/version.txt)
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
   release_npm:
@@ -1068,7 +1068,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         ],
         "steps": Array [
           Object {
-            "exec": "gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat dist/version.txt)",
+            "exec": "gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F dist/changelog.md -t v$(cat dist/version.txt)",
           },
         ],
       },
@@ -4683,8 +4683,8 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat
-          dist/version.txt)
+        run: gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F
+          dist/changelog.md -t v$(cat dist/version.txt)
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
 ",
@@ -5008,7 +5008,7 @@ junit.xml
         ],
         "steps": Array [
           Object {
-            "exec": "gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat dist/version.txt)",
+            "exec": "gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F dist/changelog.md -t v$(cat dist/version.txt)",
           },
         ],
       },

--- a/src/__tests__/__snapshots__/jsii.test.ts.snap
+++ b/src/__tests__/__snapshots__/jsii.test.ts.snap
@@ -57,8 +57,8 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat
-          dist/version.txt)
+        run: gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F
+          dist/changelog.md -t v$(cat dist/version.txt)
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
   release_npm:
@@ -166,8 +166,8 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat
-          dist/version.txt)
+        run: gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F
+          dist/changelog.md -t v$(cat dist/version.txt)
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
   release_npm:

--- a/src/__tests__/__snapshots__/new.test.ts.snap
+++ b/src/__tests__/__snapshots__/new.test.ts.snap
@@ -555,8 +555,20 @@ tsconfig.tsbuildinfo
           },
         ],
       },
+      "publish:github": Object {
+        "description": "Publish this package to GitHub Releases",
+        "name": "publish:github",
+        "requiredEnv": Array [
+          "GITHUB_TOKEN",
+        ],
+        "steps": Array [
+          Object {
+            "exec": "gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat dist/version.txt)",
+          },
+        ],
+      },
       "publish:npm": Object {
-        "description": "Publish this package to the npm Registry",
+        "description": "Publish this package to npm",
         "env": Object {
           "NPM_DIST_TAG": "latest",
           "NPM_REGISTRY": "registry.npmjs.org",
@@ -1007,6 +1019,7 @@ project.synth();",
       "eslint": "npx projen eslint",
       "package": "npx projen package",
       "projen": "npx projen",
+      "publish:github": "npx projen publish:github",
       "publish:npm": "npx projen publish:npm",
       "release": "npx projen release",
       "test": "npx projen test",

--- a/src/__tests__/release/__snapshots__/release.test.ts.snap
+++ b/src/__tests__/release/__snapshots__/release.test.ts.snap
@@ -65,8 +65,8 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat
-          dist/version.txt)
+        run: gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F
+          dist/changelog.md -t v$(cat dist/version.txt)
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
 ",
@@ -122,8 +122,8 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat
-          dist/version.txt)
+        run: gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F
+          dist/changelog.md -t v$(cat dist/version.txt)
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
 ",
@@ -179,8 +179,8 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat
-          dist/version.txt)
+        run: gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F
+          dist/changelog.md -t v$(cat dist/version.txt)
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
 ",
@@ -258,7 +258,7 @@ node_modules/
         ],
         "steps": Array [
           Object {
-            "exec": "gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat dist/version.txt)",
+            "exec": "gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F dist/changelog.md -t v$(cat dist/version.txt)",
           },
         ],
       },
@@ -421,8 +421,8 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat
-          dist/version.txt)
+        run: gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F
+          dist/changelog.md -t v$(cat dist/version.txt)
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
   release_pypi:
@@ -503,8 +503,8 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat
-          dist/version.txt)
+        run: gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F
+          dist/changelog.md -t v$(cat dist/version.txt)
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
   release_pypi:
@@ -606,7 +606,7 @@ node_modules/
         ],
         "steps": Array [
           Object {
-            "exec": "gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat dist/version.txt)",
+            "exec": "gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F dist/changelog.md -t v$(cat dist/version.txt)",
           },
         ],
       },
@@ -756,8 +756,8 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat
-          dist/version.txt)
+        run: gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F
+          dist/changelog.md -t v$(cat dist/version.txt)
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
   release_npm:
@@ -854,7 +854,7 @@ node_modules/
         ],
         "steps": Array [
           Object {
-            "exec": "gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat dist/version.txt)",
+            "exec": "gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F dist/changelog.md -t v$(cat dist/version.txt)",
           },
         ],
       },
@@ -970,8 +970,8 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat
-          dist/version.txt)
+        run: gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F
+          dist/changelog.md -t v$(cat dist/version.txt)
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
 "
@@ -1007,7 +1007,7 @@ Object {
       ],
       "steps": Array [
         Object {
-          "exec": "gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat dist/version.txt)",
+          "exec": "gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F dist/changelog.md -t v$(cat dist/version.txt)",
         },
       ],
     },
@@ -1117,8 +1117,8 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat
-          dist/version.txt)
+        run: gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F
+          dist/changelog.md -t v$(cat dist/version.txt)
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
 ",
@@ -1194,7 +1194,7 @@ node_modules/
         ],
         "steps": Array [
           Object {
-            "exec": "gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat dist/version.txt)",
+            "exec": "gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F dist/changelog.md -t v$(cat dist/version.txt)",
           },
         ],
       },
@@ -1295,8 +1295,8 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat
-          dist/version.txt)
+        run: gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F
+          dist/changelog.md -t v$(cat dist/version.txt)
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
 "
@@ -1334,7 +1334,7 @@ Object {
       ],
       "steps": Array [
         Object {
-          "exec": "gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat dist/version.txt)",
+          "exec": "gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F dist/changelog.md -t v$(cat dist/version.txt)",
         },
       ],
     },
@@ -1460,8 +1460,8 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat
-          dist/version.txt)
+        run: gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F
+          dist/changelog.md -t v$(cat dist/version.txt)
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
   release_golang:
@@ -1599,7 +1599,7 @@ Object {
       ],
       "steps": Array [
         Object {
-          "exec": "gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat dist/version.txt)",
+          "exec": "gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F dist/changelog.md -t v$(cat dist/version.txt)",
         },
       ],
     },
@@ -1779,8 +1779,8 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat
-          dist/version.txt)
+        run: gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F
+          dist/changelog.md -t v$(cat dist/version.txt)
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
 ",
@@ -1836,8 +1836,8 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat
-          dist/version.txt)
+        run: gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F
+          dist/changelog.md -t v$(cat dist/version.txt)
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
 ",
@@ -1893,8 +1893,8 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat
-          dist/version.txt)
+        run: gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F
+          dist/changelog.md -t v$(cat dist/version.txt)
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
 ",
@@ -1972,7 +1972,7 @@ node_modules/
         ],
         "steps": Array [
           Object {
-            "exec": "gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat dist/version.txt)",
+            "exec": "gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F dist/changelog.md -t v$(cat dist/version.txt)",
           },
         ],
       },
@@ -2135,8 +2135,8 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat
-          dist/version.txt)
+        run: gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F
+          dist/changelog.md -t v$(cat dist/version.txt)
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
 ",
@@ -2212,7 +2212,7 @@ node_modules/
         ],
         "steps": Array [
           Object {
-            "exec": "gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat dist/version.txt)",
+            "exec": "gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F dist/changelog.md -t v$(cat dist/version.txt)",
           },
         ],
       },

--- a/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
@@ -136,8 +136,8 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat
-          dist/version.txt)
+        run: gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F
+          dist/changelog.md -t v$(cat dist/version.txt)
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
 ",
@@ -461,7 +461,7 @@ pull_request_rules:
         ],
         "steps": Array [
           Object {
-            "exec": "gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat dist/version.txt)",
+            "exec": "gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F dist/changelog.md -t v$(cat dist/version.txt)",
           },
         ],
       },

--- a/src/__tests__/web/__snapshots__/react-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-project.test.ts.snap
@@ -126,8 +126,8 @@ jobs:
           name: dist
           path: dist
       - name: Release
-        run: gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat
-          dist/version.txt)
+        run: gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F
+          dist/changelog.md -t v$(cat dist/version.txt)
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
 ",
@@ -448,7 +448,7 @@ pull_request_rules:
         ],
         "steps": Array [
           Object {
-            "exec": "gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat dist/version.txt)",
+            "exec": "gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F dist/changelog.md -t v$(cat dist/version.txt)",
           },
         ],
       },

--- a/src/release/publisher.ts
+++ b/src/release/publisher.ts
@@ -97,6 +97,7 @@ export class Publisher extends Component {
       },
       run: [
         `gh release create ${getVersion}`,
+        '-R ${{ github.repository }}',
         `-F ${changelogFile}`,
         `-t ${getVersion}`,
       ].join(' '),


### PR DESCRIPTION
The github release publisher now needs to explicitly state which repo to work with because we do not check out the code.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.