### PR TITLE
fix(node): npm releases are broken for non-jsii projects

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,8 +91,8 @@ jobs:
           path: dist
       - name: Extract npm tarball
         run: |-
-          tar -xzf dist/*.tgz --strip-components=1
-          rm -fr dist/
+          tar -xzf dist/js/*.tgz --strip-components=1
+          rm -fr dist/js
       - name: Create js artifact
         run: >-
           jsii_version=$(node -p
@@ -118,8 +118,8 @@ jobs:
           path: dist
       - name: Extract npm tarball
         run: |-
-          tar -xzf dist/*.tgz --strip-components=1
-          rm -fr dist/
+          tar -xzf dist/js/*.tgz --strip-components=1
+          rm -fr dist/js
       - name: Create java artifact
         run: >-
           jsii_version=$(node -p
@@ -144,8 +144,8 @@ jobs:
           path: dist
       - name: Extract npm tarball
         run: |-
-          tar -xzf dist/*.tgz --strip-components=1
-          rm -fr dist/
+          tar -xzf dist/js/*.tgz --strip-components=1
+          rm -fr dist/js
       - name: Create python artifact
         run: >-
           jsii_version=$(node -p
@@ -170,8 +170,8 @@ jobs:
           path: dist
       - name: Extract npm tarball
         run: |-
-          tar -xzf dist/*.tgz --strip-components=1
-          rm -fr dist/
+          tar -xzf dist/js/*.tgz --strip-components=1
+          rm -fr dist/js
       - name: Create go artifact
         run: >-
           jsii_version=$(node -p

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,8 +104,8 @@ jobs:
           path: dist
       - name: Extract npm tarball
         run: |-
-          tar -xzf dist/*.tgz --strip-components=1
-          rm -fr dist/
+          tar -xzf dist/js/*.tgz --strip-components=1
+          rm -fr dist/js
       - name: Create js artifact
         run: >-
           jsii_version=$(node -p
@@ -155,8 +155,8 @@ jobs:
           path: dist
       - name: Extract npm tarball
         run: |-
-          tar -xzf dist/*.tgz --strip-components=1
-          rm -fr dist/
+          tar -xzf dist/js/*.tgz --strip-components=1
+          rm -fr dist/js
       - name: Create java artifact
         run: >-
           jsii_version=$(node -p
@@ -209,8 +209,8 @@ jobs:
           path: dist
       - name: Extract npm tarball
         run: |-
-          tar -xzf dist/*.tgz --strip-components=1
-          rm -fr dist/
+          tar -xzf dist/js/*.tgz --strip-components=1
+          rm -fr dist/js
       - name: Create python artifact
         run: >-
           jsii_version=$(node -p
@@ -258,8 +258,8 @@ jobs:
           path: dist
       - name: Extract npm tarball
         run: |-
-          tar -xzf dist/*.tgz --strip-components=1
-          rm -fr dist/
+          tar -xzf dist/js/*.tgz --strip-components=1
+          rm -fr dist/js
       - name: Create go artifact
         run: >-
           jsii_version=$(node -p

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -164,10 +164,10 @@
       "description": "Creates the distribution package",
       "steps": [
         {
-          "exec": "mkdir -p dist"
+          "exec": "mkdir -p dist/js"
         },
         {
-          "exec": "mv $(npm pack) dist/"
+          "exec": "mv $(npm pack) dist/js/"
         }
       ]
     },

--- a/API.md
+++ b/API.md
@@ -6481,6 +6481,7 @@ Name | Type | Description
 **allowLibraryDependencies**⚠️ | <code>boolean</code> | <span></span>
 **antitamper**🔹 | <code>boolean</code> | Indicates if workflows have anti-tamper checks.
 **artifactsDirectory**🔹 | <code>string</code> | The build output directory.
+**artifactsJavascriptDirectory**🔹 | <code>string</code> | The location of the npm tarball after build (`${artifactsDirectory}/js`).
 **bundler**🔹 | <code>[javascript.Bundler](#projen-javascript-bundler)</code> | <span></span>
 **entrypoint**⚠️ | <code>string</code> | <span></span>
 **installWorkflowSteps**🔹 | <code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code> | <span></span>

--- a/src/cdk/jsii-project.ts
+++ b/src/cdk/jsii-project.ts
@@ -365,8 +365,8 @@ export class JsiiProject extends TypeScriptProject {
         {
           name: 'Extract npm tarball',
           run: [
-            `tar -xzf ${this.artifactsDirectory}/*.tgz --strip-components=1`,
-            `rm -fr ${this.artifactsDirectory}/`,
+            `tar -xzf ${this.artifactsJavascriptDirectory}/*.tgz --strip-components=1`,
+            `rm -fr ${this.artifactsJavascriptDirectory}`,
           ].join('\n'),
         },
         {

--- a/src/javascript/node-project.ts
+++ b/src/javascript/node-project.ts
@@ -1,3 +1,4 @@
+import { join } from 'path';
 import { BuildWorkflow } from '../build';
 import { PROJEN_DIR, PROJEN_RC } from '../common';
 import { AutoMerge, DependabotOptions, GitHubProject, GitHubProjectOptions, GitIdentity } from '../github';
@@ -402,9 +403,16 @@ export class NodeProject extends GitHubProject {
   public readonly bundler: Bundler;
 
   /**
-   * The build output directory. By default this is `dist`.
+   * The build output directory. An npm tarball will be created under the `js`
+   * subdirectory. For example, if this is set to `dist` (the default), the npm
+   * tarball will be placed under `dist/js/boom-boom-1.2.3.tg`.
    */
   public readonly artifactsDirectory: string;
