### PR TITLE
feat: adding ability to set git-push flags for manual releases

### DIFF
--- a/src/release/publisher.ts
+++ b/src/release/publisher.ts
@@ -112,6 +112,7 @@ export class Publisher extends Component implements IJobProvider {
     const changelog = options.changelogFile;
     const projectChangelogFile = options.projectChangelogFile;
     const gitBranch = options.gitBranch ?? 'main';
+    const gitPushFlags = options.gitPushFlags ?? [];
 
     const taskName = (gitBranch === 'main' || gitBranch === 'master') ? 'publish:git' : `publish:git:${gitBranch}` ;
 
@@ -128,7 +129,9 @@ export class Publisher extends Component implements IJobProvider {
       publishTask.builtin('release/update-changelog');
     }
     publishTask.builtin('release/tag-version');
-    publishTask.exec(`git push --follow-tags origin ${gitBranch}`);
+
+    const flags = ['--follow-tags', ...gitPushFlags].join(' ');
+    publishTask.exec(`git push ${flags} origin ${gitBranch}`);
 
     return publishTask;
   }
@@ -753,4 +756,9 @@ export interface GitPublishOptions extends VersionArtifactOptions {
    * @default "main"
    */
   readonly gitBranch?: string;
+
+  /**
+   * Additional git push flags 
+   */
+  readonly gitPushFlags?: string[]
 }

--- a/src/release/release-trigger.ts
+++ b/src/release/release-trigger.ts
@@ -140,7 +140,7 @@ export class ReleaseTrigger {
   /**
    * Additional git push flags for manual releases
    */
-  readonly gitPushFlags?: string[]
+  public readonly gitPushFlags?: string[]
 
   private constructor(options: ReleaseTriggerOptions = {}) {
     this.isContinuous = options.continuous ?? false;

--- a/src/release/release-trigger.ts
+++ b/src/release/release-trigger.ts
@@ -25,6 +25,11 @@ export interface ManualReleaseOptions {
    * @default 'CHANGELOG.md'
    */
   readonly changelogPath?: string;
+
+  /**
+   * Additional git push flags 
+   */
+   readonly gitPushFlags?: string[]
 }
 
 interface ReleaseTriggerOptions {
@@ -50,6 +55,11 @@ interface ReleaseTriggerOptions {
    * @example '0 17 * * *' - every day at 5 pm
    */
   readonly schedule?: string;
+
+  /**
+   * Additional git push flags 
+   */
+  readonly gitPushFlags?: string[]
 }
 
 /**
@@ -126,10 +136,16 @@ export class ReleaseTrigger {
    */
   public readonly isContinuous: boolean;
 
+  /**
+   * Additional git push flags for manual releases
+   */
+  readonly gitPushFlags?: string[]
+
   private constructor(options: ReleaseTriggerOptions = {}) {
     this.isContinuous = options.continuous ?? false;
     this.schedule = options.schedule;
     this.changelogPath = options.changelogPath;
+    this.gitPushFlags = options.gitPushFlags;
   }
 
   /**

--- a/src/release/release-trigger.ts
+++ b/src/release/release-trigger.ts
@@ -29,7 +29,7 @@ export interface ManualReleaseOptions {
   /**
    * Additional git push flags 
    */
-   readonly gitPushFlags?: string[]
+  readonly gitPushFlags?: string[]
 }
 
 interface ReleaseTriggerOptions {
@@ -90,6 +90,7 @@ export class ReleaseTrigger {
 
     return new ReleaseTrigger({
       changelogPath: changelogPath,
+      gitPushFlags: options.gitPushFlags
     });
   }
 

--- a/src/release/release.ts
+++ b/src/release/release.ts
@@ -399,6 +399,7 @@ export class Release extends Component {
         releaseTagFile: path.posix.join(this.artifactsDirectory, this.version.releaseTagFileName),
         projectChangelogFile: this.releaseTrigger.changelogPath,
         gitBranch: branch.name,
+        gitPushFlags: this.releaseTrigger.gitPushFlags
       });
 
       releaseTask.spawn(publishTask);

--- a/test/release/release-trigger.test.ts
+++ b/test/release/release-trigger.test.ts
@@ -39,6 +39,14 @@ describe('manual release', () => {
       expect(releaseTrigger.changelogPath).toBeUndefined();
     });
   });
+
+  describe('with git push flags', () => {
+    test('equals values provided', () => {
+      releaseTrigger = ReleaseTrigger.manual({ gitPushFlags: ['-o', 'ci.skip'] });
+
+      expect(releaseTrigger.gitPushFlags).toEqual(['-o', 'ci.skip']);
+    });
+  });
 });
 
 describe('continuous release', () => {


### PR DESCRIPTION
The goal of this PR is to provide a means of adding additional cli flags to the `git push` command executed by running a manual release.

See the below issue for more information.

closes #1267 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.