### PR TITLE
feat(github): allow disabling all workflows

### DIFF
--- a/API.md
+++ b/API.md
@@ -172,6 +172,7 @@ Name|Description
 [github.DependabotOptions](#projen-github-dependabotoptions)|*No description*
 [github.DependabotRegistry](#projen-github-dependabotregistry)|Use to add private registry support for dependabot.
 [github.GitHubOptions](#projen-github-githuboptions)|*No description*
+[github.GithubWorkflowOptions](#projen-github-githubworkflowoptions)|*No description*
 [github.MergifyConditionalOperator](#projen-github-mergifyconditionaloperator)|The Mergify conditional operators that can be used are: `or` and `and`.
 [github.MergifyOptions](#projen-github-mergifyoptions)|*No description*
 [github.MergifyRule](#projen-github-mergifyrule)|*No description*
@@ -5243,6 +5244,7 @@ new github.GitHub(project: Project, options?: GitHubOptions)
 * **project** (<code>[Project](#projen-project)</code>)  *No description*
 * **options** (<code>[github.GitHubOptions](#projen-github-githuboptions)</code>)  *No description*
   * **mergify** (<code>boolean</code>)  Whether mergify should be enabled on this repository or not. __*Default*__: true
+  * **workflows** (<code>boolean</code>)  Enables GitHub workflows. __*Default*__: true
 
 
 
@@ -5251,6 +5253,7 @@ new github.GitHub(project: Project, options?: GitHubOptions)
 
 Name | Type | Description 
 -----|------|-------------
+**workflows**🔹 | <code>boolean</code> | Are workflows enabled?
 **mergify**?🔹 | <code>[github.Mergify](#projen-github-mergify)</code> | The `Mergify` configured on this repository.<br/>__*Optional*__
 
 ### Methods
@@ -5319,11 +5322,13 @@ __Extends__: [Component](#projen-component)
 
 
 ```ts
-new github.GithubWorkflow(github: GitHub, name: string)
+new github.GithubWorkflow(github: GitHub, name: string, options?: GithubWorkflowOptions)
 ```
 
 * **github** (<code>[github.GitHub](#projen-github-github)</code>)  *No description*
 * **name** (<code>string</code>)  *No description*
+* **options** (<code>[github.GithubWorkflowOptions](#projen-github-githubworkflowoptions)</code>)  *No description*
+  * **force** (<code>boolean</code>)  Force the creation of the workflow even if `workflows` is disabled in `GitHub`. __*Default*__: false
 
 
 
@@ -5332,8 +5337,8 @@ new github.GithubWorkflow(github: GitHub, name: string)
 
 Name | Type | Description 
 -----|------|-------------
-**file**🔹 | <code>[YamlFile](#projen-yamlfile)</code> | <span></span>
 **name**🔹 | <code>string</code> | <span></span>
+**file**?🔹 | <code>[YamlFile](#projen-yamlfile)</code> | __*Optional*__
 
 ### Methods
 
@@ -10867,6 +10872,20 @@ Name | Type | Description
 Name | Type | Description 
 -----|------|-------------
 **mergify**?🔹 | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
+**workflows**?🔹 | <code>boolean</code> | Enables GitHub workflows.<br/>__*Default*__: true
+
+
+
+## struct GithubWorkflowOptions 🔹 <a id="projen-github-githubworkflowoptions"></a>
+
+
+
+
+
+
+Name | Type | Description 
+-----|------|-------------
+**force**?🔹 | <code>boolean</code> | Force the creation of the workflow even if `workflows` is disabled in `GitHub`.<br/>__*Default*__: false
 
 
 

--- a/src/__tests__/__snapshots__/new.test.ts.snap
+++ b/src/__tests__/__snapshots__/new.test.ts.snap
@@ -563,7 +563,7 @@ tsconfig.tsbuildinfo
         ],
         "steps": Array [
           Object {
-            "exec": "gh release create v$(cat dist/version.txt) -F dist/changelog.md -t v$(cat dist/version.txt)",
+            "exec": "gh release create v$(cat dist/version.txt) -R \${{ github.repository }} -F dist/changelog.md -t v$(cat dist/version.txt)",
           },
         ],
       },

--- a/src/__tests__/node-project.test.ts
+++ b/src/__tests__/node-project.test.ts
@@ -1,7 +1,6 @@
 import * as yaml from 'yaml';
 import { NodeProject, NodeProjectOptions, LogLevel } from '..';
 import { DependencyType } from '../deps';
-import { TaskWorkflow } from '../github';
 import { JobPermission } from '../github/workflows-model';
 import * as logging from '../logging';
 import { NodePackage, NodePackageManager, NpmAccess } from '../node-package';

--- a/src/__tests__/node-project.test.ts
+++ b/src/__tests__/node-project.test.ts
@@ -1,6 +1,7 @@
 import * as yaml from 'yaml';
 import { NodeProject, NodeProjectOptions, LogLevel } from '..';
 import { DependencyType } from '../deps';
+import { TaskWorkflow } from '../github';
 import { JobPermission } from '../github/workflows-model';
 import * as logging from '../logging';
 import { NodePackage, NodePackageManager, NpmAccess } from '../node-package';
@@ -528,6 +529,19 @@ test('github: false disables github integration', () => {
   // THEN
   const output = synthSnapshot(project);
   expect(Object.keys(output).filter(p => p.startsWith('.github/'))).toStrictEqual([]);
+});
+
+test('githubOptions.workflows:false disables github workflows but not github integration', () => {
+  // WHEN
+  const project = new TestNodeProject({
+    githubOptions: {
+      workflows: false,
+    },
+  });
+
+  // THEN
+  const output = synthSnapshot(project);
+  expect(Object.keys(output).filter(p => p.startsWith('.github/'))).toStrictEqual(['.github/pull_request_template.md']);
 });
 
 function packageJson(project: Project) {

--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -12,6 +12,13 @@ export interface GitHubOptions {
    * @default true
    */
   readonly mergify?: boolean;
+
+  /**
+   * Enables GitHub workflows. If this is set to `false`, workflows will not be created.
+   *
+   * @default true
+   */
+  readonly workflows?: boolean;
 }
 
 export class GitHub extends Component {
@@ -21,8 +28,15 @@ export class GitHub extends Component {
    */
   public readonly mergify?: Mergify;
 
+  /**
+   * Are workflows enabled?
+   */
+  public readonly workflows: boolean;
+
   public constructor(project: Project, options: GitHubOptions = {}) {
     super(project);
+
+    this.workflows = options.workflows ?? true;
 
     if (options.mergify ?? true) {
       this.mergify = new Mergify(this);

--- a/src/github/workflows.ts
+++ b/src/github/workflows.ts
@@ -8,6 +8,15 @@ import { GitHub } from './github';
 
 import * as workflows from './workflows-model';
 
+export interface GithubWorkflowOptions {
+  /**
+   * Force the creation of the workflow even if `workflows` is disabled in `GitHub`.
+   *
+   * @default false
+   */
+  readonly force?: boolean;
+}
+
 /**
  * Workflow for GitHub.
  * A workflow is a configurable automated process made up of one or more jobs.
@@ -15,18 +24,23 @@ import * as workflows from './workflows-model';
  */
 export class GithubWorkflow extends Component {
   public readonly name: string;
-  public readonly file: YamlFile;
+  public readonly file: YamlFile | undefined;
 
   private events: workflows.Triggers = { };
   private jobs: Record<string, workflows.Job> = { };
 
-  constructor(github: GitHub, name: string) {
+  constructor(github: GitHub, name: string, options: GithubWorkflowOptions = {}) {
     super(github.project);
 
     this.name = name;
-    this.file = new YamlFile(this.project, `.github/workflows/${name.toLocaleLowerCase()}.yml`, {
-      obj: () => this.renderWorkflow(),
-    });
+
+    const workflowsEnabled = github.workflows || options.force;
+
+    if (workflowsEnabled) {
+      this.file = new YamlFile(this.project, `.github/workflows/${name.toLocaleLowerCase()}.yml`, {
+        obj: () => this.renderWorkflow(),
+      });
+    }
   }
 
   public on(events: workflows.Triggers) {


### PR DESCRIPTION
You can now set `githubOptions.workflows` to `false` in order to just disable workflows without
completely disabling GitHub integration.

Resolves #828

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.