### PR TITLE
fix(build): build should fail if mutations were found

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,9 +43,11 @@ jobs:
         with:
           name: .repo.patch
           path: .repo.patch
+      - name: Fail build on mutation
+        if: ${{ steps.self_mutation.outputs.self_mutation_happened }}
+        run: exit 1
       - name: Upload artifact
         uses: actions/upload-artifact@v2.1.1
-        if: ${{ ! steps.self_mutation.outputs.self_mutation_happened }}
         with:
           name: build-artifact
           path: dist
@@ -53,8 +55,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions: {}
-    if: ${{ needs.build.outputs.self_mutation_happened &&
-      github.event.pull_request.head.repo.full_name != github.repository }}
+    if: always() && needs.build.outputs.self_mutation_happened &&
+      github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -76,8 +78,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: ${{ needs.build.outputs.self_mutation_happened &&
-      !(github.event.pull_request.head.repo.full_name != github.repository) }}
+    if: always() && needs.build.outputs.self_mutation_happened &&
+      !(github.event.pull_request.head.repo.full_name != github.repository)
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -106,7 +108,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions: {}
-    if: ${{ ! needs.build.outputs.self_mutation_happened }}
+    if: "! needs.build.outputs.self_mutation_happened"
     steps:
       - uses: actions/setup-node@v2
         with:
@@ -128,7 +130,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions: {}
-    if: ${{ ! needs.build.outputs.self_mutation_happened }}
+    if: "! needs.build.outputs.self_mutation_happened"
     steps:
       - uses: actions/setup-java@v2
         with:
@@ -154,7 +156,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions: {}
-    if: ${{ ! needs.build.outputs.self_mutation_happened }}
+    if: "! needs.build.outputs.self_mutation_happened"
     steps:
       - uses: actions/setup-node@v2
         with:
@@ -179,7 +181,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions: {}
-    if: ${{ ! needs.build.outputs.self_mutation_happened }}
+    if: "! needs.build.outputs.self_mutation_happened"
     steps:
       - uses: actions/setup-node@v2
         with:

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -297,9 +297,11 @@ jobs:
         with:
           name: .repo.patch
           path: .repo.patch
+      - name: Fail build on mutation
+        if: \${{ steps.self_mutation.outputs.self_mutation_happened }}
+        run: exit 1
       - name: Upload artifact
         uses: actions/upload-artifact@v2.1.1
-        if: \${{ ! steps.self_mutation.outputs.self_mutation_happened }}
         with:
           name: build-artifact
           path: dist
@@ -307,8 +309,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions: {}
-    if: \${{ needs.build.outputs.self_mutation_happened &&
-      github.event.pull_request.head.repo.full_name != github.repository }}
+    if: always() && needs.build.outputs.self_mutation_happened &&
+      github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -330,8 +332,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: \${{ needs.build.outputs.self_mutation_happened &&
-      !(github.event.pull_request.head.repo.full_name != github.repository) }}
+    if: always() && needs.build.outputs.self_mutation_happened &&
+      !(github.event.pull_request.head.repo.full_name != github.repository)
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -360,7 +362,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions: {}
-    if: \${{ ! needs.build.outputs.self_mutation_happened }}
+    if: \\"! needs.build.outputs.self_mutation_happened\\"
     steps:
       - uses: actions/setup-node@v2
         with:
@@ -382,7 +384,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions: {}
-    if: \${{ ! needs.build.outputs.self_mutation_happened }}
+    if: \\"! needs.build.outputs.self_mutation_happened\\"
     steps:
       - uses: actions/setup-java@v2
         with:
@@ -408,7 +410,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions: {}
-    if: \${{ ! needs.build.outputs.self_mutation_happened }}
+    if: \\"! needs.build.outputs.self_mutation_happened\\"
     steps:
       - uses: actions/setup-node@v2
         with:
