### PR TITLE
chore: resynth after compiling projen

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -247,6 +247,9 @@
         },
         {
           "spawn": "readme-macros"
+        },
+        {
+          "spawn": "default"
         }
       ]
     },

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -192,4 +192,9 @@ project.buildWorkflow.addPostBuildJobTask(integTask, {
   tools: { python: { version: "3.x" }, go: { version: "1.16.x" } },
 });
 
+// we are projen, so re-synth after compiling.
+// fixes feedback loop where projen contibutors run "build"
+// but not all files are updated
+project.postCompileTask.spawn(project.defaultTask);
+
 project.synth();


### PR DESCRIPTION
This fixes a feedback loop where contributors add some change to projen (that happens to affect projen's own configuration files), and running `build` will compile and run all tests but not necessarily run update projen's own config because the `compile` task runs after `default`.

This is not totally fool-proof, since it's possible the change to projen could affect the actual build steps and thus require a full build again, but it might be possible to make this smarter in the future with https://github.com/projen/projen/issues/1515.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.