### PR TITLE
feat(release): dry-run

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -16,6 +16,7 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - -label~=(do-not-merge)
       - status-success=build
+      - status-success=integ
   - name: Label core contributions
     actions:
       label:

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -143,6 +143,9 @@
           "spawn": "build"
         },
         {
+          "spawn": "package:python"
+        },
+        {
           "spawn": "integ:python-compat"
         }
       ]

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -195,6 +195,7 @@ const integTask = project.addTask('integ');
 integTask.spawn(project.buildTask);
 integTask.spawn(project.tasks.tryFind('package:python'));
 integTask.spawn(pythonCompatTask);
+project.tryFindObjectFile('.mergify.yml').addOverride('pull_request_rules.0.conditions.3', 'status-success=integ');
 
 new github.TaskWorkflow(project.github, {
   name: 'integ',

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -193,6 +193,7 @@ const pythonCompatTask = project.addTask('integ:python-compat', {
 });
 const integTask = project.addTask('integ');
 integTask.spawn(project.buildTask);
+integTask.spawn(project.tasks.tryFind('package:python'));
 integTask.spawn(pythonCompatTask);
 
 new github.TaskWorkflow(project.github, {

--- a/docs/publisher.md
+++ b/docs/publisher.md
@@ -138,3 +138,11 @@ This will create an issue labeled with the `failed-release` label for every indi
 For example, if Nuget publishing failed for a specific version, it will create an issue titled *Publishing v1.0.4 to Nuget gallery failed*.
 
 This can be helpful to keep track of failed releases as well as integrate with third-party ticketing systems by querying issues labeled with `failed-release`.
+
+## Dry run
+
+If you wish to completely disable publishing, you can enable the `dryRun` option on
+`Publisher` or `publishDryRun` on the project.
+
+This will cause all publishing tasks and jobs to just print the publishing
+command but not actually publish.


### PR DESCRIPTION
To disable publishing, set `publishDryRun` to `true` in your project definition.

The feature was actually added in #1359 - this commit just adds a test and docs.

Also: fixes the integ test.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.