### PR TITLE
feat: allow customising or disabling git-push used by manual release

### DIFF
--- a/API.md
+++ b/API.md
@@ -857,6 +857,7 @@ new Cdk8sTypeScriptApp(options: Cdk8sTypeScriptAppOptions)
   * **appEntrypoint** (<code>string</code>)  The CDK8s app's entrypoint (relative to the source directory, which is "src" by default). __*Default*__: "main.ts"
   * **cdk8sCliVersion** (<code>string</code>)  cdk8s-cli version. __*Default*__: "cdk8sVersion"
   * **cdk8sCliVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for CDK8s-cli. __*Default*__: false
+  * **cdk8sPlusVersion** (<code>string</code>)  cdk8s-plus-17 version. __*Default*__: "cdk8sVersion"
   * **cdk8sPlusVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for cdk8s-plus-17. __*Default*__: false
   * **cdk8sVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for CDK8s. __*Default*__: false
   * **constructsVersion** (<code>string</code>)  constructs verion. __*Default*__: "3.2.34"
@@ -871,6 +872,7 @@ Name | Type | Description
 -----|------|-------------
 **appEntrypoint**🔹 | <code>string</code> | The CDK8s app entrypoint.
 **cdk8sCliVersion**🔹 | <code>string</code> | The cdk8s-cli version this app is using.
+**cdk8sPlusVersion**🔹 | <code>string</code> | The cdk8s-plus-17 version this app is using.
 **cdk8sVersion**🔹 | <code>string</code> | The CDK8s version this app is using.
 **constructsVersion**🔹 | <code>string</code> | The constructs version this app is using.
 
