### PR TITLE
fix(awscdk): integration tests should deploy ** by default instead of *

### DIFF
--- a/API.md
+++ b/API.md
@@ -3917,7 +3917,7 @@ new awscdk.IntegrationTest(project: Project, options: IntegrationTestOptions)
   * **entrypoint** (<code>string</code>)  A path from the project root directory to a TypeScript file which contains the integration test app. 
   * **tsconfigPath** (<code>string</code>)  The path of the tsconfig.json file to use when running integration test cdk apps. 
   * **name** (<code>string</code>)  Name of the integration test. __*Default*__: Derived from the entrypoint filename.
-  * **stacks** (<code>Array<string></code>)  A list of stacks within the integration test to deploy/destroy. __*Default*__: ["*"]
+  * **stacks** (<code>Array<string></code>)  A list of stacks within the integration test to deploy/destroy. __*Default*__: ["**"]
 
 
 
@@ -11706,7 +11706,7 @@ Name | Type | Description
 **tsconfigPath**🔹 | <code>string</code> | The path of the tsconfig.json file to use when running integration test cdk apps.
 **destroyAfterDeploy**?🔹 | <code>boolean</code> | Destroy the test app after a successful deployment.<br/>__*Default*__: true
 **name**?🔹 | <code>string</code> | Name of the integration test.<br/>__*Default*__: Derived from the entrypoint filename.
-**stacks**?🔹 | <code>Array<string></code> | A list of stacks within the integration test to deploy/destroy.<br/>__*Default*__: ["*"]
+**stacks**?🔹 | <code>Array<string></code> | A list of stacks within the integration test to deploy/destroy.<br/>__*Default*__: ["**"]
 
 
 