+
+  /**
+   * The location of the npm tarball after build (`${artifactsDirectory}/js`).
+   */
+  public readonly artifactsJavascriptDirectory: string;
 
   /**
    * The upgrade workflow.
@@ -421,6 +429,7 @@ export class NodeProject extends GitHubProject {
     this.workflowBootstrapSteps = options.workflowBootstrapSteps ?? [];
     this.workflowGitIdentity = options.workflowGitIdentity ?? DEFAULT_GITHUB_ACTIONS_USER;
     this.artifactsDirectory = options.artifactsDirectory ?? 'dist';
+    this.artifactsJavascriptDirectory = join(this.artifactsDirectory, 'js');
 
     this.runScriptCommand = (() => {
       switch (this.packageManager) {
@@ -655,11 +664,11 @@ export class NodeProject extends GitHubProject {
     this.bundler = new Bundler(this, options.bundlerOptions);
 
     if (options.package ?? true) {
-      this.packageTask.exec(`mkdir -p ${this.artifactsDirectory}`);
+      this.packageTask.exec(`mkdir -p ${this.artifactsJavascriptDirectory}`);
 
       // always use npm here - yarn doesn't add much value
       // sadly we cannot use --pack-destination because it is not supported by older npm
-      this.packageTask.exec(`mv $(npm pack) ${this.artifactsDirectory}/`);
+      this.packageTask.exec(`mv $(npm pack) ${this.artifactsJavascriptDirectory}/`);
     }
   }
 

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -344,8 +344,8 @@ jobs:
           path: dist
       - name: Extract npm tarball
         run: |-
-          tar -xzf dist/*.tgz --strip-components=1
-          rm -fr dist/
+          tar -xzf dist/js/*.tgz --strip-components=1
+          rm -fr dist/js
       - name: Create js artifact
         run: >-
           jsii_version=$(node -p
@@ -371,8 +371,8 @@ jobs:
           path: dist
       - name: Extract npm tarball
         run: |-
-          tar -xzf dist/*.tgz --strip-components=1
-          rm -fr dist/
+          tar -xzf dist/js/*.tgz --strip-components=1
+          rm -fr dist/js
       - name: Create java artifact
         run: >-
           jsii_version=$(node -p
@@ -397,8 +397,8 @@ jobs:
           path: dist
       - name: Extract npm tarball
         run: |-
-          tar -xzf dist/*.tgz --strip-components=1
-          rm -fr dist/
+          tar -xzf dist/js/*.tgz --strip-components=1
+          rm -fr dist/js
       - name: Create python artifact
         run: >-
           jsii_version=$(node -p
@@ -524,8 +524,8 @@ jobs:
           path: dist
       - name: Extract npm tarball
         run: |-
-          tar -xzf dist/*.tgz --strip-components=1
-          rm -fr dist/
+          tar -xzf dist/js/*.tgz --strip-components=1
+          rm -fr dist/js
       - name: Create js artifact
         run: >-
           jsii_version=$(node -p
@@ -560,8 +560,8 @@ jobs:
           path: dist
       - name: Extract npm tarball
         run: |-
-          tar -xzf dist/*.tgz --strip-components=1
-          rm -fr dist/
+          tar -xzf dist/js/*.tgz --strip-components=1
+          rm -fr dist/js
       - name: Create java artifact
         run: >-
           jsii_version=$(node -p
@@ -597,8 +597,8 @@ jobs:
           path: dist
       - name: Extract npm tarball
         run: |-
-          tar -xzf dist/*.tgz --strip-components=1
-          rm -fr dist/
+          tar -xzf dist/js/*.tgz --strip-components=1
+          rm -fr dist/js
       - name: Create python artifact
         run: >-
           jsii_version=$(node -p
@@ -1272,10 +1272,10 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": Array [
           Object {
-            "exec": "mkdir -p dist",
+            "exec": "mkdir -p dist/js",
           },
           Object {
-            "exec": "mv $(npm pack) dist/",
+            "exec": "mv $(npm pack) dist/js/",
           },
         ],
       },
@@ -2693,10 +2693,10 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": Array [
           Object {
-            "exec": "mkdir -p dist",
+            "exec": "mkdir -p dist/js",
           },
           Object {
-            "exec": "mv $(npm pack) dist/",
+            "exec": "mv $(npm pack) dist/js/",
           },
         ],
       },
@@ -4156,10 +4156,10 @@ tsconfig.tsbuildinfo
         "name": "package",
         "steps": Array [
           Object {
-            "exec": "mkdir -p dist",
+            "exec": "mkdir -p dist/js",
           },
           Object {
-            "exec": "mv $(npm pack) dist/",
+            "exec": "mv $(npm pack) dist/js/",
           },
         ],
       },
@@ -5442,10 +5442,10 @@ junit.xml
         "name": "package",
         "steps": Array [
           Object {
-            "exec": "mkdir -p dist",
+            "exec": "mkdir -p dist/js",
           },
           Object {
-            "exec": "mv $(npm pack) dist/",
+            "exec": "mv $(npm pack) dist/js/",
           },
         ],
       },

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -131,8 +131,8 @@ Object {
     },
     Object {
       "name": "Extract npm tarball",
-      "run": "tar -xzf dist/*.tgz --strip-components=1
-rm -fr dist/",
+      "run": "tar -xzf dist/js/*.tgz --strip-components=1
+rm -fr dist/js",
     },
     Object {
       "name": "Create go artifact",
@@ -185,8 +185,8 @@ Object {
     },
     Object {
       "name": "Extract npm tarball",
-      "run": "tar -xzf dist/*.tgz --strip-components=1
-rm -fr dist/",
+      "run": "tar -xzf dist/js/*.tgz --strip-components=1
+rm -fr dist/js",
     },
     Object {
       "name": "Create java artifact",
@@ -234,8 +234,8 @@ Object {
     },
     Object {
       "name": "Extract npm tarball",
-      "run": "tar -xzf dist/*.tgz --strip-components=1
-rm -fr dist/",
+      "run": "tar -xzf dist/js/*.tgz --strip-components=1
+rm -fr dist/js",
     },
     Object {
       "name": "Create js artifact",
@@ -287,8 +287,8 @@ Object {
     },
     Object {
       "name": "Extract npm tarball",
-      "run": "tar -xzf dist/*.tgz --strip-components=1
-rm -fr dist/",
+      "run": "tar -xzf dist/js/*.tgz --strip-components=1
+rm -fr dist/js",
     },
     Object {
       "name": "Create dotnet artifact",
@@ -338,8 +338,8 @@ Object {
     },
     Object {
       "name": "Extract npm tarball",
-      "run": "tar -xzf dist/*.tgz --strip-components=1
-rm -fr dist/",
+      "run": "tar -xzf dist/js/*.tgz --strip-components=1
+rm -fr dist/js",
     },
     Object {
       "name": "Create python artifact",
@@ -386,8 +386,8 @@ Object {
     },
     Object {
       "name": "Extract npm tarball",
-      "run": "tar -xzf dist/*.tgz --strip-components=1
-rm -fr dist/",
+      "run": "tar -xzf dist/js/*.tgz --strip-components=1
+rm -fr dist/js",
     },
     Object {
       "name": "Create dotnet artifact",
@@ -426,8 +426,8 @@ Object {
     },
     Object {
       "name": "Extract npm tarball",
-      "run": "tar -xzf dist/*.tgz --strip-components=1
-rm -fr dist/",
+      "run": "tar -xzf dist/js/*.tgz --strip-components=1
+rm -fr dist/js",
     },
     Object {
       "name": "Create go artifact",
@@ -467,8 +467,8 @@ Object {
     },
     Object {
       "name": "Extract npm tarball",
-      "run": "tar -xzf dist/*.tgz --strip-components=1
-rm -fr dist/",
+      "run": "tar -xzf dist/js/*.tgz --strip-components=1
+rm -fr dist/js",
     },
     Object {
       "name": "Create java artifact",
@@ -501,8 +501,8 @@ Object {
     },
     Object {
       "name": "Extract npm tarball",
-      "run": "tar -xzf dist/*.tgz --strip-components=1
-rm -fr dist/",
+      "run": "tar -xzf dist/js/*.tgz --strip-components=1
+rm -fr dist/js",
     },
     Object {
       "name": "Create js artifact",
@@ -541,8 +541,8 @@ Object {
     },
     Object {
       "name": "Extract npm tarball",
-      "run": "tar -xzf dist/*.tgz --strip-components=1
-rm -fr dist/",
+      "run": "tar -xzf dist/js/*.tgz --strip-components=1
+rm -fr dist/js",
     },
     Object {
       "name": "Create python artifact",
@@ -639,8 +639,8 @@ jobs:
           path: dist
       - name: Extract npm tarball
         run: |-
-          tar -xzf dist/*.tgz --strip-components=1
-          rm -fr dist/
+          tar -xzf dist/js/*.tgz --strip-components=1
+          rm -fr dist/js
       - name: Create js artifact
         run: >-
           jsii_version=$(node -p
@@ -674,8 +674,8 @@ jobs:
           path: dist
       - name: Extract npm tarball
         run: |-
-          tar -xzf dist/*.tgz --strip-components=1
-          rm -fr dist/
+          tar -xzf dist/js/*.tgz --strip-components=1
+          rm -fr dist/js
       - name: Create go artifact
         run: >-
           jsii_version=$(node -p
@@ -780,8 +780,8 @@ jobs:
           path: dist
       - name: Extract npm tarball
         run: |-
-          tar -xzf dist/*.tgz --strip-components=1
-          rm -fr dist/
+          tar -xzf dist/js/*.tgz --strip-components=1
+          rm -fr dist/js
       - name: Create js artifact
         run: >-
           jsii_version=$(node -p
@@ -815,8 +815,8 @@ jobs:
           path: dist
       - name: Extract npm tarball
         run: |-
-          tar -xzf dist/*.tgz --strip-components=1
-          rm -fr dist/
+          tar -xzf dist/js/*.tgz --strip-components=1
+          rm -fr dist/js
       - name: Create go artifact
         run: >-
           jsii_version=$(node -p

--- a/test/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-project.test.ts.snap
@@ -569,10 +569,10 @@ pull_request_rules:
         "name": "package",
         "steps": Array [
           Object {
-            "exec": "mkdir -p dist",
+            "exec": "mkdir -p dist/js",
           },
           Object {
-            "exec": "mv $(npm pack) dist/",
+            "exec": "mv $(npm pack) dist/js/",
           },
         ],
       },

--- a/test/web/__snapshots__/react-project.test.ts.snap
+++ b/test/web/__snapshots__/react-project.test.ts.snap
@@ -554,10 +554,10 @@ pull_request_rules:
         "name": "package",
         "steps": Array [
           Object {
-            "exec": "mkdir -p dist",
+            "exec": "mkdir -p dist/js",
           },
           Object {
-            "exec": "mv $(npm pack) dist/",
+            "exec": "mv $(npm pack) dist/js/",
           },
         ],
       },


### PR DESCRIPTION
Adds a property to `NodeProject` which can be used to determine where the npm tarball is so that release jobs can use it instead of assuming things.

Fixes #1376

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.