@@ -1420,6 +1422,7 @@ new ConstructLibraryCdk8s(options: ConstructLibraryCdk8sOptions)
   * **rootdir** (<code>string</code>)  *No description* __*Default*__: "."
   * **catalog** (<code>[Catalog](#projen-catalog)</code>)  Libraries will be picked up by the construct catalog when they are published to npm as jsii modules and will be published under:. __*Default*__: new version will be announced
   * **cdk8sVersion** (<code>string</code>)  Minimum target version this library is tested against. 
+  * **cdk8sPlusVersion** (<code>string</code>)  cdk8s-plus-17 version. __*Default*__: "cdk8sVersion"
   * **cdk8sPlusVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for cdk8s-plus-17. __*Default*__: false
   * **cdk8sVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for CDK8s. __*Default*__: false
   * **constructsVersion** (<code>string</code>)  constructs verion. __*Default*__: "3.2.34"
@@ -1432,6 +1435,7 @@ new ConstructLibraryCdk8s(options: ConstructLibraryCdk8sOptions)
 
 Name | Type | Description 
 -----|------|-------------
+**cdk8sPlusVersion**🔹 | <code>string</code> | The cdk8s-plus-17 version this app is using.
 **cdk8sVersion**🔹 | <code>string</code> | The CDK8s version this app is using.
 **constructsVersion**🔹 | <code>string</code> | The constructs version this app is using.
 
@@ -7324,6 +7328,7 @@ publishToGit(options: GitPublishOptions): Task
   * **releaseTagFile** (<code>string</code>)  The location of a text file (relative to `dist/`) that contains the release tag. 
   * **versionFile** (<code>string</code>)  The location of a text file (relative to `dist/`) that contains the version number. 
   * **gitBranch** (<code>string</code>)  Branch to push to. __*Default*__: "main"
+  * **gitPushFlags** (<code>Array<string></code>)  Additional git push flags. __*Optional*__
   * **projectChangelogFile** (<code>string</code>)  The location of an .md file that includes the project-level changelog. __*Optional*__
 
 __Returns__:
@@ -7558,6 +7563,7 @@ Name | Type | Description
 **isContinuous**🔹 | <code>boolean</code> | Whether or not this is a continuous release.
 **isManual**🔹 | <code>boolean</code> | Whether or not this is a manual release trigger.
 **changelogPath**?🔹 | <code>string</code> | Project-level changelog file path.<br/>__*Optional*__
+**gitPushFlags**?🔹 | <code>Array<string></code> | Additional git push flags for manual releases.<br/>__*Optional*__
 **schedule**?🔹 | <code>string</code> | Cron schedule for releases.<br/>__*Optional*__
 
 ### Methods
@@ -7597,6 +7603,7 @@ static manual(options?: ManualReleaseOptions): ReleaseTrigger
 * **options** (<code>[release.ManualReleaseOptions](#projen-release-manualreleaseoptions)</code>)  release options.
   * **changelog** (<code>boolean</code>)  Maintain a project-level changelog. __*Default*__: true
   * **changelogPath** (<code>string</code>)  Project-level changelog file path. __*Default*__: 'CHANGELOG.md'
+  * **gitPushFlags** (<code>Array<string></code>)  Additional git push flags. __*Optional*__
 
 __Returns__:
 * <code>[release.ReleaseTrigger](#projen-release-releasetrigger)</code>
@@ -9297,6 +9304,7 @@ Name | Type | Description
 **bundlerOptions**?🔹 | <code>[javascript.BundlerOptions](#projen-javascript-bundleroptions)</code> | Options for `Bundler`.<br/>__*Optional*__
 **cdk8sCliVersion**?🔹 | <code>string</code> | cdk8s-cli version.<br/>__*Default*__: "cdk8sVersion"
 **cdk8sCliVersionPinning**?🔹 | <code>boolean</code> | Use pinned version instead of caret version for CDK8s-cli.<br/>__*Default*__: false
+**cdk8sPlusVersion**?🔹 | <code>string</code> | cdk8s-plus-17 version.<br/>__*Default*__: "cdk8sVersion"
 **cdk8sPlusVersionPinning**?🔹 | <code>boolean</code> | Use pinned version instead of caret version for cdk8s-plus-17.<br/>__*Default*__: false
 **cdk8sVersionPinning**?🔹 | <code>boolean</code> | Use pinned version instead of caret version for CDK8s.<br/>__*Default*__: false
 **clobber**?🔹 | <code>boolean</code> | Add a `clobber` task which resets the repo to origin.<br/>__*Default*__: true
@@ -9610,6 +9618,7 @@ Name | Type | Description
 **bundledDeps**?🔹 | <code>Array<string></code> | List of dependencies to bundle into this module.<br/>__*Optional*__
 **bundlerOptions**?🔹 | <code>[javascript.BundlerOptions](#projen-javascript-bundleroptions)</code> | Options for `Bundler`.<br/>__*Optional*__
 **catalog**?🔹 | <code>[Catalog](#projen-catalog)</code> | Libraries will be picked up by the construct catalog when they are published to npm as jsii modules and will be published under:.<br/>__*Default*__: new version will be announced
+**cdk8sPlusVersion**?🔹 | <code>string</code> | cdk8s-plus-17 version.<br/>__*Default*__: "cdk8sVersion"
 **cdk8sPlusVersionPinning**?🔹 | <code>boolean</code> | Use pinned version instead of caret version for cdk8s-plus-17.<br/>__*Default*__: false
 **cdk8sVersionPinning**?🔹 | <code>boolean</code> | Use pinned version instead of caret version for CDK8s.<br/>__*Default*__: false
 **clobber**?🔹 | <code>boolean</code> | Add a `clobber` task which resets the repo to origin.<br/>__*Default*__: true
@@ -12957,6 +12966,7 @@ Name | Type | Description
 **releaseTagFile**🔹 | <code>string</code> | The location of a text file (relative to `dist/`) that contains the release tag.
 **versionFile**🔹 | <code>string</code> | The location of a text file (relative to `dist/`) that contains the version number.
 **gitBranch**?🔹 | <code>string</code> | Branch to push to.<br/>__*Default*__: "main"
+**gitPushFlags**?🔹 | <code>Array<string></code> | Additional git push flags.<br/>__*Optional*__
 **projectChangelogFile**?🔹 | <code>string</code> | The location of an .md file that includes the project-level changelog.<br/>__*Optional*__
 
 
@@ -13054,6 +13064,7 @@ Name | Type | Description
 -----|------|-------------
 **changelog**?🔹 | <code>boolean</code> | Maintain a project-level changelog.<br/>__*Default*__: true
 **changelogPath**?🔹 | <code>string</code> | Project-level changelog file path.<br/>__*Default*__: 'CHANGELOG.md'
+**gitPushFlags**?🔹 | <code>Array<string></code> | Additional git push flags.<br/>__*Optional*__
 
 
 

--- a/API.md
+++ b/API.md
@@ -857,7 +857,6 @@ new Cdk8sTypeScriptApp(options: Cdk8sTypeScriptAppOptions)
   * **appEntrypoint** (<code>string</code>)  The CDK8s app's entrypoint (relative to the source directory, which is "src" by default). __*Default*__: "main.ts"
   * **cdk8sCliVersion** (<code>string</code>)  cdk8s-cli version. __*Default*__: "cdk8sVersion"
   * **cdk8sCliVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for CDK8s-cli. __*Default*__: false
-  * **cdk8sPlusVersion** (<code>string</code>)  cdk8s-plus-17 version. __*Default*__: "cdk8sVersion"
   * **cdk8sPlusVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for cdk8s-plus-17. __*Default*__: false
   * **cdk8sVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for CDK8s. __*Default*__: false
   * **constructsVersion** (<code>string</code>)  constructs verion. __*Default*__: "3.2.34"
@@ -872,7 +871,6 @@ Name | Type | Description
 -----|------|-------------
 **appEntrypoint**🔹 | <code>string</code> | The CDK8s app entrypoint.
 **cdk8sCliVersion**🔹 | <code>string</code> | The cdk8s-cli version this app is using.
-**cdk8sPlusVersion**🔹 | <code>string</code> | The cdk8s-plus-17 version this app is using.
 **cdk8sVersion**🔹 | <code>string</code> | The CDK8s version this app is using.
 **constructsVersion**🔹 | <code>string</code> | The constructs version this app is using.
 
@@ -1422,7 +1420,6 @@ new ConstructLibraryCdk8s(options: ConstructLibraryCdk8sOptions)
   * **rootdir** (<code>string</code>)  *No description* __*Default*__: "."
   * **catalog** (<code>[Catalog](#projen-catalog)</code>)  Libraries will be picked up by the construct catalog when they are published to npm as jsii modules and will be published under:. __*Default*__: new version will be announced
   * **cdk8sVersion** (<code>string</code>)  Minimum target version this library is tested against. 
-  * **cdk8sPlusVersion** (<code>string</code>)  cdk8s-plus-17 version. __*Default*__: "cdk8sVersion"
   * **cdk8sPlusVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for cdk8s-plus-17. __*Default*__: false
   * **cdk8sVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for CDK8s. __*Default*__: false
   * **constructsVersion** (<code>string</code>)  constructs verion. __*Default*__: "3.2.34"
@@ -1435,7 +1432,6 @@ new ConstructLibraryCdk8s(options: ConstructLibraryCdk8sOptions)
 
 Name | Type | Description 
 -----|------|-------------
-**cdk8sPlusVersion**🔹 | <code>string</code> | The cdk8s-plus-17 version this app is using.
 **cdk8sVersion**🔹 | <code>string</code> | The CDK8s version this app is using.
 **constructsVersion**🔹 | <code>string</code> | The constructs version this app is using.
 
@@ -7328,7 +7324,7 @@ publishToGit(options: GitPublishOptions): Task
   * **releaseTagFile** (<code>string</code>)  The location of a text file (relative to `dist/`) that contains the release tag. 
   * **versionFile** (<code>string</code>)  The location of a text file (relative to `dist/`) that contains the version number. 
   * **gitBranch** (<code>string</code>)  Branch to push to. __*Default*__: "main"
-  * **gitPushFlags** (<code>Array<string></code>)  Additional git push flags. __*Optional*__
+  * **gitPushCommand** (<code>string</code>)  Override git-push command. __*Optional*__
   * **projectChangelogFile** (<code>string</code>)  The location of an .md file that includes the project-level changelog. __*Optional*__
 
 __Returns__:
@@ -7563,7 +7559,7 @@ Name | Type | Description
 **isContinuous**🔹 | <code>boolean</code> | Whether or not this is a continuous release.
 **isManual**🔹 | <code>boolean</code> | Whether or not this is a manual release trigger.
 **changelogPath**?🔹 | <code>string</code> | Project-level changelog file path.<br/>__*Optional*__
-**gitPushFlags**?🔹 | <code>Array<string></code> | Additional git push flags for manual releases.<br/>__*Optional*__
+**gitPushCommand**?🔹 | <code>string</code> | Override git-push command used when releasing manually.<br/>__*Optional*__
 **schedule**?🔹 | <code>string</code> | Cron schedule for releases.<br/>__*Optional*__
 
 ### Methods
@@ -7594,6 +7590,9 @@ release activities will trigger a `publish:git` task. This task will
 handle project-level changelog management, release tagging, and pushing
 these artifacts to origin.
 
+The command used for pushing can be customised by specifying
+`gitPushCommand`. Set to an empty string to disable pushing entirely.
+
 Simply run `yarn release` to trigger a manual release.
 
 ```ts
@@ -7603,7 +7602,7 @@ static manual(options?: ManualReleaseOptions): ReleaseTrigger
 * **options** (<code>[release.ManualReleaseOptions](#projen-release-manualreleaseoptions)</code>)  release options.
   * **changelog** (<code>boolean</code>)  Maintain a project-level changelog. __*Default*__: true
   * **changelogPath** (<code>string</code>)  Project-level changelog file path. __*Default*__: 'CHANGELOG.md'
-  * **gitPushFlags** (<code>Array<string></code>)  Additional git push flags. __*Optional*__
+  * **gitPushCommand** (<code>string</code>)  Override git-push command. __*Optional*__
 
 __Returns__:
 * <code>[release.ReleaseTrigger](#projen-release-releasetrigger)</code>
@@ -9304,7 +9303,6 @@ Name | Type | Description
 **bundlerOptions**?🔹 | <code>[javascript.BundlerOptions](#projen-javascript-bundleroptions)</code> | Options for `Bundler`.<br/>__*Optional*__
 **cdk8sCliVersion**?🔹 | <code>string</code> | cdk8s-cli version.<br/>__*Default*__: "cdk8sVersion"
 **cdk8sCliVersionPinning**?🔹 | <code>boolean</code> | Use pinned version instead of caret version for CDK8s-cli.<br/>__*Default*__: false
-**cdk8sPlusVersion**?🔹 | <code>string</code> | cdk8s-plus-17 version.<br/>__*Default*__: "cdk8sVersion"
 **cdk8sPlusVersionPinning**?🔹 | <code>boolean</code> | Use pinned version instead of caret version for cdk8s-plus-17.<br/>__*Default*__: false
 **cdk8sVersionPinning**?🔹 | <code>boolean</code> | Use pinned version instead of caret version for CDK8s.<br/>__*Default*__: false
 **clobber**?🔹 | <code>boolean</code> | Add a `clobber` task which resets the repo to origin.<br/>__*Default*__: true
@@ -9618,7 +9616,6 @@ Name | Type | Description
 **bundledDeps**?🔹 | <code>Array<string></code> | List of dependencies to bundle into this module.<br/>__*Optional*__
 **bundlerOptions**?🔹 | <code>[javascript.BundlerOptions](#projen-javascript-bundleroptions)</code> | Options for `Bundler`.<br/>__*Optional*__
 **catalog**?🔹 | <code>[Catalog](#projen-catalog)</code> | Libraries will be picked up by the construct catalog when they are published to npm as jsii modules and will be published under:.<br/>__*Default*__: new version will be announced
-**cdk8sPlusVersion**?🔹 | <code>string</code> | cdk8s-plus-17 version.<br/>__*Default*__: "cdk8sVersion"
 **cdk8sPlusVersionPinning**?🔹 | <code>boolean</code> | Use pinned version instead of caret version for cdk8s-plus-17.<br/>__*Default*__: false
 **cdk8sVersionPinning**?🔹 | <code>boolean</code> | Use pinned version instead of caret version for CDK8s.<br/>__*Default*__: false
 **clobber**?🔹 | <code>boolean</code> | Add a `clobber` task which resets the repo to origin.<br/>__*Default*__: true
@@ -12966,7 +12963,7 @@ Name | Type | Description
 **releaseTagFile**🔹 | <code>string</code> | The location of a text file (relative to `dist/`) that contains the release tag.
 **versionFile**🔹 | <code>string</code> | The location of a text file (relative to `dist/`) that contains the version number.
 **gitBranch**?🔹 | <code>string</code> | Branch to push to.<br/>__*Default*__: "main"
-**gitPushFlags**?🔹 | <code>Array<string></code> | Additional git push flags.<br/>__*Optional*__
+**gitPushCommand**?🔹 | <code>string</code> | Override git-push command.<br/>__*Optional*__
 **projectChangelogFile**?🔹 | <code>string</code> | The location of an .md file that includes the project-level changelog.<br/>__*Optional*__
 
 
@@ -13064,7 +13061,7 @@ Name | Type | Description
 -----|------|-------------
 **changelog**?🔹 | <code>boolean</code> | Maintain a project-level changelog.<br/>__*Default*__: true
 **changelogPath**?🔹 | <code>string</code> | Project-level changelog file path.<br/>__*Default*__: 'CHANGELOG.md'
-**gitPushFlags**?🔹 | <code>Array<string></code> | Additional git push flags.<br/>__*Optional*__
+**gitPushCommand**?🔹 | <code>string</code> | Override git-push command.<br/>__*Optional*__
 
 
 

--- a/src/release/publisher.ts
+++ b/src/release/publisher.ts
@@ -128,7 +128,7 @@ export class Publisher extends Component implements IJobProvider {
       publishTask.builtin('release/update-changelog');
     }
     publishTask.builtin('release/tag-version');
-    
+
     if (options.gitPushCommand !== '') {
       const gitPushCommand = options.gitPushCommand || `git push --follow-tags origin ${gitBranch}`;
       publishTask.exec(gitPushCommand);
@@ -757,10 +757,10 @@ export interface GitPublishOptions extends VersionArtifactOptions {
    * @default "main"
    */
   readonly gitBranch?: string;
-  
+
   /**
-   * Override git-push command. 
-   * 
+   * Override git-push command.
+   *
    * Set to an empty string to disable pushing.
    */
   readonly gitPushCommand?: string;

--- a/src/release/publisher.ts
+++ b/src/release/publisher.ts
@@ -129,7 +129,7 @@ export class Publisher extends Component implements IJobProvider {
     }
     publishTask.builtin('release/tag-version');
     
-    if (options.gitPushCommand !== null) {
+    if (options.gitPushCommand !== '') {
       const gitPushCommand = options.gitPushCommand || `git push --follow-tags origin ${gitBranch}`;
       publishTask.exec(gitPushCommand);
     }
@@ -761,7 +761,7 @@ export interface GitPublishOptions extends VersionArtifactOptions {
   /**
    * Override git-push command. 
    * 
-   * Set to null to disable pushing.
+   * Set to an empty string to disable pushing.
    */
-  readonly gitPushCommand?: string | null;
+  readonly gitPushCommand?: string;
 }

--- a/src/release/publisher.ts
+++ b/src/release/publisher.ts
@@ -128,7 +128,11 @@ export class Publisher extends Component implements IJobProvider {
       publishTask.builtin('release/update-changelog');
     }
     publishTask.builtin('release/tag-version');
-    publishTask.exec(`git push --follow-tags origin ${gitBranch}`);
+    
+    if (options.gitPushCommand !== null) {
+      const gitPushCommand = options.gitPushCommand || `git push --follow-tags origin ${gitBranch}`;
+      publishTask.exec(gitPushCommand);
+    }
 
     return publishTask;
   }
@@ -753,4 +757,11 @@ export interface GitPublishOptions extends VersionArtifactOptions {
    * @default "main"
    */
   readonly gitBranch?: string;
+  
+  /**
+   * Override git-push command. 
+   * 
+   * Set to null to disable pushing.
+   */
+  readonly gitPushCommand?: string | null;
 }

--- a/src/release/release-trigger.ts
+++ b/src/release/release-trigger.ts
@@ -29,9 +29,9 @@ export interface ManualReleaseOptions {
   /**
    * Override git-push command. 
    * 
-   * Set to null to disable pushing.
+   * Set to an empty string to disable pushing.
    */
-  readonly gitPushCommand?: string | null;
+  readonly gitPushCommand?: string;
 }
 
 interface ReleaseTriggerOptions {
@@ -61,9 +61,9 @@ interface ReleaseTriggerOptions {
   /**
    * Override git-push command. 
    * 
-   * Set to null to disable pushing.
+   * Set to an empty string to disable pushing.
    */
-  readonly gitPushCommand?: string | null;
+  readonly gitPushCommand?: string;
 }
 
 /**
@@ -82,7 +82,7 @@ export class ReleaseTrigger {
    * these artifacts to origin. 
    * 
    * The command used for pushing can be customised by specifying 
-   * `gitPushCommand`. Set to null to disable pushing entirely.
+   * `gitPushCommand`. Set to an empty string to disable pushing entirely.
    *
    * Simply run `yarn release` to trigger a manual release.
    *
@@ -147,9 +147,9 @@ export class ReleaseTrigger {
   /**
    * Override git-push command used when releasing manually. 
    * 
-   * Set to null to disable pushing.
+   * Set to an empty string to disable pushing.
    */
-  public readonly gitPushCommand?: string | null;
+  public readonly gitPushCommand?: string;
 
   private constructor(options: ReleaseTriggerOptions = {}) {
     this.isContinuous = options.continuous ?? false;

--- a/src/release/release-trigger.ts
+++ b/src/release/release-trigger.ts
@@ -27,8 +27,8 @@ export interface ManualReleaseOptions {
   readonly changelogPath?: string;
 
   /**
-   * Override git-push command. 
-   * 
+   * Override git-push command.
+   *
    * Set to an empty string to disable pushing.
    */
   readonly gitPushCommand?: string;
@@ -59,8 +59,8 @@ interface ReleaseTriggerOptions {
   readonly schedule?: string;
 
   /**
-   * Override git-push command. 
-   * 
+   * Override git-push command.
+   *
    * Set to an empty string to disable pushing.
    */
   readonly gitPushCommand?: string;
@@ -79,9 +79,9 @@ export class ReleaseTrigger {
    * This will give you a release task that, in addition to the normal
    * release activities will trigger a `publish:git` task. This task will
    * handle project-level changelog management, release tagging, and pushing
-   * these artifacts to origin. 
-   * 
-   * The command used for pushing can be customised by specifying 
+   * these artifacts to origin.
+   *
+   * The command used for pushing can be customised by specifying
    * `gitPushCommand`. Set to an empty string to disable pushing entirely.
    *
    * Simply run `yarn release` to trigger a manual release.
@@ -97,7 +97,7 @@ export class ReleaseTrigger {
 
     return new ReleaseTrigger({
       changelogPath: changelogPath,
-      gitPushCommand: options.gitPushCommand
+      gitPushCommand: options.gitPushCommand,
     });
   }
 
@@ -145,8 +145,8 @@ export class ReleaseTrigger {
   public readonly isContinuous: boolean;
 
   /**
-   * Override git-push command used when releasing manually. 
-   * 
+   * Override git-push command used when releasing manually.
+   *
    * Set to an empty string to disable pushing.
    */
   public readonly gitPushCommand?: string;

--- a/src/release/release-trigger.ts
+++ b/src/release/release-trigger.ts
@@ -25,6 +25,13 @@ export interface ManualReleaseOptions {
    * @default 'CHANGELOG.md'
    */
   readonly changelogPath?: string;
+
+  /**
+   * Override git-push command. 
+   * 
+   * Set to null to disable pushing.
+   */
+  readonly gitPushCommand?: string | null;
 }
 
 interface ReleaseTriggerOptions {
@@ -50,6 +57,13 @@ interface ReleaseTriggerOptions {
    * @example '0 17 * * *' - every day at 5 pm
    */
   readonly schedule?: string;
+
+  /**
+   * Override git-push command. 
+   * 
+   * Set to null to disable pushing.
+   */
+  readonly gitPushCommand?: string | null;
 }
 
 /**
@@ -65,7 +79,10 @@ export class ReleaseTrigger {
    * This will give you a release task that, in addition to the normal
    * release activities will trigger a `publish:git` task. This task will
    * handle project-level changelog management, release tagging, and pushing
-   * these artifacts to origin.
+   * these artifacts to origin. 
+   * 
+   * The command used for pushing can be customised by specifying 
+   * `gitPushCommand`. Set to null to disable pushing entirely.
    *
    * Simply run `yarn release` to trigger a manual release.
    *
@@ -80,6 +97,7 @@ export class ReleaseTrigger {
 
     return new ReleaseTrigger({
       changelogPath: changelogPath,
+      gitPushCommand: options.gitPushCommand
     });
   }
 
@@ -126,10 +144,18 @@ export class ReleaseTrigger {
    */
   public readonly isContinuous: boolean;
 
+  /**
+   * Override git-push command used when releasing manually. 
+   * 
+   * Set to null to disable pushing.
+   */
+  public readonly gitPushCommand?: string | null;
+
   private constructor(options: ReleaseTriggerOptions = {}) {
     this.isContinuous = options.continuous ?? false;
     this.schedule = options.schedule;
     this.changelogPath = options.changelogPath;
+    this.gitPushCommand = options.gitPushCommand;
   }
 
   /**

--- a/test/release/release-trigger.test.ts
+++ b/test/release/release-trigger.test.ts
@@ -39,6 +39,14 @@ describe('manual release', () => {
       expect(releaseTrigger.changelogPath).toBeUndefined();
     });
   });
+
+  describe('with custom git-push command', () => {
+    test('has custom git-push command', () => {
+      releaseTrigger = ReleaseTrigger.manual({ gitPushCommand: 'git push --follow-tags -o ci.skip origin main' });
+
+      expect(releaseTrigger.gitPushCommand).toEqual('git push --follow-tags -o ci.skip origin main');
+    });
+  });
 });
 
 describe('continuous release', () => {


### PR DESCRIPTION
This adds the ability for a user to customise (or disable) the git-push command which is run as part of a manual release.

closes #1267 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.