### PR TITLE
fix: projen incompatible with node 10.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.2.0
         with:
-          node-version: 14.17.0
+          node-version: 10.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.2.0
         with:
-          node-version: 14.17.0
+          node-version: 10.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.2.0
         with:
-          node-version: 14.17.0
+          node-version: 10.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "@types/node",
-      "version": "^14.17.0",
+      "version": "^10.17.0",
       "type": "build"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -56,7 +56,7 @@
           "spawn": "test:compile"
         },
         {
-          "exec": "jest --passWithNoTests --all --updateSnapshot --coverageProvider=v8"
+          "exec": "jest --passWithNoTests --all --updateSnapshot"
         },
         {
           "spawn": "eslint"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -41,7 +41,7 @@ const project = new JsiiProject({
 
   projenDevDependency: false, // because I am projen
   releaseToNpm: true,
-  minNodeVersion: '14.17.0',
+  minNodeVersion: '10.24.1',
   codeCov: true,
   defaultReleaseBranch: 'main',
   gitpod: true,

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -41,7 +41,7 @@ const project = new JsiiProject({
 
   projenDevDependency: false, // because I am projen
   releaseToNpm: true,
-  minNodeVersion: '10.24.1',
+  minNodeVersion: '10.17.0',
   codeCov: true,
   defaultReleaseBranch: 'main',
   gitpod: true,

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/glob": "^7.1.4",
     "@types/ini": "^1.3.30",
     "@types/jest": "^26.0.24",
-    "@types/node": "^14.17.0",
+    "@types/node": "^10.17.0",
     "@types/semver": "^7.3.8",
     "@types/yargs": "^15.0.14",
     "@typescript-eslint/eslint-plugin": "^4.30.0",
@@ -94,7 +94,7 @@
     "yargs"
   ],
   "engines": {
-    "node": ">= 14.17.0"
+    "node": ">= 10.17.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/src/__tests__/__snapshots__/integ.test.ts.snap
+++ b/src/__tests__/__snapshots__/integ.test.ts.snap
@@ -2064,7 +2064,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.2.0
         with:
-          node-version: 14.17.0
+          node-version: 10.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -2225,7 +2225,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^14.17.0",
+        "version": "^10.17.0",
       },
       Object {
         "name": "@types/yaml",
@@ -2450,7 +2450,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
             "spawn": "test:compile",
           },
           Object {
-            "exec": "jest --passWithNoTests --all --coverageProvider=v8",
+            "exec": "jest --passWithNoTests --all",
           },
           Object {
             "spawn": "eslint",
@@ -2847,7 +2847,7 @@ common.fixup(project);
 project.synth();
 ",
   "cdk8s.common.js": "exports.options = {
-  minNodeVersion: '14.17.0',
+  minNodeVersion: '10.17.0',
   repository: 'https://github.com/awslabs/cdk8s.git',
   authorName: 'Amazon Web Services',
   authorUrl: 'https://aws.amazon.com',
@@ -2972,7 +2972,7 @@ project.synth();
       "@types/follow-redirects": "*",
       "@types/jest": "*",
       "@types/json-stable-stringify": "*",
-      "@types/node": "^14.17.0",
+      "@types/node": "^10.17.0",
       "@types/yaml": "*",
       "@typescript-eslint/eslint-plugin": "*",
       "@typescript-eslint/parser": "*",
@@ -2995,7 +2995,7 @@ project.synth();
       "typescript": "*",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 10.17.0",
     },
     "jest": Object {
       "clearMocks": true,
@@ -3486,7 +3486,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2.2.0
         with:
-          node-version: 14.17.0
+          node-version: 10.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -3641,7 +3641,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^14.17.0",
+        "version": "^10.17.0",
       },
       Object {
         "name": "@typescript-eslint/eslint-plugin",
@@ -3847,7 +3847,7 @@ tsconfig.tsbuildinfo
             "spawn": "test:compile",
           },
           Object {
-            "exec": "jest --passWithNoTests --all --coverageProvider=v8",
+            "exec": "jest --passWithNoTests --all",
           },
           Object {
             "spawn": "eslint",
@@ -4226,7 +4226,7 @@ common.fixup(project);
 project.synth();
 ",
   "cdk8s.common.js": "exports.options = {
-  minNodeVersion: '14.17.0',
+  minNodeVersion: '10.17.0',
   repository: 'https://github.com/awslabs/cdk8s.git',
   authorName: 'Amazon Web Services',
   authorUrl: 'https://aws.amazon.com',
@@ -4357,7 +4357,7 @@ project.synth();
       "@types/fs-extra": "*",
       "@types/jest": "*",
       "@types/json-schema": "*",
-      "@types/node": "^14.17.0",
+      "@types/node": "^10.17.0",
       "@typescript-eslint/eslint-plugin": "*",
       "@typescript-eslint/parser": "*",
       "eslint": "*",
@@ -4373,7 +4373,7 @@ project.synth();
       "typescript": "*",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 10.17.0",
     },
     "jest": Object {
       "clearMocks": true,

--- a/src/__tests__/__snapshots__/new.test.ts.snap
+++ b/src/__tests__/__snapshots__/new.test.ts.snap
@@ -785,6 +785,7 @@ const project = new AwsCdkAppSyncApp({
   cdkVersion: '1.95.2',
   defaultReleaseBranch: 'main',
   devDeps: ['cdk-appsync-project@1.1.2'],
+  minNodeVersion: '10.17.0',
   name: 'my-project',
   transformerVersion: '1.77.15',
 
@@ -1054,6 +1055,9 @@ project.synth();",
       "ts-jest": "*",
       "ts-node": "*",
       "typescript": "*",
+    },
+    "engines": Object {
+      "node": ">= 10.17.0",
     },
     "jest": Object {
       "clearMocks": true,

--- a/src/__tests__/integration/cdk8s/cdk8s.common.js
+++ b/src/__tests__/integration/cdk8s/cdk8s.common.js
@@ -1,5 +1,5 @@
 exports.options = {
-  minNodeVersion: '14.17.0',
+  minNodeVersion: '10.17.0',
   repository: 'https://github.com/awslabs/cdk8s.git',
   authorName: 'Amazon Web Services',
   authorUrl: 'https://aws.amazon.com',

--- a/src/__tests__/new.test.ts
+++ b/src/__tests__/new.test.ts
@@ -7,6 +7,8 @@ import * as inventory from '../inventory';
 import { execCapture } from '../util';
 import { directorySnapshot, execProjenCLI, mkdtemp, sanitizeOutput, synthSnapshot, synthSnapshotWithPost, TestProject } from './util';
 
+const MIN_NODE_VERSION_OPTION = '--min-node-version=10.17.0';
+
 for (const type of inventory.discover()) {
   test(`projen new ${type.pjid}`, () => {
     withProjectDir(projectdir => {
@@ -42,7 +44,7 @@ test('projen new --from external', () => {
   withProjectDir(projectdir => {
 
     // execute `projen new --from cdk-appsync-project` in the project directory
-    execProjenCLI(projectdir, ['new', '--from', 'cdk-appsync-project@1.1.2', '--no-post']);
+    execProjenCLI(projectdir, ['new', '--from', 'cdk-appsync-project@1.1.2', '--no-post', MIN_NODE_VERSION_OPTION]);
 
     // patch the projen version in package.json to match the current version
     // otherwise, every bump would need to update these snapshots.
@@ -68,7 +70,7 @@ test('options are not overwritten when creating from external project types', ()
   withProjectDir(projectdir => {
 
     // execute `projen new --from cdk-appsync-project` in the project directory
-    execProjenCLI(projectdir, ['new', '--from', 'cdk-appsync-project@1.1.2', '--no-synth', '--cdk-version', '1.63.0']);
+    execProjenCLI(projectdir, ['new', '--from', 'cdk-appsync-project@1.1.2', '--no-synth', '--cdk-version', '1.63.0', MIN_NODE_VERSION_OPTION]);
 
     // compare generated .projenrc.js to the snapshot
     const actual = directorySnapshot(projectdir, {
@@ -88,7 +90,7 @@ test('can choose from one of multiple external project types', () => {
   withProjectDir(projectdir => {
 
     // execute `projen new --from cdk-appsync-project` in the project directory
-    execProjenCLI(projectdir, ['new', '--from', '@taimos/projen@0.0.121', 'taimos-ts-lib', '--no-post']);
+    execProjenCLI(projectdir, ['new', '--from', '@taimos/projen@0.0.121', 'taimos-ts-lib', '--no-post', MIN_NODE_VERSION_OPTION]);
 
     // patch the projen version in package.json to match the current version
     // otherwise, every bump would need to update these snapshots.
@@ -156,7 +158,7 @@ test('projenrc-json creates node-project', () => {
 
 test('projenrc-json creates external project type', () => {
   withProjectDir(projectdir => {
-    execProjenCLI(projectdir, ['new', '--from', 'cdk-appsync-project@1.1.2', '--cdk-version', '1.63.0', '--projenrc-json', '--no-synth']);
+    execProjenCLI(projectdir, ['new', '--from', 'cdk-appsync-project@1.1.2', '--cdk-version', '1.63.0', '--projenrc-json', '--no-synth', MIN_NODE_VERSION_OPTION]);
 
     // exclude node_modules to work around bug where node_modules is generated AND one of the
     // dependencies includes a file with .json extension that isn't valid JSON

--- a/yarn.lock
+++ b/yarn.lock
@@ -816,10 +816,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.7.10.tgz#7aa732cc47341c12a16b7d562f519c2383b6d4fc"
   integrity sha512-S63Dlv4zIPb8x6MMTgDq5WWRJQe56iBEY0O3SOFA9JrRienkOVDXSXBjjJw6HTNQYSE2JI6GMCR6LVbIMHJVvA==
 
-"@types/node@^14.17.0":
-  version "14.17.15"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.15.tgz#d5ebfb62a69074ebb85cbe0529ad917bb8f2bae8"
-  integrity sha512-D1sdW0EcSCmNdLKBGMYb38YsHUS6JcM7yQ6sLQ9KuZ35ck7LYCKE7kYFHOO59ayFOY3zobWVZxf4KXhYHcHYFA==
+"@types/node@^10.17.0":
+  version "10.17.60"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
+  integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"


### PR DESCRIPTION
A recent change updated the minimum node version of projen itself to 14.x. This implies that it is now impossible to use it in environments with older node, including any existing workflows.

In the meantime, we set the min version back to 10.x.

NOTE: This change also relaxes engine checks during `projen new`. This technically means that users are able to create a new project within a non-compatible environment, but since engine checks are performed all the time anyway, they won't be able to go a long way without a compatible node version. The reason this was needed is because our "new" tests use the latest version of node when they test external projects and version 0.28.0 now requires node 14.x... Anyway - a bit of a mess.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.