### PR TITLE
fix(release): update-changelog pull from version file

### DIFF
--- a/src/__tests__/release/update-changelog.test.ts
+++ b/src/__tests__/release/update-changelog.test.ts
@@ -13,10 +13,10 @@ import { execCapture, tryReadFile } from '../../util';
 logging.disable();
 jest.setTimeout(1000 * 60); // 1min
 
-const DEFAULT_RELEASE_TAG = '0.1.1';
-const DEFAULT_RELEASE_TAG_FILE = 'dist/releasetag.txt';
+const DEFAULT_VERSION = '0.1.1';
+const DEFAULT_VERSION_FILE = 'dist/version.txt';
 const DEFAULT_INPUT_CHANGELOG = 'dist/changelog.md';
-const DEFAULT_INPUT_CHANGELOG_CONTENT = `### [${DEFAULT_RELEASE_TAG}](https://examplerepourl.com/diff/path) (2021-09-04)`;
+const DEFAULT_INPUT_CHANGELOG_CONTENT = `### [${DEFAULT_VERSION}](https://examplerepourl.com/diff/path) (2021-09-04)`;
 const DEFAULT_OUTPUT_CHANGELOG = 'CHANGELOG.md';
 const DEFAULT_OUTPUT_CHANGELOG_CONTENT =
   '### output changelog original content';
@@ -24,13 +24,13 @@ const DEFAULT_OUTPUT_CHANGELOG_CONTENT =
 test('updates project changelog from bump artifacts', async () => {
   const result = await testUpdateChangelog();
 
-  expect(result.projectChangelogContent).toMatch(DEFAULT_RELEASE_TAG);
+  expect(result.projectChangelogContent).toMatch(DEFAULT_VERSION);
 });
 
 test('commits new changelog', async () => {
   const result = await testUpdateChangelog();
 
-  expect(result.commits[0]).toMatch(`chore(release): ${DEFAULT_RELEASE_TAG}`);
+  expect(result.commits[0]).toMatch(`chore(release): ${DEFAULT_VERSION}`);
   expect(result.lastCommitContent).toMatch(/.*CHANGELOG\.md.*/g);
 });
 
@@ -41,12 +41,12 @@ test('duplicate release tag update is idempotent', async () => {
       cwd: result1.cwd,
     },
   });
-  const commitsForReleaseTag = result2.commits.filter((commit) =>
-    commit.includes(DEFAULT_RELEASE_TAG),
+  const commitsForVersion = result2.commits.filter((commit) =>
+    commit.includes(DEFAULT_VERSION),
   );
 
-  expect(commitsForReleaseTag.length).toEqual(1);
-  expect(result2.projectChangelogContent.match(DEFAULT_RELEASE_TAG)?.length).toEqual(
+  expect(commitsForVersion.length).toEqual(1);
+  expect(result2.projectChangelogContent.match(DEFAULT_VERSION)?.length).toEqual(
     1,
   );
 });
