### PR TITLE
feat: projen library in go

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -28,5 +28,9 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.x
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16.0
       - name: integ
         run: /bin/bash ./projen.bash integ

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,3 +194,39 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     container:
       image: jsii/superchain:1-buster-slim-node14
+  release_golang:
+    name: Publish to GitHub
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    if: needs.release.outputs.latest_commit == github.sha
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+      - name: Release
+        run: npx -p jsii-release@latest jsii-release-golang
+        env:
+          GIT_USER_NAME: github-actions
+          GIT_USER_EMAIL: github-actions@github.com
+          GITHUB_TOKEN: ${{ secrets.GO_GITHUB_TOKEN }}
+      - name: Extract Version
+        if: ${{ failure() }}
+        id: extract-version
+        run: echo "::set-output name=VERSION::$(cat dist/version.txt)"
+      - name: Create Issue
+        if: ${{ failure() }}
+        uses: imjohnbo/issue-bot@v3
+        with:
+          labels: failed-release
+          title: Publishing v${{ steps.extract-version.outputs.VERSION }} to GitHub failed
+          body: See https://github.com/${{ github.repository }}/actions/runs/${{
+            github.run_id }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    container:
+      image: jsii/superchain:1-buster-slim-node14

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -74,17 +74,15 @@ const project = new cdk.JsiiProject({
     mavenArtifactId: 'projen',
     mavenEndpoint: 'https://s01.oss.sonatype.org',
   },
-
   publishToPypi: {
     distName: 'projen',
     module: 'projen',
   },
-  releaseFailureIssue: true,
+  publishToGo: {
+    moduleName: 'github.com/projen/projen-go',
+  },
 
-  // Disabled due to cycles between main module and submodules
-  // publishToGo: {
-  //   moduleName: 'github.com/projen/projen-go',
-  // },
+  releaseFailureIssue: true,
 
   autoApproveUpgrades: true,
   autoApproveOptions: { allowedUsernames: ['cdklabs-automation'], secret: 'GITHUB_TOKEN' },

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -216,6 +216,13 @@ new github.TaskWorkflow(project.github, {
         'python-version': '3.x',
       },
     },
+    {
+      name: 'Set up Go 1.16',
+      uses: 'actions/setup-go@v2',
+      with: {
+        'go-version': '^1.16.0',
+      },
+    },
   ],
 
   task: integTask,

