### PR TITLE
fix: honor outdirectory resolution

### DIFF
--- a/src/project.ts
+++ b/src/project.ts
@@ -458,7 +458,7 @@ export class Project {
       return mkdtempSync(path.join(tmpdir(), 'projen.'));
     }
 
-    return path.resolve(outdirOption || '.');
+    return path.resolve(outdirOption ?? '.');
   }
 }
 


### PR DESCRIPTION
### Issue:

Projen will not honor an outdirectory if the project is not a subproject

### Fix:

Updating outdirectory resolution to prefer a passed outdirectory, and optionally default to '.'

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.