### PR TITLE
feat: make cdktf construct dependencies settable

### DIFF
--- a/API.md
+++ b/API.md
@@ -4999,6 +4999,7 @@ new cdktf.ConstructLibraryCdktf(options: ConstructLibraryCdktfOptions)
   * **rootdir** (<code>string</code>)  *No description* __*Default*__: "."
   * **catalog** (<code>[cdk.Catalog](#projen-cdk-catalog)</code>)  Libraries will be picked up by the construct catalog when they are published to npm as jsii modules and will be published under:. __*Default*__: new version will be announced
   * **cdktfVersion** (<code>string</code>)  Minimum target version this library is tested against. 
+  * **constructsVersion** (<code>string</code>)  Construct version to use. __*Default*__: "^10.0.12"
 
 
 
@@ -12499,6 +12500,7 @@ Name | Type | Description
 **codeCovTokenSecret**?🔹 | <code>string</code> | Define the secret name for a specified https://codecov.io/ token A secret is required to send coverage for private repositories.<br/>__*Default*__: if this option is not specified, only public repositories are supported
 **compat**?🔹 | <code>boolean</code> | Automatically run API compatibility test against the latest version published to npm after compilation.<br/>__*Default*__: false
 **compatIgnore**?🔹 | <code>string</code> | Name of the ignore file for API compatibility tests.<br/>__*Default*__: ".compatignore"
+**constructsVersion**?🔹 | <code>string</code> | Construct version to use.<br/>__*Default*__: "^10.0.12"
 **copyrightOwner**?🔹 | <code>string</code> | License copyright owner.<br/>__*Default*__: defaults to the value of authorName or "" if `authorName` is undefined.
 **copyrightPeriod**?🔹 | <code>string</code> | The copyright years to put in the LICENSE file.<br/>__*Default*__: current year
 **dependabot**?🔹 | <code>boolean</code> | Use dependabot to handle dependency upgrades.<br/>__*Default*__: false

--- a/src/cdktf/cdktf-construct.ts
+++ b/src/cdktf/cdktf-construct.ts
@@ -1,12 +1,19 @@
+import * as semver from "semver";
 import { ConstructLibrary, ConstructLibraryOptions } from "../cdk";
 
 export interface ConstructLibraryCdktfOptions extends ConstructLibraryOptions {
   /**
    * Minimum target version this library is tested against.
-   * @default "0.4.0"
+   * @default "^0.8.3"
    * @featured
    */
   readonly cdktfVersion: string;
+
+  /**
+   * Construct version to use
+   * @default "^10.0.12"
+   */
+  readonly constructsVersion?: string;
 }
 
 /**
@@ -26,8 +33,20 @@ export class ConstructLibraryCdktf extends ConstructLibrary {
       throw new Error("Required field cdktfVersion is not specified.");
     }
 
-    const ver = options.cdktfVersion;
+    function getDefaultConstructVersion() {
+      const semverCDKTFVersion = semver.coerce(options.cdktfVersion);
+      if (semverCDKTFVersion && semver.lte(semverCDKTFVersion, "0.5.0")) {
+        return "^3.0.0";
+      }
 
-    this.addPeerDeps("constructs@^10", `cdktf@^${ver}`);
+      return "^10.0.12";
+    }
+
+    const ver = options.cdktfVersion;
+    const constructVersion =
+      options.constructsVersion ?? getDefaultConstructVersion();
+
+    this.addPeerDeps(`constructs@${constructVersion}`, `cdktf@${ver}`);
+    this.addKeywords("cdktf");
   }
 }

--- a/test/__snapshots__/inventory.test.ts.snap
+++ b/test/__snapshots__/inventory.test.ts.snap
@@ -11848,7 +11848,7 @@ Array [
         "switch": "catalog",
       },
       Object {
-        "default": "\\"0.4.0\\"",
+        "default": "\\"^0.8.3\\"",
         "docs": "Minimum target version this library is tested against.",
         "featured": true,
         "fullType": Object {
@@ -11966,6 +11966,23 @@ Array [
         ],
         "simpleType": "string",
         "switch": "compat-ignore",
+      },
+      Object {
+        "default": "\\"^10.0.12\\"",
+        "docs": "Construct version to use.",
+        "featured": false,
+        "fullType": Object {
+          "primitive": "string",
+        },
+        "jsonLike": true,
+        "name": "constructsVersion",
+        "optional": true,
+        "parent": "ConstructLibraryCdktfOptions",
+        "path": Array [
+          "constructsVersion",
+        ],
+        "simpleType": "string",
+        "switch": "constructs-version",
       },
       Object {
         "default": "- defaults to the value of authorName or \\"\\" if \`authorName\` is undefined.",

--- a/test/cdktf-construct.test.ts
+++ b/test/cdktf-construct.test.ts
@@ -14,9 +14,29 @@ describe("constructs dependency selection", () => {
     const snapshot = synthSnapshot(project);
 
     // THEN
-    expect(snapshot["package.json"]?.peerDependencies?.cdktf).toBe("^0.99");
+    expect(snapshot["package.json"]?.peerDependencies?.cdktf).toBe("0.99");
     expect(snapshot["package.json"]?.devDependencies?.cdktf).toBe("0.99.0");
     expect(snapshot["package.json"]?.dependencies?.cdktf).toBeUndefined();
+  });
+
+  test("user-selected constructs version", () => {
+    // GIVEN
+    const project = new TestProject({
+      cdktfVersion: "0.99",
+      constructsVersion: "10.0.1",
+    });
+
+    // WHEN
+    const snapshot = synthSnapshot(project);
+
+    // THEN
+    expect(snapshot["package.json"]?.peerDependencies?.constructs).toBe(
+      "10.0.1"
+    );
+    expect(snapshot["package.json"]?.devDependencies?.constructs).toBe(
+      "10.0.1"
+    );
+    expect(snapshot["package.json"]?.dependencies?.constructs).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
The smart default is a goodie to make life easier, but the main part is making it easy to override the constructs version

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.