### PR TITLE
fix: do not use aws-cdk/assert in v2

### DIFF
--- a/src/awscdk/awscdk-app-ts.ts
+++ b/src/awscdk/awscdk-app-ts.ts
@@ -103,18 +103,26 @@ export class AwsCdkTypeScriptApp extends TypeScriptAppProject {
 
     // CLI
     this.addDevDeps(this.formatModuleSpec('aws-cdk'));
-    this.addCdkDependency('@aws-cdk/assert');
 
     if (!this.cdkVersion) {
       throw new Error('Required field cdkVersion is not specified.');
     }
 
     const cdkMajorVersion = semver.minVersion(this.cdkVersion)?.major ?? 1;
-    if (cdkMajorVersion < 2) {
-      this.addCdkDependency('@aws-cdk/core');
-    } else {
-      this.addCdkDependency('aws-cdk-lib');
-      this.addDeps('constructs@^10.0.5');
+
+    switch (cdkMajorVersion) {
+      case 1:
+        this.addCdkDependency('@aws-cdk/core');
+        this.addCdkDependency('@aws-cdk/assert');
+        break;
+      case 2:
+        this.addCdkDependency('aws-cdk-lib');
+        this.addDeps('constructs@^10.0.5');
+        break;
+      default:
+        // Otherwise, let the user manage which version they use
+        this.addPeerDeps('constructs');
+        break;
     }
 
     this.addCdkDependency(...options.cdkDependencies ?? []);


### PR DESCRIPTION
Applied similar logic like in AwsCdkTypeScriptApp. 

But it keeps the aws-cdk/assert library as I didn't want to add another option.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.