### PR TITLE
feat(cdk8s): import additional specs

### DIFF
--- a/API.md
+++ b/API.md
@@ -4648,6 +4648,7 @@ new cdk8s.Cdk8sTypeScriptApp(options: Cdk8sTypeScriptAppOptions)
   * **appEntrypoint** (<code>string</code>)  The CDK8s app's entrypoint (relative to the source directory, which is "src" by default). __*Default*__: "main.ts"
   * **cdk8sCliVersion** (<code>string</code>)  cdk8s-cli version. __*Default*__: "cdk8sVersion"
   * **cdk8sCliVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for CDK8s-cli. __*Default*__: false
+  * **cdk8sImports** (<code>Array<string></code>)  Import additional specs. __*Default*__: no additional specs imported
   * **cdk8sPlusVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for cdk8s-plus-17. __*Default*__: false
   * **cdk8sVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for CDK8s. __*Default*__: false
   * **constructsVersion** (<code>string</code>)  constructs verion. __*Default*__: "3.2.34"
@@ -12231,6 +12232,7 @@ Name | Type | Description
 **bundlerOptions**?🔹 | <code>[javascript.BundlerOptions](#projen-javascript-bundleroptions)</code> | Options for `Bundler`.<br/>__*Optional*__
 **cdk8sCliVersion**?🔹 | <code>string</code> | cdk8s-cli version.<br/>__*Default*__: "cdk8sVersion"
 **cdk8sCliVersionPinning**?🔹 | <code>boolean</code> | Use pinned version instead of caret version for CDK8s-cli.<br/>__*Default*__: false
+**cdk8sImports**?🔹 | <code>Array<string></code> | Import additional specs.<br/>__*Default*__: no additional specs imported
 **cdk8sPlusVersionPinning**?🔹 | <code>boolean</code> | Use pinned version instead of caret version for cdk8s-plus-17.<br/>__*Default*__: false
 **cdk8sVersionPinning**?🔹 | <code>boolean</code> | Use pinned version instead of caret version for CDK8s.<br/>__*Default*__: false
 **clobber**?🔹 | <code>boolean</code> | Add a `clobber` task which resets the repo to origin.<br/>__*Default*__: true

--- a/src/cdk8s/cdk8s-app-ts.ts
+++ b/src/cdk8s/cdk8s-app-ts.ts
@@ -13,6 +13,13 @@ export interface Cdk8sTypeScriptAppOptions extends TypeScriptProjectOptions {
   readonly cdk8sVersion: string;
 
   /**
+   * Import additional specs
+   *
+   * @default - no additional specs imported
+   */
+  readonly cdk8sImports?: string[];
+
+  /**
    * constructs verion
    *
    * @default "3.2.34"
@@ -166,10 +173,14 @@ export class Cdk8sTypeScriptApp extends TypeScriptAppProject {
       exec: "cdk8s synth",
     });
 
-    this.addTask("import", {
+    const importTask = this.addTask("import", {
       description: "Imports API objects to your app by generating constructs.",
       exec: "cdk8s import -o src/imports",
     });
+
+    for (const importSpec of options.cdk8sImports ?? []) {
+      importTask.exec(`cdk8s import ${importSpec} -o src/imports`);
+    }
 
     this.gitignore.include("imports/");
     this.gitignore.include("cdk8s.yaml");

--- a/test/__snapshots__/inventory.test.ts.snap
+++ b/test/__snapshots__/inventory.test.ts.snap
@@ -6755,6 +6755,28 @@ Array [
         "switch": "cdk8s-cli-version-pinning",
       },
       Object {
+        "default": "- no additional specs imported",
+        "docs": "Import additional specs.",
+        "featured": false,
+        "fullType": Object {
+          "collection": Object {
+            "elementtype": Object {
+              "primitive": "string",
+            },
+            "kind": "array",
+          },
+        },
+        "jsonLike": true,
+        "name": "cdk8sImports",
+        "optional": true,
+        "parent": "Cdk8sTypeScriptAppOptions",
+        "path": Array [
+          "cdk8sImports",
+        ],
+        "simpleType": "unknown",
+        "switch": "cdk8s-imports",
+      },
+      Object {
         "default": "false",
         "docs": "Use pinned version instead of caret version for cdk8s-plus-17.",
         "featured": false,

--- a/test/cdk8s-app-project-ts.test.ts
+++ b/test/cdk8s-app-project-ts.test.ts
@@ -40,6 +40,30 @@ test("test if cdk8s synth is possible", () => {
   });
 });
 
+test("adding cdk8sImports", () => {
+  const project = new Cdk8sTypeScriptApp({
+    cdk8sVersion: "1.0.0-beta.18",
+    name: "project",
+    defaultReleaseBranch: "main",
+    releaseWorkflow: true,
+    constructsVersion: "3.3.75",
+    cdk8sImports: ["github:crossplane/crossplane@0.14.0"],
+  });
+
+  // WHEN
+  const output = synthSnapshot(project);
+
+  // THEN
+  expect(output[".projen/tasks.json"].tasks.import.steps).toStrictEqual([
+    {
+      exec: "cdk8s import -o src/imports",
+    },
+    {
+      exec: "cdk8s import github:crossplane/crossplane@0.14.0 -o src/imports",
+    },
+  ]);
+});
+
 test("constructs version undefined", () => {
   const project = new Cdk8sTypeScriptApp({
     cdk8sVersion: "1.0.0-beta.11",


### PR DESCRIPTION
Adds `cdk8sImports` which allows the user to import additional Kubernetes specs.

Fixes #1535

﻿---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