--- a/src/awscdk/integration-test.ts
+++ b/src/awscdk/integration-test.ts
@@ -27,7 +27,7 @@ export interface IntegrationTestOptions extends IntegrationTestCommonOptions {
 
   /**
    * A list of stacks within the integration test to deploy/destroy.
-   * @default ["*"]
+   * @default ["**"]
    */
   readonly stacks?: string[];
 
@@ -120,7 +120,7 @@ export class IntegrationTest extends Component {
     const cdkopts = opts.join(" ");
 
     // Determine which stacks to deploy
-    const stacks = options.stacks ?? ["*"];
+    const stacks = options.stacks ?? ["**"];
     const stackOpts = stacks.map((stack) => `'${stack}'`).join(" ");
 
     const deployTask = project.addTask(`integ:${name}:deploy`, {

--- a/test/awscdk/__snapshots__/integration-test.test.ts.snap
+++ b/test/awscdk/__snapshots__/integration-test.test.ts.snap
@@ -27,7 +27,7 @@ Object {
       "exec": "rm -fr test/.tmp/foo.integ/deploy.cdk.out",
     },
     Object {
-      "exec": "cdk deploy --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata --context aws-cdk:enableDiffNoFail=true --context @aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId=true --context @aws-cdk/core:enableStackNameDuplicates=true --context @aws-cdk/core:stackRelativeExports=true --context @aws-cdk/aws-ecr-assets:dockerIgnoreSupport=true --context @aws-cdk/aws-secretsmanager:parseOwnedSecretName=true --context @aws-cdk/aws-kms:defaultKeyPolicies=true --context @aws-cdk/aws-s3:grantWriteWithoutAcl=true --context @aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount=true --context @aws-cdk/aws-rds:lowercaseDbIdentifier=true --context @aws-cdk/aws-efs:defaultEncryptionAtRest=true --context @aws-cdk/aws-lambda:recognizeVersionProps=true --context @aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021=true --context @aws-cdk/core:newStyleStackSynthesis=true '*' --require-approval=never -o test/.tmp/foo.integ/deploy.cdk.out",
+      "exec": "cdk deploy --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata --context aws-cdk:enableDiffNoFail=true --context @aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId=true --context @aws-cdk/core:enableStackNameDuplicates=true --context @aws-cdk/core:stackRelativeExports=true --context @aws-cdk/aws-ecr-assets:dockerIgnoreSupport=true --context @aws-cdk/aws-secretsmanager:parseOwnedSecretName=true --context @aws-cdk/aws-kms:defaultKeyPolicies=true --context @aws-cdk/aws-s3:grantWriteWithoutAcl=true --context @aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount=true --context @aws-cdk/aws-rds:lowercaseDbIdentifier=true --context @aws-cdk/aws-efs:defaultEncryptionAtRest=true --context @aws-cdk/aws-lambda:recognizeVersionProps=true --context @aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021=true --context @aws-cdk/core:newStyleStackSynthesis=true '**' --require-approval=never -o test/.tmp/foo.integ/deploy.cdk.out",
     },
     Object {
       "exec": "rm -fr test/foo.integ.snapshot",
@@ -48,7 +48,7 @@ Object {
   "name": "integ:foo:destroy",
   "steps": Array [
     Object {
-      "exec": "cdk destroy --app test/foo.integ.snapshot '*' --no-version-reporting",
+      "exec": "cdk destroy --app test/foo.integ.snapshot '**' --no-version-reporting",
     },
   ],
 }
@@ -72,7 +72,7 @@ Object {
   "name": "integ:foo:watch",
   "steps": Array [
     Object {
-      "exec": "cdk watch --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata --context aws-cdk:enableDiffNoFail=true --context @aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId=true --context @aws-cdk/core:enableStackNameDuplicates=true --context @aws-cdk/core:stackRelativeExports=true --context @aws-cdk/aws-ecr-assets:dockerIgnoreSupport=true --context @aws-cdk/aws-secretsmanager:parseOwnedSecretName=true --context @aws-cdk/aws-kms:defaultKeyPolicies=true --context @aws-cdk/aws-s3:grantWriteWithoutAcl=true --context @aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount=true --context @aws-cdk/aws-rds:lowercaseDbIdentifier=true --context @aws-cdk/aws-efs:defaultEncryptionAtRest=true --context @aws-cdk/aws-lambda:recognizeVersionProps=true --context @aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021=true --context @aws-cdk/core:newStyleStackSynthesis=true '*' -o test/.tmp/foo.integ/deploy.cdk.out",
+      "exec": "cdk watch --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata --context aws-cdk:enableDiffNoFail=true --context @aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId=true --context @aws-cdk/core:enableStackNameDuplicates=true --context @aws-cdk/core:stackRelativeExports=true --context @aws-cdk/aws-ecr-assets:dockerIgnoreSupport=true --context @aws-cdk/aws-secretsmanager:parseOwnedSecretName=true --context @aws-cdk/aws-kms:defaultKeyPolicies=true --context @aws-cdk/aws-s3:grantWriteWithoutAcl=true --context @aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount=true --context @aws-cdk/aws-rds:lowercaseDbIdentifier=true --context @aws-cdk/aws-efs:defaultEncryptionAtRest=true --context @aws-cdk/aws-lambda:recognizeVersionProps=true --context @aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021=true --context @aws-cdk/core:newStyleStackSynthesis=true '**' -o test/.tmp/foo.integ/deploy.cdk.out",
     },
   ],
 }
@@ -135,7 +135,7 @@ Object {
       "exec": "rm -fr test/.tmp/foo.integ/deploy.cdk.out",
     },
     Object {
-      "exec": "cdk deploy --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata '*' --require-approval=never -o test/.tmp/foo.integ/deploy.cdk.out",
+      "exec": "cdk deploy --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata '**' --require-approval=never -o test/.tmp/foo.integ/deploy.cdk.out",
     },
     Object {
       "exec": "rm -fr test/foo.integ.snapshot",
@@ -168,7 +168,7 @@ Object {
   "name": "integ:foo:watch",
   "steps": Array [
     Object {
-      "exec": "cdk watch --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata '*' -o test/.tmp/foo.integ/deploy.cdk.out",
+      "exec": "cdk watch --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata '**' -o test/.tmp/foo.integ/deploy.cdk.out",
     },
   ],
 }


### PR DESCRIPTION
Per discussion in https://github.com/projen/projen/pull/1496#discussion_r783660269, `**` is a better choice for the default integration test stack to deploy, as using `**` targets stacks including those nested in stages.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.