### PR TITLE
feat(awscdk): task to update snapshot of all integrations tests

### DIFF
--- a/src/awscdk/integration-test.ts
+++ b/src/awscdk/integration-test.ts
@@ -179,6 +179,14 @@ export class IntegrationTest extends Component {
       exec: `cdk synth ${cdkopts} -o ${snapshotdir} > /dev/null`,
     });
 
+    let snapshotAllTask = project.tasks.tryFind("integ:snapshot-all");
+    if (!snapshotAllTask) {
+      snapshotAllTask = project.addTask("integ:snapshot-all", {
+        description: "update snapshot for all integration tests",
+      });
+    }
+    snapshotAllTask.spawn(snapshotTask);
+
     // synth as part of our tests, which means that if outdir changes, anti-tamper will fail
     project.testTask.spawn(assertTask);
     project.addGitIgnore(`!${snapshotdir}`); // commit outdir to git but not assets

--- a/test/awscdk/__snapshots__/integration-test.test.ts.snap
+++ b/test/awscdk/__snapshots__/integration-test.test.ts.snap
@@ -78,6 +78,21 @@ Object {
 }
 `;
 
+exports[`IntegrationTest tasks 6`] = `
+Object {
+  "description": "update snapshot for all integration tests",
+  "name": "integ:snapshot-all",
+  "steps": Array [
+    Object {
+      "spawn": "integ:foo:snapshot",
+    },
+    Object {
+      "spawn": "integ:bar:snapshot",
+    },
+  ],
+}
+`;
+
 exports[`synthesizing an integration test containing a multi-stack stage 1`] = `
 Object {
   "description": "deploy integration test 'my-stage' and capture snapshot",

--- a/test/awscdk/integration-test.test.ts
+++ b/test/awscdk/integration-test.test.ts
@@ -19,6 +19,12 @@ describe("IntegrationTest", () => {
     cdkDeps: project.cdkDeps,
   });
 
+  new awscdk.IntegrationTest(project, {
+    entrypoint: "test/bar.integ.ts",
+    tsconfigPath: project.tsconfigDev.fileName,
+    cdkDeps: project.cdkDeps,
+  });
+
   // THEN
   const output = Testing.synth(project);
 
@@ -59,6 +65,7 @@ describe("IntegrationTest", () => {
       "integ:foo:destroy",
       "integ:foo:snapshot",
       "integ:foo:watch",
+      "integ:snapshot-all",
     ];
 
     const actualTaskNames = Object.keys(output[".projen/tasks.json"].tasks);


### PR DESCRIPTION
The task is named `integ:snapshot-all` and can be used together with the
feat added in #1476.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.