### PR TITLE
fix: README logo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # projen
 
-![projen logo](/logo/projen.svg)
+![projen logo](./logo/projen.svg)
 
 
 Define and maintain complex project configuration through code.


### PR DESCRIPTION
Changing the path from an absolute path to a relative path should make it appear correctly on Construct Hub

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.