--- a/API.md
+++ b/API.md
@@ -137,11 +137,11 @@ Name|Description
 [GitpodPrebuilds](#projen-gitpodprebuilds)|Configure the Gitpod App for prebuilds.
 [GitpodTask](#projen-gitpodtask)|Configure options for a task to be run when opening a Gitpod workspace (e.g. running tests, or starting a dev server).
 [IniFileOptions](#projen-inifileoptions)|Options for `IniFile`.
+[InitProject](#projen-initproject)|Information passed from `projen new` to the project object when the project is first created.
 [JsonFileOptions](#projen-jsonfileoptions)|Options for `JsonFile`.
 [LicenseOptions](#projen-licenseoptions)|*No description*
 [LoggerOptions](#projen-loggeroptions)|Options for logging utilities.
 [MakefileOptions](#projen-makefileoptions)|Options for Makefiles.
-[NewProject](#projen-newproject)|Information passed from `projen new` to the project object when the project is first created.
 [ObjectFileOptions](#projen-objectfileoptions)|Options for `ObjectFile`.
 [ProjectOptions](#projen-projectoptions)|Options for `Project`.
 [ProjenrcOptions](#projen-projenrcoptions)|*No description*
@@ -310,8 +310,8 @@ Name|Description
 [GitpodOpenIn](#projen-gitpodopenin)|Configure where in the IDE the terminal should be opened.
 [GitpodOpenMode](#projen-gitpodopenmode)|Configure how the terminal should be opened relative to the previous task.
 [GitpodPortVisibility](#projen-gitpodportvisibility)|Whether the port visibility should be private or public.
+[InitProjectOptionHints](#projen-initprojectoptionhints)|Choices for how to display commented out options in projenrc files.
 [LogLevel](#projen-loglevel)|Logging verbosity.
-[NewProjectOptionHints](#projen-newprojectoptionhints)|Choices for how to display commented out options in projenrc files.
 [ProjectType](#projen-projecttype)|Which type of project this is.
 [awscdk.ApprovalLevel](#projen-awscdk-approvallevel)|Which approval is required when deploying CDK apps.
 [cdk.Stability](#projen-cdk-stability)|*No description*
@@ -1633,7 +1633,7 @@ Name | Type | Description
 **root**🔹 | <code>[Project](#projen-project)</code> | The root project.
 **tasks**🔹 | <code>[Tasks](#projen-tasks)</code> | Project tasks.
 **testTask**🔹 | <code>[Task](#projen-task)</code> | <span></span>
-**newProject**?🔹 | <code>[NewProject](#projen-newproject)</code> | The options used when this project is bootstrapped via `projen new`.<br/>__*Optional*__
+**initProject**?🔹 | <code>[InitProject](#projen-initproject)</code> | The options used when this project is bootstrapped via `projen new`.<br/>__*Optional*__
 **parent**?🔹 | <code>[Project](#projen-project)</code> | A parent project.<br/>__*Optional*__
 *static* **DEFAULT_TASK**🔹 | <code>string</code> | The name of the default task (the task executed when `projen` is run without arguments).
 
@@ -1920,7 +1920,7 @@ static createProject(options: CreateProjectOptions): void
   * **dir** (<code>string</code>)  Directory that the project will be generated in. 
   * **projectFqn** (<code>string</code>)  Fully-qualified name of the project type (usually formatted as `module.ProjectType`). 
   * **projectOptions** (<code>Map<string, any></code>)  Project options. 
-  * **optionHints** (<code>[NewProjectOptionHints](#projen-newprojectoptionhints)</code>)  Should we render commented-out default options in the projenrc file? __*Default*__: NewProjectOptionHints.FEATURED
+  * **optionHints** (<code>[InitProjectOptionHints](#projen-initprojectoptionhints)</code>)  Should we render commented-out default options in the projenrc file? __*Default*__: InitProjectOptionHints.FEATURED
   * **post** (<code>boolean</code>)  Should we execute post synthesis hooks? __*Default*__: true
   * **synth** (<code>boolean</code>)  Should we call `project.synth()` or instantiate the project (could still have side-effects) and render the .projenrc file. __*Default*__: true
 
@@ -9201,7 +9201,7 @@ Name | Type | Description
 **dir**🔹 | <code>string</code> | Directory that the project will be generated in.
 **projectFqn**🔹 | <code>string</code> | Fully-qualified name of the project type (usually formatted as `module.ProjectType`).
 **projectOptions**🔹 | <code>Map<string, any></code> | Project options.
-**optionHints**?🔹 | <code>[NewProjectOptionHints](#projen-newprojectoptionhints)</code> | Should we render commented-out default options in the projenrc file?<br/>__*Default*__: NewProjectOptionHints.FEATURED
+**optionHints**?🔹 | <code>[InitProjectOptionHints](#projen-initprojectoptionhints)</code> | Should we render commented-out default options in the projenrc file?<br/>__*Default*__: InitProjectOptionHints.FEATURED
 **post**?🔹 | <code>boolean</code> | Should we execute post synthesis hooks?<br/>__*Default*__: true
 **synth**?🔹 | <code>boolean</code> | Should we call `project.synth()` or instantiate the project (could still have side-effects) and render the .projenrc file.<br/>__*Default*__: true
 
@@ -9668,6 +9668,24 @@ Name | Type | Description
 
 
 
+## struct InitProject 🔹 <a id="projen-initproject"></a>
+
+
+Information passed from `projen new` to the project object when the project is first created.
+
+It is used to generate projenrc files in various languages.
+
+
+
+Name | Type | Description 
+-----|------|-------------
+**args**🔹 | <code>Map<string, any></code> | Initial arguments passed to `projen new`.
+**comments**🔹 | <code>[InitProjectOptionHints](#projen-initprojectoptionhints)</code> | Include commented out options.
+**fqn**🔹 | <code>string</code> | The JSII FQN of the project type.
+**type**🔹 | <code>[ProjectType](#projen-projecttype)</code> | Project metadata.
+
+
+
 ## struct JsonFileOptions 🔹 <a id="projen-jsonfileoptions"></a>
 
 
@@ -9731,24 +9749,6 @@ Name | Type | Description
 **executable**?🔹 | <code>boolean</code> | Whether the generated file should be marked as executable.<br/>__*Default*__: false
 **readonly**?🔹 | <code>boolean</code> | Whether the generated file should be readonly.<br/>__*Default*__: true
 **rules**?🔹 | <code>Array<[Rule](#projen-rule)></code> | Rules to include in the Makefile.<br/>__*Default*__: []
-
-
-
-## struct NewProject 🔹 <a id="projen-newproject"></a>
-
-
-Information passed from `projen new` to the project object when the project is first created.
-
-It is used to generate projenrc files in various languages.
-
-
-
-Name | Type | Description 
------|------|-------------
-**args**🔹 | <code>Map<string, any></code> | Initial arguments passed to `projen new`.
-**comments**🔹 | <code>[NewProjectOptionHints](#projen-newprojectoptionhints)</code> | Include commented out options.
-**fqn**🔹 | <code>string</code> | The JSII FQN of the project type.
-**type**🔹 | <code>[ProjectType](#projen-projecttype)</code> | Project metadata.
 
 
 
@@ -14427,6 +14427,19 @@ Name | Description
 **PRIVATE** 🔹|Only allows users with workspace access to access the port.
 
 
+## enum InitProjectOptionHints 🔹 <a id="projen-initprojectoptionhints"></a>
+
+Choices for how to display commented out options in projenrc files.
+
+Does not apply to projenrc.json files.
+
+Name | Description
+-----|-----
+**ALL** 🔹|Display all possible options (grouped by which interface they belong to).
+**FEATURED** 🔹|Display only featured options, in alphabetical order.
+**NONE** 🔹|Display no extra options.
+
+
 ## enum LogLevel 🔹 <a id="projen-loglevel"></a>
 
 Logging verbosity.
@@ -14439,19 +14452,6 @@ Name | Description
 **INFO** 🔹|
 **DEBUG** 🔹|
 **VERBOSE** 🔹|
-
-
-## enum NewProjectOptionHints 🔹 <a id="projen-newprojectoptionhints"></a>
-
-Choices for how to display commented out options in projenrc files.
-
-Does not apply to projenrc.json files.
-
-Name | Description
------|-----
-**ALL** 🔹|Display all possible options (grouped by which interface they belong to).
-**FEATURED** 🔹|Display only featured options, in alphabetical order.
-**NONE** 🔹|Display no extra options.
 
 
 ## enum ProjectType ⚠️ <a id="projen-projecttype"></a>

--- a/package.json
+++ b/package.json
@@ -163,6 +163,9 @@
       "python": {
         "distName": "projen",
         "module": "projen"
+      },
+      "go": {
+        "moduleName": "github.com/projen/projen-go"
       }
     },
     "tsc": {

--- a/src/cli/cmds/new.ts
+++ b/src/cli/cmds/new.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import * as fs from 'fs-extra';
 import * as yargs from 'yargs';
 import * as inventory from '../../inventory';
-import { NewProjectOptionHints } from '../../option-hints';
+import { InitProjectOptionHints } from '../../option-hints';
 import { Projects } from '../../projects';
 import { exec, isTruthy } from '../../util';
 import { tryProcessMacro } from '../macros';
@@ -60,7 +60,7 @@ class Command implements yargs.CommandModule {
 
           return cargs;
         },
-        handler: argv => newProject(process.cwd(), type, argv),
+        handler: argv => initProject(process.cwd(), type, argv),
       });
     }
 
@@ -71,7 +71,7 @@ class Command implements yargs.CommandModule {
     // handle --from which means we want to first install a jsii module and then
     // create a project defined within this module.
     if (args.from) {
-      return newProjectFromModule(process.cwd(), args.from, args);
+      return initProjectFromModule(process.cwd(), args.from, args);
     }
 
     // project type is defined but was not matched by yargs, so print the list of supported types
@@ -144,7 +144,7 @@ function commandLineToProps(cwd: string, type: inventory.ProjectType, argv: Reco
  * @param spec The name of the external module to load
  * @param args Command line arguments (incl. project type)
  */
-async function newProjectFromModule(baseDir: string, spec: string, args: any) {
+async function initProjectFromModule(baseDir: string, spec: string, args: any) {
   const projenVersion = args.projenVersion ?? 'latest';
   const installCommand = renderInstallCommand(baseDir, `projen@${projenVersion}`);
   if (args.projenVersion) {
@@ -217,7 +217,7 @@ async function newProjectFromModule(baseDir: string, spec: string, args: any) {
   args.devDeps = [spec];
   args['dev-deps'] = [spec];
 
-  await newProject(baseDir, type, args);
+  await initProject(baseDir, type, args);
 }
 
 /**
@@ -226,7 +226,7 @@ async function newProjectFromModule(baseDir: string, spec: string, args: any) {
  * @param args Command line arguments
  * @param additionalProps Additional parameters to include in .projenrc.js
  */
-async function newProject(baseDir: string, type: inventory.ProjectType, args: any) {
+async function initProject(baseDir: string, type: inventory.ProjectType, args: any) {
   // convert command line arguments to project props using type information
   const props = commandLineToProps(baseDir, type, args);
 
@@ -234,7 +234,7 @@ async function newProject(baseDir: string, type: inventory.ProjectType, args: an
     dir: props.outdir ?? baseDir,
     projectFqn: type.fqn,
     projectOptions: props,
-    optionHints: args.comments ? NewProjectOptionHints.FEATURED : NewProjectOptionHints.NONE,
+    optionHints: args.comments ? InitProjectOptionHints.FEATURED : InitProjectOptionHints.NONE,
     synth: args.synth,
     post: args.post,
   });

--- a/src/java/projenrc.ts
+++ b/src/java/projenrc.ts
@@ -79,7 +79,7 @@ export class Projenrc extends Component {
   }
 
   private generateProjenrc() {
-    const bootstrap = this.project.newProject;
+    const bootstrap = this.project.initProject;
     if (!bootstrap) {
       return;
     }

--- a/src/javascript/projenrc.ts
+++ b/src/javascript/projenrc.ts
@@ -34,7 +34,7 @@ export class Projenrc extends Component {
       return; // already exists
     }
 
-    const bootstrap = this.project.newProject;
+    const bootstrap = this.project.initProject;
     if (!bootstrap) {
       return;
     }

--- a/src/javascript/render-options.ts
+++ b/src/javascript/render-options.ts
@@ -1,5 +1,5 @@
 import * as inventory from '../inventory';
-import { NewProjectOptionHints } from '../option-hints';
+import { InitProjectOptionHints } from '../option-hints';
 
 const PROJEN_NEW = '__new__';
 const TAB = makePadding(2);
@@ -20,9 +20,9 @@ export interface RenderProjectOptions {
 
   /**
    * Include commented out options.
-   * @default NewProjectOptionHints.FEATURED
+   * @default InitProjectOptionHints.FEATURED
    */
-  readonly comments?: NewProjectOptionHints;
+  readonly comments?: InitProjectOptionHints;
 
   /**
    * Inject a `__new__` attribute to the project constructor with a stringified
@@ -45,7 +45,7 @@ export interface RenderProjectOptions {
  * Information passed from `projen new` to the project object when the project
  * is first created. It is used to generate projenrc files in various languages.
  */
-interface ProjenNew {
+interface ProjenInit {
   /**
    * The JSII FQN of the project type.
    */
@@ -59,22 +59,22 @@ interface ProjenNew {
   /**
    * Include commented out options. Does not apply to projenrc.json files.
    */
-  readonly comments: NewProjectOptionHints;
+  readonly comments: InitProjectOptionHints;
 }
 
 
 /**
  * Renders options as if the project was created via `projen new` (embeds the __new__ field).
  */
-export function renderProjenNewOptions(fqn: string, args: Record<string, any>, comments: NewProjectOptionHints = NewProjectOptionHints.NONE): any {
+export function renderProjenInitOptions(fqn: string, args: Record<string, any>, comments: InitProjectOptionHints = InitProjectOptionHints.NONE): any {
   return {
     ...args,
-    [PROJEN_NEW]: { fqn, args, comments } as ProjenNew,
+    [PROJEN_NEW]: { fqn, args, comments } as ProjenInit,
   };
 }
 
-export function resolveNewProject(opts: any) {
-  const f = opts[PROJEN_NEW] as ProjenNew;
+export function resolveInitProject(opts: any) {
+  const f = opts[PROJEN_NEW] as ProjenInit;
   if (!f) {
     return undefined;
   }
@@ -131,7 +131,7 @@ export function renderJavaScriptOptions(opts: RenderProjectOptions) {
     for (const arg of (opts.omitFromBootstrap ?? [])) {
       delete opts.args[arg];
     }
-    renders[PROJEN_NEW] = `${PROJEN_NEW}: ${JSON.stringify({ args: opts.args, fqn: opts.type.fqn, comments: opts.comments } as ProjenNew)},`;
+    renders[PROJEN_NEW] = `${PROJEN_NEW}: ${JSON.stringify({ args: opts.args, fqn: opts.type.fqn, comments: opts.comments } as ProjenInit)},`;
     optionsWithDefaults.push(PROJEN_NEW);
   }
 
@@ -149,13 +149,13 @@ export function renderJavaScriptOptions(opts: RenderProjectOptions) {
   }
 
   // render options without defaults as comments
-  if (opts.comments === NewProjectOptionHints.ALL) {
+  if (opts.comments === InitProjectOptionHints.ALL) {
     const options = opts.type.options.filter((opt) => !opt.deprecated && opts.args[opt.name] === undefined);
     result.push(...renderCommentedOptionsByModule(renders, options));
-  } else if (opts.comments === NewProjectOptionHints.FEATURED) {
+  } else if (opts.comments === InitProjectOptionHints.FEATURED) {
     const options = opts.type.options.filter((opt) => !opt.deprecated && opts.args[opt.name] === undefined && opt.featured);
     result.push(...renderCommentedOptionsInOrder(renders, options));
-  } else if (opts.comments === NewProjectOptionHints.NONE) {
+  } else if (opts.comments === InitProjectOptionHints.NONE) {
     // don't render any extra options
   }
 

--- a/src/option-hints.ts
+++ b/src/option-hints.ts
@@ -2,7 +2,7 @@
  * Choices for how to display commented out options in projenrc files.
  * Does not apply to projenrc.json files.
  */
-export enum NewProjectOptionHints {
+export enum InitProjectOptionHints {
   /**
    * Display all possible options (grouped by which interface they belong to).
    */

--- a/src/project.ts
+++ b/src/project.ts
@@ -9,11 +9,11 @@ import { FileBase } from './file';
 import { GitAttributesFile } from './gitattributes';
 import { IgnoreFile } from './ignore-file';
 import * as inventory from './inventory';
-import { resolveNewProject } from './javascript/render-options';
+import { resolveInitProject } from './javascript/render-options';
 import { JsonFile } from './json';
 import { Logger, LoggerOptions } from './logger';
 import { ObjectFile } from './object-file';
-import { NewProjectOptionHints } from './option-hints';
+import { InitProjectOptionHints } from './option-hints';
 import { ProjectBuild as ProjectBuild } from './project-build';
 import { Projenrc, ProjenrcOptions } from './projenrc-json';
 import { Task, TaskOptions } from './task';
@@ -142,7 +142,7 @@ export class Project {
    * includes the original set of options passed to the CLI and also the JSII
    * FQN of the project type.
    */
-  public readonly newProject?: NewProject;
+  public readonly initProject?: InitProject;
 
   /**
    * The command to use in order to run the projen CLI.
@@ -165,7 +165,7 @@ export class Project {
   private readonly excludeFromCleanup: string[];
 
   constructor(options: ProjectOptions) {
-    this.newProject = resolveNewProject(options);
+    this.initProject = resolveInitProject(options);
 
     this.name = options.name;
     this.parent = options.parent;
@@ -534,7 +534,7 @@ export enum ProjectType {
  * Information passed from `projen new` to the project object when the project
  * is first created. It is used to generate projenrc files in various languages.
  */
-export interface NewProject {
+export interface InitProject {
   /**
    * The JSII FQN of the project type.
    */
@@ -552,7 +552,7 @@ export interface NewProject {
 
   /**
    * Include commented out options. Does not apply to projenrc.json files.
-   * @default NewProjectOptionHints.FEATURED
+   * @default InitProjectOptionHints.FEATURED
    */
-  readonly comments: NewProjectOptionHints;
+  readonly comments: InitProjectOptionHints;
 }

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import * as vm from 'vm';
 import { resolveProjectType } from './inventory';
 import { renderJavaScriptOptions } from './javascript/render-options';
-import { NewProjectOptionHints } from './option-hints';
+import { InitProjectOptionHints } from './option-hints';
 
 export interface CreateProjectOptions {
   /**
@@ -31,9 +31,9 @@ export interface CreateProjectOptions {
    * Should we render commented-out default options in the projenrc file?
    * Does not apply to projenrc.json files.
    *
-   * @default NewProjectOptionHints.FEATURED
+   * @default InitProjectOptionHints.FEATURED
    */
-  readonly optionHints?: NewProjectOptionHints;
+  readonly optionHints?: InitProjectOptionHints;
 
   /**
    * Should we call `project.synth()` or instantiate the project (could still
@@ -96,7 +96,7 @@ function createProject(opts: CreateProjectOptions) {
   // generate the projenrc file.
   const { renderedOptions } = renderJavaScriptOptions({
     bootstrap: true,
-    comments: opts.optionHints ?? NewProjectOptionHints.FEATURED,
+    comments: opts.optionHints ?? InitProjectOptionHints.FEATURED,
     type: projectType,
     args: opts.projectOptions,
     omitFromBootstrap: ['outdir'],
@@ -109,7 +109,7 @@ function createProject(opts: CreateProjectOptions) {
   //
   // errors if this isn't unique
   const varName = 'project' + Math.random().toString(36).slice(2);
-  const newProjectCode = `const ${varName} = new ${projectType.typename}(${renderedOptions});`;
+  const initProjectCode = `const ${varName} = new ${projectType.typename}(${renderedOptions});`;
 
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const module = require(mod);
@@ -119,7 +119,7 @@ function createProject(opts: CreateProjectOptions) {
   const postSynth = opts.post ?? true;
   process.env.PROJEN_DISABLE_POST = (!postSynth).toString();
   vm.runInContext([
-    newProjectCode,
+    initProjectCode,
     synth ? `${varName}.synth();` : '',
   ].join('\n'), ctx);
 }

--- a/src/projenrc-json.ts
+++ b/src/projenrc-json.ts
@@ -35,7 +35,7 @@ export class Projenrc extends Component {
       return; // already exists
     }
 
-    const bootstrap = this.project.newProject;
+    const bootstrap = this.project.initProject;
     if (!bootstrap) {
       return;
     }

--- a/src/python/projenrc.ts
+++ b/src/python/projenrc.ts
@@ -52,7 +52,7 @@ export class Projenrc extends Component {
   }
 
   private generateProjenrc() {
-    const bootstrap = this.project.newProject;
+    const bootstrap = this.project.initProject;
     if (!bootstrap) {
       return;
     }

--- a/src/run-projenrc-json.task.ts
+++ b/src/run-projenrc-json.task.ts
@@ -8,7 +8,7 @@
  *   Defaults to `.projenrc.json`.
  */
 import * as fs from 'fs-extra';
-import { NewProjectOptionHints } from './option-hints';
+import { InitProjectOptionHints } from './option-hints';
 import { Projects } from './projects';
 
 let filename = process.env.PROJENRC_FILE;
@@ -26,7 +26,7 @@ Projects.createProject({
   dir: '.',
   projectFqn: type,
   projectOptions: json,
-  optionHints: NewProjectOptionHints.NONE,
+  optionHints: InitProjectOptionHints.NONE,
   synth: true,
   post: false,
 });

--- a/src/typescript/projenrc.ts
+++ b/src/typescript/projenrc.ts
@@ -60,7 +60,7 @@ export class Projenrc extends Component {
       return; // already exists
     }
 
-    const bootstrap = this.project.newProject;
+    const bootstrap = this.project.initProject;
     if (!bootstrap) {
       return;
     }

--- a/test/java/java-project.test.ts
+++ b/test/java/java-project.test.ts
@@ -1,5 +1,5 @@
 import { JavaProject, JavaProjectOptions } from '../../src/java/java-project';
-import { renderProjenNewOptions } from '../../src/javascript/render-options';
+import { renderProjenInitOptions } from '../../src/javascript/render-options';
 import { synthSnapshot } from '../util';
 
 test('defaults', () => {
@@ -69,7 +69,7 @@ function snapPom(p: JavaProject) {
 
 class TestJavaProject extends JavaProject {
   constructor(options: Partial<JavaProjectOptions> = { }) {
-    super(renderProjenNewOptions('projen.java.JavaProject', {
+    super(renderProjenInitOptions('projen.java.JavaProject', {
       ...options,
       groupId: 'org.acme',
       artifactId: 'my-artifact',

--- a/test/java/projenrc.test.ts
+++ b/test/java/projenrc.test.ts
@@ -1,6 +1,6 @@
 import { Pom } from '../../src/java';
 import { Projenrc } from '../../src/java/projenrc';
-import { renderProjenNewOptions } from '../../src/javascript/render-options';
+import { renderProjenInitOptions } from '../../src/javascript/render-options';
 import { synthSnapshot, TestProject } from '../util';
 
 test('projenrc.java support', () => {
@@ -61,7 +61,7 @@ test('set the class name', () => {
 
 test('generate projenrc in java', () => {
   // GIVEN
-  const project = new TestProject(renderProjenNewOptions('projen.java.JavaProject', {}));
+  const project = new TestProject(renderProjenInitOptions('projen.java.JavaProject', {}));
   const pom = new Pom(project, {
     groupId: 'my.group.id',
     artifactId: 'hello-world',

--- a/test/json/projenrc.test.ts
+++ b/test/json/projenrc.test.ts
@@ -1,4 +1,4 @@
-import { renderProjenNewOptions } from '../../src/javascript/render-options';
+import { renderProjenInitOptions } from '../../src/javascript/render-options';
 import { Projenrc } from '../../src/projenrc-json';
 import { synthSnapshot, TestProject } from '../util';
 
@@ -15,7 +15,7 @@ test('projenrc.json default project', () => {
 
 test('projenrc.json with typed options', () => {
   // GIVEN
-  const project = new TestProject(renderProjenNewOptions('projen.typescript.TypeScriptProject', {
+  const project = new TestProject(renderProjenInitOptions('projen.typescript.TypeScriptProject', {
     staleOptions: {
       issues: {
         daysBeforeStale: 100, // number, nested option

--- a/test/projects.test.ts
+++ b/test/projects.test.ts
@@ -1,4 +1,4 @@
-import { NewProjectOptionHints } from '../src/option-hints';
+import { InitProjectOptionHints } from '../src/option-hints';
 import { Projects } from '../src/projects';
 import { directorySnapshot, withProjectDir } from './util';
 
@@ -7,7 +7,7 @@ describe('createProject', () => {
     withProjectDir(projectdir => {
       // GIVEN
       Projects.createProject({
-        optionHints: NewProjectOptionHints.FEATURED,
+        optionHints: InitProjectOptionHints.FEATURED,
         dir: projectdir,
         post: false,
         synth: false,
@@ -30,7 +30,7 @@ describe('createProject', () => {
     withProjectDir(projectdir => {
       // GIVEN
       Projects.createProject({
-        optionHints: NewProjectOptionHints.FEATURED,
+        optionHints: InitProjectOptionHints.FEATURED,
         dir: projectdir,
         post: false,
         synth: false,
@@ -67,7 +67,7 @@ describe('createProject', () => {
 
       // WHEN
       Projects.createProject({
-        optionHints: NewProjectOptionHints.FEATURED,
+        optionHints: InitProjectOptionHints.FEATURED,
         dir: projectdir,
         post: false,
         synth: false,

--- a/test/python/projenrc.test.ts
+++ b/test/python/projenrc.test.ts
@@ -1,4 +1,4 @@
-import { renderProjenNewOptions } from '../../src/javascript/render-options';
+import { renderProjenInitOptions } from '../../src/javascript/render-options';
 import { ProjectType } from '../../src/project';
 import { Projenrc } from '../../src/python/projenrc';
 import { synthSnapshot, TestProject } from '../util';
@@ -19,7 +19,7 @@ test('projenrc.py support', () => {
 
 test('generate projenrc in python', () => {
   // GIVEN
-  const project = new TestProject(renderProjenNewOptions('projen.python.PythonProject', {}));
+  const project = new TestProject(renderProjenInitOptions('projen.python.PythonProject', {}));
 
   // WHEN
   new Projenrc(project);
@@ -30,7 +30,7 @@ test('generate projenrc in python', () => {
 
 test('javascript values are translated to python', () => {
   // GIVEN
-  const project = new TestProject(renderProjenNewOptions('projen.python.PythonProject', {
+  const project = new TestProject(renderProjenInitOptions('projen.python.PythonProject', {
     stringArg: 'hello',
     intArg: 123,
     floatArg: 123.45,


### PR DESCRIPTION
Fixes #1344

In order to publish to Go, we have to rename `NewProject`, since any type named `NewXxx` can potentially conflict with Go constructor functions with the name `NewXxx` generated by jsii.

BREAKING CHANGE: `NewProject` has been renamed `InitProject`, and `NewProjectOptionHints` has been renamed `InitProjectOptionHints`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.