### PR TITLE
chore: use major-pinned version of @types/node

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -23,7 +23,7 @@
     },
     {
       "name": "@types/node",
-      "version": "^12.7.0",
+      "version": "^12",
       "type": "build"
     },
     {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/glob": "^7.2.0",
     "@types/ini": "^1.3.31",
     "@types/jest": "^27.0.3",
-    "@types/node": "^12.7.0",
+    "@types/node": "^12",
     "@types/semver": "^7.3.9",
     "@types/yargs": "^15.0.14",
     "@typescript-eslint/eslint-plugin": "^5",

--- a/src/typescript/typescript.ts
+++ b/src/typescript/typescript.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import * as semver from 'semver';
 import { PROJEN_DIR, PROJEN_RC } from '../common';
 import { Component } from '../component';
 import { Eslint, EslintOptions, NodeProject, NodeProjectOptions, TypeScriptCompilerOptions, TypescriptConfig, TypescriptConfigOptions } from '../javascript';
@@ -353,7 +354,16 @@ export class TypeScriptProject extends NodeProject {
 
     this.addDevDeps(
       `typescript${tsver}`,
-      `@types/node@^${this.package.minNodeVersion ?? '14.17.0'}`, // install the minimum version to ensure compatibility
+      // @types/node versions numbers match the node runtime versions' major.minor, however, new
+      // releases are only created when API changes are included in a node release... We might for
+      // example have dependencies that require `node >= 12.22`, but as 12.21 and 12.22 did not
+      // include API changes, `@types/node@12.20.x` is the "correct" version to use. As it is not
+      // possible to easily determine the correct version to use, we pick up the latest version.
+      //
+      // Additionally, we default to tracking the 12.x line, as the current earliest LTS release of
+      // node is 12.x, so this is what corresponds to the broadest compatibility with supported node
+      // runtimes.
+      `@types/node@^${semver.major(this.package.minNodeVersion ?? '12.0.0')}`,
     );
 
     // generate sample code in `src` and `lib` if these directories are empty or non-existent.

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -745,7 +745,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^14.0.0",
+        "version": "^14",
       },
       Object {
         "name": "@typescript-eslint/eslint-plugin",
@@ -1567,7 +1567,7 @@ project.synth();
     "devDependencies": Object {
       "@aws-cdk/assertions": "^1.75.0",
       "@types/jest": "*",
-      "@types/node": "^14.0.0",
+      "@types/node": "^14",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
       "aws-sdk": "*",
@@ -2258,7 +2258,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^12.7.0",
+        "version": "^12",
       },
       Object {
         "name": "@types/yaml",
@@ -3056,7 +3056,7 @@ project.synth();
       "@types/follow-redirects": "*",
       "@types/jest": "*",
       "@types/json-stable-stringify": "*",
-      "@types/node": "^12.7.0",
+      "@types/node": "^12",
       "@types/yaml": "*",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
@@ -3732,7 +3732,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^12.7.0",
+        "version": "^12",
       },
       Object {
         "name": "@typescript-eslint/eslint-plugin",
@@ -4499,7 +4499,7 @@ project.synth();
       "@types/fs-extra": "*",
       "@types/jest": "*",
       "@types/json-schema": "*",
-      "@types/node": "^12.7.0",
+      "@types/node": "^12",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
       "eslint": "^8",

--- a/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -348,7 +348,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^12.13.0",
+        "version": "^12",
       },
       Object {
         "name": "@types/react",
@@ -820,7 +820,7 @@ tsconfig.tsbuildinfo
       "tailwindcss": "*",
     },
     "devDependencies": Object {
-      "@types/node": "^12.13.0",
+      "@types/node": "^12",
       "@types/react": "*",
       "@types/react-dom": "*",
       "npm-check-updates": "^12",

--- a/test/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/react-ts-project.test.ts.snap
@@ -352,7 +352,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^14.17.0",
+        "version": "^12",
       },
       Object {
         "name": "@types/react",
@@ -810,7 +810,7 @@ tsconfig.tsbuildinfo
       "@testing-library/react": "*",
       "@testing-library/user-event": "*",
       "@types/jest": "*",
-      "@types/node": "^14.17.0",
+      "@types/node": "^12",
       "@types/react": "*",
       "@types/react-dom": "*",
       "npm-check-updates": "^12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -813,7 +813,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.12.tgz#ac7fb693ac587ee182c3780c26eb65546a1a3c10"
   integrity sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==
 
-"@types/node@^12.7.0":
+"@types/node@^12":
   version "12.20.37"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.37.tgz#abb38afa9d6e8a2f627a8cb52290b3c80fbe61ed"
   integrity sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA==


### PR DESCRIPTION
`@types/node` versions numbers match the node runtime versions'
`major.minor`, however new releases are only created when API changes
are included in a node release... We might for example have dependencies
that require `node >= 12.22`, but as 12.21 and 12.22 did not include API
changes, `@types/node@12.20.x` is the "correct" version to use. As it is
not possible to easily determine the correct version to use, we pick up
the latest version.

BREAKING CHANGE: the default version of `@types/node` installed if no
`minNodeVersion` is specified on Node projects is now `^12` instead of
`^14`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.