### PR TITLE
feat: install AWS CDK CLI for integration snapshot tests

### DIFF
--- a/src/awscdk/integration-test.ts
+++ b/src/awscdk/integration-test.ts
@@ -93,6 +93,10 @@ export class IntegrationTest extends Component {
 
     const app = `ts-node -P ${options.tsconfigPath} ${entry}`;
 
+    if (!project.deps.tryGetDependency("aws-cdk")) {
+      project.deps.addDependency(`aws-cdk@^${options.cdkDeps.cdkMajorVersion}`, DependencyType.BUILD);
+    }
+
     if (!project.deps.tryGetDependency("ts-node")) {
       project.deps.addDependency("ts-node", DependencyType.BUILD);
     }

--- a/src/awscdk/integration-test.ts
+++ b/src/awscdk/integration-test.ts
@@ -94,7 +94,10 @@ export class IntegrationTest extends Component {
     const app = `ts-node -P ${options.tsconfigPath} ${entry}`;
 
     if (!project.deps.tryGetDependency("aws-cdk")) {
-      project.deps.addDependency(`aws-cdk@^${options.cdkDeps.cdkMajorVersion}`, DependencyType.BUILD);
+      project.deps.addDependency(
+        `aws-cdk@^${options.cdkDeps.cdkMajorVersion}`,
+        DependencyType.BUILD
+      );
     }
 
     if (!project.deps.tryGetDependency("ts-node")) {

--- a/test/awscdk/integration-test.test.ts
+++ b/test/awscdk/integration-test.test.ts
@@ -90,6 +90,50 @@ test("installs ts-node if needed", () => {
   });
 });
 
+test("installs aws-cdk v1 if needed", () => {
+  const project = new TypeScriptProject({
+    name: "test",
+    defaultReleaseBranch: "main",
+  });
+
+  new IntegrationTest(project, {
+    entrypoint: "test/foo.integ.ts",
+    tsconfigPath: project.tsconfigDev.fileName,
+    cdkDeps: new AwsCdkDepsJs(project, {
+      cdkVersion: "1.0.0",
+      dependencyType: DependencyType.RUNTIME,
+    }),
+  });
+
+  expect(project.deps.getDependency("aws-cdk")).toStrictEqual({
+    name: "aws-cdk",
+    type: "build",
+    version: "^1",
+  });
+});
+
+test("installs aws-cdk v2 if needed", () => {
+  const project = new TypeScriptProject({
+    name: "test",
+    defaultReleaseBranch: "main",
+  });
+
+  new IntegrationTest(project, {
+    entrypoint: "test/foo.integ.ts",
+    tsconfigPath: project.tsconfigDev.fileName,
+    cdkDeps: new AwsCdkDepsJs(project, {
+      cdkVersion: "2.8.0",
+      dependencyType: DependencyType.RUNTIME,
+    }),
+  });
+
+  expect(project.deps.getDependency("aws-cdk")).toStrictEqual({
+    name: "aws-cdk",
+    type: "build",
+    version: "^2",
+  });
+});
+
 test("synthesizing cdk v2 integration tests", () => {
   // GIVEN
   const project = new awscdk.AwsCdkTypeScriptApp({


### PR DESCRIPTION
Currently when using a `AwsCdkConstructLibrary` it must be manually
added to the project.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.