### PR TITLE
chore: `bundledDeps` docstring incorrectly mentions `peerDependencies`

### DIFF
--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -87,7 +87,7 @@ export interface NodePackageOptions {
 
   /**
    * List of dependencies to bundle into this module. These modules will be
-   * added both to the `dependencies` section and `peerDependencies` section of
+   * added both to the `dependencies` section and `bundledDependencies` section of
    * your `package.json`.
    *
    * The recommendation is to only specify the module name here (e.g.


### PR DESCRIPTION
Super minor, but I noticed it the other day and it seems worth fixing in case someone gets confused.
Luckily, `addBundledDeps` was already correct.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.