### PR TITLE
Update README to be clear that git v2.28 or later is needed (to support git init -b) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ $ npx projen new PROJECT-TYPE
 ...
 ```
 
+NOTE:   If creating a new project fails while doing "git init -b" you probably skipped
+the "git init" step.  *projen* will do that for you but requires that you have at least 
+git version 2.28 installed in order for "git init -b <branch>" to be supported. 
+
 Currently supported project types (use `npx projen new` without a type for a
 list):
 


### PR DESCRIPTION
I stupidly missed the git init step on an Ubuntu 20.10 EC2 instance (quite a common instance type) and was confused when git init -b failed.  Updating the readme to hopefully help someone else.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.