### PR TITLE
chore: pwd artifact for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,11 @@ jobs:
         if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
+            !node_modules
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -58,8 +61,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)
@@ -100,8 +102,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Install Dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Create js artifact
@@ -145,8 +146,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Install Dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Create java artifact
@@ -193,8 +193,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Install Dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Create python artifact
@@ -236,8 +235,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Install Dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Create go artifact

--- a/src/build/build-workflow.ts
+++ b/src/build/build-workflow.ts
@@ -1,7 +1,7 @@
 import { Task } from '..';
 import { Component } from '../component';
 import { GitHub, GithubWorkflow, GitIdentity } from '../github';
-import { DEFAULT_GITHUB_ACTIONS_USER, setGitIdentityStep } from '../github/constants';
+import { BUILD_ARTIFACT_NAME, DEFAULT_GITHUB_ACTIONS_USER, setGitIdentityStep } from '../github/constants';
 import { Job, JobPermission, JobStep } from '../github/workflows-model';
 import { NodeProject } from '../javascript';
 import { Project } from '../project';
@@ -214,7 +214,6 @@ export class BuildWorkflow extends Component {
     const steps = [];
 
     if (this.artifactsDirectory) {
-      const artfiactName = 'build-artifact';
 
       // add a step at the end of the build workflow which will upload the
       // artifact so we can download it in each post-build job (do it once).
@@ -237,7 +236,7 @@ export class BuildWorkflow extends Component {
           // the previous ones have failed (e.g. coverage report, internal logs, etc)
           if: 'always()',
           with: {
-            name: artfiactName,
+            name: BUILD_ARTIFACT_NAME,
             path: paths.join('\n'),
           },
         }];
@@ -247,7 +246,7 @@ export class BuildWorkflow extends Component {
         name: 'Download build artifacts',
         uses: 'actions/download-artifact@v2',
         with: {
-          name: artfiactName,
+          name: BUILD_ARTIFACT_NAME,
         },
       });
     }

