### PR TITLE
feat: allow build workflow github runner to be customised

### DIFF
--- a/API.md
+++ b/API.md
@@ -4019,6 +4019,7 @@ new build.BuildWorkflow(project: Project, options: BuildWorkflowOptions)
   * **mutableBuild** (<code>boolean</code>)  Automatically update files modified during builds to pull-request branches. __*Default*__: true
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build. __*Default*__: []
   * **preBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute before the build. __*Default*__: []
+  * **runsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
 
 
 
@@ -4084,6 +4085,7 @@ addPostBuildJobCommands(id: string, commands: Array<string>, options?: AddPostBu
 * **options** (<code>[build.AddPostBuildJobCommandsOptions](#projen-build-addpostbuildjobcommandsoptions)</code>)  Specify tools and other options.
   * **checkoutRepo** (<code>boolean</code>)  Check out the repository at the pull request branch before commands are run. __*Default*__: false
   * **installDeps** (<code>boolean</code>)  Install project dependencies before running commands. `checkoutRepo` must also be set to true. __*Default*__: false
+  * **runsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
   * **tools** (<code>[github.workflows.Tools](#projen-github-workflows-tools)</code>)  Tools that should be installed before the commands are run. __*Optional*__
 
 
@@ -4106,6 +4108,7 @@ addPostBuildJobTask(task: Task, options: AddPostBuildJobTaskOptions): void
 
 * **task** (<code>[Task](#projen-task)</code>)  *No description*
 * **options** (<code>[build.AddPostBuildJobTaskOptions](#projen-build-addpostbuildjobtaskoptions)</code>)  Specify tools and other options.
+  * **runsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
   * **tools** (<code>[github.workflows.Tools](#projen-github-workflows-tools)</code>)  Tools that should be installed before the task is run. __*Optional*__
 
 
@@ -11731,6 +11734,7 @@ Name | Type | Description
 -----|------|-------------
 **checkoutRepo**?🔹 | <code>boolean</code> | Check out the repository at the pull request branch before commands are run.<br/>__*Default*__: false
 **installDeps**?🔹 | <code>boolean</code> | Install project dependencies before running commands. `checkoutRepo` must also be set to true.<br/>__*Default*__: false
+**runsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 **tools**?🔹 | <code>[github.workflows.Tools](#projen-github-workflows-tools)</code> | Tools that should be installed before the commands are run.<br/>__*Optional*__
 
 
@@ -11744,6 +11748,7 @@ Options for `BuildWorkflow.addPostBuildJobTask`.
 
 Name | Type | Description 
 -----|------|-------------
+**runsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 **tools**?🔹 | <code>[github.workflows.Tools](#projen-github-workflows-tools)</code> | Tools that should be installed before the task is run.<br/>__*Optional*__
 
 
@@ -11765,6 +11770,7 @@ Name | Type | Description
 **mutableBuild**?🔹 | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **postBuildSteps**?🔹 | <code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code> | Steps to execute after build.<br/>__*Default*__: []
 **preBuildSteps**?🔹 | <code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code> | Steps to execute before the build.<br/>__*Default*__: []
+**runsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 
 
 

--- a/src/build/build-workflow.ts
+++ b/src/build/build-workflow.ts
@@ -76,6 +76,12 @@ export interface BuildWorkflowOptions {
    * @default {}
    */
   readonly env?: { [key: string]: string };
+
+  /**
+   * Github Runner selection labels
+   * @default ["ubuntu-latest"]
+   */
+  readonly runsOn?: string[];
 }
 
 export class BuildWorkflow extends Component {
@@ -86,6 +92,7 @@ export class BuildWorkflow extends Component {
   private readonly github: GitHub;
   private readonly workflow: GithubWorkflow;
   private readonly artifactsDirectory: string;
+  private readonly defaultRunners: string[] = ["ubuntu-latest"];
 
   private readonly _postBuildJobs: string[] = [];
 
@@ -116,13 +123,13 @@ export class BuildWorkflow extends Component {
     this.addBuildJob(options);
 
     if (mutableBuilds) {
-      this.addSelfMutationJob();
+      this.addSelfMutationJob(options);
     }
   }
 
   private addBuildJob(options: BuildWorkflowOptions) {
     this.workflow.addJob(BUILD_JOBID, {
-      runsOn: ["ubuntu-latest"],
+      runsOn: options.runsOn ?? this.defaultRunners,
       container: options.containerImage
         ? { image: options.containerImage }
         : undefined,
@@ -218,6 +225,7 @@ export class BuildWorkflow extends Component {
         checkoutRepo: true,
         installDeps: true,
         tools: options.tools,
+        runsOn: options.runsOn,
       }
     );
   }
@@ -268,14 +276,14 @@ export class BuildWorkflow extends Component {
         contents: JobPermission.READ,
       },
       tools: options?.tools,
-      runsOn: ["ubuntu-latest"],
+      runsOn: options?.runsOn ?? this.defaultRunners,
       steps,
     });
   }
 
-  private addSelfMutationJob() {
+  private addSelfMutationJob(options: BuildWorkflowOptions) {
     this.workflow.addJob("self-mutation", {
-      runsOn: ["ubuntu-latest"],
+      runsOn: options.runsOn ?? this.defaultRunners,
       permissions: {
         contents: JobPermission.WRITE,
       },
@@ -357,6 +365,12 @@ export interface AddPostBuildJobTaskOptions {
    * Tools that should be installed before the task is run.
    */
   readonly tools?: Tools;
+
+  /**
+   * Github Runner selection labels
+   * @default ["ubuntu-latest"]
+   */
+  readonly runsOn?: string[];
 }
 
 /**
@@ -385,4 +399,10 @@ export interface AddPostBuildJobCommandsOptions {
    * @default false
    */
   readonly installDeps?: boolean;
+
+  /**
+   * Github Runner selection labels
+   * @default ["ubuntu-latest"]
+   */
+  readonly runsOn?: string[];
 }

--- a/src/javascript/node-project.ts
+++ b/src/javascript/node-project.ts
@@ -552,6 +552,7 @@ export class NodeProject extends GitHubProject {
         mutableBuild: options.mutableBuild,
         preBuildSteps: this.renderWorkflowSetup({ mutable: true }),
         postBuildSteps: options.postBuildSteps,
+        runsOn: options.workflowRunsOn,
       });
 
       // run codecov if enabled or a secret token name is passed in

--- a/test/node-project.test.ts
+++ b/test/node-project.test.ts
@@ -762,6 +762,36 @@ test("workflowGitIdentity can be used to customize the git identity used in buil
   });
 });
 
+describe("workflowRunsOn", () => {
+  test("default to ubuntu-latest", () => {
+    // WHEN
+    const project = new TestNodeProject();
+
+    // THEN
+    const output = synthSnapshot(project);
+    const buildWorkflow = yaml.parse(output[".github/workflows/build.yml"]);
+    expect(buildWorkflow.jobs.build["runs-on"]).toEqual("ubuntu-latest");
+    expect(buildWorkflow.jobs["self-mutation"]["runs-on"]).toEqual(
+      "ubuntu-latest"
+    );
+  });
+
+  test("use github runner specified in workflowRunsOn", () => {
+    // WHEN
+    const project = new TestNodeProject({
+      workflowRunsOn: ["self-hosted"],
+    });
+
+    // THEN
+    const output = synthSnapshot(project);
+    const buildWorkflow = yaml.parse(output[".github/workflows/build.yml"]);
+    expect(buildWorkflow.jobs.build["runs-on"]).toEqual("self-hosted");
+    expect(buildWorkflow.jobs["self-mutation"]["runs-on"]).toEqual(
+      "self-hosted"
+    );
+  });
+});
+
 class TestNodeProject extends NodeProject {
   constructor(options: Partial<NodeProjectOptions> = {}) {
     super({


### PR DESCRIPTION
Fixes https://github.com/projen/projen/issues/1491

Allow using a different github runner than `ubuntu-latest` when running the build in github action.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.