### PR TITLE
fix(release): fix changelog release tag parsing

### DIFF
--- a/src/__tests__/release/update-changelog.test.ts
+++ b/src/__tests__/release/update-changelog.test.ts
@@ -63,7 +63,7 @@ test('missing release tag throws an error', async () => {
 
 test('mismatched release tag and input changelog release tag throws an error', async () => {
   const releaseTag = 'v1.2.0';
-  const inputChangelogReleaseTag = 'v1.1.0';
+  const inputChangelogReleaseTag = '1.1.0';
 
   await expect(
     testUpdateChangelog({

--- a/src/release/update-changelog.ts
+++ b/src/release/update-changelog.ts
@@ -52,6 +52,10 @@ export async function updateChangelog(
 
   let releaseTag = (await utils.tryReadFile(releaseTagFile)).trim();
 
+  if (releaseTag.startsWith('v')) {
+    releaseTag = releaseTag.slice(1);
+  }
+
   if (!releaseTag) {
     throw new Error(
       `Unable to determine version from ${releaseTagFile}. Cannot proceed with changelog update. Did you run 'bump'?`,


### PR DESCRIPTION
Now that we're pulling from the release tag file
we have to strip the preceding `v` since the version
is recorded without it in changelogs.

Parsing rules might need to change depending on #1118, but as is it should unblock folks not using prefixes.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.