### PR TITLE
fix(jsii): github release not created

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,10 @@ jobs:
         with:
           name: build-artifact
           path: dist
+      - name: Prepare Repository
+        run: mv dist .repo
+      - name: Collect GitHub Metadata
+        run: mv .repo/dist dist
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)

--- a/API.md
+++ b/API.md
@@ -7816,6 +7816,28 @@ Name | Type | Description
 ### Methods
 
 
+#### addGitHubPrePublishingSteps(...steps)🔹 <a id="projen-release-publisher-addgithubprepublishingsteps"></a>
+
+Adds pre publishing steps for the GitHub release job.
+
+```ts
+addGitHubPrePublishingSteps(...steps: JobStep[]): void
+```
+
+* **steps** (<code>[github.workflows.JobStep](#projen-github-workflows-jobstep)</code>)  The steps.
+  * **continueOnError** (<code>boolean</code>)  Prevents a job from failing when a step fails. __*Optional*__
+  * **env** (<code>Map<string, string></code>)  Sets environment variables for steps to use in the runner environment. __*Optional*__
+  * **id** (<code>string</code>)  A unique identifier for the step. __*Optional*__
+  * **if** (<code>string</code>)  You can use the if conditional to prevent a job from running unless a condition is met. __*Optional*__
+  * **name** (<code>string</code>)  A name for your step to display on GitHub. __*Optional*__
+  * **run** (<code>string</code>)  Runs command-line programs using the operating system's shell. __*Optional*__
+  * **timeoutMinutes** (<code>number</code>)  The maximum number of minutes to run the step before killing the process. __*Optional*__
+  * **uses** (<code>string</code>)  Selects an action to run as part of a step in your job. __*Optional*__
+  * **with** (<code>Map<string, any></code>)  A map of the input parameters defined by the action. __*Optional*__
+
+
+
+
 #### publishToGit(options)🔹 <a id="projen-release-publisher-publishtogit"></a>
 
 Publish to git.

--- a/src/release/publisher.ts
+++ b/src/release/publisher.ts
@@ -545,7 +545,7 @@ export interface CommonPublishOptions {
    * These steps are executed after `dist/` has been populated with the build
    * output.
    *
-   * Note that this will override steps added via `addGitHubPrePublishingSteps`.
+   * Note that when using this in `publishToGitHubReleases` this will override steps added via `addGitHubPrePublishingSteps`.
    */
   readonly prePublishSteps?: JobStep[];
 

--- a/src/release/publisher.ts
+++ b/src/release/publisher.ts
@@ -104,6 +104,8 @@ export class Publisher extends Component {
   // functions that create jobs associated with a specific branch
   private readonly _jobFactories: PublishJobFactory[] = [];
 
+  private readonly _gitHubPrePublishing: JobStep[] = [];
+
   private readonly dryRun: boolean;
 
   constructor(project: Project, options: PublisherOptions) {
@@ -140,6 +142,15 @@ export class Publisher extends Component {
     }
 
     return jobs;
+  }
+
+  /**
+   * Adds pre publishing steps for the GitHub release job.
+   *
+   * @param steps The steps.
+   */
+  public addGitHubPrePublishingSteps(...steps: JobStep[]) {
+    this._gitHubPrePublishing.push(...steps);
   }
 
   /**
@@ -214,7 +225,7 @@ export class Publisher extends Component {
       return {
         name: 'github',
         registryName: 'GitHub Releases',
-        prePublishSteps: options.prePublishSteps ?? [],
+        prePublishSteps: options.prePublishSteps ?? this._gitHubPrePublishing,
         publishTools: options.publishTools,
         permissions: {
           contents: JobPermission.WRITE,
@@ -533,6 +544,8 @@ export interface CommonPublishOptions {
    *
    * These steps are executed after `dist/` has been populated with the build
    * output.
+   *
+   * Note that this will override steps added via `addGitHubPrePublishingSteps`.
    */
   readonly prePublishSteps?: JobStep[];
 

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -505,6 +505,10 @@ jobs:
         with:
           name: build-artifact
           path: dist
+      - name: Prepare Repository
+        run: mv dist .repo
+      - name: Collect GitHub Metadata
+        run: mv .repo/dist dist
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -675,6 +675,10 @@ jobs:
         with:
           name: build-artifact
           path: dist
+      - name: Prepare Repository
+        run: mv dist .repo
+      - name: Collect GitHub Metadata
+        run: mv .repo/dist dist
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)
@@ -811,6 +815,10 @@ jobs:
         with:
           name: build-artifact
           path: dist
+      - name: Prepare Repository
+        run: mv dist .repo
+      - name: Collect GitHub Metadata
+        run: mv .repo/dist dist
       - name: Release
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R
           $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt)


### PR DESCRIPTION
Introduce a way to configure github pre-publishing steps so that jsii projects can properly prepare the working directory for the expected paths of the release job.

Fixes https://github.com/projen/projen/issues/1431

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.