@@ -4989,12 +4991,15 @@ jobs:
         with:
           name: .repo.patch
           path: .repo.patch
+      - name: Fail build on mutation
+        if: \${{ steps.self_mutation.outputs.self_mutation_happened }}
+        run: exit 1
   anti-tamper:
     needs: build
     runs-on: ubuntu-latest
     permissions: {}
-    if: \${{ needs.build.outputs.self_mutation_happened &&
-      github.event.pull_request.head.repo.full_name != github.repository }}
+    if: always() && needs.build.outputs.self_mutation_happened &&
+      github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -5016,8 +5021,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: \${{ needs.build.outputs.self_mutation_happened &&
-      !(github.event.pull_request.head.repo.full_name != github.repository) }}
+    if: always() && needs.build.outputs.self_mutation_happened &&
+      !(github.event.pull_request.head.repo.full_name != github.repository)
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/test/__snapshots__/node-project.test.ts.snap
+++ b/test/__snapshots__/node-project.test.ts.snap
@@ -102,12 +102,17 @@ git diff --staged --patch --exit-code > .repo.patch || echo \\"::set-output name
       "path": ".repo.patch",
     },
   },
+  Object {
+    "if": "\${{ steps.self_mutation.outputs.self_mutation_happened }}",
+    "name": "Fail build on mutation",
+    "run": "exit 1",
+  },
 ]
 `;
 
 exports[`enable anti-tamper 2`] = `
 Object {
-  "if": "\${{ needs.build.outputs.self_mutation_happened }}",
+  "if": "always() && needs.build.outputs.self_mutation_happened",
   "needs": "build",
   "permissions": Object {},
   "runs-on": "ubuntu-latest",
@@ -172,6 +177,11 @@ git diff --staged --patch --exit-code > .repo.patch || echo \\"::set-output name
       "name": ".repo.patch",
       "path": ".repo.patch",
     },
