### PR TITLE
fix: error in IntegrationTest is not thrown correctly

### DIFF
--- a/API.md
+++ b/API.md
@@ -49,7 +49,7 @@ Name|Description
 [Version](#projen-version)|*No description*
 [XmlFile](#projen-xmlfile)|Represents an XML file.
 [YamlFile](#projen-yamlfile)|Represents a YAML file.
-[awscdk.AutoDiscover](#projen-awscdk-autodiscover)|Automatically creates a `LambdaFunction` for all `.lambda.ts` files under the source directory of the project.
+[awscdk.AutoDiscover](#projen-awscdk-autodiscover)|Automatically creates a `LambdaFunction` for all `.lambda.ts` files under the source directory, and integration test tasks for each `.integ.ts` file under the source directory.
 [awscdk.AwsCdkJavaApp](#projen-awscdk-awscdkjavaapp)|AWS CDK app in Java.
 [awscdk.CdkConfig](#projen-awscdk-cdkconfig)|Represents cdk.json file.
 [awscdk.CdkTasks](#projen-awscdk-cdktasks)|Adds standard AWS CDK tasks to your project.
@@ -5162,7 +5162,7 @@ __Returns__:
 
 ## class AutoDiscover 🔹 <a id="projen-awscdk-autodiscover"></a>
 
-Automatically creates a `LambdaFunction` for all `.lambda.ts` files under the source directory of the project.
+Automatically creates a `LambdaFunction` for all `.lambda.ts` files under the source directory, and integration test tasks for each `.integ.ts` file under the source directory.
 
 __Submodule__: awscdk
 

--- a/API.md
+++ b/API.md
@@ -5534,6 +5534,23 @@ removeDependency(name: string, type?: DependencyType): void
 
 
 
+#### tryGetDependency(name, type?)🔹 <a id="projen-deps-dependencies-trygetdependency"></a>
+
+Returns a dependency by name, or undefined.
+
+Returns undefined if the dependency does not exist with that name OR
+there is more than one dependency type for this dependency.
+
+```ts
+tryGetDependency(name: string, type?: DependencyType): Dependency
+```
+
+* **name** (<code>string</code>)  The name of the dependency.
+* **type** (<code>[deps.DependencyType](#projen-deps-dependencytype)</code>)  The dependency type.
+
+__Returns__:
+* <code>[deps.Dependency](#projen-deps-dependency)</code>
+
 #### *static* parseDependency(spec)🔹 <a id="projen-deps-dependencies-parsedependency"></a>
 
 Returns the coordinates of a dependency spec.
@@ -11910,7 +11927,7 @@ Name | Type | Description
 
 ## struct Dependency 🔹 <a id="projen-deps-dependency"></a>
 
-__Obtainable from__: [Dependencies](#projen-deps-dependencies).[addDependency](#projen-deps-dependencies#projen-deps-dependencies-adddependency)(), [Dependencies](#projen-deps-dependencies).[getDependency](#projen-deps-dependencies#projen-deps-dependencies-getdependency)(), [JavaProject](#projen-java-javaproject).[addPlugin](#projen-java-javaproject#projen-java-javaproject-addplugin)(), [Pom](#projen-java-pom).[addPlugin](#projen-java-pom#projen-java-pom-addplugin)()
+__Obtainable from__: [Dependencies](#projen-deps-dependencies).[addDependency](#projen-deps-dependencies#projen-deps-dependencies-adddependency)(), [Dependencies](#projen-deps-dependencies).[getDependency](#projen-deps-dependencies#projen-deps-dependencies-getdependency)(), [Dependencies](#projen-deps-dependencies).[tryGetDependency](#projen-deps-dependencies#projen-deps-dependencies-trygetdependency)(), [JavaProject](#projen-java-javaproject).[addPlugin](#projen-java-javaproject#projen-java-javaproject-addplugin)(), [Pom](#projen-java-pom).[addPlugin](#projen-java-pom#projen-java-pom-addplugin)()
 
 Represents a project dependency.
 

--- a/src/awscdk/auto-discover.ts
+++ b/src/awscdk/auto-discover.ts
@@ -28,7 +28,8 @@ export interface AutoDiscoverOptions {
 
 /**
  * Automatically creates a `LambdaFunction` for all `.lambda.ts` files under
- * the source directory of the project.
+ * the source directory, and integration test tasks for each `.integ.ts` file
+ * under the source directory.
  */
 export class AutoDiscover extends Component {
 

--- a/src/awscdk/integration-test.ts
+++ b/src/awscdk/integration-test.ts
@@ -69,9 +69,7 @@ export class IntegrationTest extends Component {
 
     const app = `ts-node ${entry}`;
 
-    try {
-      project.deps.getDependency('ts-node');
-    } catch (e) {
+    if (!project.deps.tryGetDependency('ts-node')) {
       throw new Error('ts-node dependency is required for integration tests.');
     }
 

--- a/src/awscdk/integration-test.ts
+++ b/src/awscdk/integration-test.ts
@@ -69,7 +69,9 @@ export class IntegrationTest extends Component {
 
     const app = `ts-node ${entry}`;
 
-    if (!project.deps.getDependency('ts-node')) {
+    try {
+      project.deps.getDependency('ts-node');
+    } catch (e) {
       throw new Error('ts-node dependency is required for integration tests.');
     }
 

--- a/src/deps/dependencies.ts
+++ b/src/deps/dependencies.ts
@@ -96,6 +96,27 @@ export class Dependencies extends Component {
   }
 
   /**
+   * Returns a dependency by name, or undefined.
+   *
+   * Returns undefined if the dependency does not exist with that name OR
+   * there is more than one dependency type for this dependency.
+   *
+   * @param name The name of the dependency
+   * @param type The dependency type. If this dependency is defined only for a
+   * single type, this argument can be omitted.
+   *
+   * @returns a copy (cannot be modified)
+   */
+  public tryGetDependency(name: string, type?: DependencyType): Dependency | undefined {
+    try {
+      return this.getDependency(name, type);
+    } catch (err) {
+      this.project.logger.warn(`tryGetDependency: ${(err as Error).message}`);
+      return undefined;
+    }
+  }
+
+  /**
    * Adds a dependency to this project.
    * @param spec The dependency spec in the format `MODULE[@VERSION]` where
    * `MODULE` is the package-manager-specific module name and `VERSION` is an

--- a/src/deps/dependencies.ts
+++ b/src/deps/dependencies.ts
@@ -81,18 +81,14 @@ export class Dependencies extends Component {
    * @returns a copy (cannot be modified)
    */
   public getDependency(name: string, type?: DependencyType): Dependency {
-    const idx = this.tryGetDependencyIndex(name, type);
-    if (idx === -1) {
+    const dep = this.tryGetDependency(name, type);
+    if (!dep) {
       const msg = type
         ? `there is no ${type} dependency defined on "${name}"`
         : `there is no dependency defined on "${name}"`;
-
       throw new Error(msg);
     }
-
-    return {
-      ...normalizeDep(this._deps[idx]),
-    };
+    return dep;
   }
 
   /**
@@ -108,12 +104,14 @@ export class Dependencies extends Component {
    * @returns a copy (cannot be modified)
    */
   public tryGetDependency(name: string, type?: DependencyType): Dependency | undefined {
-    try {
-      return this.getDependency(name, type);
-    } catch (err) {
-      this.project.logger.warn(`tryGetDependency: ${(err as Error).message}`);
+    const idx = this.tryGetDependencyIndex(name, type);
+    if (idx === -1) {
       return undefined;
     }
+
+    return {
+      ...normalizeDep(this._deps[idx]),
+    };
   }
 
   /**


### PR DESCRIPTION
`getDependency` throws an error if the dependency isn't found, so the "ts-node dependency is required for integration tests" error message never appears to the user.

Also updated the docs since it wasn't apparent that `AutoDiscover` was also auto-discovering integration tests.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.