### PR TITLE
fix: disabled github components throws error

### DIFF
--- a/src/javascript/node-project.ts
+++ b/src/javascript/node-project.ts
@@ -662,13 +662,13 @@ export class NodeProject extends GitHubProject {
 
     if (projenAutoApprove && !this.autoApprove) {
       throw new Error(
-        "Autoamtic approval of projen upgrades requires configuring `autoApproveOptions`"
+        "Automatic approval of projen upgrades requires configuring `autoApproveOptions`"
       );
     }
 
     if (depsAutoApprove && !this.autoApprove) {
       throw new Error(
-        "Autoamtic approval of dependencies upgrades requires configuring `autoApproveOptions`"
+        "Automatic approval of dependencies upgrades requires configuring `autoApproveOptions`"
       );
     }
 

--- a/src/javascript/node-project.ts
+++ b/src/javascript/node-project.ts
@@ -660,13 +660,13 @@ export class NodeProject extends GitHubProject {
       false;
     const depsAutoApprove = options.autoApproveUpgrades ?? false;
 
-    if (projenAutoApprove && !this.autoApprove) {
+    if (projenAutoApprove && !this.autoApprove && this.github) {
       throw new Error(
         "Automatic approval of projen upgrades requires configuring `autoApproveOptions`"
       );
     }
 
-    if (depsAutoApprove && !this.autoApprove) {
+    if (depsAutoApprove && !this.autoApprove && this.github) {
       throw new Error(
         "Automatic approval of dependencies upgrades requires configuring `autoApproveOptions`"
       );

--- a/test/node-project.test.ts
+++ b/test/node-project.test.ts
@@ -203,7 +203,7 @@ test("throw when 'autoApproveProjenUpgrades' is used with 'projenUpgradeAutoMerg
 describe("deps upgrade", () => {
   test("throws when trying to auto approve projen but auto approve is not defined", () => {
     const message =
-      "Autoamtic approval of projen upgrades requires configuring `autoApproveOptions`";
+      "Automatic approval of projen upgrades requires configuring `autoApproveOptions`";
     expect(() => {
       new TestNodeProject({ autoApproveProjenUpgrades: true });
     }).toThrow(message);
@@ -216,7 +216,7 @@ describe("deps upgrade", () => {
     expect(() => {
       new TestNodeProject({ autoApproveUpgrades: true });
     }).toThrow(
-      "Autoamtic approval of dependencies upgrades requires configuring `autoApproveOptions`"
+      "Automatic approval of dependencies upgrades requires configuring `autoApproveOptions`"
     );
   });
 

--- a/test/node-project.test.ts
+++ b/test/node-project.test.ts
@@ -717,6 +717,8 @@ test("github: false disables github integration", () => {
   // WHEN
   const project = new TestNodeProject({
     github: false,
+    autoApproveUpgrades: true,
+    autoApproveOptions: {},
   });
 
   // THEN


### PR DESCRIPTION
If `github: false` is configured the `NodeProject` throwing an error, when there is auto approval configured.

The error occured with an external projen project type, which has presets for github, but should just be disabled on some projects. I would like to keep the configuration and just disable the github feature.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.