### PR TITLE
chore: stop using mergify's commit_message

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,7 +5,10 @@ pull_request_rules:
     actions:
       merge:
         method: squash
-        commit_message: title+body
+        commit_message_template: |-
+          {{ title }} (#{{ number }})
+
+          {{ body }}
         strict: smart
         strict_method: merge
       delete_head_branch: {}

--- a/src/github/auto-merge.ts
+++ b/src/github/auto-merge.ts
@@ -53,7 +53,11 @@ export class AutoMerge extends Component {
         method: 'squash',
 
         // use PR title+body as the commit message
-        commit_message: 'title+body',
+        commit_message_template: [
+          '{{ title }} (#{{ number }})',
+          '',
+          '{{ body }}',
+        ].join('\n'),
 
         // update PR branch so it's up-to-date before merging
         strict: 'smart',

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -694,7 +694,10 @@ pull_request_rules:
     actions:
       merge:
         method: squash
-        commit_message: title+body
+        commit_message_template: |-
+          {{ title }} (#{{ number }})
+
+          {{ body }}
         strict: smart
         strict_method: merge
       delete_head_branch: {}
@@ -5050,7 +5053,10 @@ pull_request_rules:
     actions:
       merge:
         method: squash
-        commit_message: title+body
+        commit_message_template: |-
+          {{ title }} (#{{ number }})
+
+          {{ body }}
         strict: smart
         strict_method: merge
       delete_head_branch: {}

--- a/test/github/__snapshots__/mergify.test.ts.snap
+++ b/test/github/__snapshots__/mergify.test.ts.snap
@@ -8,7 +8,10 @@ pull_request_rules:
     actions:
       merge:
         method: squash
-        commit_message: title+body
+        commit_message_template: |-
+          {{ title }} (#{{ number }})
+
+          {{ body }}
         strict: smart
         strict_method: merge
       delete_head_branch: {}
@@ -27,7 +30,10 @@ pull_request_rules:
     actions:
       merge:
         method: squash
-        commit_message: title+body
+        commit_message_template: |-
+          {{ title }} (#{{ number }})
+
+          {{ body }}
         strict: smart
         strict_method: merge
       delete_head_branch: {}

--- a/test/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-project.test.ts.snap
@@ -379,7 +379,10 @@ pull_request_rules:
     actions:
       merge:
         method: squash
-        commit_message: title+body
+        commit_message_template: |-
+          {{ title }} (#{{ number }})
+
+          {{ body }}
         strict: smart
         strict_method: merge
       delete_head_branch: {}

--- a/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -310,7 +310,10 @@ pull_request_rules:
     actions:
       merge:
         method: squash
-        commit_message: title+body
+        commit_message_template: |-
+          {{ title }} (#{{ number }})
+
+          {{ body }}
         strict: smart
         strict_method: merge
       delete_head_branch: {}

--- a/test/web/__snapshots__/react-project.test.ts.snap
+++ b/test/web/__snapshots__/react-project.test.ts.snap
@@ -363,7 +363,10 @@ pull_request_rules:
     actions:
       merge:
         method: squash
-        commit_message: title+body
+        commit_message_template: |-
+          {{ title }} (#{{ number }})
+
+          {{ body }}
         strict: smart
         strict_method: merge
       delete_head_branch: {}

--- a/test/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/react-ts-project.test.ts.snap
@@ -300,7 +300,10 @@ pull_request_rules:
     actions:
       merge:
         method: squash
-        commit_message: title+body
+        commit_message_template: |-
+          {{ title }} (#{{ number }})
+
+          {{ body }}
         strict: smart
         strict_method: merge
       delete_head_branch: {}


### PR DESCRIPTION
The `commit_message` option is deprecated and replaced by
`commit_message_template`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.