### PR TITLE
chore(project): default outdir to /tmp in tests

### DIFF
--- a/test/awscdk-app.test.ts
+++ b/test/awscdk-app.test.ts
@@ -1,10 +1,9 @@
 import { AwsCdkTypeScriptApp } from '../src/awscdk-app-ts';
-import { mkdtemp, synthSnapshot } from './util';
+import { synthSnapshot } from './util';
 
 describe('cdkVersion is >= 2.0.0', () => {
   test('use "aws-cdk-lib" the constructs at ^10.0.5', () => {
     const project = new AwsCdkTypeScriptApp({
-      outdir: mkdtemp(),
       cdkVersion: '2.0.0-rc.1',
       defaultReleaseBranch: 'main',
       name: 'test',

--- a/test/awscdk-construct.test.ts
+++ b/test/awscdk-construct.test.ts
@@ -1,7 +1,6 @@
 import { AwsCdkConstructLibrary, AwsCdkConstructLibraryOptions } from '../src/awscdk-construct';
-import { LogLevel } from '../src/logger';
 import { NpmAccess } from '../src/node-package';
-import { mkdtemp, synthSnapshot } from './util';
+import { synthSnapshot } from './util';
 
 describe('constructs dependency selection', () => {
   test('user-selected', () => {
@@ -72,10 +71,6 @@ const defaultOptions = {
 class TestProject extends AwsCdkConstructLibrary {
   constructor(options: Omit<AwsCdkConstructLibraryOptions, keyof typeof defaultOptions>) {
     super({
-      outdir: mkdtemp(),
-      logging: {
-        level: LogLevel.OFF,
-      },
       ...defaultOptions,
       ...options,
     });

--- a/test/cdk8s-app-project-ts.test.ts
+++ b/test/cdk8s-app-project-ts.test.ts
@@ -1,9 +1,8 @@
-import { Cdk8sTypeScriptAppOptions, Cdk8sTypeScriptApp } from '../src/cdk8s-app-ts';
-import { LogLevel } from '../src/logger';
-import { synthSnapshot, mkdtemp } from './util';
+import { Cdk8sTypeScriptApp } from '../src/cdk8s-app-ts';
+import { synthSnapshot } from './util';
 
 test ('test if cdk8s synth is possible', () => {
-  const project = new TestCdk8sAppProject({
+  const project = new Cdk8sTypeScriptApp({
     cdk8sVersion: '1.0.0-beta.18',
     name: 'project',
     defaultReleaseBranch: 'main',
@@ -50,7 +49,7 @@ test ('test if cdk8s synth is possible', () => {
 });
 
 test ('constructs version undefined', () => {
-  const project = new TestCdk8sAppProject({
+  const project = new Cdk8sTypeScriptApp({
     cdk8sVersion: '1.0.0-beta.11',
     name: 'project',
     defaultReleaseBranch: 'main',
@@ -69,7 +68,7 @@ test ('constructs version undefined', () => {
 });
 
 test ('constructs version pinning', () => {
-  const project = new TestCdk8sAppProject({
+  const project = new Cdk8sTypeScriptApp({
     cdk8sVersion: '1.0.0-beta.18',
     name: 'project',
     defaultReleaseBranch: 'main',
@@ -88,7 +87,7 @@ test ('constructs version pinning', () => {
 });
 
 test ('cdk8sPlusVersion undefined', () => {
-  const project = new TestCdk8sAppProject({
+  const project = new Cdk8sTypeScriptApp({
     cdk8sVersion: '1.0.0-beta.11',
     name: 'project',
     defaultReleaseBranch: 'main',
@@ -106,7 +105,7 @@ test ('cdk8sPlusVersion undefined', () => {
 });
 
 test ('cdk8sPlusVersion defined', () => {
-  const project = new TestCdk8sAppProject({
+  const project = new Cdk8sTypeScriptApp({
     cdk8sVersion: '1.0.0-beta.11',
     name: 'project',
     defaultReleaseBranch: 'main',
@@ -125,7 +124,7 @@ test ('cdk8sPlusVersion defined', () => {
 });
 
 test ('cdk8sPlusVersion pinning', () => {
-  const project = new TestCdk8sAppProject({
+  const project = new Cdk8sTypeScriptApp({
     cdk8sVersion: '1.0.0-beta.11',
     name: 'project',
     defaultReleaseBranch: 'main',
@@ -143,15 +142,3 @@ test ('cdk8sPlusVersion pinning', () => {
     'constructs': '^3.3.75',
   });
 });
-
-class TestCdk8sAppProject extends Cdk8sTypeScriptApp {
-  constructor(options: Cdk8sTypeScriptAppOptions) {
-    super({
-      outdir: mkdtemp(),
-      logging: {
-        level: LogLevel.OFF,
-      },
-      ...options,
-    });
-  }
-}

--- a/test/cdk8s-construct.test.ts
+++ b/test/cdk8s-construct.test.ts
@@ -1,9 +1,8 @@
-import { ConstructLibraryCdk8s, ConstructLibraryCdk8sOptions } from '../src/cdk8s-construct';
-import { LogLevel } from '../src/logger';
-import { synthSnapshot, mkdtemp } from './util';
+import { ConstructLibraryCdk8s } from '../src/cdk8s-construct';
+import { synthSnapshot } from './util';
 
 test ('constructs version defined', () => {
-  const project = new TestCdk8sConstructsProject({
+  const project = new ConstructLibraryCdk8s({
     cdk8sVersion: '1.0.0-beta.18',
     name: 'project',
     defaultReleaseBranch: 'main',
@@ -26,7 +25,7 @@ test ('constructs version defined', () => {
 });
 
 test ('constructs version undefined', () => {
-  const project = new TestCdk8sConstructsProject({
+  const project = new ConstructLibraryCdk8s({
     cdk8sVersion: '1.0.0-beta.11',
     name: 'project',
     defaultReleaseBranch: 'main',
@@ -48,7 +47,7 @@ test ('constructs version undefined', () => {
 });
 
 test ('constructs version pinning', () => {
-  const project = new TestCdk8sConstructsProject({
+  const project = new ConstructLibraryCdk8s({
     cdk8sVersion: '1.0.0-beta.18',
     name: 'project',
     defaultReleaseBranch: 'main',
@@ -71,7 +70,7 @@ test ('constructs version pinning', () => {
 });
 
 test ('cdk8sPlusVersion undefined', () => {
-  const project = new TestCdk8sConstructsProject({
+  const project = new ConstructLibraryCdk8s({
     cdk8sVersion: '1.0.0-beta.11',
     name: 'project',
     defaultReleaseBranch: 'main',
@@ -92,7 +91,7 @@ test ('cdk8sPlusVersion undefined', () => {
 });
 
 test ('cdk8sPlusVersion defined', () => {
-  const project = new TestCdk8sConstructsProject({
+  const project = new ConstructLibraryCdk8s({
     cdk8sVersion: '1.0.0-beta.11',
     name: 'project',
     defaultReleaseBranch: 'main',
@@ -114,7 +113,7 @@ test ('cdk8sPlusVersion defined', () => {
 });
 
 test ('cdk8sPlusVersion pinning', () => {
-  const project = new TestCdk8sConstructsProject({
+  const project = new ConstructLibraryCdk8s({
     cdk8sVersion: '1.0.0-beta.11',
     name: 'project',
     defaultReleaseBranch: 'main',
@@ -135,15 +134,3 @@ test ('cdk8sPlusVersion pinning', () => {
     'constructs': '^3.3.75',
   });
 });
-
-class TestCdk8sConstructsProject extends ConstructLibraryCdk8s {
-  constructor(options: ConstructLibraryCdk8sOptions) {
-    super({
-      outdir: mkdtemp(),
-      logging: {
-        level: LogLevel.OFF,
-      },
-      ...options,
-    });
-  }
-}

--- a/test/cdktf-construct.test.ts
+++ b/test/cdktf-construct.test.ts
@@ -1,7 +1,6 @@
 import { ConstructLibraryCdktf, ConstructLibraryCdktfOptions } from '../src/cdktf-construct';
-import { LogLevel } from '../src/logger';
 import { NpmAccess } from '../src/node-package';
-import { mkdtemp, synthSnapshot } from './util';
+import { synthSnapshot } from './util';
 
 describe('constructs dependency selection', () => {
   test('user-selected', () => {
@@ -32,10 +31,6 @@ const defaultOptions = {
 class TestProject extends ConstructLibraryCdktf {
   constructor(options: Omit<ConstructLibraryCdktfOptions, keyof typeof defaultOptions>) {
     super({
-      outdir: mkdtemp(),
-      logging: {
-        level: LogLevel.OFF,
-      },
       ...defaultOptions,
       ...options,
     });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,6 +1,5 @@
 import { join } from 'path';
 import { writeFileSync } from 'fs-extra';
-import { LogLevel } from '../src/logger';
 import { Project } from '../src/project';
 import { directorySnapshot, execProjenCLI, mkdtemp } from './util';
 
@@ -27,11 +26,10 @@ test('running "projen" with no arguments will execute .projenrc.js', () => {
 });
 
 test('running "projen" for projects with a "default" task will execute it', () => {
-  const workdir = mkdtemp();
-  const project = new Project({ outdir: workdir, name: 'my-project', logging: { level: LogLevel.OFF } });
+  const project = new Project({ name: 'my-project' });
   project.addTask(Project.DEFAULT_TASK, { exec: 'echo "foo" > bar.txt' });
   project.synth();
 
-  execProjenCLI(workdir);
-  expect(directorySnapshot(workdir)['bar.txt']).toStrictEqual('foo\n');
+  execProjenCLI(project.outdir);
+  expect(directorySnapshot(project.outdir)['bar.txt']).toStrictEqual('foo\n');
 });

--- a/test/eslint.test.ts
+++ b/test/eslint.test.ts
@@ -1,13 +1,10 @@
 import { Eslint, NodeProject } from '../src';
-import { LogLevel } from '../src/logger';
-import { mkdtemp, synthSnapshot } from './util';
+import { synthSnapshot } from './util';
 
 test('devdirs', () => {
   // GIVEN
   const project = new NodeProject({
-    outdir: mkdtemp(),
     name: 'test',
-    logging: { level: LogLevel.OFF },
     defaultReleaseBranch: 'master',
   });
 
@@ -25,9 +22,7 @@ describe('prettier', () => {
   test('snapshot', () => {
     // GIVEN
     const project = new NodeProject({
-      outdir: mkdtemp(),
       name: 'test',
-      logging: { level: LogLevel.OFF },
       defaultReleaseBranch: 'master',
     });
 
@@ -45,9 +40,7 @@ describe('prettier', () => {
   test('error on formatting when enabled', () => {
     // GIVEN
     const project = new NodeProject({
-      outdir: mkdtemp(),
       name: 'test',
-      logging: { level: LogLevel.OFF },
       defaultReleaseBranch: 'master',
     });
 
@@ -66,9 +59,7 @@ describe('alias', () => {
   test('custom config', () => {
     // GIVEN
     const project = new NodeProject({
-      outdir: mkdtemp(),
       name: 'test',
-      logging: { level: LogLevel.OFF },
       defaultReleaseBranch: 'master',
     });
 

--- a/test/github/auto-approve.test.ts
+++ b/test/github/auto-approve.test.ts
@@ -1,6 +1,6 @@
 import { AutoApprove } from '../../src/github/auto-approve';
 import { NodeProject, NodeProjectOptions } from '../../src/node-project';
-import { mkdtemp, synthSnapshot } from '../util';
+import { synthSnapshot } from '../util';
 
 describe('auto-approve', () => {
   test('default', () => {
@@ -47,7 +47,6 @@ describe('auto-approve', () => {
 type ProjectOptions = Omit<NodeProjectOptions, 'outdir' | 'defaultReleaseBranch' | 'name'>;
 function createProject(options: ProjectOptions = {}): NodeProject {
   return new NodeProject({
-    outdir: mkdtemp(),
     defaultReleaseBranch: 'main',
     name: 'node-project',
     ...options,

--- a/test/github/dependabot.test.ts
+++ b/test/github/dependabot.test.ts
@@ -1,6 +1,6 @@
 import { Dependabot, DependabotRegistryType } from '../../src/github';
 import { NodeProject, NodeProjectOptions } from '../../src/node-project';
-import { mkdtemp, synthSnapshot } from '../util';
+import { synthSnapshot } from '../util';
 
 describe('dependabot', () => {
   test('default', () => {
@@ -112,7 +112,6 @@ describe('dependabot', () => {
 type ProjectOptions = Omit<NodeProjectOptions, 'outdir' | 'defaultReleaseBranch' | 'name'>;
 function createProject(options: ProjectOptions = {}): NodeProject {
   return new NodeProject({
-    outdir: mkdtemp(),
     defaultReleaseBranch: 'main',
     name: 'node-project',
     ...options,

--- a/test/github/mergify.test.ts
+++ b/test/github/mergify.test.ts
@@ -1,6 +1,5 @@
-import { LogLevel } from '../../src/logger';
 import { NodeProject, NodeProjectOptions } from '../../src/node-project';
-import { mkdtemp, synthSnapshot } from '../util';
+import { synthSnapshot } from '../util';
 
 describe('mergify', () => {
   test('default', () => {
@@ -35,12 +34,8 @@ describe('mergify', () => {
 type ProjectOptions = Omit<NodeProjectOptions, 'outdir' | 'defaultReleaseBranch' | 'name'>;
 function createProject(options: ProjectOptions = {}): NodeProject {
   return new NodeProject({
-    outdir: mkdtemp(),
     defaultReleaseBranch: 'main',
     name: 'node-project',
-    logging: {
-      level: LogLevel.OFF,
-    },
     ...options,
   });
 }

--- a/test/java/__snapshots__/java-project.test.ts.snap
+++ b/test/java/__snapshots__/java-project.test.ts.snap
@@ -411,12 +411,10 @@ import io.github.cdklabs.projen.java.JavaProjectOptions;
 public class projenrc {
     public static void main(String[] args) {
         JavaProject project = new JavaProject(JavaProjectOptions.builder()
-            .outdir(\\"./project-temp-dir\\")
             .groupId(\\"org.acme\\")
             .artifactId(\\"my-artifact\\")
             .name(\\"test-project\\")
             .version(\\"1.0.0\\")
-            .logging({\\"level\\":\\"00.off\\"})
             .projenrcJavaOptions({\\"projenVersion\\":\\"^1.2.3\\"})
             .build());
         project.synth();
@@ -1069,12 +1067,10 @@ public class projenrc {
     public static void main(String[] args) {
         JavaProject project = new JavaProject(JavaProjectOptions.builder()
             .junit(false)
-            .outdir(\\"./project-temp-dir\\")
             .groupId(\\"org.acme\\")
             .artifactId(\\"my-artifact\\")
             .name(\\"test-project\\")
             .version(\\"1.0.0\\")
-            .logging({\\"level\\":\\"00.off\\"})
             .projenrcJavaOptions({\\"projenVersion\\":\\"^1.2.3\\"})
             .build());
         project.synth();
@@ -1213,12 +1209,10 @@ import io.github.cdklabs.projen.java.JavaProjectOptions;
 public class projenrc {
     public static void main(String[] args) {
         JavaProject project = new JavaProject(JavaProjectOptions.builder()
-            .outdir(\\"./project-temp-dir\\")
             .groupId(\\"org.acme\\")
             .artifactId(\\"my-artifact\\")
             .name(\\"test-project\\")
             .version(\\"1.0.0\\")
-            .logging({\\"level\\":\\"00.off\\"})
             .projenrcJavaOptions({\\"projenVersion\\":\\"^1.2.3\\"})
             .build());
         project.synth();

--- a/test/java/java-project.test.ts
+++ b/test/java/java-project.test.ts
@@ -1,13 +1,6 @@
-import { mkdirpSync } from 'fs-extra';
 import { JavaProject, JavaProjectOptions } from '../../src/java/java-project';
 import { renderProjenNewOptions } from '../../src/javascript/render-options';
-import { LogLevel } from '../../src/logger';
-import { mkdtemp, synthSnapshot } from '../util';
-
-let cwd = process.cwd();
-
-beforeEach(() => process.chdir(mkdtemp()));
-afterEach(() => process.chdir(cwd));
+import { synthSnapshot } from '../util';
 
 test('defaults', () => {
   const p = new TestJavaProject();
@@ -76,18 +69,12 @@ function snapPom(p: JavaProject) {
 
 class TestJavaProject extends JavaProject {
   constructor(options: Partial<JavaProjectOptions> = { }) {
-    // using a subdirectory to ensure synthSnapshot can clean up the project safely
-    mkdirpSync('project-temp-dir');
-
     super(renderProjenNewOptions('projen.java.JavaProject', {
       ...options,
-      // not using outdir: mkdtemp() since that will make snapshots non-deterministic
-      outdir: './project-temp-dir',
       groupId: 'org.acme',
       artifactId: 'my-artifact',
       name: 'test-project',
       version: '1.0.0',
-      logging: { level: LogLevel.OFF },
       projenrcJavaOptions: {
         projenVersion: '^1.2.3',
       },

--- a/test/javascript/npm-config.test.ts
+++ b/test/javascript/npm-config.test.ts
@@ -1,7 +1,6 @@
 import { NpmConfig } from '../../src/javascript/npm-config';
-import { LogLevel } from '../../src/logger';
 import { NodeProject, NodeProjectOptions } from '../../src/node-project';
-import { mkdtemp, synthSnapshot } from '../util';
+import { synthSnapshot } from '../util';
 
 test('registry is handled correctly', () => {
   const prj = new TestNodeProject({
@@ -63,11 +62,7 @@ test('generic prop is set correctly', () => {
 class TestNodeProject extends NodeProject {
   constructor(options: Partial<NodeProjectOptions> = {}) {
     super({
-      outdir: mkdtemp(),
       name: 'test-node-project',
-      logging: {
-        level: LogLevel.OFF,
-      },
       defaultReleaseBranch: 'master',
       ...options,
     });

--- a/test/jest.test.ts
+++ b/test/jest.test.ts
@@ -1,4 +1,4 @@
-import { Jest, NodeProject, TypeScriptProject, LogLevel } from '../src';
+import { Jest, NodeProject, TypeScriptProject } from '../src';
 import { PROJEN_RC } from '../src/common';
 import * as logging from '../src/logging';
 import { mkdtemp, synthSnapshot } from './util';
@@ -31,15 +31,11 @@ const compilerOptionDefaults = {
 
 test('Node Project Jest Defaults Configured', () => {
   const project = new NodeProject({
-    outdir: mkdtemp(),
     name: 'test-node-project',
     mergify: false,
     projenDevDependency: false,
     defaultReleaseBranch: 'master',
     jest: true,
-    logging: {
-      level: LogLevel.OFF,
-    },
   });
 
   expect(project.jest?.config).toBeTruthy();
@@ -57,7 +53,6 @@ test('Node Project Jest Defaults Configured', () => {
 
 test('Node Project Jest With Options Configured', () => {
   const project = new NodeProject({
-    outdir: mkdtemp(),
     name: 'test-node-project',
     defaultReleaseBranch: 'master',
     mergify: false,
@@ -69,9 +64,6 @@ test('Node Project Jest With Options Configured', () => {
         bail: 5,
         notify: false,
       },
-    },
-    logging: {
-      level: LogLevel.OFF,
     },
   });
 
@@ -86,7 +78,6 @@ test('Node Project Jest With Options Configured', () => {
 
 test('Node Project Jest With Path Configured', () => {
   const project = new NodeProject({
-    outdir: mkdtemp(),
     name: 'test-node-project',
     defaultReleaseBranch: 'master',
     mergify: false,
@@ -99,9 +90,6 @@ test('Node Project Jest With Path Configured', () => {
         bail: 5,
         notify: false,
       },
-    },
-    logging: {
-      level: LogLevel.OFF,
     },
   });
 
@@ -117,15 +105,11 @@ test('Node Project Jest With Path Configured', () => {
 test('Typescript Project Jest Defaults Configured', () => {
   // WHEN
   const project = new TypeScriptProject({
-    outdir: mkdtemp(),
     name: 'test-typescript-project',
     defaultReleaseBranch: 'master',
     mergify: false,
     projenDevDependency: false,
     jest: true,
-    logging: {
-      level: LogLevel.OFF,
-    },
   });
 
   const snapshot = synthSnapshot(project);
@@ -145,7 +129,6 @@ test('Typescript Project Jest With Compiler Options', () => {
   };
 
   const project = new TypeScriptProject({
-    outdir: mkdtemp(),
     name: 'test-typescript-project',
     defaultReleaseBranch: 'master',
     mergify: false,
@@ -153,9 +136,6 @@ test('Typescript Project Jest With Compiler Options', () => {
     jest: true,
     tsconfigDev: {
       compilerOptions,
-    },
-    logging: {
-      level: LogLevel.OFF,
     },
   });
 
@@ -173,7 +153,6 @@ test('Typescript Project Jest With Compiler Options', () => {
 
 test('jestOptions.typeScriptCompilerOptions is deprecated', () => {
   expect(() => new TypeScriptProject({
-    outdir: mkdtemp(),
     name: 'test-typescript-project',
     defaultReleaseBranch: 'master',
     mergify: false,
@@ -190,9 +169,7 @@ test('jestOptions.typeScriptCompilerOptions is deprecated', () => {
 test('testdir is under src', () => {
   // WHEN
   const project = new TypeScriptProject({
-    outdir: mkdtemp(),
     defaultReleaseBranch: 'master',
-    logging: { level: LogLevel.OFF },
     name: 'test-typescript-project',
     srcdir: 'mysrc',
     testdir: 'mysrc/boom/bam/__tests',
@@ -209,9 +186,6 @@ test('addTestMatch() can be used to add patterns', () => {
     outdir: mkdtemp(),
     defaultReleaseBranch: 'master',
     name: 'test',
-    logging: {
-      level: LogLevel.OFF,
-    },
   });
   const jest = new Jest(project, { jestConfig: { testMatch: [] } });
 

--- a/test/jsii.test.ts
+++ b/test/jsii.test.ts
@@ -1,9 +1,9 @@
-import { JsiiProject, JsiiProjectOptions, LogLevel } from '../src';
-import { mkdtemp, synthSnapshot } from './util';
+import { JsiiProject } from '../src';
+import { synthSnapshot } from './util';
 
 describe('author', () => {
   test('authorEmail and authorAddress can be the same value', () => {
-    const project = new TestJsiiProject({
+    const project = new JsiiProject({
       authorAddress: 'hello@hello.com',
       authorEmail: 'hello@hello.com',
       repositoryUrl: 'https://github.com/foo/bar.git',
@@ -21,7 +21,7 @@ describe('author', () => {
   });
 
   test('authorUrl and authorAddress can be the same value', () => {
-    const project = new TestJsiiProject({
+    const project = new JsiiProject({
       authorAddress: 'https://foo.bar',
       authorUrl: 'https://foo.bar',
       repositoryUrl: 'https://github.com/foo/bar.git',
@@ -41,7 +41,7 @@ describe('author', () => {
 
 describe('maven repository options', () => {
   test('use maven central as repository', () => {
-    const project = new TestJsiiProject({
+    const project = new JsiiProject({
       authorAddress: 'https://foo.bar',
       authorUrl: 'https://foo.bar',
       repositoryUrl: 'https://github.com/foo/bar.git',
@@ -79,7 +79,7 @@ describe('maven repository options', () => {
   });
 
   test('use nexus repo new endpoint', () => {
-    const project = new TestJsiiProject({
+    const project = new JsiiProject({
       authorAddress: 'https://foo.bar',
       authorUrl: 'https://foo.bar',
       repositoryUrl: 'https://github.com/foo/bar.git',
@@ -122,7 +122,7 @@ describe('maven repository options', () => {
   });
 
   test('use github as repository', () => {
-    const project = new TestJsiiProject({
+    const project = new JsiiProject({
       authorAddress: 'https://foo.bar',
       authorUrl: 'https://foo.bar',
       repositoryUrl: 'https://github.com/foo/bar.git',
@@ -162,7 +162,7 @@ describe('maven repository options', () => {
   });
 
   test('using github as repository with incorrect server id should throw', () => {
-    expect(() => new TestJsiiProject({
+    expect(() => new JsiiProject({
       authorAddress: 'https://foo.bar',
       authorUrl: 'https://foo.bar',
       repositoryUrl: 'https://github.com/foo/bar.git',
@@ -182,7 +182,7 @@ describe('maven repository options', () => {
 
 describe('publish to go', () => {
   test('defaults', () => {
-    const project = new TestJsiiProject({
+    const project = new JsiiProject({
       authorAddress: 'https://foo.bar',
       authorUrl: 'https://foo.bar',
       repositoryUrl: 'https://github.com/foo/bar.git',
@@ -206,7 +206,7 @@ describe('publish to go', () => {
   });
 
   test('release to npm undefined', () => {
-    const project = new TestJsiiProject({
+    const project = new JsiiProject({
       authorAddress: 'https://foo.bar',
       authorUrl: 'https://foo.bar',
       repositoryUrl: 'https://github.com/foo/bar.git',
@@ -220,7 +220,7 @@ describe('publish to go', () => {
   });
 
   test('release to npm true', () => {
-    const project = new TestJsiiProject({
+    const project = new JsiiProject({
       authorAddress: 'https://foo.bar',
       authorUrl: 'https://foo.bar',
       repositoryUrl: 'https://github.com/foo/bar.git',
@@ -235,7 +235,7 @@ describe('publish to go', () => {
   });
 
   test('release to npm false', () => {
-    const project = new TestJsiiProject({
+    const project = new JsiiProject({
       authorAddress: 'https://foo.bar',
       authorUrl: 'https://foo.bar',
       repositoryUrl: 'https://github.com/foo/bar.git',
@@ -250,7 +250,7 @@ describe('publish to go', () => {
   });
 
   test('customizations', () => {
-    const project = new TestJsiiProject({
+    const project = new JsiiProject({
       authorAddress: 'https://foo.bar',
       authorUrl: 'https://foo.bar',
       repositoryUrl: 'https://github.com/foo/bar.git',
@@ -278,7 +278,7 @@ describe('publish to go', () => {
 });
 
 test('docgen: true should just work', () => {
-  const project = new TestJsiiProject({
+  const project = new JsiiProject({
     author: 'My name',
     name: 'testproject',
     authorAddress: 'https://foo.bar',
@@ -301,43 +301,31 @@ describe('superchain image is selected based on the node version', () => {
   };
 
   test('defaults to 1-buster-slim without minNodeVersion', () => {
-    const project = new TestJsiiProject(opts);
+    const project = new JsiiProject(opts);
     const output = synthSnapshot(project);
     expect(output['.github/workflows/build.yml']).toContain('image: jsii/superchain:1-buster-slim');
   });
 
   test('12.x', () => {
-    const project = new TestJsiiProject({ ...opts, minNodeVersion: '12.22.1' });
+    const project = new JsiiProject({ ...opts, minNodeVersion: '12.22.1' });
     const output = synthSnapshot(project);
     expect(output['.github/workflows/build.yml']).toContain('image: jsii/superchain:1-buster-slim-node12');
   });
 
   test('14.x', () => {
-    const project = new TestJsiiProject({ ...opts, minNodeVersion: '14.42.1' });
+    const project = new JsiiProject({ ...opts, minNodeVersion: '14.42.1' });
     const output = synthSnapshot(project);
     expect(output['.github/workflows/build.yml']).toContain('image: jsii/superchain:1-buster-slim-node14');
   });
 
   test('16.x', () => {
-    const project = new TestJsiiProject({ ...opts, minNodeVersion: '16.22.1' });
+    const project = new JsiiProject({ ...opts, minNodeVersion: '16.22.1' });
     const output = synthSnapshot(project);
     expect(output['.github/workflows/build.yml']).toContain('image: jsii/superchain:1-buster-slim-node16');
   });
 
   test('unsupported version', () => {
-    expect(() => new TestJsiiProject({ ...opts, minNodeVersion: '15.3.20' })).toThrow('No jsii/superchain image available for node 15.x. Supported node versions: 12.x,14.x,16.x');
-    expect(() => new TestJsiiProject({ ...opts, minNodeVersion: '10.2.3' })).toThrow('No jsii/superchain image available for node 10.x. Supported node versions: 12.x,14.x,16.x');
+    expect(() => new JsiiProject({ ...opts, minNodeVersion: '15.3.20' })).toThrow('No jsii/superchain image available for node 15.x. Supported node versions: 12.x,14.x,16.x');
+    expect(() => new JsiiProject({ ...opts, minNodeVersion: '10.2.3' })).toThrow('No jsii/superchain image available for node 10.x. Supported node versions: 12.x,14.x,16.x');
   });
 });
-
-class TestJsiiProject extends JsiiProject {
-  constructor(options: JsiiProjectOptions) {
-    super({
-      outdir: mkdtemp(),
-      logging: {
-        level: LogLevel.OFF,
-      },
-      ...options,
-    });
-  }
-}

--- a/test/node-project.test.ts
+++ b/test/node-project.test.ts
@@ -1,12 +1,12 @@
 import * as yaml from 'yaml';
-import { NodeProject, NodeProjectOptions, LogLevel } from '../src';
+import { NodeProject, NodeProjectOptions } from '../src';
 import { DependencyType } from '../src/deps';
 import { JobPermission } from '../src/github/workflows-model';
 import * as logging from '../src/logging';
 import { NodePackage, NodePackageManager, NpmAccess } from '../src/node-package';
 import { Project } from '../src/project';
 import { Tasks } from '../src/tasks';
-import { mkdtemp, synthSnapshot, TestProject } from './util';
+import { synthSnapshot, TestProject } from './util';
 
 logging.disable();
 
@@ -647,11 +647,7 @@ test('workflowGitIdentity can be used to customize the git identity used in buil
 class TestNodeProject extends NodeProject {
   constructor(options: Partial<NodeProjectOptions> = {}) {
     super({
-      outdir: mkdtemp(),
       name: 'test-node-project',
-      logging: {
-        level: LogLevel.OFF,
-      },
       defaultReleaseBranch: 'main',
       ...options,
     });

--- a/test/python/poetry.test.ts
+++ b/test/python/poetry.test.ts
@@ -1,6 +1,5 @@
-import { LogLevel } from '../../src/logger';
 import { PythonProject, PythonProjectOptions } from '../../src/python';
-import { mkdtemp, synthSnapshot } from '../util';
+import { synthSnapshot } from '../util';
 
 test('poetry enabled', () => {
   const p = new TestPythonProject({
@@ -113,8 +112,6 @@ class TestPythonProject extends PythonProject {
       authorName: 'First Last',
       authorEmail: 'email@example.com',
       version: '0.1.0',
-      outdir: mkdtemp(),
-      logging: { level: LogLevel.OFF },
     });
   }
 }

--- a/test/python/python-project.test.ts
+++ b/test/python/python-project.test.ts
@@ -1,6 +1,5 @@
-import { LogLevel } from '../../src/logger';
 import { PythonProject, PythonProjectOptions } from '../../src/python';
-import { mkdtemp, synthSnapshot } from '../util';
+import { synthSnapshot } from '../util';
 
 test('defaults', () => {
   const p = new TestPythonProject();
@@ -56,8 +55,6 @@ class TestPythonProject extends PythonProject {
       authorName: 'First Last',
       authorEmail: 'email@example.com',
       version: '0.1.0',
-      outdir: mkdtemp(),
-      logging: { level: LogLevel.OFF },
     });
   }
 }

--- a/test/python/setuptools.test.ts
+++ b/test/python/setuptools.test.ts
@@ -1,6 +1,5 @@
-import { LogLevel } from '../../src/logger';
 import { PythonProject, PythonProjectOptions } from '../../src/python';
-import { mkdtemp, synthSnapshot } from '../util';
+import { synthSnapshot } from '../util';
 
 test('setuptools enabled', () => {
   const p = new TestPythonProject({
@@ -32,8 +31,6 @@ class TestPythonProject extends PythonProject {
       authorName: 'First Last',
       authorEmail: 'email@example.com',
       version: '0.1.0',
-      outdir: mkdtemp(),
-      logging: { level: LogLevel.OFF },
     });
   }
 }

--- a/test/sample-file.test.ts
+++ b/test/sample-file.test.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
-import { LogLevel, Project, ProjectOptions } from '../src';
+import { Project, ProjectOptions } from '../src';
 import { SampleDir, SampleFile } from '../src/sample-file';
-import { mkdtemp, synthSnapshot } from './util';
+import { synthSnapshot } from './util';
 
 
 test('sample file from text contents', () => {
@@ -79,13 +79,8 @@ test('sample directory from source with overwritten files', () => {
 
 export class TestProject extends Project {
   constructor(options: Omit<ProjectOptions, 'name'> = {}) {
-    const tmpdir = mkdtemp();
     super({
       name: 'my-project',
-      outdir: tmpdir,
-      logging: {
-        level: LogLevel.OFF,
-      },
       ...options,
     });
   }

--- a/test/subproject.test.ts
+++ b/test/subproject.test.ts
@@ -1,12 +1,12 @@
 import * as path from 'path';
 import * as fs from 'fs-extra';
-import { Project, TextFile, LogLevel, ProjectOptions } from '../src';
+import { Project, TextFile, ProjectOptions } from '../src';
 import { PROJEN_MARKER } from '../src/common';
 import { TestProject } from './util';
 
 test('composing projects declaratively', () => {
   const comp = new TestProject();
-  new TestSubproject({ name: 'foo', parent: comp, outdir: path.join('packages', 'foo') });
+  new Project({ name: 'foo', parent: comp, outdir: path.join('packages', 'foo') });
   comp.synth();
 
   // THEN
@@ -18,8 +18,8 @@ test('composing projects synthesizes to subdirs', () => {
   const comp = new TestProject();
 
   // WHEN
-  new TestSubproject({ name: 'foo', parent: comp, outdir: path.join('packages', 'foo') });
-  new TestSubproject({ name: 'bar', parent: comp, outdir: path.join('packages', 'bar') });
+  new Project({ name: 'foo', parent: comp, outdir: path.join('packages', 'foo') });
+  new Project({ name: 'bar', parent: comp, outdir: path.join('packages', 'bar') });
 
   comp.synth();
 
@@ -32,16 +32,16 @@ test('composing projects synthesizes to subdirs', () => {
 test('errors when paths overlap', () => {
   // GIVEN
   const comp = new TestProject();
-  new TestSubproject({ name: 'foo', parent: comp, outdir: path.join('packages', 'foo') });
+  new Project({ name: 'foo', parent: comp, outdir: path.join('packages', 'foo') });
 
   // WHEN/THEN
-  expect(() => new TestSubproject({ name: 'foo', parent: comp, outdir: path.join('packages', 'foo') })).toThrowError(/there is already a sub-project with/i);
+  expect(() => new Project({ name: 'foo', parent: comp, outdir: path.join('packages', 'foo') })).toThrowError(/there is already a sub-project with/i);
 });
 
 test('multiple levels', () => {
   const root = new TestProject();
-  const child1 = new TestSubproject({ name: 'child1', parent: root, outdir: 'child1' });
-  const child2 = new TestSubproject({ name: 'child2', parent: child1, outdir: 'child2' });
+  const child1 = new Project({ name: 'child1', parent: root, outdir: 'child1' });
+  const child2 = new Project({ name: 'child2', parent: child1, outdir: 'child2' });
 
   expect(child1.outdir).toEqual(path.join(root.outdir, 'child1'));
   expect(child2.outdir).toEqual(path.join(root.outdir, 'child1', 'child2'));
@@ -49,7 +49,7 @@ test('multiple levels', () => {
 
 test('subprojects cannot introduce files that override each other', () => {
   const root = new TestProject();
-  const child = new TestSubproject({ name: 'sub-project', parent: root, outdir: 'sub-project' });
+  const child = new Project({ name: 'sub-project', parent: root, outdir: 'sub-project' });
 
   new TextFile(root, 'sub-project/file.txt');
   expect(() => new TextFile(child, 'file.txt')).toThrow(/there is already a file under sub-project(\\|\/)file\.txt/);
@@ -57,7 +57,7 @@ test('subprojects cannot introduce files that override each other', () => {
 
 test('"outdir" for subprojects must be relative', () => {
   const root = new TestProject();
-  expect(() => new TestSubproject({ name: 'foobar', parent: root, outdir: '/foo/bar' })).toThrow(/"outdir" must be a relative path/);
+  expect(() => new Project({ name: 'foobar', parent: root, outdir: '/foo/bar' })).toThrow(/"outdir" must be a relative path/);
 });
 
 test('subproject generated files do not get cleaned up by parent project', () => {
@@ -83,7 +83,7 @@ class PreSynthProject extends Project {
   public file: TextFile;
   public fileExistedDuringPresynth: boolean;
   constructor(options: Omit<ProjectOptions, 'name'> = {}) {
-    super({ name: 'presynth-project', logging: { level: LogLevel.OFF }, ...options });
+    super({ name: 'presynth-project', ...options });
 
     this.file = new TextFile(this, 'presynth.txt', { lines: [PROJEN_MARKER] });
     this.fileExistedDuringPresynth = false;
@@ -91,11 +91,5 @@ class PreSynthProject extends Project {
 
   preSynthesize() {
     this.fileExistedDuringPresynth = fs.existsSync(this.file.absolutePath);
-  }
-}
-
-class TestSubproject extends Project {
-  constructor(options: ProjectOptions) {
-    super({ logging: { level: LogLevel.OFF }, ...options });
   }
 }

--- a/test/typescript.test.ts
+++ b/test/typescript.test.ts
@@ -1,6 +1,6 @@
 import { PROJEN_RC } from '../src/common';
 import { mergeTsconfigOptions, TypeScriptProject } from '../src/typescript';
-import { mkdtemp, synthSnapshot } from './util';
+import { synthSnapshot } from './util';
 
 describe('mergeTsconfigOptions', () => {
   test('merging includes', () => {
@@ -63,7 +63,6 @@ describe('mergeTsconfigOptions', () => {
 test('tsconfig prop is propagated to eslint and jest tsconfigs', () => {
   const prj = new TypeScriptProject({
     name: 'test',
-    outdir: mkdtemp(),
     defaultReleaseBranch: 'test',
     tsconfig: {
       include: ['typescript.test.ts'],
@@ -114,7 +113,6 @@ test('sources and compiled output can be collocated', () => {
 
   const prj = new TypeScriptProject({
     name: 'test',
-    outdir: mkdtemp(),
     defaultReleaseBranch: 'test',
     libdir: 'lib',
     srcdir: 'lib',
@@ -131,7 +129,6 @@ test('sources and compiled output can be collocated', () => {
 test('tsconfigDevFile can be used to control the name of the tsconfig dev file', () => {
   const prj = new TypeScriptProject({
     name: 'test',
-    outdir: mkdtemp(),
     defaultReleaseBranch: 'test',
     tsconfigDevFile: 'tsconfig.foo.json',
     libdir: 'lib',
@@ -147,7 +144,6 @@ test('tsconfigDevFile can be used to control the name of the tsconfig dev file',
 test('projenrc.ts', () => {
   const prj = new TypeScriptProject({
     name: 'test',
-    outdir: mkdtemp(),
     defaultReleaseBranch: 'main',
     projenrcTs: true,
   });

--- a/test/upgrade-dependencies.test.ts
+++ b/test/upgrade-dependencies.test.ts
@@ -2,7 +2,7 @@ import * as yaml from 'yaml';
 import { NodeProject, UpgradeDependenciesSchedule } from '../src';
 import { NodeProjectOptions } from '../src/node-project';
 import { Tasks } from '../src/tasks';
-import { mkdtemp, synthSnapshot } from './util';
+import { synthSnapshot } from './util';
 
 test('upgrades command includes all dependencies', () => {
 
@@ -175,7 +175,6 @@ test('git identity can be customized', () => {
 
 function createProject(options: Omit<NodeProjectOptions, 'outdir' | 'defaultReleaseBranch' | 'name' | 'dependenciesUpgrade'> = {}): NodeProject {
   return new NodeProject({
-    outdir: mkdtemp(),
     defaultReleaseBranch: 'main',
     name: 'node-project',
     ...options,

--- a/test/util.ts
+++ b/test/util.ts
@@ -2,7 +2,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import { glob } from 'glob';
-import { LogLevel, Project } from '../src';
+import { Project } from '../src';
 import * as logging from '../src/logging';
 import { GitHubProject, GitHubProjectOptions } from '../src/project';
 import { Task } from '../src/tasks';
@@ -14,14 +14,9 @@ logging.disable(); // no logging during tests
 
 export class TestProject extends GitHubProject {
   constructor(options: Omit<GitHubProjectOptions, 'name'> = {}) {
-    const tmpdir = mkdtemp();
     super({
       name: 'my-project',
-      outdir: tmpdir,
       clobber: false,
-      logging: {
-        level: LogLevel.OFF,
-      },
       ...options,
     });
   }

--- a/test/web/nextjs-project.test.ts
+++ b/test/web/nextjs-project.test.ts
@@ -1,6 +1,5 @@
-import { LogLevel } from '../../src/logger';
 import { NextJsProject, NextJsProjectOptions } from '../../src/web';
-import { mkdtemp, synthSnapshot } from '../util';
+import { synthSnapshot } from '../util';
 
 test('defaults', () => {
   const p = new TestNextJsProject();
@@ -20,8 +19,6 @@ class TestNextJsProject extends NextJsProject {
       ...options,
       clobber: false,
       name: 'test-nextjs-project',
-      outdir: mkdtemp(),
-      logging: { level: LogLevel.OFF },
       defaultReleaseBranch: 'main',
     });
   }

--- a/test/web/nextjs-ts-project.test.ts
+++ b/test/web/nextjs-ts-project.test.ts
@@ -1,6 +1,5 @@
-import { LogLevel } from '../../src/logger';
 import { NextJsTypeScriptProject, NextJsTypeScriptProjectOptions } from '../../src/web';
-import { mkdtemp, synthSnapshot } from '../util';
+import { synthSnapshot } from '../util';
 
 test('defaults', () => {
   const p = new TestNextJsTypeScriptProject();
@@ -20,8 +19,6 @@ class TestNextJsTypeScriptProject extends NextJsTypeScriptProject {
       ...options,
       clobber: false,
       name: 'test-nextjs-project',
-      outdir: mkdtemp(),
-      logging: { level: LogLevel.OFF },
       defaultReleaseBranch: 'main',
     });
   }

--- a/test/web/react-project.test.ts
+++ b/test/web/react-project.test.ts
@@ -1,6 +1,5 @@
-import { LogLevel } from '../../src/logger';
 import { ReactProject, ReactProjectOptions } from '../../src/web';
-import { mkdtemp, synthSnapshot } from '../util';
+import { synthSnapshot } from '../util';
 
 test('defaults', () => {
   const p = new TestReactProject();
@@ -54,8 +53,6 @@ class TestReactProject extends ReactProject {
       ...options,
       clobber: false,
       name: 'test-nextjs-project',
-      outdir: mkdtemp(),
-      logging: { level: LogLevel.OFF },
       defaultReleaseBranch: 'main',
     });
   }

--- a/test/web/react-ts-project.test.ts
+++ b/test/web/react-ts-project.test.ts
@@ -1,6 +1,5 @@
-import { LogLevel } from '../../src/logger';
 import { ReactTypeScriptProject, ReactTypeScriptProjectOptions } from '../../src/web';
-import { mkdtemp, synthSnapshot } from '../util';
+import { synthSnapshot } from '../util';
 
 test('defaults', () => {
   const p = new TestReactTypeScriptProject();
@@ -13,8 +12,6 @@ class TestReactTypeScriptProject extends ReactTypeScriptProject {
       ...options,
       clobber: false,
       name: 'test-nextjs-project',
-      outdir: mkdtemp(),
-      logging: { level: LogLevel.OFF },
       defaultReleaseBranch: 'main',
     });
   }


### PR DESCRIPTION
When running in the context of a jest test, default `outdir` to a temporary directory instead of cwd. Otherwise, by default, projects created in tests will override the current project and that’s undesirable.
It also cleans up a lot of the boilerplate when creating projects in tests.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.