### PR TITLE
feat: support alwaysTryTypes config for typescript eslint import resolver

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,7 +27,8 @@
     "import/resolver": {
       "node": {},
       "typescript": {
-        "project": "./tsconfig.dev.json"
+        "project": "./tsconfig.dev.json",
+        "alwaysTryTypes": true
       }
     }
   },

--- a/API.md
+++ b/API.md
@@ -1910,6 +1910,7 @@ new Eslint(project: NodeProject, options: EslintOptions)
   * **lintProjenRc** (<code>boolean</code>)  Should we lint .projenrc.js. __*Default*__: true
   * **prettier** (<code>boolean</code>)  Enable prettier for code formatting. __*Default*__: false
   * **tsconfigPath** (<code>string</code>)  Path to `tsconfig.json` which should be used by eslint. __*Default*__: "./tsconfig.json"
+  * **typescriptAlwaysTryTypes** (<code>boolean</code>)  Always try to resolve types under `<root>@types` directory even it doesn't contain any source code. __*Optional*__
 
 
 
@@ -9910,6 +9911,7 @@ Name | Type | Description
 **lintProjenRc**?🔹 | <code>boolean</code> | Should we lint .projenrc.js.<br/>__*Default*__: true
 **prettier**?🔹 | <code>boolean</code> | Enable prettier for code formatting.<br/>__*Default*__: false
 **tsconfigPath**?🔹 | <code>string</code> | Path to `tsconfig.json` which should be used by eslint.<br/>__*Default*__: "./tsconfig.json"
+**typescriptAlwaysTryTypes**?🔹 | <code>boolean</code> | Always try to resolve types under `<root>@types` directory even it doesn't contain any source code.<br/>__*Optional*__
 
 
 

--- a/API.md
+++ b/API.md
@@ -1909,8 +1909,8 @@ new Eslint(project: NodeProject, options: EslintOptions)
   * **ignorePatterns** (<code>Array<string></code>)  List of file patterns that should not be linted, using the same syntax as .gitignore patterns. __*Default*__: [ '*.js', '*.d.ts', 'node_modules/', '*.generated.ts', 'coverage' ]
   * **lintProjenRc** (<code>boolean</code>)  Should we lint .projenrc.js. __*Default*__: true
   * **prettier** (<code>boolean</code>)  Enable prettier for code formatting. __*Default*__: false
+  * **tsAlwaysTryTypes** (<code>boolean</code>)  Always try to resolve types under `<root>@types` directory even it doesn't contain any source code. __*Default*__: true
   * **tsconfigPath** (<code>string</code>)  Path to `tsconfig.json` which should be used by eslint. __*Default*__: "./tsconfig.json"
-  * **typescriptAlwaysTryTypes** (<code>boolean</code>)  Always try to resolve types under `<root>@types` directory even it doesn't contain any source code. __*Optional*__
 
 
 
@@ -9910,8 +9910,8 @@ Name | Type | Description
 **ignorePatterns**?🔹 | <code>Array<string></code> | List of file patterns that should not be linted, using the same syntax as .gitignore patterns.<br/>__*Default*__: [ '*.js', '*.d.ts', 'node_modules/', '*.generated.ts', 'coverage' ]
 **lintProjenRc**?🔹 | <code>boolean</code> | Should we lint .projenrc.js.<br/>__*Default*__: true
 **prettier**?🔹 | <code>boolean</code> | Enable prettier for code formatting.<br/>__*Default*__: false
+**tsAlwaysTryTypes**?🔹 | <code>boolean</code> | Always try to resolve types under `<root>@types` directory even it doesn't contain any source code.<br/>__*Default*__: true
 **tsconfigPath**?🔹 | <code>string</code> | Path to `tsconfig.json` which should be used by eslint.<br/>__*Default*__: "./tsconfig.json"
-**typescriptAlwaysTryTypes**?🔹 | <code>boolean</code> | Always try to resolve types under `<root>@types` directory even it doesn't contain any source code.<br/>__*Optional*__
 
 
 

