### PR TITLE
fix: require node.js ^12.7.0 instead of ^12.13.0

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "@types/node",
-      "version": "^12.13.0",
+      "version": "^12.7.0",
       "type": "build"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -41,7 +41,9 @@ const project = new JsiiProject({
 
   projenDevDependency: false, // because I am projen
   releaseToNpm: true,
-  minNodeVersion: '12.13.0',
+  minNodeVersion: '12.7.0',
+  workflowNodeVersion: '12.13.0', // required by jest
+
   codeCov: true,
   defaultReleaseBranch: 'main',
   gitpod: true,

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/glob": "^7.1.4",
     "@types/ini": "^1.3.30",
     "@types/jest": "^27.0.2",
-    "@types/node": "^12.13.0",
+    "@types/node": "^12.7.0",
     "@types/semver": "^7.3.8",
     "@types/yargs": "^15.0.14",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
@@ -94,7 +94,7 @@
     "yargs"
   ],
   "engines": {
-    "node": ">= 12.13.0"
+    "node": ">= 12.7.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -812,7 +812,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.10.3.tgz#7a8f2838603ea314d1d22bb3171d899e15c57bd5"
   integrity sha512-ho3Ruq+fFnBrZhUYI46n/bV2GjwzSkwuT4dTf0GkuNFmnb8nq4ny2z9JEVemFi6bdEJanHLlYfy9c6FN9B9McQ==
 
-"@types/node@^12.13.0":
+"@types/node@^12.7.0":
   version "12.20.28"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.28.tgz#4b20048c6052b5f51a8d5e0d2acbf63d5a17e1e2"
   integrity sha512-cBw8gzxUPYX+/5lugXIPksioBSbE42k0fZ39p+4yRzfYjN6++eq9kAPdlY9qm+MXyfbk9EmvCYAYRn380sF46w==


### PR DESCRIPTION
The latest projen release bumped the minimum node.js version requirement to ^12.13.0 but this is technically a breaking change and blocks upgrades for projects that execute workflows against 12.7.0 (such as `constructs`).

This change reverts the minimum node engine version to 12.7.0 while still running our workflows against 12.13.0, which is required by `jest`. This is not perfectly correct as it means projen may depend on functionality that does not exist in 12.7.0 but its pragmatic and will cause less grief.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.