--- a/src/github/constants.ts
+++ b/src/github/constants.ts
@@ -2,6 +2,12 @@ import { GitIdentity } from '.';
 import * as workflow from './workflows-model';
 
 /**
+ * Name of the artifact produced by the build job. Its contains the entire
+ * working directory.
+ */
+export const BUILD_ARTIFACT_NAME = 'build-artifact';
+
+/**
  * Represents the github-actions user.
  *
  * Use this when you need to perform a commit as part of your workflow.

--- a/src/release/publisher.ts
+++ b/src/release/publisher.ts
@@ -1,6 +1,6 @@
 import { JSII_TOOLCHAIN } from '../cdk/consts';
 import { Component } from '../component';
-import { DEFAULT_GITHUB_ACTIONS_USER } from '../github/constants';
+import { BUILD_ARTIFACT_NAME, DEFAULT_GITHUB_ACTIONS_USER } from '../github/constants';
 import { Job, JobPermission, JobPermissions, JobStep, Tools } from '../github/workflows-model';
 import { defaultNpmToken } from '../javascript/node-package';
 import { Project } from '../project';
@@ -9,7 +9,6 @@ import { BranchOptions } from './release';
 const JSII_RELEASE_VERSION = 'latest';
 const GITHUB_PACKAGES_REGISTRY = 'npm.pkg.github.com';
 const GITHUB_PACKAGES_MAVEN_REPOSITORY = 'https://maven.pkg.github.com';
-const ARTIFACTS_DOWNLOAD_DIR = 'dist';
 const AWS_CODEARTIFACT_REGISTRY_REGEX = /.codeartifact.*.amazonaws.com/;
 
 /**
@@ -414,8 +413,7 @@ export class Publisher extends Component {
           name: 'Download build artifacts',
           uses: 'actions/download-artifact@v2',
           with: {
-            name: this.artifactName,
-            path: ARTIFACTS_DOWNLOAD_DIR, // this must be "dist" for jsii-release
+            name: BUILD_ARTIFACT_NAME,
           },
         },
         ...opts.prePublishSteps,

--- a/src/release/release.ts
+++ b/src/release/release.ts
@@ -1,7 +1,9 @@
 import * as path from 'path';
 import { Component } from '../component';
 import { GitHub, GitHubProject, GithubWorkflow, TaskWorkflow } from '../github';
+import { BUILD_ARTIFACT_NAME } from '../github/constants';
 import { Job, JobPermission, JobStep } from '../github/workflows-model';
+import { NodeProject } from '../javascript';
 import { Task } from '../task';
 import { Version } from '../version';
 import { Publisher } from './publisher';
@@ -478,13 +480,23 @@ export class Release extends Component {
       run: `echo ::set-output name=${LATEST_COMMIT_OUTPUT}::"$(git ls-remote origin -h \${{ github.ref }} | cut -f1)"`,
     });
 
+    const paths = ['.', '!.git'];
+
+    if (this.project instanceof NodeProject) {
+      paths.push(
+        // node_modules takes forever to compress.
+        // instead, we skip it and re-install after downloading.
+        '!node_modules',
+      );
+    }
+
     postBuildSteps.push({
       name: 'Upload artifact',
       if: noNewCommits,
       uses: 'actions/upload-artifact@v2.1.1',
       with: {
-        name: this.artifactsDirectory,
-        path: this.artifactsDirectory,
+        name: BUILD_ARTIFACT_NAME,
+        path: paths.join('\n'),
       },
     });
 

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -460,8 +460,11 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
+            !node_modules
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -476,8 +479,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)
@@ -502,8 +504,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Install Dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Create js artifact
@@ -532,8 +533,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Install Dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Create java artifact
@@ -563,8 +563,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Install Dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Create python artifact
@@ -5058,8 +5057,11 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
+            !node_modules
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -5074,8 +5076,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -125,8 +125,7 @@ Object {
       "name": "Download build artifacts",
       "uses": "actions/download-artifact@v2",
       "with": Object {
-        "name": "dist",
-        "path": "dist",
+        "name": "build-artifact",
       },
     },
     Object {
@@ -177,8 +176,7 @@ Object {
       "name": "Download build artifacts",
       "uses": "actions/download-artifact@v2",
       "with": Object {
-        "name": "dist",
-        "path": "dist",
+        "name": "build-artifact",
       },
     },
     Object {
@@ -224,8 +222,7 @@ Object {
       "name": "Download build artifacts",
       "uses": "actions/download-artifact@v2",
       "with": Object {
-        "name": "dist",
-        "path": "dist",
+        "name": "build-artifact",
       },
     },
     Object {
@@ -275,8 +272,7 @@ Object {
       "name": "Download build artifacts",
       "uses": "actions/download-artifact@v2",
       "with": Object {
-        "name": "dist",
-        "path": "dist",
+        "name": "build-artifact",
       },
     },
     Object {
@@ -324,8 +320,7 @@ Object {
       "name": "Download build artifacts",
       "uses": "actions/download-artifact@v2",
       "with": Object {
-        "name": "dist",
-        "path": "dist",
+        "name": "build-artifact",
       },
     },
     Object {
@@ -568,8 +563,11 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
+            !node_modules
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -584,8 +582,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)
@@ -610,8 +607,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Install Dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Create js artifact
@@ -639,8 +635,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Install Dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Create go artifact
@@ -697,8 +692,11 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
+            !node_modules
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -713,8 +711,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)
@@ -739,8 +736,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Install Dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Create js artifact
@@ -768,8 +764,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Install Dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Create go artifact

--- a/test/release/__snapshots__/release.test.ts.snap
+++ b/test/release/__snapshots__/release.test.ts.snap
@@ -79,8 +79,10 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -95,8 +97,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)
@@ -121,8 +122,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: npx -p jsii-release@latest jsii-release-npm
         env:
@@ -417,8 +417,10 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -433,8 +435,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)
@@ -459,8 +460,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: npx -p jsii-release@latest jsii-release-npm
         env:
@@ -755,8 +755,10 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -771,8 +773,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)
@@ -797,8 +798,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: npx -p jsii-release@latest jsii-release-npm
         env:
@@ -1097,8 +1097,10 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -1113,8 +1115,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)
@@ -1163,8 +1164,10 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -1179,8 +1182,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)
@@ -1229,8 +1231,10 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -1245,8 +1249,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)
@@ -1585,8 +1588,10 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -1601,8 +1606,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)
@@ -1630,8 +1634,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: npx -p jsii-release@latest jsii-release-pypi
         env:
@@ -1709,8 +1712,10 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -1725,8 +1730,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)
@@ -1754,8 +1758,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: npx -p jsii-release@latest jsii-release-pypi
         env:
@@ -2111,8 +2114,10 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -2127,8 +2132,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)
@@ -2367,8 +2371,10 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -2384,8 +2390,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)
@@ -2427,8 +2432,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: npx -p jsii-release@latest jsii-release-npm
         env:
@@ -2531,8 +2535,10 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -2547,8 +2553,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)
@@ -2574,8 +2579,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: npx -p jsii-release@latest jsii-release-npm
         env:
@@ -2827,8 +2831,10 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -2843,8 +2849,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)
@@ -3066,8 +3071,10 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -3082,8 +3089,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)
@@ -3320,8 +3326,10 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -3336,8 +3344,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)
@@ -3563,8 +3570,10 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -3579,8 +3588,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)
@@ -3608,8 +3616,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: npx -p jsii-release@latest jsii-release-golang
         env:
@@ -3634,8 +3641,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: npx -p jsii-release@latest jsii-release-maven
         env:
@@ -3658,8 +3664,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: npx -p jsii-release@latest jsii-release-npm
         env:
@@ -3682,8 +3687,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: npx -p jsii-release@latest jsii-release-nuget
         env:
@@ -3705,8 +3709,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: npx -p jsii-release@latest jsii-release-pypi
         env:
@@ -4010,8 +4013,10 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -4026,8 +4031,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)
@@ -4076,8 +4080,10 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -4092,8 +4098,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)
@@ -4420,8 +4425,10 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -4436,8 +4443,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)
@@ -4486,8 +4492,10 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -4502,8 +4510,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)
@@ -4552,8 +4559,10 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -4568,8 +4577,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)
@@ -4937,8 +4945,10 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -4953,8 +4963,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)
@@ -5233,8 +5242,10 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -5249,8 +5260,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)

--- a/test/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-project.test.ts.snap
@@ -161,8 +161,11 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
+            !node_modules
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -177,8 +180,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)

--- a/test/web/__snapshots__/react-project.test.ts.snap
+++ b/test/web/__snapshots__/react-project.test.ts.snap
@@ -151,8 +151,11 @@ jobs:
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
         uses: actions/upload-artifact@v2.1.1
         with:
-          name: dist
-          path: dist
+          name: build-artifact
+          path: |-
+            .
+            !.git
+            !node_modules
   release_github:
     name: Publish to GitHub Releases
     needs: release
@@ -167,8 +170,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:
-          name: dist
-          path: dist
+          name: build-artifact
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)


### PR DESCRIPTION
Same as https://github.com/projen/projen/pull/1384, but for the release workflow. 

Should free the release which is currently [failing](https://github.com/projen/projen/runs/4644112485?check_suite_focus=true):

```console
Run npx projen package:js
npx: installed 65 in 5.454s
Unknown command: package:js
Error: Process completed with exit code 1.
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.