+  },
+  Object {
+    "if": "\${{ steps.self_mutation.outputs.self_mutation_happened }}",
+    "name": "Fail build on mutation",
+    "run": "exit 1",
   },
 ]
 `;

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -390,7 +390,7 @@ Object {
 
 exports[`language bindings snapshot dotnet 1`] = `
 Object {
-  "if": "\${{ ! needs.build.outputs.self_mutation_happened }}",
+  "if": "! needs.build.outputs.self_mutation_happened",
   "needs": "build",
   "permissions": Object {},
   "runs-on": "ubuntu-latest",
@@ -437,7 +437,7 @@ Object {
 
 exports[`language bindings snapshot go 1`] = `
 Object {
-  "if": "\${{ ! needs.build.outputs.self_mutation_happened }}",
+  "if": "! needs.build.outputs.self_mutation_happened",
   "needs": "build",
   "permissions": Object {},
   "runs-on": "ubuntu-latest",
@@ -484,7 +484,7 @@ Object {
 
 exports[`language bindings snapshot java 1`] = `
 Object {
-  "if": "\${{ ! needs.build.outputs.self_mutation_happened }}",
+  "if": "! needs.build.outputs.self_mutation_happened",
   "needs": "build",
   "permissions": Object {},
   "runs-on": "ubuntu-latest",
@@ -532,7 +532,7 @@ Object {
 
 exports[`language bindings snapshot js 1`] = `
 Object {
-  "if": "\${{ ! needs.build.outputs.self_mutation_happened }}",
+  "if": "! needs.build.outputs.self_mutation_happened",
   "needs": "build",
   "permissions": Object {},
   "runs-on": "ubuntu-latest",
@@ -573,7 +573,7 @@ Object {
 
 exports[`language bindings snapshot python 1`] = `
 Object {
-  "if": "\${{ ! needs.build.outputs.self_mutation_happened }}",
+  "if": "! needs.build.outputs.self_mutation_happened",
   "needs": "build",
   "permissions": Object {},
   "runs-on": "ubuntu-latest",

--- a/test/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-project.test.ts.snap
@@ -65,12 +65,15 @@ jobs:
         with:
           name: .repo.patch
           path: .repo.patch
+      - name: Fail build on mutation
+        if: \${{ steps.self_mutation.outputs.self_mutation_happened }}
+        run: exit 1
   anti-tamper:
     needs: build
     runs-on: ubuntu-latest
     permissions: {}
-    if: \${{ needs.build.outputs.self_mutation_happened &&
-      github.event.pull_request.head.repo.full_name != github.repository }}
+    if: always() && needs.build.outputs.self_mutation_happened &&
+      github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -92,8 +95,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: \${{ needs.build.outputs.self_mutation_happened &&
-      !(github.event.pull_request.head.repo.full_name != github.repository) }}
+    if: always() && needs.build.outputs.self_mutation_happened &&
+      !(github.event.pull_request.head.repo.full_name != github.repository)
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -66,12 +66,15 @@ jobs:
         with:
           name: .repo.patch
           path: .repo.patch
+      - name: Fail build on mutation
+        if: \${{ steps.self_mutation.outputs.self_mutation_happened }}
+        run: exit 1
   anti-tamper:
     needs: build
     runs-on: ubuntu-latest
     permissions: {}
-    if: \${{ needs.build.outputs.self_mutation_happened &&
-      github.event.pull_request.head.repo.full_name != github.repository }}
+    if: always() && needs.build.outputs.self_mutation_happened &&
+      github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -93,8 +96,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: \${{ needs.build.outputs.self_mutation_happened &&
-      !(github.event.pull_request.head.repo.full_name != github.repository) }}
+    if: always() && needs.build.outputs.self_mutation_happened &&
+      !(github.event.pull_request.head.repo.full_name != github.repository)
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/test/web/__snapshots__/react-project.test.ts.snap
+++ b/test/web/__snapshots__/react-project.test.ts.snap
@@ -59,12 +59,15 @@ jobs:
         with:
           name: .repo.patch
           path: .repo.patch
+      - name: Fail build on mutation
+        if: \${{ steps.self_mutation.outputs.self_mutation_happened }}
+        run: exit 1
   anti-tamper:
     needs: build
     runs-on: ubuntu-latest
     permissions: {}
-    if: \${{ needs.build.outputs.self_mutation_happened &&
-      github.event.pull_request.head.repo.full_name != github.repository }}
+    if: always() && needs.build.outputs.self_mutation_happened &&
+      github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -86,8 +89,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: \${{ needs.build.outputs.self_mutation_happened &&
-      !(github.event.pull_request.head.repo.full_name != github.repository) }}
+    if: always() && needs.build.outputs.self_mutation_happened &&
+      !(github.event.pull_request.head.repo.full_name != github.repository)
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/test/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/react-ts-project.test.ts.snap
@@ -61,12 +61,15 @@ jobs:
         with:
           name: .repo.patch
           path: .repo.patch
+      - name: Fail build on mutation
+        if: \${{ steps.self_mutation.outputs.self_mutation_happened }}
+        run: exit 1
   anti-tamper:
     needs: build
     runs-on: ubuntu-latest
     permissions: {}
-    if: \${{ needs.build.outputs.self_mutation_happened &&
-      github.event.pull_request.head.repo.full_name != github.repository }}
+    if: always() && needs.build.outputs.self_mutation_happened &&
+      github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -88,8 +91,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: \${{ needs.build.outputs.self_mutation_happened &&
-      !(github.event.pull_request.head.repo.full_name != github.repository) }}
+    if: always() && needs.build.outputs.self_mutation_happened &&
+      !(github.event.pull_request.head.repo.full_name != github.repository)
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Fixes #1423 and fixes #1422 by failing the build job when a mutation was found and allowing the `self-mutation` and the `anti-tamper` jobs to execute even if the `build` job failed.

Here is an [example](https://github.com/projen/projen/runs/4664625019).

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.