### PR TITLE
fix: incorrect workflow token

### DIFF
--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -75,7 +75,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@v3
         with:
-          token: ${{ secrets.PROJEN_UPGRADE_TOKEN }}
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: >-
             chore(deps): upgrade dependencies
 

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -79,7 +79,7 @@ const project = new JsiiProject({
 
   depsUpgradeOptions: {
     workflowOptions: {
-      secret: 'PROJEN_UPGRADE_TOKEN',
+      secret: 'PROJEN_GITHUB_TOKEN',
     },
   },
 });


### PR DESCRIPTION
The token PROJEN_UPGRADE_TOKEN isn't one we currently have set in our repo.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.