### PR TITLE
fix: speed up discovery of external types

### DIFF
--- a/src/inventory.ts
+++ b/src/inventory.ts
@@ -105,12 +105,19 @@ export function discover(...moduleDirs: string[]) {
  */
 function discoverJsiiTypes(...moduleDirs: string[]) {
   const jsii: JsiiTypes = {};
+  const discoveredManifests: Array<string> = [];
 
   const discoverJsii = (dir: string) => {
     const jsiiFile = path.join(dir, '.jsii');
     if (!fs.existsSync(jsiiFile)) { return; } // no jsii manifest
 
     const manifest = fs.readJsonSync(jsiiFile);
+
+    if (discoveredManifests.includes(manifest.fingerprint)) {
+      return;
+    }
+    discoveredManifests.push(manifest.fingerprint);
+
     for (const [fqn, type] of Object.entries(manifest.types as JsiiTypes)) {
       jsii[fqn] = {
         ...type,


### PR DESCRIPTION
by avoiding re-probing same dependencies multiple times

No new tests added as the functionality will still be the same.
It's just a performance boost when the extnernal module
has multiple dependencies (e.g. aws cdk v1).

Fixes #1101

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.