### PR TITLE
chore: improve mutation error message

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,8 +45,12 @@ jobs:
           path: .repo.patch
       - name: Fail build on mutation
         if: steps.self_mutation.outputs.self_mutation_happened
-        run: |-
-          echo "::error::Mutation detected, please update your branch."
+        run: >-
+          echo "::error::Files were changed during build (see build log). If
+          this was triggered from a fork, you will need to update your branch."
+
+          cat .repo.patch
+
           exit 1
       - name: Upload artifact
         uses: actions/upload-artifact@v2.1.1

--- a/src/build/build-workflow.ts
+++ b/src/build/build-workflow.ts
@@ -242,7 +242,7 @@ export class BuildWorkflow extends Component {
       ...WorkflowActions.createUploadGitPatch({
         stepId: SELF_MUTATION_STEP,
         outputName: SELF_MUTATION_HAPPENED_OUTPUT,
-        failOnMutation: true,
+        mutationError: 'Files were changed during build (see build log). If this was triggered from a fork, you will need to update your branch.',
       }),
 
       // upload the build artifact only if we have post-build jobs (otherwise, there's no point)

--- a/src/github/workflow-actions.ts
+++ b/src/github/workflow-actions.ts
@@ -18,7 +18,6 @@ export class WorkflowActions {
    * @returns Job steps
    */
   public static createUploadGitPatch(options: CreateUploadGitPatchOptions): JobStep[] {
-
     const MUTATIONS_FOUND = `steps.${options.stepId}.outputs.${options.outputName}`;
 
     const steps: JobStep[] = [
@@ -38,12 +37,13 @@ export class WorkflowActions {
       },
     ];
 
-    if (options.failOnMutation ?? false) {
+    if (options.mutationError) {
       steps.push({
         name: 'Fail build on mutation',
         if: MUTATIONS_FOUND,
         run: [
-          'echo "::error::Mutation detected, please update your branch."',
+          `echo "::error::${options.mutationError}"`,
+          `cat ${GIT_PATCH_FILE}`,
           'exit 1',
         ].join('\n'),
       });
@@ -139,8 +139,8 @@ export interface CreateUploadGitPatchOptions {
   readonly outputName: string;
 
   /**
-   * Fail if a mutation was found.
-   * @default false
+   * Fail if a mutation was found and print this error message.
+   * @default - do not fail upon mutation
    */
-  readonly failOnMutation?: boolean;
+  readonly mutationError?: string;
 }

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -299,8 +299,12 @@ jobs:
           path: .repo.patch
       - name: Fail build on mutation
         if: steps.self_mutation.outputs.self_mutation_happened
-        run: |-
-          echo \\"::error::Mutation detected, please update your branch.\\"
+        run: >-
+          echo \\"::error::Files were changed during build (see build log). If
+          this was triggered from a fork, you will need to update your branch.\\"
+
+          cat .repo.patch
+
           exit 1
       - name: Upload artifact
         uses: actions/upload-artifact@v2.1.1
@@ -4973,8 +4977,12 @@ jobs:
           path: .repo.patch
       - name: Fail build on mutation
         if: steps.self_mutation.outputs.self_mutation_happened
-        run: |-
-          echo \\"::error::Mutation detected, please update your branch.\\"
+        run: >-
+          echo \\"::error::Files were changed during build (see build log). If
+          this was triggered from a fork, you will need to update your branch.\\"
+
+          cat .repo.patch
+
           exit 1
   self-mutation:
     needs: build

--- a/test/__snapshots__/node-project.test.ts.snap
+++ b/test/__snapshots__/node-project.test.ts.snap
@@ -105,7 +105,8 @@ git diff --staged --patch --exit-code > .repo.patch || echo \\"::set-output name
   Object {
     "if": "steps.self_mutation.outputs.self_mutation_happened",
     "name": "Fail build on mutation",
-    "run": "echo \\"::error::Mutation detected, please update your branch.\\"
+    "run": "echo \\"::error::Files were changed during build (see build log). If this was triggered from a fork, you will need to update your branch.\\"
+cat .repo.patch
 exit 1",
   },
 ]

--- a/test/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-project.test.ts.snap
@@ -67,8 +67,12 @@ jobs:
           path: .repo.patch
       - name: Fail build on mutation
         if: steps.self_mutation.outputs.self_mutation_happened
-        run: |-
-          echo \\"::error::Mutation detected, please update your branch.\\"
+        run: >-
+          echo \\"::error::Files were changed during build (see build log). If
+          this was triggered from a fork, you will need to update your branch.\\"
+
+          cat .repo.patch
+
           exit 1
   self-mutation:
     needs: build

--- a/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -68,8 +68,12 @@ jobs:
           path: .repo.patch
       - name: Fail build on mutation
         if: steps.self_mutation.outputs.self_mutation_happened
-        run: |-
-          echo \\"::error::Mutation detected, please update your branch.\\"
+        run: >-
+          echo \\"::error::Files were changed during build (see build log). If
+          this was triggered from a fork, you will need to update your branch.\\"
+
+          cat .repo.patch
+
           exit 1
   self-mutation:
     needs: build

--- a/test/web/__snapshots__/react-project.test.ts.snap
+++ b/test/web/__snapshots__/react-project.test.ts.snap
@@ -61,8 +61,12 @@ jobs:
           path: .repo.patch
       - name: Fail build on mutation
         if: steps.self_mutation.outputs.self_mutation_happened
-        run: |-
-          echo \\"::error::Mutation detected, please update your branch.\\"
+        run: >-
+          echo \\"::error::Files were changed during build (see build log). If
+          this was triggered from a fork, you will need to update your branch.\\"
+
+          cat .repo.patch
+
           exit 1
   self-mutation:
     needs: build

--- a/test/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/react-ts-project.test.ts.snap
@@ -63,8 +63,12 @@ jobs:
           path: .repo.patch
       - name: Fail build on mutation
         if: steps.self_mutation.outputs.self_mutation_happened
-        run: |-
-          echo \\"::error::Mutation detected, please update your branch.\\"
+        run: >-
+          echo \\"::error::Files were changed during build (see build log). If
+          this was triggered from a fork, you will need to update your branch.\\"
+
+          cat .repo.patch
+
           exit 1
   self-mutation:
     needs: build


### PR DESCRIPTION
Improve the error displayed when mutation is found during build, to indicate to forks that they need to update their branch.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.