### PR TITLE
fix(release): prefix env variable clash

### DIFF
--- a/src/__tests__/release/__snapshots__/release.test.ts.snap
+++ b/src/__tests__/release/__snapshots__/release.test.ts.snap
@@ -2129,8 +2129,8 @@ node_modules/
         "description": "Prepare a release from \\"firefox\\" branch",
         "env": Object {
           "MAJOR": "1",
-          "PREFIX": "firefox/",
           "RELEASE": "true",
+          "RELEASE_TAG_PREFIX": "firefox/",
         },
         "name": "release:firefox",
         "steps": Array [
@@ -2155,8 +2155,8 @@ node_modules/
         "description": "Prepare a release from \\"safari\\" branch",
         "env": Object {
           "MAJOR": "1",
-          "PREFIX": "safari/",
           "RELEASE": "true",
+          "RELEASE_TAG_PREFIX": "safari/",
         },
         "name": "release:safari",
         "steps": Array [
@@ -2929,8 +2929,8 @@ node_modules/
         "description": "Prepare a release from \\"10.x\\" branch",
         "env": Object {
           "MAJOR": "10",
-          "PREFIX": "prefix/",
           "RELEASE": "true",
+          "RELEASE_TAG_PREFIX": "prefix/",
         },
         "name": "release:10.x",
         "steps": Array [

--- a/src/release/bump-version.task.ts
+++ b/src/release/bump-version.task.ts
@@ -12,7 +12,7 @@
  * - MAJOR: major version number NN to filter (tags are filtered by "vNN."
  *   prefix). if not specified, the last major version is selected
  * - CHANGELOG: name of changelog file to create
- * - PREFIX: (optional) a prefix to apply to the release tag
+ * - RELEASE_TAG_PREFIX: (optional) a prefix to apply to the release tag
  *
  */
 import { bump, BumpOptions } from './bump-version';
@@ -23,7 +23,7 @@ const major = process.env.MAJOR;
 const changelog = process.env.CHANGELOG;
 const bumpFile = process.env.BUMPFILE;
 const releaseTagFile = process.env.RELEASETAG;
-const prefix = process.env.PREFIX;
+const prefix = process.env.RELEASE_TAG_PREFIX;
 
 if (!versionFile) {
   throw new Error('OUTFILE is required');

--- a/src/release/release.ts
+++ b/src/release/release.ts
@@ -360,7 +360,7 @@ export class Release extends Component {
     }
 
     if (branch.tagPrefix) {
-      env.PREFIX = branch.tagPrefix;
+      env.RELEASE_TAG_PREFIX = branch.tagPrefix;
     }
 
     // the "release" task prepares a release but does not publish anything. the


### PR DESCRIPTION
I think PREFIX is clashing with an existing environment
variable used by nodejs or maybe nvm. When I run `yarn bump`
locally using manual releases and no prefix, PREFIX gets set
to `/usr/local`. Given the significance of that path I assume
that PREFIX is being used by some other tool on my system.

Making PREFIX naming more specific to avoid this problem.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.