### PR TITLE
fix(cdk8s): import location should be in the rootDir

### DIFF
--- a/src/cdk8s/cdk8s-app-ts.ts
+++ b/src/cdk8s/cdk8s-app-ts.ts
@@ -168,7 +168,7 @@ export class Cdk8sTypeScriptApp extends TypeScriptAppProject {
 
     this.addTask("import", {
       description: "Imports API objects to your app by generating constructs.",
-      exec: "cdk8s import",
+      exec: "cdk8s import -o src/imports",
     });
 
     this.gitignore.include("imports/");

--- a/test/cdk8s-app-project-ts.test.ts
+++ b/test/cdk8s-app-project-ts.test.ts
@@ -22,6 +22,13 @@ test("test if cdk8s synth is possible", () => {
     },
   ]);
 
+  // expect an import task
+  expect(output[".projen/tasks.json"].tasks.import.steps).toStrictEqual([
+    {
+      exec: "cdk8s import -o src/imports",
+    },
+  ]);
+
   // expect postcompile step to contain synth
   expect(
     output[".projen/tasks.json"].tasks["post-compile"].steps


### PR DESCRIPTION
Changes the default `cdk8s import` location to `./src/imports` so that imported resource specs can be accessed from the rest of the cdk8s app.

Fixes #1534

BREAKING CHANGE: The `import` task in the `Cdk8sTypeScriptApp` project now outputs to the `src` directory by default instead of the project root.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.