### PR TITLE
chore: enable release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,11 +61,11 @@ jobs:
           name: build-artifact
           path: dist
       - name: Release
-        run: 'echo "DRY RUN: errout=$(mktemp); gh release create $(cat
-          dist/releasetag.txt) -R $GITHUB_REPOSITORY -F dist/changelog.md -t
-          $(cat dist/releasetag.txt) --target $GITHUB_REF 2> $errout && true;
-          exitcode=$?; if [ $exitcode -ne 0 ] && ! grep -q "Release.tag_name
-          already exists" $errout; then cat $errout; exit $exitcode; fi"'
+        run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
+          $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)
+          --target $GITHUB_REF 2> $errout && true; exitcode=$?; if [ $exitcode
+          -ne 0 ] && ! grep -q "Release.tag_name already exists" $errout; then
+          cat $errout; exit $exitcode; fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -111,7 +111,7 @@ jobs:
       - name: Collect js Artifact
         run: mv .repo/dist dist
       - name: Release
-        run: 'echo "DRY RUN: npx -p jsii-release@latest jsii-release-npm"'
+        run: npx -p jsii-release@latest jsii-release-npm
         env:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
@@ -160,7 +160,7 @@ jobs:
       - name: Collect java Artifact
         run: mv .repo/dist dist
       - name: Release
-        run: 'echo "DRY RUN: npx -p jsii-release@latest jsii-release-maven"'
+        run: npx -p jsii-release@latest jsii-release-maven
         env:
           MAVEN_ENDPOINT: https://s01.oss.sonatype.org
           MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
@@ -212,7 +212,7 @@ jobs:
       - name: Collect python Artifact
         run: mv .repo/dist dist
       - name: Release
-        run: 'echo "DRY RUN: npx -p jsii-release@latest jsii-release-pypi"'
+        run: npx -p jsii-release@latest jsii-release-pypi
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
@@ -259,7 +259,7 @@ jobs:
       - name: Collect go Artifact
         run: mv .repo/dist dist
       - name: Release
-        run: 'echo "DRY RUN: npx -p jsii-release@latest jsii-release-golang"'
+        run: npx -p jsii-release@latest jsii-release-golang
         env:
           GIT_USER_NAME: github-actions
           GIT_USER_EMAIL: github-actions@github.com

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -48,8 +48,6 @@ const project = new cdk.JsiiProject({
     'all-contributors-cli',
   ],
 
-  publishDryRun: true,
-
   projenDevDependency: false, // because I am projen
   releaseToNpm: true,
   minNodeVersion: '12.7.0',


### PR DESCRIPTION
Following https://github.com/projen/projen/pull/1408, I downloaded the build artifact and observed `package.json` indeed contains the correct future version:

```json
  ...
  "version": "0.46.9",
  ...
```

In addition, the publishing jobs successfully packaged all artifacts, the only way they could do that is by using this build artifact because the normal repository isn't available for them. 

This makes me confident enough the release should go through well. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.