### PR TITLE
chore: update mutableBuild unit tests

### DIFF
--- a/test/__snapshots__/node-project.test.ts.snap
+++ b/test/__snapshots__/node-project.test.ts.snap
@@ -69,6 +69,49 @@ Upgrades project dependencies. See details in [workflow run].
 }
 `;
 
+exports[`disabling mutableBuild will skip pushing changes to PR branches 1`] = `
+Array [
+  Object {
+    "name": "Checkout",
+    "uses": "actions/checkout@v2",
+    "with": Object {
+      "ref": "\${{ github.event.pull_request.head.ref }}",
+      "repository": "\${{ github.event.pull_request.head.repo.full_name }}",
+    },
+  },
+  Object {
+    "name": "Install dependencies",
+    "run": "yarn install --check-files",
+  },
+  Object {
+    "name": "build",
+    "run": "npx projen build",
+  },
+  Object {
+    "id": "self_mutation",
+    "name": "Find mutations",
+    "run": "git add .
+git diff --staged --patch --exit-code > .repo.patch || echo \\"::set-output name=self_mutation_happened::true\\"",
+  },
+  Object {
+    "if": "steps.self_mutation.outputs.self_mutation_happened",
+    "name": "Upload patch",
+    "uses": "actions/upload-artifact@v2",
+    "with": Object {
+      "name": ".repo.patch",
+      "path": ".repo.patch",
+    },
+  },
+  Object {
+    "if": "steps.self_mutation.outputs.self_mutation_happened",
+    "name": "Fail build on mutation",
+    "run": "echo \\"::error::Files were changed during build (see build log). If this was triggered from a fork, you will need to update your branch.\\"
+cat .repo.patch
+exit 1",
+  },
+]
+`;
+
 exports[`mutableBuild will push changes to PR branches 1`] = `
 Array [
   Object {
@@ -108,6 +151,43 @@ git diff --staged --patch --exit-code > .repo.patch || echo \\"::set-output name
     "run": "echo \\"::error::Files were changed during build (see build log). If this was triggered from a fork, you will need to update your branch.\\"
 cat .repo.patch
 exit 1",
+  },
+]
+`;
+
+exports[`mutableBuild will push changes to PR branches 2`] = `
+Array [
+  Object {
+    "name": "Checkout",
+    "uses": "actions/checkout@v2",
+    "with": Object {
+      "ref": "\${{ github.event.pull_request.head.ref }}",
+      "repository": "\${{ github.event.pull_request.head.repo.full_name }}",
+      "token": "\${{ secrets.PROJEN_GITHUB_TOKEN }}",
+    },
+  },
+  Object {
+    "name": "Download patch",
+    "uses": "actions/download-artifact@v2",
+    "with": Object {
+      "name": ".repo.patch",
+      "path": "\${{ runner.temp }}",
+    },
+  },
+  Object {
+    "name": "Apply patch",
+    "run": "[ -s \${{ runner.temp }}/.repo.patch ] && git apply \${{ runner.temp }}/.repo.patch || echo \\"Empty patch. Skipping.\\"",
+  },
+  Object {
+    "name": "Set git identity",
+    "run": "git config user.name \\"github-actions\\"
+git config user.email \\"github-actions@github.com\\"",
+  },
+  Object {
+    "name": "Push changes",
+    "run": "  git add .
+  git commit -m \\"chore: self mutation\\"
+  git push origin HEAD:\${{ github.event.pull_request.head.ref }}",
   },
 ]
 `;

--- a/test/node-project.test.ts
+++ b/test/node-project.test.ts
@@ -645,6 +645,21 @@ test("mutableBuild will push changes to PR branches", () => {
   const workflowYaml = synthSnapshot(project)[".github/workflows/build.yml"];
   const workflow = yaml.parse(workflowYaml);
   expect(workflow.jobs.build.steps).toMatchSnapshot();
+  expect(Object.keys(workflow.jobs)).toContain("self-mutation");
+  expect(workflow.jobs["self-mutation"].steps).toMatchSnapshot();
+});
+
+test("disabling mutableBuild will skip pushing changes to PR branches", () => {
+  // WHEN
+  const project = new TestNodeProject({
+    mutableBuild: false,
+  });
+
+  // THEN
+  const workflowYaml = synthSnapshot(project)[".github/workflows/build.yml"];
+  const workflow = yaml.parse(workflowYaml);
+  expect(workflow.jobs.build.steps).toMatchSnapshot();
+  expect(Object.keys(workflow.jobs)).not.toContain("self-mutation");
 });
 
 test("projen synth is only executed for subprojects", () => {


### PR DESCRIPTION
`mutableBuild` is enabled by default, so we should have at least one test validating that disabling it does the right thing.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.