### PR TITLE
fix(cleanup): Only clean up orphaned files

### DIFF
--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -12,7 +12,7 @@ export function cleanup(dir: string, newFiles: string[], exclude: string[]) {
     const manifestFiles = getFilesFromManifest(dir);
     if (manifestFiles.length > 0) {
       // Use `FILE_MANIFEST` to remove files that are no longer managed by projen
-      cleanOrphanedFiles(dir, manifestFiles, newFiles);
+      removeFiles(findOrphanedFiles(dir, manifestFiles, newFiles));
     } else {
       // Remove all files managed by projen with legacy logic
       removeFiles(findGeneratedFiles(dir, exclude));
@@ -57,14 +57,14 @@ function findGeneratedFiles(dir: string, exclude: string[]) {
   return generated;
 }
 
-function cleanOrphanedFiles(
+function findOrphanedFiles(
   dir: string,
   oldFiles: string[],
   newFiles: string[]
 ) {
-  const orphaned = oldFiles.filter((old) => !newFiles.includes(old));
-
-  removeFiles(orphaned.map((f: string) => path.resolve(dir, f)));
+  return oldFiles
+    .filter((old) => !newFiles.includes(old))
+    .map((f: string) => path.resolve(dir, f));
 }
 
 function getFilesFromManifest(dir: string): string[] {

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -14,7 +14,7 @@ export function cleanup(dir: string, newFiles: string[], exclude: string[]) {
       // Use `FILE_MANIFEST` to remove files that are no longer managed by projen
       cleanOrphanedFiles(dir, manifestFiles, newFiles);
     } else {
-      // Remove all files managed by projen
+      // Remove all files managed by projen with legacy logic
       removeFiles(findGeneratedFiles(dir, exclude));
     }
   } catch (e) {

--- a/src/file.ts
+++ b/src/file.ts
@@ -1,4 +1,5 @@
 import * as path from "path";
+import { removeSync } from "fs-extra";
 import { resolve } from "./_resolve";
 import { PROJEN_MARKER, PROJEN_RC } from "./common";
 import { Component } from "./component";
@@ -127,7 +128,9 @@ export abstract class FileBase extends Component {
     };
     const content = this.synthesizeContent(resolver);
     if (content === undefined) {
-      return; // skip
+      // remove file (if exists) and skip rest of synthesis
+      removeSync(filePath);
+      return;
     }
 
     // check if the file was changed.

--- a/src/project.ts
+++ b/src/project.ts
@@ -209,9 +209,7 @@ export class Project {
       omitEmpty: true,
       obj: () => ({
         // replace `\` with `/` to ensure paths match across platforms
-        files: this.files
-          .filter((f) => f.readonly)
-          .map((f) => f.path.replace(/\\/g, "/")),
+        files: this.managedFiles(),
       }),
     });
   }
@@ -427,7 +425,7 @@ export class Project {
     }
 
     // delete all generated files before we start synthesizing new ones
-    cleanup(outdir, this.excludeFromCleanup);
+    cleanup(outdir, this.managedFiles(), this.excludeFromCleanup);
 
     for (const subproject of this.subprojects) {
       subproject.synth();
@@ -491,6 +489,12 @@ export class Project {
     }
 
     this.subprojects.push(subproject);
+  }
+
+  private managedFiles() {
+    return this.files
+      .filter((f) => f.readonly)
+      .map((f) => f.path.replace(/\\/g, "/"));
   }
 
   /**

--- a/src/project.ts
+++ b/src/project.ts
@@ -208,7 +208,6 @@ export class Project {
     new JsonFile(this, FILE_MANIFEST, {
       omitEmpty: true,
       obj: () => ({
-        // replace `\` with `/` to ensure paths match across platforms
         files: this.managedFiles(),
       }),
     });
@@ -491,6 +490,11 @@ export class Project {
     this.subprojects.push(subproject);
   }
 
+  /**
+   * Files that are fully managed by projen. 
+   * 
+   * `\` replaced with `/` to ensure paths match across platforms.
+   */
   private managedFiles() {
     return this.files
       .filter((f) => f.readonly)

--- a/test/__snapshots__/cleanup.test.ts.snap
+++ b/test/__snapshots__/cleanup.test.ts.snap
@@ -13,6 +13,19 @@ Array [
 ]
 `;
 
+exports[`cleanup only orphaned files 1`] = `
+Array [
+  ".gitattributes",
+  ".github/workflows/pull-request-lint.yml",
+  ".github/workflows/stale.yml",
+  ".gitignore",
+  ".projen/deps.json",
+  ".projen/files.json",
+  ".projen/tasks.json",
+  "not-this",
+]
+`;
+
 exports[`cleanup uses cache file 1`] = `
 Array [
   ".gitattributes",

--- a/test/__snapshots__/cleanup.test.ts.snap
+++ b/test/__snapshots__/cleanup.test.ts.snap
@@ -25,6 +25,12 @@ Array [
 ]
 `;
 
+exports[`cleanup only orphaned files 2 1`] = `
+Array [
+  "will-be-empty",
+]
+`;
+
 exports[`cleanup uses cache file 1`] = `
 Array [
   ".gitattributes",

--- a/test/__snapshots__/cleanup.test.ts.snap
+++ b/test/__snapshots__/cleanup.test.ts.snap
@@ -19,7 +19,6 @@ Array [
   ".github/workflows/pull-request-lint.yml",
   ".github/workflows/stale.yml",
   ".gitignore",
-  ".projen/deps.json",
   ".projen/files.json",
   ".projen/tasks.json",
   "not-this",

--- a/test/__snapshots__/cleanup.test.ts.snap
+++ b/test/__snapshots__/cleanup.test.ts.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`cleanup empty files 1`] = `
+Array [
+  "will-be-empty",
+]
+`;
+
 exports[`cleanup falls back to greedy method 1`] = `
 Array [
   ".gitattributes",
@@ -22,12 +28,6 @@ Array [
   ".projen/files.json",
   ".projen/tasks.json",
   "not-this",
-]
-`;
-
-exports[`cleanup only orphaned files 2 1`] = `
-Array [
-  "will-be-empty",
 ]
 `;
 

--- a/test/cleanup.test.ts
+++ b/test/cleanup.test.ts
@@ -1,6 +1,12 @@
 import { join } from "path";
 import { readJsonSync } from "fs-extra";
-import { DependencyType, FileBase, SampleFile, TextFile } from "../src";
+import {
+  DependencyType,
+  FileBase,
+  JsonFile,
+  SampleFile,
+  TextFile,
+} from "../src";
 import { cleanup, FILE_MANIFEST } from "../src/cleanup";
 import { directorySnapshot, TestProject } from "./util";
 
@@ -92,5 +98,32 @@ test("cleanup only orphaned files", () => {
   expect(deletedFiles).not.toEqual(fileList);
   expect(deletedFiles).toContain(deleteFile.path);
   expect(deletedFiles).not.toContain(keepFile.path);
+  expect(deletedFiles).toMatchSnapshot();
+});
+
+test("cleanup only orphaned files 2", () => {
+  // GIVEN
+  const p = new TestProject();
+  const emptyFile = new JsonFile(p, "will-be-empty", { obj: { test: "test" } });
+
+  // WHEN
+  p.synth();
+
+  // Force file to be empty on next synth
+  (emptyFile as any).synthesizeContent = () => undefined;
+
+  const preDirSnapshot = directorySnapshot(p.outdir, { onlyFileNames: true });
+  const preFiles = Object.keys(preDirSnapshot);
+  const fileList: string[] = readJsonSync(join(p.outdir, FILE_MANIFEST)).files;
+
+  p.synth();
+
+  const postDirSnapshot = directorySnapshot(p.outdir, { onlyFileNames: true });
+  const postFiles = Object.keys(postDirSnapshot);
+  const deletedFiles = preFiles.filter((f) => !postFiles.includes(f));
+
+  // THEN
+  expect(deletedFiles).not.toEqual(fileList);
+  expect(deletedFiles).toContain(emptyFile.path);
   expect(deletedFiles).toMatchSnapshot();
 });

--- a/test/cleanup.test.ts
+++ b/test/cleanup.test.ts
@@ -101,7 +101,7 @@ test("cleanup only orphaned files", () => {
   expect(deletedFiles).toMatchSnapshot();
 });
 
-test("cleanup only orphaned files 2", () => {
+test("cleanup empty files", () => {
   // GIVEN
   const p = new TestProject();
   const emptyFile = new JsonFile(p, "will-be-empty", { obj: { test: "test" } });

--- a/test/cleanup.test.ts
+++ b/test/cleanup.test.ts
@@ -70,7 +70,6 @@ test("cleanup falls back to greedy method", () => {
 test("cleanup only orphaned files", () => {
   // GIVEN
   const p = new TestProject();
-  p.deps.addDependency("test", DependencyType.BUILD);
   const keepFile = new TextFile(p, "keep-this");
   const deleteFile = new TextFile(p, "not-this");
 

--- a/test/cleanup.test.ts
+++ b/test/cleanup.test.ts
@@ -21,7 +21,7 @@ test("cleanup uses cache file", () => {
 
   const fileList: string[] = readJsonSync(join(p.outdir, FILE_MANIFEST)).files;
 
-  cleanup(p.outdir, []);
+  cleanup(p.outdir, [], []);
 
   const postDirSnapshot = directorySnapshot(p.outdir, { onlyFileNames: true });
   const postFiles = Object.keys(postDirSnapshot);
@@ -55,7 +55,7 @@ test("cleanup falls back to greedy method", () => {
   const preDirSnapshot = directorySnapshot(p.outdir, { onlyFileNames: true });
   const preFiles = Object.keys(preDirSnapshot);
 
-  cleanup(p.outdir, []);
+  cleanup(p.outdir, [], []);
 
   const postDirSnapshot = directorySnapshot(p.outdir, { onlyFileNames: true });
   const postFiles = Object.keys(postDirSnapshot);
@@ -64,5 +64,34 @@ test("cleanup falls back to greedy method", () => {
 
   // THEN
   expect(postFiles).not.toContain("delete.txt");
+  expect(deletedFiles).toMatchSnapshot();
+});
+
+test("cleanup only orphaned files", () => {
+  // GIVEN
+  const p = new TestProject();
+  p.deps.addDependency("test", DependencyType.BUILD);
+  const keepFile = new TextFile(p, "keep-this");
+  const deleteFile = new TextFile(p, "not-this");
+
+  // WHEN
+  p.synth();
+
+  const preDirSnapshot = directorySnapshot(p.outdir, { onlyFileNames: true });
+  const preFiles = Object.keys(preDirSnapshot);
+
+  const fileList: string[] = readJsonSync(join(p.outdir, FILE_MANIFEST)).files;
+
+  cleanup(p.outdir, ["keep-this"], []);
+
+  const postDirSnapshot = directorySnapshot(p.outdir, { onlyFileNames: true });
+  const postFiles = Object.keys(postDirSnapshot);
+
+  const deletedFiles = preFiles.filter((f) => !postFiles.includes(f));
+
+  // THEN
+  expect(deletedFiles).not.toEqual(fileList);
+  expect(deletedFiles).toContain(deleteFile.path);
+  expect(deletedFiles).not.toContain(keepFile.path);
   expect(deletedFiles).toMatchSnapshot();
 });


### PR DESCRIPTION
To avoid unnecessary thrashing of projen managed files, we can skip cleaning up files that we know we're just going to be creating again during synthesis. This means that changed files will simply be overwritten during synthesis. Even better, unchanged files won't be written at all.
With this PR, an orphaned file is one that is present in `files.json` (from the previous synthesis) but not one of the files that are about to be synthesized.

Included some refactoring in `cleanup.ts` to make the control flow more (hopefully) clear with this additional logic.

fixes #1484 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.