### PR TITLE
fix: CDK v2 integration tests should not use v1 feature flags

### DIFF
--- a/API.md
+++ b/API.md
@@ -3711,6 +3711,7 @@ new awscdk.IntegrationTest(project: Project, options: IntegrationTestOptions)
 * **project** (<code>[Project](#projen-project)</code>)  *No description*
 * **options** (<code>[awscdk.IntegrationTestOptions](#projen-awscdk-integrationtestoptions)</code>)  *No description*
   * **destroyAfterDeploy** (<code>boolean</code>)  Destroy the test app after a successful deployment. __*Default*__: true
+  * **cdkDeps** (<code>[awscdk.AwsCdkDeps](#projen-awscdk-awscdkdeps)</code>)  AWS CDK dependency manager. 
   * **entrypoint** (<code>string</code>)  A path from the project root directory to a TypeScript file which contains the integration test app. 
   * **tsconfigPath** (<code>string</code>)  The path of the tsconfig.json file to use when running integration test cdk apps. 
 
@@ -10730,6 +10731,7 @@ Options for `IntegrationTest`.
 
 Name | Type | Description 
 -----|------|-------------
+**cdkDeps**🔹 | <code>[awscdk.AwsCdkDeps](#projen-awscdk-awscdkdeps)</code> | AWS CDK dependency manager.
 **entrypoint**🔹 | <code>string</code> | A path from the project root directory to a TypeScript file which contains the integration test app.
 **tsconfigPath**🔹 | <code>string</code> | The path of the tsconfig.json file to use when running integration test cdk apps.
 **destroyAfterDeploy**?🔹 | <code>boolean</code> | Destroy the test app after a successful deployment.<br/>__*Default*__: true

--- a/src/awscdk/auto-discover.ts
+++ b/src/awscdk/auto-discover.ts
@@ -71,6 +71,7 @@ export class AutoDiscover extends Component {
     for (const entrypoint of entrypoints) {
       new IntegrationTest(this.project, {
         entrypoint: join(options.testdir, entrypoint),
+        cdkDeps: options.cdkDeps,
         tsconfigPath: options.tsconfigPath,
       });
     }

--- a/src/awscdk/integration-test.ts
+++ b/src/awscdk/integration-test.ts
@@ -3,6 +3,7 @@ import { Component } from '../component';
 import { DependencyType } from '../dependencies';
 import { Project } from '../project';
 import { Task } from '../task';
+import { AwsCdkDeps } from './awscdk-deps';
 import { FEATURE_FLAGS, TYPESCRIPT_INTEG_EXT } from './internal';
 
 export interface IntegrationTestCommonOptions {
@@ -32,6 +33,11 @@ export interface IntegrationTestOptions extends IntegrationTestCommonOptions {
    * The path of the tsconfig.json file to use when running integration test cdk apps.
    */
   readonly tsconfigPath: string;
+
+  /**
+   * AWS CDK dependency manager.
+   */
+  readonly cdkDeps: AwsCdkDeps;
 }
 
 /**
@@ -84,14 +90,16 @@ export class IntegrationTest extends Component {
       '--no-version-reporting',
     ];
 
-    // add all feature flags
-    const features = [
-      ...FEATURE_FLAGS,
-      '@aws-cdk/core:newStyleStackSynthesis', // simplifies asset coordinates in synth output
-    ];
+    if (options.cdkDeps.cdkMajorVersion === 1) {
+      // add all feature flags
+      const features = [
+        ...FEATURE_FLAGS,
+        '@aws-cdk/core:newStyleStackSynthesis', // simplifies asset coordinates in synth output
+      ];
 
-    for (const feature of features) {
-      opts.push(`--context ${feature}=true`);
+      for (const feature of features) {
+        opts.push(`--context ${feature}=true`);
+      }
     }
 
     const cdkopts = opts.join(' ');

--- a/test/awscdk/__snapshots__/integration-test.test.ts.snap
+++ b/test/awscdk/__snapshots__/integration-test.test.ts.snap
@@ -77,3 +77,51 @@ Object {
   ],
 }
 `;
+
+exports[`synthesizing cdk v2 integration tests 1`] = `
+Object {
+  "description": "deploy integration test 'foo' and capture snapshot",
+  "name": "integ:foo:deploy",
+  "steps": Array [
+    Object {
+      "exec": "rm -fr test/.tmp/foo.integ/deploy.cdk.out",
+    },
+    Object {
+      "exec": "cdk deploy --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --require-approval=never -o test/.tmp/foo.integ/deploy.cdk.out",
+    },
+    Object {
+      "exec": "rm -fr test/foo.integ.snapshot",
+    },
+    Object {
+      "exec": "mv test/.tmp/foo.integ/deploy.cdk.out test/foo.integ.snapshot",
+    },
+    Object {
+      "spawn": "integ:foo:destroy",
+    },
+  ],
+}
+`;
+
+exports[`synthesizing cdk v2 integration tests 2`] = `
+Object {
+  "description": "update snapshot for integration test \\"foo\\"",
+  "name": "integ:foo:snapshot",
+  "steps": Array [
+    Object {
+      "exec": "cdk synth --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting -o test/foo.integ.snapshot > /dev/null",
+    },
+  ],
+}
+`;
+
+exports[`synthesizing cdk v2 integration tests 3`] = `
+Object {
+  "description": "watch integration test 'foo' (without updating snapshots)",
+  "name": "integ:foo:watch",
+  "steps": Array [
+    Object {
+      "exec": "cdk watch --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting -o test/.tmp/foo.integ/deploy.cdk.out",
+    },
+  ],
+}
+`;

--- a/test/awscdk/integration-test.test.ts
+++ b/test/awscdk/integration-test.test.ts
@@ -96,20 +96,7 @@ test('synthesizing cdk v2 integration tests', () => {
   // THEN
   const output = Testing.synth(project);
 
-  const tasks = output['.projen/tasks.json'].tasks;
-  expect(tasks['integ:foo:deploy'].steps).toEqual(
-    expect.arrayContaining([
-      { exec: 'cdk deploy --app "ts-node -P tsconfig.dev.json test/foo.integ.ts" --no-version-reporting --require-approval=never -o test/.tmp/foo.integ/deploy.cdk.out' },
-    ]),
-  );
-  expect(tasks['integ:foo:snapshot'].steps).toEqual(
-    expect.arrayContaining([
-      { exec: 'cdk synth --app "ts-node -P tsconfig.dev.json test/foo.integ.ts" --no-version-reporting -o test/foo.integ.snapshot > /dev/null' },
-    ]),
-  );
-  expect(tasks['integ:foo:watch'].steps).toEqual(
-    expect.arrayContaining([
-      { exec: 'cdk watch --app "ts-node -P tsconfig.dev.json test/foo.integ.ts" --no-version-reporting -o test/.tmp/foo.integ/deploy.cdk.out' },
-    ]),
-  );
+  expect(output['.projen/tasks.json'].tasks['integ:foo:deploy']).toMatchSnapshot();
+  expect(output['.projen/tasks.json'].tasks['integ:foo:snapshot']).toMatchSnapshot();
+  expect(output['.projen/tasks.json'].tasks['integ:foo:watch']).toMatchSnapshot();
 });

--- a/test/awscdk/integration-test.test.ts
+++ b/test/awscdk/integration-test.test.ts
@@ -107,4 +107,9 @@ test('synthesizing cdk v2 integration tests', () => {
       { exec: 'cdk synth --app "ts-node -P tsconfig.dev.json test/foo.integ.ts" --no-version-reporting -o test/foo.integ.snapshot > /dev/null' },
     ]),
   );
+  expect(tasks['integ:foo:watch'].steps).toEqual(
+    expect.arrayContaining([
+      { exec: 'cdk watch --app "ts-node -P tsconfig.dev.json test/foo.integ.ts" --no-version-reporting -o test/.tmp/foo.integ/deploy.cdk.out' },
+    ]),
+  );
 });

--- a/test/awscdk/integration-test.test.ts
+++ b/test/awscdk/integration-test.test.ts
@@ -1,5 +1,5 @@
-import { awscdk } from '../../src';
-import { IntegrationTest } from '../../src/awscdk';
+import { awscdk, DependencyType } from '../../src';
+import { AwsCdkDeps, IntegrationTest } from '../../src/awscdk';
 import { Testing } from '../../src/testing';
 import { TypeScriptProject } from '../../src/typescript';
 
@@ -11,6 +11,7 @@ describe('IntegrationTest', () => {
   new awscdk.IntegrationTest(project, {
     entrypoint: 'test/foo.integ.ts',
     tsconfigPath: project.tsconfigDev.fileName,
+    cdkDeps: project.cdkDeps,
   });
 
   // THEN
@@ -72,10 +73,33 @@ test('installs ts-node if needed', () => {
   new IntegrationTest(project, {
     entrypoint: 'test/foo.integ.ts',
     tsconfigPath: project.tsconfigDev.fileName,
+    cdkDeps: new AwsCdkDeps(project, { cdkVersion: '1.0.0', dependencyType: DependencyType.RUNTIME }),
   });
 
   expect(project.deps.getDependency('ts-node')).toStrictEqual({
     name: 'ts-node',
     type: 'build',
   });
+});
+
+test('synthesizing cdk v2 integration tests', () => {
+  // GIVEN
+  const project = new awscdk.AwsCdkTypeScriptApp({ name: 'test', defaultReleaseBranch: 'main', cdkVersion: '2.3.1' });
+
+  // WHEN
+  new awscdk.IntegrationTest(project, {
+    entrypoint: 'test/foo.integ.ts',
+    tsconfigPath: project.tsconfigDev.fileName,
+    cdkDeps: project.cdkDeps,
+  });
+
+  // THEN
+  const output = Testing.synth(project);
+
+  const fooDeployTask = output['.projen/tasks.json'].tasks['integ:foo:deploy'];
+  expect(fooDeployTask.steps).toEqual(
+    expect.arrayContaining([
+      { exec: 'cdk deploy --app "ts-node -P tsconfig.dev.json test/foo.integ.ts" --no-version-reporting --require-approval=never -o test/.tmp/foo.integ/deploy.cdk.out' },
+    ]),
+  );
 });

--- a/test/awscdk/integration-test.test.ts
+++ b/test/awscdk/integration-test.test.ts
@@ -96,10 +96,15 @@ test('synthesizing cdk v2 integration tests', () => {
   // THEN
   const output = Testing.synth(project);
 
-  const fooDeployTask = output['.projen/tasks.json'].tasks['integ:foo:deploy'];
-  expect(fooDeployTask.steps).toEqual(
+  const tasks = output['.projen/tasks.json'].tasks;
+  expect(tasks['integ:foo:deploy'].steps).toEqual(
     expect.arrayContaining([
       { exec: 'cdk deploy --app "ts-node -P tsconfig.dev.json test/foo.integ.ts" --no-version-reporting --require-approval=never -o test/.tmp/foo.integ/deploy.cdk.out' },
+    ]),
+  );
+  expect(tasks['integ:foo:snapshot'].steps).toEqual(
+    expect.arrayContaining([
+      { exec: 'cdk synth --app "ts-node -P tsconfig.dev.json test/foo.integ.ts" --no-version-reporting -o test/foo.integ.snapshot > /dev/null' },
     ]),
   );
 });


### PR DESCRIPTION
Changes CDK v2 integration tests so that they don't use the v1 feature flags.

Fixes #1343

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.