### PR TITLE
feat(awscdk): allow users to integration test multi-stack stages

### DIFF
--- a/API.md
+++ b/API.md
@@ -3915,9 +3915,9 @@ new awscdk.IntegrationTest(project: Project, options: IntegrationTestOptions)
   * **destroyAfterDeploy** (<code>boolean</code>)  Destroy the test app after a successful deployment. __*Default*__: true
   * **cdkDeps** (<code>[awscdk.AwsCdkDeps](#projen-awscdk-awscdkdeps)</code>)  AWS CDK dependency manager. 
   * **entrypoint** (<code>string</code>)  A path from the project root directory to a TypeScript file which contains the integration test app. 
-  * **name** (<code>string</code>)  Name of the integration test. 
   * **tsconfigPath** (<code>string</code>)  The path of the tsconfig.json file to use when running integration test cdk apps. 
-  * **stacks** (<code>Array<string></code>)  A list of stacks within the integration test to deploy/destroy. __*Default*__: The CLI is not told any one stack in particular
+  * **name** (<code>string</code>)  Name of the integration test. __*Default*__: Derived from the entrypoint filename.
+  * **stacks** (<code>Array<string></code>)  A list of stacks within the integration test to deploy/destroy. __*Default*__: ["*"]
 
 
 
@@ -11703,10 +11703,10 @@ Name | Type | Description
 -----|------|-------------
 **cdkDeps**🔹 | <code>[awscdk.AwsCdkDeps](#projen-awscdk-awscdkdeps)</code> | AWS CDK dependency manager.
 **entrypoint**🔹 | <code>string</code> | A path from the project root directory to a TypeScript file which contains the integration test app.
-**name**🔹 | <code>string</code> | Name of the integration test.
 **tsconfigPath**🔹 | <code>string</code> | The path of the tsconfig.json file to use when running integration test cdk apps.
 **destroyAfterDeploy**?🔹 | <code>boolean</code> | Destroy the test app after a successful deployment.<br/>__*Default*__: true
-**stacks**?🔹 | <code>Array<string></code> | A list of stacks within the integration test to deploy/destroy.<br/>__*Default*__: The CLI is not told any one stack in particular
+**name**?🔹 | <code>string</code> | Name of the integration test.<br/>__*Default*__: Derived from the entrypoint filename.
+**stacks**?🔹 | <code>Array<string></code> | A list of stacks within the integration test to deploy/destroy.<br/>__*Default*__: ["*"]
 
 
 

--- a/API.md
+++ b/API.md
@@ -3915,8 +3915,8 @@ new awscdk.IntegrationTest(project: Project, options: IntegrationTestOptions)
   * **destroyAfterDeploy** (<code>boolean</code>)  Destroy the test app after a successful deployment. __*Default*__: true
   * **cdkDeps** (<code>[awscdk.AwsCdkDeps](#projen-awscdk-awscdkdeps)</code>)  AWS CDK dependency manager. 
   * **entrypoint** (<code>string</code>)  A path from the project root directory to a TypeScript file which contains the integration test app. 
+  * **name** (<code>string</code>)  Name of the integration test. 
   * **tsconfigPath** (<code>string</code>)  The path of the tsconfig.json file to use when running integration test cdk apps. 
-  * **name** (<code>string</code>)  Name of the integration test. __*Default*__: Derived from the entrypoint by removing ".integ.ts"
   * **stacks** (<code>Array<string></code>)  A list of stacks within the integration test to deploy/destroy. __*Default*__: The CLI is not told any one stack in particular
 
 
@@ -11703,9 +11703,9 @@ Name | Type | Description
 -----|------|-------------
 **cdkDeps**🔹 | <code>[awscdk.AwsCdkDeps](#projen-awscdk-awscdkdeps)</code> | AWS CDK dependency manager.
 **entrypoint**🔹 | <code>string</code> | A path from the project root directory to a TypeScript file which contains the integration test app.
+**name**🔹 | <code>string</code> | Name of the integration test.
 **tsconfigPath**🔹 | <code>string</code> | The path of the tsconfig.json file to use when running integration test cdk apps.
 **destroyAfterDeploy**?🔹 | <code>boolean</code> | Destroy the test app after a successful deployment.<br/>__*Default*__: true
-**name**?🔹 | <code>string</code> | Name of the integration test.<br/>__*Default*__: Derived from the entrypoint by removing ".integ.ts"
 **stacks**?🔹 | <code>Array<string></code> | A list of stacks within the integration test to deploy/destroy.<br/>__*Default*__: The CLI is not told any one stack in particular
 
 

--- a/API.md
+++ b/API.md
@@ -3916,6 +3916,8 @@ new awscdk.IntegrationTest(project: Project, options: IntegrationTestOptions)
   * **cdkDeps** (<code>[awscdk.AwsCdkDeps](#projen-awscdk-awscdkdeps)</code>)  AWS CDK dependency manager. 
   * **entrypoint** (<code>string</code>)  A path from the project root directory to a TypeScript file which contains the integration test app. 
   * **tsconfigPath** (<code>string</code>)  The path of the tsconfig.json file to use when running integration test cdk apps. 
+  * **name** (<code>string</code>)  Name of the integration test. __*Default*__: Derived from the entrypoint by removing ".integ.ts"
+  * **stacks** (<code>Array<string></code>)  A list of stacks within the integration test to deploy/destroy. __*Default*__: The CLI is not told any one stack in particular
 
 
 
@@ -11703,6 +11705,8 @@ Name | Type | Description
 **entrypoint**🔹 | <code>string</code> | A path from the project root directory to a TypeScript file which contains the integration test app.
 **tsconfigPath**🔹 | <code>string</code> | The path of the tsconfig.json file to use when running integration test cdk apps.
 **destroyAfterDeploy**?🔹 | <code>boolean</code> | Destroy the test app after a successful deployment.<br/>__*Default*__: true
+**name**?🔹 | <code>string</code> | Name of the integration test.<br/>__*Default*__: Derived from the entrypoint by removing ".integ.ts"
+**stacks**?🔹 | <code>Array<string></code> | A list of stacks within the integration test to deploy/destroy.<br/>__*Default*__: The CLI is not told any one stack in particular
 
 
 

--- a/src/awscdk/auto-discover.ts
+++ b/src/awscdk/auto-discover.ts
@@ -1,4 +1,4 @@
-import { join } from "path";
+import { join, basename } from "path";
 import * as glob from "glob";
 import { Component } from "../component";
 import { Project } from "../project";
@@ -70,6 +70,7 @@ export class AutoDiscover extends Component {
 
     for (const entrypoint of entrypoints) {
       new IntegrationTest(this.project, {
+        name: basename(entrypoint, TYPESCRIPT_INTEG_EXT),
         entrypoint: join(options.testdir, entrypoint),
         cdkDeps: options.cdkDeps,
         tsconfigPath: options.tsconfigPath,

--- a/src/awscdk/auto-discover.ts
+++ b/src/awscdk/auto-discover.ts
@@ -1,4 +1,4 @@
-import { join, basename } from "path";
+import { join } from "path";
 import * as glob from "glob";
 import { Component } from "../component";
 import { Project } from "../project";
@@ -70,7 +70,6 @@ export class AutoDiscover extends Component {
 
     for (const entrypoint of entrypoints) {
       new IntegrationTest(this.project, {
-        name: basename(entrypoint, TYPESCRIPT_INTEG_EXT),
         entrypoint: join(options.testdir, entrypoint),
         cdkDeps: options.cdkDeps,
         tsconfigPath: options.tsconfigPath,

--- a/src/awscdk/integration-test.ts
+++ b/src/awscdk/integration-test.ts
@@ -1,10 +1,10 @@
-import { basename, dirname, join } from "path";
+import { dirname, join } from "path";
 import { Component } from "../component";
 import { DependencyType } from "../dependencies";
 import { Project } from "../project";
 import { Task } from "../task";
 import { AwsCdkDeps } from "./awscdk-deps";
-import { FEATURE_FLAGS, TYPESCRIPT_INTEG_EXT } from "./internal";
+import { FEATURE_FLAGS } from "./internal";
 
 export interface IntegrationTestCommonOptions {
   /**
@@ -21,9 +21,8 @@ export interface IntegrationTestCommonOptions {
 export interface IntegrationTestOptions extends IntegrationTestCommonOptions {
   /**
    * Name of the integration test
-   * @default - Derived from the entrypoint by removing ".integ.ts"
    */
-  readonly name?: string;
+  readonly name: string;
 
   /**
    * A list of stacks within the integration test to deploy/destroy.
@@ -84,7 +83,7 @@ export class IntegrationTest extends Component {
   constructor(project: Project, options: IntegrationTestOptions) {
     super(project);
     const entry = options.entrypoint;
-    const name = options.name ?? basename(entry, TYPESCRIPT_INTEG_EXT);
+    const name = options.name;
     const dir = dirname(entry);
 
     const deploydir = join(dir, ".tmp", `${name}.integ`, "deploy.cdk.out");

--- a/test/awscdk/__snapshots__/integration-test.test.ts.snap
+++ b/test/awscdk/__snapshots__/integration-test.test.ts.snap
@@ -27,7 +27,7 @@ Object {
       "exec": "rm -fr test/.tmp/foo.integ/deploy.cdk.out",
     },
     Object {
-      "exec": "cdk deploy --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata --context aws-cdk:enableDiffNoFail=true --context @aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId=true --context @aws-cdk/core:enableStackNameDuplicates=true --context @aws-cdk/core:stackRelativeExports=true --context @aws-cdk/aws-ecr-assets:dockerIgnoreSupport=true --context @aws-cdk/aws-secretsmanager:parseOwnedSecretName=true --context @aws-cdk/aws-kms:defaultKeyPolicies=true --context @aws-cdk/aws-s3:grantWriteWithoutAcl=true --context @aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount=true --context @aws-cdk/aws-rds:lowercaseDbIdentifier=true --context @aws-cdk/aws-efs:defaultEncryptionAtRest=true --context @aws-cdk/aws-lambda:recognizeVersionProps=true --context @aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021=true --context @aws-cdk/core:newStyleStackSynthesis=true --require-approval=never -o test/.tmp/foo.integ/deploy.cdk.out",
+      "exec": "cdk deploy --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata --context aws-cdk:enableDiffNoFail=true --context @aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId=true --context @aws-cdk/core:enableStackNameDuplicates=true --context @aws-cdk/core:stackRelativeExports=true --context @aws-cdk/aws-ecr-assets:dockerIgnoreSupport=true --context @aws-cdk/aws-secretsmanager:parseOwnedSecretName=true --context @aws-cdk/aws-kms:defaultKeyPolicies=true --context @aws-cdk/aws-s3:grantWriteWithoutAcl=true --context @aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount=true --context @aws-cdk/aws-rds:lowercaseDbIdentifier=true --context @aws-cdk/aws-efs:defaultEncryptionAtRest=true --context @aws-cdk/aws-lambda:recognizeVersionProps=true --context @aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021=true --context @aws-cdk/core:newStyleStackSynthesis=true '*' --require-approval=never -o test/.tmp/foo.integ/deploy.cdk.out",
     },
     Object {
       "exec": "rm -fr test/foo.integ.snapshot",
@@ -48,7 +48,7 @@ Object {
   "name": "integ:foo:destroy",
   "steps": Array [
     Object {
-      "exec": "cdk destroy --app test/foo.integ.snapshot --no-version-reporting",
+      "exec": "cdk destroy --app test/foo.integ.snapshot '*' --no-version-reporting",
     },
   ],
 }
@@ -72,7 +72,7 @@ Object {
   "name": "integ:foo:watch",
   "steps": Array [
     Object {
-      "exec": "cdk watch --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata --context aws-cdk:enableDiffNoFail=true --context @aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId=true --context @aws-cdk/core:enableStackNameDuplicates=true --context @aws-cdk/core:stackRelativeExports=true --context @aws-cdk/aws-ecr-assets:dockerIgnoreSupport=true --context @aws-cdk/aws-secretsmanager:parseOwnedSecretName=true --context @aws-cdk/aws-kms:defaultKeyPolicies=true --context @aws-cdk/aws-s3:grantWriteWithoutAcl=true --context @aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount=true --context @aws-cdk/aws-rds:lowercaseDbIdentifier=true --context @aws-cdk/aws-efs:defaultEncryptionAtRest=true --context @aws-cdk/aws-lambda:recognizeVersionProps=true --context @aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021=true --context @aws-cdk/core:newStyleStackSynthesis=true -o test/.tmp/foo.integ/deploy.cdk.out",
+      "exec": "cdk watch --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata --context aws-cdk:enableDiffNoFail=true --context @aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId=true --context @aws-cdk/core:enableStackNameDuplicates=true --context @aws-cdk/core:stackRelativeExports=true --context @aws-cdk/aws-ecr-assets:dockerIgnoreSupport=true --context @aws-cdk/aws-secretsmanager:parseOwnedSecretName=true --context @aws-cdk/aws-kms:defaultKeyPolicies=true --context @aws-cdk/aws-s3:grantWriteWithoutAcl=true --context @aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount=true --context @aws-cdk/aws-rds:lowercaseDbIdentifier=true --context @aws-cdk/aws-efs:defaultEncryptionAtRest=true --context @aws-cdk/aws-lambda:recognizeVersionProps=true --context @aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021=true --context @aws-cdk/core:newStyleStackSynthesis=true '*' -o test/.tmp/foo.integ/deploy.cdk.out",
     },
   ],
 }
@@ -135,7 +135,7 @@ Object {
       "exec": "rm -fr test/.tmp/foo.integ/deploy.cdk.out",
     },
     Object {
-      "exec": "cdk deploy --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata --require-approval=never -o test/.tmp/foo.integ/deploy.cdk.out",
+      "exec": "cdk deploy --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata '*' --require-approval=never -o test/.tmp/foo.integ/deploy.cdk.out",
     },
     Object {
       "exec": "rm -fr test/foo.integ.snapshot",
@@ -168,7 +168,7 @@ Object {
   "name": "integ:foo:watch",
   "steps": Array [
     Object {
-      "exec": "cdk watch --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata -o test/.tmp/foo.integ/deploy.cdk.out",
+      "exec": "cdk watch --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata '*' -o test/.tmp/foo.integ/deploy.cdk.out",
     },
   ],
 }

--- a/test/awscdk/__snapshots__/integration-test.test.ts.snap
+++ b/test/awscdk/__snapshots__/integration-test.test.ts.snap
@@ -78,6 +78,54 @@ Object {
 }
 `;
 
+exports[`synthesizing an integration test containing a multi-stack stage 1`] = `
+Object {
+  "description": "deploy integration test 'my-stage' and capture snapshot",
+  "name": "integ:my-stage:deploy",
+  "steps": Array [
+    Object {
+      "exec": "rm -fr test/.tmp/my-stage.integ/deploy.cdk.out",
+    },
+    Object {
+      "exec": "cdk deploy --app \\"ts-node -P tsconfig.dev.json test/my-stage.myinteg.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata 'my-stage/*' --require-approval=never -o test/.tmp/my-stage.integ/deploy.cdk.out",
+    },
+    Object {
+      "exec": "rm -fr test/my-stage.integ.snapshot",
+    },
+    Object {
+      "exec": "mv test/.tmp/my-stage.integ/deploy.cdk.out test/my-stage.integ.snapshot",
+    },
+    Object {
+      "spawn": "integ:my-stage:destroy",
+    },
+  ],
+}
+`;
+
+exports[`synthesizing an integration test containing a multi-stack stage 2`] = `
+Object {
+  "description": "update snapshot for integration test \\"my-stage\\"",
+  "name": "integ:my-stage:snapshot",
+  "steps": Array [
+    Object {
+      "exec": "cdk synth --app \\"ts-node -P tsconfig.dev.json test/my-stage.myinteg.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata -o test/my-stage.integ.snapshot > /dev/null",
+    },
+  ],
+}
+`;
+
+exports[`synthesizing an integration test containing a multi-stack stage 3`] = `
+Object {
+  "description": "watch integration test 'my-stage' (without updating snapshots)",
+  "name": "integ:my-stage:watch",
+  "steps": Array [
+    Object {
+      "exec": "cdk watch --app \\"ts-node -P tsconfig.dev.json test/my-stage.myinteg.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata 'my-stage/*' -o test/.tmp/my-stage.integ/deploy.cdk.out",
+    },
+  ],
+}
+`;
+
 exports[`synthesizing cdk v2 integration tests 1`] = `
 Object {
   "description": "deploy integration test 'foo' and capture snapshot",

--- a/test/awscdk/integration-test.test.ts
+++ b/test/awscdk/integration-test.test.ts
@@ -14,6 +14,7 @@ describe("IntegrationTest", () => {
 
   // WHEN
   new awscdk.IntegrationTest(project, {
+    name: "foo",
     entrypoint: "test/foo.integ.ts",
     tsconfigPath: project.tsconfigDev.fileName,
     cdkDeps: project.cdkDeps,
@@ -76,6 +77,7 @@ test("installs ts-node if needed", () => {
   });
 
   new IntegrationTest(project, {
+    name: "foo",
     entrypoint: "test/foo.integ.ts",
     tsconfigPath: project.tsconfigDev.fileName,
     cdkDeps: new AwsCdkDepsJs(project, {
@@ -100,6 +102,7 @@ test("synthesizing cdk v2 integration tests", () => {
 
   // WHEN
   new awscdk.IntegrationTest(project, {
+    name: "foo",
     entrypoint: "test/foo.integ.ts",
     tsconfigPath: project.tsconfigDev.fileName,
     cdkDeps: project.cdkDeps,

--- a/test/awscdk/integration-test.test.ts
+++ b/test/awscdk/integration-test.test.ts
@@ -14,7 +14,6 @@ describe("IntegrationTest", () => {
 
   // WHEN
   new awscdk.IntegrationTest(project, {
-    name: "foo",
     entrypoint: "test/foo.integ.ts",
     tsconfigPath: project.tsconfigDev.fileName,
     cdkDeps: project.cdkDeps,
@@ -77,7 +76,6 @@ test("installs ts-node if needed", () => {
   });
 
   new IntegrationTest(project, {
-    name: "foo",
     entrypoint: "test/foo.integ.ts",
     tsconfigPath: project.tsconfigDev.fileName,
     cdkDeps: new AwsCdkDepsJs(project, {
@@ -102,7 +100,6 @@ test("synthesizing cdk v2 integration tests", () => {
 
   // WHEN
   new awscdk.IntegrationTest(project, {
-    name: "foo",
     entrypoint: "test/foo.integ.ts",
     tsconfigPath: project.tsconfigDev.fileName,
     cdkDeps: project.cdkDeps,

--- a/test/awscdk/integration-test.test.ts
+++ b/test/awscdk/integration-test.test.ts
@@ -118,3 +118,34 @@ test("synthesizing cdk v2 integration tests", () => {
     output[".projen/tasks.json"].tasks["integ:foo:watch"]
   ).toMatchSnapshot();
 });
+
+test("synthesizing an integration test containing a multi-stack stage", () => {
+  // GIVEN
+  const project = new awscdk.AwsCdkTypeScriptApp({
+    name: "test",
+    defaultReleaseBranch: "main",
+    cdkVersion: "2.3.1",
+  });
+
+  // WHEN
+  new awscdk.IntegrationTest(project, {
+    name: "my-stage",
+    entrypoint: "test/my-stage.myinteg.ts",
+    stacks: ["my-stage/*"],
+    tsconfigPath: project.tsconfigDev.fileName,
+    cdkDeps: project.cdkDeps,
+  });
+
+  // THEN
+  const output = Testing.synth(project);
+
+  expect(
+    output[".projen/tasks.json"].tasks["integ:my-stage:deploy"]
+  ).toMatchSnapshot();
+  expect(
+    output[".projen/tasks.json"].tasks["integ:my-stage:snapshot"]
+  ).toMatchSnapshot();
+  expect(
+    output[".projen/tasks.json"].tasks["integ:my-stage:watch"]
+  ).toMatchSnapshot();
+});


### PR DESCRIPTION
Allows users to add AWS CDK integration tests consisting of stages with multiple stacks.

```ts
new awscdk.IntegrationTest(project, {
  name: "my-stage",
  entrypoint: "test/my-stage.myinteg.ts",
  stacks: ["my-stage/*"],
  tsconfigPath: project.tsconfigDev.fileName,
  cdkDeps: project.cdkDeps,
});
```

Fixes #1495

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
