### PR TITLE
fix(jsii): upgrade workflow no longer needs to run pacmak

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,13 +33,13 @@ jobs:
           directory: coverage
       - name: Check self-mutation
         id: self_mutation
-        run: git diff --exit-code || echo "::set-output
+        run: git diff --staged --exit-code || echo "::set-output
           name=self_mutation_happened::true"
       - if: ${{ steps.self_mutation.outputs.self_mutation_happened }}
         name: Create Patch
         run: |-
           git add .
-          git diff --patch --staged > .repo.patch
+          git diff --staged --patch > .repo.patch
       - if: ${{ steps.self_mutation.outputs.self_mutation_happened }}
         name: Upload patch
         uses: actions/upload-artifact@v2
@@ -73,7 +73,7 @@ jobs:
         run: '[ -s ${{ runner.temp }}/.repo.patch ] && git apply ${{ runner.temp
           }}/.repo.patch || echo "Empty patch. Skipping."'
       - name: Found diff after build (update your branch)
-        run: git diff --exit-code
+        run: git diff --staged --exit-code
   self-mutation:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -24,19 +24,15 @@ jobs:
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
         run: /bin/bash ./projen.bash upgrade
-      - name: Verify language bindings
-        run: /bin/bash ./projen.bash package-all
       - name: Create Patch
         run: |-
           git add .
-          git diff --patch --staged > .repo.patch
+          git diff --staged --patch > .repo.patch
       - name: Upload patch
         uses: actions/upload-artifact@v2
         with:
           name: .repo.patch
           path: .repo.patch
-    container:
-      image: jsii/superchain:1-buster-slim-node12
   pr:
     name: Create Pull Request
     needs: upgrade

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -287,7 +287,7 @@
           "spawn": "unbump"
         },
         {
-          "exec": "git diff --ignore-space-at-eol --exit-code"
+          "exec": "git diff --staged --ignore-space-at-eol --exit-code"
         }
       ]
     },

--- a/src/build/build-workflow.ts
+++ b/src/build/build-workflow.ts
@@ -235,7 +235,7 @@ export class BuildWorkflow extends Component {
         }),
         {
           name: 'Found diff after build (update your branch)',
-          run: 'git diff --exit-code',
+          run: 'git diff --staged --exit-code',
         },
       ],
     });
@@ -267,7 +267,7 @@ export class BuildWorkflow extends Component {
       {
         name: 'Check self-mutation',
         id: SELF_MUTATION_STEP,
-        run: `git diff --exit-code || echo "::set-output name=${SELF_MUTATION_HAPPENED_OUTPUT}::true"`,
+        run: `git diff --staged --exit-code || echo "::set-output name=${SELF_MUTATION_HAPPENED_OUTPUT}::true"`,
       },
 
       ...WorkflowActions.createUploadGitPatch({

--- a/src/cdk/consts.ts
+++ b/src/cdk/consts.ts
@@ -1,4 +1,3 @@
-import * as semver from 'semver';
 import { Tools } from '../github/workflows-model';
 
 export type JsiiPacmakTarget = 'js' | 'go' | 'java' | 'python' | 'dotnet';
@@ -13,29 +12,3 @@ export const JSII_TOOLCHAIN: Record<JsiiPacmakTarget, Tools> = {
   go: { go: { version: '^1.16.0' } },
   dotnet: { dotnet: { version: '3.x' } },
 };
-
-const SUPERCHAIN_IMAGE = 'jsii/superchain:1-buster-slim';
-const SUPERCHAIN_NODE_VERSIONS = [12, 14, 16]; // supported jsii/superchain image tags: `1-buster-slim-nodeNN`
-
-/**
- * Determines the jsii/superchain image to use based on the minimum node
- * version.
- *
- * @param minNodeVersion The minimum node version of the project. If not
- * specified, v14.17.4 is used.
- */
-export function determineSuperchainImage(minNodeVersion?: string): string {
-  // the default image (`jsii/superchain:1-buster-slim`) will include the
-  // minimum supported node version of JSII (as of this writing it is 12.x).
-  if (!minNodeVersion) {
-    return SUPERCHAIN_IMAGE;
-  }
-
-  const major = semver.major(minNodeVersion);
-
-  if (!SUPERCHAIN_NODE_VERSIONS.includes(major)) {
-    throw new Error(`No jsii/superchain image available for node ${major}.x. Supported node versions: ${SUPERCHAIN_NODE_VERSIONS.map(m => `${m}.x`).join(',')}`);
-  }
-
-  return `${SUPERCHAIN_IMAGE}-node${major}`;
-}

--- a/src/cdk/jsii-project.ts
+++ b/src/cdk/jsii-project.ts
@@ -2,7 +2,7 @@ import { Task } from '..';
 import { Eslint } from '../javascript';
 import { GoPublishOptions, MavenPublishOptions, PyPiPublishOptions, NugetPublishOptions, CommonPublishOptions } from '../release';
 import { TypeScriptProject, TypeScriptProjectOptions } from '../typescript';
-import { determineSuperchainImage, JsiiPacmakTarget, JSII_TOOLCHAIN } from './consts';
+import { JsiiPacmakTarget, JSII_TOOLCHAIN } from './consts';
 import { JsiiDocgen } from './jsii-docgen';
 
 const EMAIL_REGEX = /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/;
@@ -308,25 +308,6 @@ export class JsiiProject extends TypeScriptProject {
     if (this.npmignore) {
       this.npmignore.readonly = false;
     }
-
-    // run `jsii-pacmak` at the end of the upgrade workflow because at the moment
-    // we don't have an ability to leverage the multiple build jobs in the upgrade workflow
-    // and we want to preserve the behavior of the old upgrade workflow.
-    if (this.upgradeWorkflow) {
-      this.upgradeWorkflow.containerOptions = { image: this.superchainImage };
-      this.upgradeWorkflow.addPostBuildSteps({
-        name: 'Verify language bindings',
-        run: this.runTaskCommand(this.packageAllTask),
-      });
-    }
-  }
-
-  /**
-   * Returns the jsii/superchain image that is compatible with the minimum node
-   * version of this project.
-   */
-  private get superchainImage() {
-    return determineSuperchainImage(this.minNodeVersion);
   }
 
   /**

--- a/src/github/workflow-actions.ts
+++ b/src/github/workflow-actions.ts
@@ -22,7 +22,7 @@ export class WorkflowActions {
         name: 'Create Patch',
         run: [
           'git add .',
-          `git diff --patch --staged > ${GIT_PATCH_FILE}`,
+          `git diff --staged --patch > ${GIT_PATCH_FILE}`,
         ].join('\n'),
       },
       {

--- a/src/release/release.ts
+++ b/src/release/release.ts
@@ -457,7 +457,7 @@ export class Release extends Component {
 
     // anti-tamper check (fails if there were changes to committed files)
     // this will identify any non-committed files generated during build (e.g. test snapshots)
-    releaseTask.exec('git diff --ignore-space-at-eol --exit-code');
+    releaseTask.exec('git diff --staged --ignore-space-at-eol --exit-code');
 
     const postBuildSteps = [...this.postBuildSteps];
 


### PR DESCRIPTION
Now that the upgrade workflow can trigger a proper build when the pull request is created, we no longer need to run pacmak.

Additionally, add "--staged" when doing `git diff` for tamper-checks as a follow up on https://github.com/projen/projen/pull/1383#discussion_r776334094

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.