### PR TITLE
fix(upgrade): some dependencies are not upgraded when shared between different dependency types

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -155,7 +155,19 @@
       },
       "steps": [
         {
-          "exec": "npm-check-updates --upgrade --target=minor --reject='projen'"
+          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='projen'"
+        },
+        {
+          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='projen'"
+        },
+        {
+          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='projen'"
+        },
+        {
+          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='projen'"
+        },
+        {
+          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='projen'"
         },
         {
           "exec": "yarn install --check-files"

--- a/src/__tests__/__snapshots__/integ.test.ts.snap
+++ b/src/__tests__/__snapshots__/integ.test.ts.snap
@@ -1225,7 +1225,19 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "upgrade",
         "steps": Array [
           Object {
-            "exec": "npm-check-updates --upgrade --target=minor",
+            "exec": "npm-check-updates --dep dev --upgrade --target=minor",
+          },
+          Object {
+            "exec": "npm-check-updates --dep optional --upgrade --target=minor",
+          },
+          Object {
+            "exec": "npm-check-updates --dep peer --upgrade --target=minor",
+          },
+          Object {
+            "exec": "npm-check-updates --dep prod --upgrade --target=minor",
+          },
+          Object {
+            "exec": "npm-check-updates --dep bundle --upgrade --target=minor",
           },
           Object {
             "exec": "yarn install --check-files",
@@ -2517,7 +2529,19 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "upgrade",
         "steps": Array [
           Object {
-            "exec": "npm-check-updates --upgrade --target=minor --reject='projen'",
+            "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='projen'",
           },
           Object {
             "exec": "yarn install --check-files",
@@ -2538,7 +2562,19 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "upgrade-projen",
         "steps": Array [
           Object {
-            "exec": "npm-check-updates --upgrade --target=minor --filter='projen'",
+            "exec": "npm-check-updates --dep dev --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep optional --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep peer --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep prod --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep bundle --upgrade --target=minor --filter='projen'",
           },
           Object {
             "exec": "yarn install --check-files",
@@ -3923,7 +3959,19 @@ tsconfig.tsbuildinfo
         "name": "upgrade",
         "steps": Array [
           Object {
-            "exec": "npm-check-updates --upgrade --target=minor --reject='projen'",
+            "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='projen'",
           },
           Object {
             "exec": "yarn install --check-files",
@@ -3944,7 +3992,19 @@ tsconfig.tsbuildinfo
         "name": "upgrade-projen",
         "steps": Array [
           Object {
-            "exec": "npm-check-updates --upgrade --target=minor --filter='projen'",
+            "exec": "npm-check-updates --dep dev --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep optional --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep peer --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep prod --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep bundle --upgrade --target=minor --filter='projen'",
           },
           Object {
             "exec": "yarn install --check-files",
@@ -5161,7 +5221,19 @@ junit.xml
         "name": "upgrade",
         "steps": Array [
           Object {
-            "exec": "npm-check-updates --upgrade --target=minor --reject='projen'",
+            "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='projen'",
           },
           Object {
             "exec": "pnpm i",
@@ -5182,7 +5254,19 @@ junit.xml
         "name": "upgrade-projen",
         "steps": Array [
           Object {
-            "exec": "npm-check-updates --upgrade --target=minor --filter='projen'",
+            "exec": "npm-check-updates --dep dev --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep optional --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep peer --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep prod --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep bundle --upgrade --target=minor --filter='projen'",
           },
           Object {
             "exec": "pnpm i",

--- a/src/__tests__/node-project.test.ts
+++ b/src/__tests__/node-project.test.ts
@@ -237,7 +237,7 @@ describe('deps upgrade', () => {
 
     // make sure yarn upgrade all deps, including projen.
     const tasks = snapshot[Tasks.MANIFEST_FILE].tasks;
-    expect(tasks.upgrade.steps[2].exec).toStrictEqual('yarn upgrade');
+    expect(tasks.upgrade.steps[6].exec).toStrictEqual('yarn upgrade');
   });
 
   test('default - no projen secret', () => {

--- a/src/__tests__/upgrade-dependencies.test.ts
+++ b/src/__tests__/upgrade-dependencies.test.ts
@@ -12,7 +12,7 @@ test('upgrades command includes all dependencies', () => {
   const deps = 'jest jest-junit npm-check-updates standard-version some-dep';
 
   const tasks = synthSnapshot(project)[Tasks.MANIFEST_FILE].tasks;
-  expect(tasks.upgrade.steps[2].exec).toStrictEqual(`yarn upgrade ${deps}`);
+  expect(tasks.upgrade.steps[6].exec).toStrictEqual(`yarn upgrade ${deps}`);
 
 });
 
@@ -25,7 +25,7 @@ test('upgrades command includes dependencies added post instantiation', () => {
   const deps = 'jest jest-junit npm-check-updates standard-version some-dep';
 
   const tasks = synthSnapshot(project)[Tasks.MANIFEST_FILE].tasks;
-  expect(tasks.upgrade.steps[2].exec).toStrictEqual(`yarn upgrade ${deps}`);
+  expect(tasks.upgrade.steps[6].exec).toStrictEqual(`yarn upgrade ${deps}`);
 
 });
 
@@ -42,7 +42,7 @@ test('upgrades command doesnt include ignored packages', () => {
   const deps = 'jest jest-junit npm-check-updates projen standard-version dep1';
 
   const tasks = synthSnapshot(project)[Tasks.MANIFEST_FILE].tasks;
-  expect(tasks.upgrade.steps[2].exec).toStrictEqual(`yarn upgrade ${deps}`);
+  expect(tasks.upgrade.steps[6].exec).toStrictEqual(`yarn upgrade ${deps}`);
 
 });
 
@@ -59,7 +59,7 @@ test('upgrades command includes only included packages', () => {
   const deps = 'dep1';
 
   const tasks = synthSnapshot(project)[Tasks.MANIFEST_FILE].tasks;
-  expect(tasks.upgrade.steps[2].exec).toStrictEqual(`yarn upgrade ${deps}`);
+  expect(tasks.upgrade.steps[6].exec).toStrictEqual(`yarn upgrade ${deps}`);
 
 });
 

--- a/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/nextjs-project.test.ts.snap
@@ -559,7 +559,19 @@ pull_request_rules:
         "name": "upgrade",
         "steps": Array [
           Object {
-            "exec": "npm-check-updates --upgrade --target=minor --reject='projen'",
+            "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='projen'",
           },
           Object {
             "exec": "yarn install --check-files",
@@ -580,7 +592,19 @@ pull_request_rules:
         "name": "upgrade-projen",
         "steps": Array [
           Object {
-            "exec": "npm-check-updates --upgrade --target=minor --filter='projen'",
+            "exec": "npm-check-updates --dep dev --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep optional --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep peer --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep prod --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep bundle --upgrade --target=minor --filter='projen'",
           },
           Object {
             "exec": "yarn install --check-files",

--- a/src/__tests__/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -456,7 +456,19 @@ tsconfig.tsbuildinfo
         "name": "upgrade",
         "steps": Array [
           Object {
-            "exec": "npm-check-updates --upgrade --target=minor --reject='projen'",
+            "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='projen'",
           },
           Object {
             "exec": "yarn install --check-files",
@@ -477,7 +489,19 @@ tsconfig.tsbuildinfo
         "name": "upgrade-projen",
         "steps": Array [
           Object {
-            "exec": "npm-check-updates --upgrade --target=minor --filter='projen'",
+            "exec": "npm-check-updates --dep dev --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep optional --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep peer --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep prod --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep bundle --upgrade --target=minor --filter='projen'",
           },
           Object {
             "exec": "yarn install --check-files",

--- a/src/__tests__/web/__snapshots__/react-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-project.test.ts.snap
@@ -531,7 +531,19 @@ pull_request_rules:
         "name": "upgrade",
         "steps": Array [
           Object {
-            "exec": "npm-check-updates --upgrade --target=minor --reject='projen'",
+            "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='projen'",
           },
           Object {
             "exec": "yarn install --check-files",
@@ -552,7 +564,19 @@ pull_request_rules:
         "name": "upgrade-projen",
         "steps": Array [
           Object {
-            "exec": "npm-check-updates --upgrade --target=minor --filter='projen'",
+            "exec": "npm-check-updates --dep dev --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep optional --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep peer --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep prod --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep bundle --upgrade --target=minor --filter='projen'",
           },
           Object {
             "exec": "yarn install --check-files",

--- a/src/__tests__/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/src/__tests__/web/__snapshots__/react-ts-project.test.ts.snap
@@ -434,7 +434,19 @@ tsconfig.tsbuildinfo
         "name": "upgrade",
         "steps": Array [
           Object {
-            "exec": "npm-check-updates --upgrade --target=minor --reject='projen'",
+            "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='projen'",
           },
           Object {
             "exec": "yarn install --check-files",
@@ -455,7 +467,19 @@ tsconfig.tsbuildinfo
         "name": "upgrade-projen",
         "steps": Array [
           Object {
-            "exec": "npm-check-updates --upgrade --target=minor --filter='projen'",
+            "exec": "npm-check-updates --dep dev --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep optional --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep peer --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep prod --upgrade --target=minor --filter='projen'",
+          },
+          Object {
+            "exec": "npm-check-updates --dep bundle --upgrade --target=minor --filter='projen'",
           },
           Object {
             "exec": "yarn install --check-files",

--- a/src/upgrade-dependencies.ts
+++ b/src/upgrade-dependencies.ts
@@ -138,15 +138,20 @@ export class UpgradeDependencies extends Component {
     if (this.ignoresProjen) {
       exclude.push('projen');
     }
-    const ncuCommand = ['npm-check-updates', '--upgrade', '--target=minor'];
-    if (exclude.length > 0) {
-      ncuCommand.push(`--reject='${exclude.join(',')}'`);
-    }
-    if (this.options.include) {
-      ncuCommand.push(`--filter='${this.options.include.join(',')}'`);
-    }
 
-    task.exec(ncuCommand.join(' '));
+    for (const dep of ['dev', 'optional', 'peer', 'prod', 'bundle']) {
+
+      const ncuCommand = ['npm-check-updates', '--dep', dep, '--upgrade', '--target=minor'];
+      if (exclude.length > 0) {
+        ncuCommand.push(`--reject='${exclude.join(',')}'`);
+      }
+      if (this.options.include) {
+        ncuCommand.push(`--filter='${this.options.include.join(',')}'`);
+      }
+
+      task.exec(ncuCommand.join(' '));
+
+    }
 
     // run "yarn/npm install" to update the lockfile and install any deps (such as projen)
     task.exec(this._project.package.installAndUpdateLockfileCommand);


### PR DESCRIPTION
When running the command separately on each dependency type (`dev`, `peer`, ...) everything is upgraded as expected.

So the solution proposed here is to expand the `npm-check-updates` command into 5 separate commands, each updating a different dependency type. 

Fixes https://github.com/projen/projen/issues/1110

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.