### PR TITLE
chore: fix projen workflow tokens

### DIFF
--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -75,7 +75,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PROJEN_UPGRADE_TOKEN }}
           commit-message: >-
             chore(deps): upgrade dependencies
 

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -76,6 +76,12 @@ const project = new JsiiProject({
 
   autoApproveUpgrades: true,
   autoApproveOptions: { allowedUsernames: ['cdklabs-automation'], secret: 'GITHUB_TOKEN' },
+
+  depsUpgradeOptions: {
+    workflowOptions: {
+      secret: 'PROJEN_UPGRADE_TOKEN',
+    },
+  },
 });
 
 // this script is what we use as the projen command in this project


### PR DESCRIPTION
Currently in the projen repo, dependency upgrade PRs generated by the `upgrade-main.yml` workflow do not get automatically approved because the PRs are generated using the GITHUB_TOKEN, which is the same token that is running the `auto-approve.yml` workflow. To fix this, we set the upgrade dependency workflow to use a different token for creating the dependency upgrade PRs.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.