--- a/src/eslint.ts
+++ b/src/eslint.ts
@@ -60,6 +60,11 @@ export interface EslintOptions {
    * @default undefined
    */
   readonly aliasExtensions?: string[];
+
+  /**
+   * Always try to resolve types under `<root>@types` directory even it doesn't contain any source code
+   */
+  readonly typescriptAlwaysTryTypes?: boolean;
 }
 
 /**
@@ -331,6 +336,7 @@ export class Eslint extends Component {
           node: {},
           typescript: {
             project: tsconfig,
+            ...( options.typescriptAlwaysTryTypes && { alwaysTryTypes: true } ),
           },
         },
       },

--- a/src/eslint.ts
+++ b/src/eslint.ts
@@ -62,9 +62,11 @@ export interface EslintOptions {
   readonly aliasExtensions?: string[];
 
   /**
-   * Always try to resolve types under `<root>@types` directory even it doesn't contain any source code
+   * Always try to resolve types under `<root>@types` directory even it doesn't contain any source code.
+   * This prevents `import/no-unresolved` eslint errors when importing a `@types/*` module that would otherwise remain unresolved.
+   * @default true
    */
-  readonly typescriptAlwaysTryTypes?: boolean;
+  readonly tsAlwaysTryTypes?: boolean;
 }
 
 /**
@@ -336,7 +338,7 @@ export class Eslint extends Component {
           node: {},
           typescript: {
             project: tsconfig,
-            ...( options.typescriptAlwaysTryTypes && { alwaysTryTypes: true } ),
+            ...( options.tsAlwaysTryTypes !== false && { alwaysTryTypes: true } ),
           },
         },
       },

--- a/test/__snapshots__/eslint.test.ts.snap
+++ b/test/__snapshots__/eslint.test.ts.snap
@@ -226,6 +226,7 @@ Object {
     "import/resolver": Object {
       "node": Object {},
       "typescript": Object {
+        "alwaysTryTypes": true,
         "project": "./tsconfig.json",
       },
     },
@@ -366,6 +367,7 @@ Object {
     "import/resolver": Object {
       "node": Object {},
       "typescript": Object {
+        "alwaysTryTypes": true,
         "project": "./tsconfig.json",
       },
     },

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -227,6 +227,7 @@ Object {
       "import/resolver": Object {
         "node": Object {},
         "typescript": Object {
+          "alwaysTryTypes": true,
           "project": "./tsconfig.dev.json",
         },
       },
@@ -1968,6 +1969,7 @@ Object {
       "import/resolver": Object {
         "node": Object {},
         "typescript": Object {
+          "alwaysTryTypes": true,
           "project": "./tsconfig.dev.json",
         },
       },
@@ -3369,6 +3371,7 @@ Object {
       "import/resolver": Object {
         "node": Object {},
         "typescript": Object {
+          "alwaysTryTypes": true,
           "project": "./tsconfig.dev.json",
         },
       },

--- a/test/eslint.test.ts
+++ b/test/eslint.test.ts
@@ -84,7 +84,7 @@ describe('alias', () => {
 
 });
 
-test('typescriptAlwaysTryTypes', () => {
+test('tsAlwaysTryTypes', () => {
   // GIVEN
   const project = new NodeProject({
     name: 'test',
@@ -94,7 +94,7 @@ test('typescriptAlwaysTryTypes', () => {
   // WHEN
   const eslint = new Eslint(project, {
     dirs: ['mysrc'],
-    typescriptAlwaysTryTypes: true,
+    tsAlwaysTryTypes: true,
   });
 
   // THEN

--- a/test/eslint.test.ts
+++ b/test/eslint.test.ts
@@ -83,3 +83,20 @@ describe('alias', () => {
   });
 
 });
+
+test('typescriptAlwaysTryTypes', () => {
+  // GIVEN
+  const project = new NodeProject({
+    name: 'test',
+    defaultReleaseBranch: 'master',
+  });
+
+  // WHEN
+  const eslint = new Eslint(project, {
+    dirs: ['mysrc'],
+    typescriptAlwaysTryTypes: true,
+  });
+
+  // THEN
+  expect(eslint.config.settings['import/resolver'].typescript).toHaveProperty('alwaysTryTypes', true);
+});


### PR DESCRIPTION
Without this setting, the eslint-import-resolver-typescript will not try to
resolve imports on the `@types/*` packages, leading to errors like the following
at build:

```
error  Unable to resolve path to module 'aws-lambda'  import/no-unresolved
```

By adding `{ alwaysTypeTypes: true }` to the typescript import resolver config,
the error is resolved.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.