### PR TITLE
fix(awscdk-app-ts): srcdir and testdir are not configurable

### DIFF
--- a/src/awscdk/awscdk-app-ts.ts
+++ b/src/awscdk/awscdk-app-ts.ts
@@ -90,16 +90,6 @@ export class AwsCdkTypeScriptApp extends TypeScriptAppProject {
       sampleCode: false,
     });
 
-    // encode a hidden assumption further down the chain
-    if (this.srcdir !== 'src') {
-      throw new Error('sources are expected under the "src" directory');
-    }
-
-    // encode a hidden assumption further down the chain
-    if (this.testdir !== 'test') {
-      throw new Error('test sources are expected under the "test" directory');
-    }
-
     this.appEntrypoint = options.appEntrypoint ?? 'main.ts';
 
     this.cdkVersion = options.cdkVersionPinning ? options.cdkVersion : `^${options.cdkVersion}`;


### PR DESCRIPTION
According to the `AwsCdkTypeScriptAppOptions` `srcdir` and `testdir` are configurable but they weren't.
This would fix it.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.