### PR TITLE
fix(awscdk-app-ts): unsetting context when cdk version > 2

### DIFF
--- a/src/awscdk-app-ts.ts
+++ b/src/awscdk-app-ts.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import * as semver from 'semver';
-import { CdkTasks, AutoDiscover, LambdaFunctionCommonOptions } from './awscdk';
+import { AutoDiscover, CdkTasks, LambdaFunctionCommonOptions } from './awscdk';
 import { CdkConfig, CdkConfigCommonOptions } from './awscdk/cdk-config';
 import { Component } from './component';
 import { TypeScriptAppProject, TypeScriptProjectOptions } from './typescript';
@@ -132,6 +132,7 @@ export class AwsCdkTypeScriptApp extends TypeScriptAppProject {
 
     this.cdkConfig = new CdkConfig(this, {
       app: `npx ts-node --prefer-ts-exts ${path.posix.join(this.srcdir, this.appEntrypoint)}`,
+      featureFlags: cdkMajorVersion < 2,
       ...options,
     });
 
@@ -176,6 +177,7 @@ export class AwsCdkTypeScriptApp extends TypeScriptAppProject {
 
 class SampleCode extends Component {
   private readonly appProject: AwsCdkTypeScriptApp;
+
   constructor(project: AwsCdkTypeScriptApp, private readonly cdkMajorVersion: number) {
     super(project);
     this.appProject = project;

--- a/test/awscdk-app.test.ts
+++ b/test/awscdk-app.test.ts
@@ -19,6 +19,16 @@ describe('cdkVersion is >= 2.0.0', () => {
     });
     expect(snap['src/main.ts'].indexOf('import { App, Stack, StackProps } from \'aws-cdk-lib\'')).not.toEqual(-1);
   });
+
+  test('empty context', () => {
+    const project = new AwsCdkTypeScriptApp({
+      cdkVersion: '2.0.0-rc.1',
+      defaultReleaseBranch: 'main',
+      name: 'test',
+    });
+    const snap = synthSnapshot(project);
+    expect(snap['cdk.json'].context).toBeUndefined();
+  });
 });
 
 


### PR DESCRIPTION
fixes #1205 

Setting context to undefined when CDK major version is >=2 

Only question: should it be undefined or an empty object?
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.