### PR TITLE
fix(node): releases for non jsii node projects is broken

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -164,10 +164,10 @@
       "description": "Creates the distribution package",
       "steps": [
         {
-          "exec": "mkdir -p dist"
+          "exec": "mkdir -p dist/js"
         },
         {
-          "exec": "mv $(npm pack) dist/"
+          "exec": "mv $(npm pack) dist/js"
         }
       ]
     },

--- a/src/javascript/node-project.ts
+++ b/src/javascript/node-project.ts
@@ -655,11 +655,11 @@ export class NodeProject extends GitHubProject {
     this.bundler = new Bundler(this, options.bundlerOptions);
 
     if (options.package ?? true) {
-      this.packageTask.exec(`mkdir -p ${this.artifactsDirectory}`);
+      this.packageTask.exec(`mkdir -p ${this.artifactsDirectory}/js`);
 
       // always use npm here - yarn doesn't add much value
       // sadly we cannot use --pack-destination because it is not supported by older npm
-      this.packageTask.exec(`mv $(npm pack) ${this.artifactsDirectory}/`);
+      this.packageTask.exec(`mv $(npm pack) ${this.artifactsDirectory}/js`);
     }
   }
 

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -1272,10 +1272,10 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": Array [
           Object {
-            "exec": "mkdir -p dist",
+            "exec": "mkdir -p dist/js",
           },
           Object {
-            "exec": "mv $(npm pack) dist/",
+            "exec": "mv $(npm pack) dist/js",
           },
         ],
       },
@@ -2693,10 +2693,10 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": Array [
           Object {
-            "exec": "mkdir -p dist",
+            "exec": "mkdir -p dist/js",
           },
           Object {
-            "exec": "mv $(npm pack) dist/",
+            "exec": "mv $(npm pack) dist/js",
           },
         ],
       },
@@ -4156,10 +4156,10 @@ tsconfig.tsbuildinfo
         "name": "package",
         "steps": Array [
           Object {
-            "exec": "mkdir -p dist",
+            "exec": "mkdir -p dist/js",
           },
           Object {
-            "exec": "mv $(npm pack) dist/",
+            "exec": "mv $(npm pack) dist/js",
           },
         ],
       },
@@ -5442,10 +5442,10 @@ junit.xml
         "name": "package",
         "steps": Array [
           Object {
-            "exec": "mkdir -p dist",
+            "exec": "mkdir -p dist/js",
           },
           Object {
-            "exec": "mv $(npm pack) dist/",
+            "exec": "mv $(npm pack) dist/js",
           },
         ],
       },

--- a/test/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-project.test.ts.snap
@@ -569,10 +569,10 @@ pull_request_rules:
         "name": "package",
         "steps": Array [
           Object {
-            "exec": "mkdir -p dist",
+            "exec": "mkdir -p dist/js",
           },
           Object {
-            "exec": "mv $(npm pack) dist/",
+            "exec": "mv $(npm pack) dist/js",
           },
         ],
       },

--- a/test/web/__snapshots__/react-project.test.ts.snap
+++ b/test/web/__snapshots__/react-project.test.ts.snap
@@ -554,10 +554,10 @@ pull_request_rules:
         "name": "package",
         "steps": Array [
           Object {
-            "exec": "mkdir -p dist",
+            "exec": "mkdir -p dist/js",
           },
           Object {
-            "exec": "mv $(npm pack) dist/",
+            "exec": "mv $(npm pack) dist/js",
           },
         ],
       },


### PR DESCRIPTION
This [PR](https://github.com/projen/projen/pull/1359) changed the implementation of the default `package` task and its no longer compatible with how `jsii-release` works.

This is currently [failing](https://github.com/cdklabs/construct-hub-webapp/runs/4636524176?check_suite_focus=true) `construct-hub-webapp` release. 

```console
Run npx -p jsii-release@latest jsii-release-npm
  npx -p jsii-release@latest jsii-release-npm
  shell: /usr/bin/bash -e {0}
  env:
    NPM_DIST_TAG: latest
    NPM_REGISTRY: registry.npmjs.org
    NPM_TOKEN: ***
npx: installed 8 in 4.902s
Publishing under the following dist-tag: latest
npm ERR! code ENOENT
npm ERR! syscall stat
npm ERR! path /home/runner/work/construct-hub-webapp/construct-hub-webapp/dist/js/**.tgz
npm ERR! errno -2
npm ERR! enoent ENOENT: no such file or directory, stat '/home/runner/work/construct-hub-webapp/construct-hub-webapp/dist/js/**.tgz'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent 
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.