### PR TITLE
chore: fix addBundle docstring

### DIFF
--- a/API.md
+++ b/API.md
@@ -6470,7 +6470,7 @@ Adds a task to the project which bundles a specific entrypoint and all of its de
 addBundle(entrypoint: string, options: AddBundleOptions): Bundle
 ```
 
-* **entrypoint** (<code>string</code>)  *No description*
+* **entrypoint** (<code>string</code>)  The relative path of the artifact within the project.
 * **options** (<code>[javascript.AddBundleOptions](#projen-javascript-addbundleoptions)</code>)  Bundling options.
   * **externals** (<code>Array<string></code>)  You can mark a file or a package as external to exclude it from your build. __*Default*__: []
   * **sourcemap** (<code>boolean</code>)  Include a source map in the bundle. __*Default*__: false

--- a/src/javascript/bundler.ts
+++ b/src/javascript/bundler.ts
@@ -84,8 +84,7 @@ export class Bundler extends Component {
    * Adds a task to the project which bundles a specific entrypoint and all of
    * its dependencies into a single javascript output file.
    *
-   * @param name The name of the artifact (the task will be named
-   * `bundle:$name`).
+   * @param entrypoint The relative path of the artifact within the project
    * @param options Bundling options
    */
   public addBundle(entrypoint: string, options: AddBundleOptions): Bundle {


### PR DESCRIPTION
The current docstring describes a parameter that does not exist on the method

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.