@@ -55,21 +55,21 @@ test('missing release tag throws an error', async () => {
   await expect(
     testUpdateChangelog({
       testOptions: {
-        releaseTag: '',
+        version: '',
       },
     }),
   ).rejects.toThrow();
 });
 
 test('mismatched release tag and input changelog release tag throws an error', async () => {
-  const releaseTag = 'v1.2.0';
-  const inputChangelogReleaseTag = '1.1.0';
+  const version = '1.2.0';
+  const inputChangelogVersion = '1.1.0';
 
   await expect(
     testUpdateChangelog({
       testOptions: {
-        releaseTag: releaseTag,
-        inputChangelogContent: `### [${inputChangelogReleaseTag}](https://examplerepourl.com/diff/path) (2021-09-04)`,
+        version: version,
+        inputChangelogContent: `### [${inputChangelogVersion}](https://examplerepourl.com/diff/path) (2021-09-04)`,
       },
     }),
   ).rejects.toThrow();
@@ -79,18 +79,18 @@ interface TestUpdateChangelogOpts {
   updateChangelogOptions?: Partial<UpdateChangelogOptions>;
   testOptions?: {
     cwd?: string;
-    releaseTag?: string;
+    version?: string;
     inputChangelogContent?: string;
-    releaseTagPath?: string;
+    versionPath?: string;
     updateCount?: number;
   };
 }
 
 async function testUpdateChangelog(opts: TestUpdateChangelogOpts = {}) {
   const workdir = opts.testOptions?.cwd ?? mkdtempSync(join(tmpdir(), 'tag-test-'));
-  const releaseTag = opts.testOptions?.releaseTag ?? DEFAULT_RELEASE_TAG;
-  const releaseTagFile =
-    opts.updateChangelogOptions?.releaseTagFile ?? DEFAULT_RELEASE_TAG_FILE;
+  const version = opts.testOptions?.version ?? DEFAULT_VERSION;
+  const versionFile =
+    opts.updateChangelogOptions?.versionFile ?? DEFAULT_VERSION_FILE;
   const inputChangelogContent =
     opts.testOptions?.inputChangelogContent ?? DEFAULT_INPUT_CHANGELOG_CONTENT;
   const inputChangelog =
@@ -111,7 +111,7 @@ async function testUpdateChangelog(opts: TestUpdateChangelogOpts = {}) {
     git('config user.name "Your Name"');
     git('config commit.gpgsign false');
     await mkdir(join(workdir, 'dist'));
-    await writeFile(join(workdir, releaseTagFile), releaseTag);
+    await writeFile(join(workdir, versionFile), version);
     await writeFile(inputChangelogFullPath, inputChangelogContent);
     await writeFile(outputChangelogFullPath, outputChangelogContent);
     git(`add ${outputChangelogFullPath}`);
@@ -121,7 +121,7 @@ async function testUpdateChangelog(opts: TestUpdateChangelogOpts = {}) {
   await updateChangelog(workdir, {
     inputChangelog,
     outputChangelog,
-    releaseTagFile,
+    versionFile: versionFile,
   });
 
   const commits = execCapture('git log --oneline', {

--- a/src/release/publisher.ts
+++ b/src/release/publisher.ts
@@ -107,6 +107,7 @@ export class Publisher extends Component {
    */
   public publishToGit(options: GitPublishOptions) {
     const releaseTagFile = options.releaseTagFile;
+    const versionFile = options.versionFile;
     const changelog = options.changelogFile;
     const projectChangelogFile = options.projectChangelogFile;
     const gitBranch = options.gitBranch ?? 'main';
@@ -119,6 +120,7 @@ export class Publisher extends Component {
         CHANGELOG: changelog,
         RELEASE_TAG_FILE: releaseTagFile,
         PROJECT_CHANGELOG_FILE: projectChangelogFile ?? '',
+        VERSION_FILE: versionFile,
       },
     });
     if (projectChangelogFile) {

--- a/src/release/update-changelog.task.ts
+++ b/src/release/update-changelog.task.ts
@@ -7,7 +7,7 @@
  *
  * Environment variables:
  *
- * - RELEASE_TAG_FILE: Current release tag file
+ * - VERSION_FILE: Current semantic version file
  * - CHANGELOG_FILE: Release changelog
  * - PROJECT_CHANGELOG_FILE: Project-level changelog
  *
@@ -16,10 +16,10 @@ import { updateChangelog, UpdateChangelogOptions } from './update-changelog';
 
 const inputChangelog = process.env.CHANGELOG;
 const outputChangelog = process.env.PROJECT_CHANGELOG_FILE;
-const releaseTagFile = process.env.RELEASE_TAG_FILE;
+const versionFile = process.env.VERSION_FILE;
 
-if (!releaseTagFile) {
-  throw new Error('RELEASE_TAG_FILE is required');
+if (!versionFile) {
+  throw new Error('VERSION_FILE is required');
 }
 
 if (!inputChangelog) {
@@ -33,7 +33,7 @@ if (!outputChangelog) {
 const opts: UpdateChangelogOptions = {
   inputChangelog,
   outputChangelog,
-  releaseTagFile: releaseTagFile,
+  versionFile: versionFile,
 };
 
 updateChangelog(process.cwd(), opts).catch((e: Error) => {

--- a/src/release/update-changelog.ts
+++ b/src/release/update-changelog.ts
@@ -28,7 +28,7 @@ export interface UpdateChangelogOptions {
   /**
    * Release version.
    */
-  releaseTagFile: string;
+  versionFile: string;
 }
 
 /**
@@ -47,27 +47,22 @@ export async function updateChangelog(
 ) {
   const inputChangelog = join(cwd, options.inputChangelog);
   const outputChangelog = join(cwd, options.outputChangelog);
-  const releaseTagFile = join(cwd, options.releaseTagFile);
+  const versionFile = join(cwd, options.versionFile);
 
+  let version = (await utils.tryReadFile(versionFile)).trim();
 
-  let releaseTag = (await utils.tryReadFile(releaseTagFile)).trim();
-
-  if (releaseTag.startsWith('v')) {
-    releaseTag = releaseTag.slice(1);
-  }
-
-  if (!releaseTag) {
+  if (!version) {
     throw new Error(
-      `Unable to determine version from ${releaseTagFile}. Cannot proceed with changelog update. Did you run 'bump'?`,
+      `Unable to determine version from ${versionFile}. Cannot proceed with changelog update. Did you run 'bump'?`,
     );
   }
 
   const inputChangelogContent = await readFile(inputChangelog, 'utf-8');
-  const changelogVersionSearchPattern = `[${releaseTag}]`;
+  const changelogVersionSearchPattern = `[${version}]`;
 
   if (!inputChangelogContent.includes(changelogVersionSearchPattern)) {
     throw new Error(
-      `Supplied version ${releaseTag} was not found in input changelog. You may want to check it's content.`,
+      `Supplied version ${version} was not found in input changelog. You may want to check it's content.`,
     );
   }
 
@@ -75,7 +70,7 @@ export async function updateChangelog(
 
   if (outputChangelogContent.indexOf(changelogVersionSearchPattern) > -1) {
     logging.info(
-      `Changelog already contains an entry for ${releaseTag}. Skipping changelog update.`,
+      `Changelog already contains an entry for ${version}. Skipping changelog update.`,
     );
     return;
   }
@@ -87,5 +82,5 @@ export async function updateChangelog(
     newChangelog,
   );
 
-  utils.exec(`git add ${outputChangelog} && git commit -m "chore(release): ${releaseTag}"`, { cwd });
+  utils.exec(`git add ${outputChangelog} && git commit -m "chore(release): ${version}"`, { cwd });
 }


### PR DESCRIPTION
Prefixes aren't recorded in the release changelog so
switching back to pulling the release version from
version.txt to simplify having to parse out the
major, minor, and patch version from the full release
tag.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.