### PR TITLE
fix: Remove markmac from autodependency updates

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -352,25 +352,25 @@
       },
       "steps": [
         {
-          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='projen'"
+          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='markmac,projen'"
         },
         {
-          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='projen'"
+          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='markmac,projen'"
         },
         {
-          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='projen'"
+          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='markmac,projen'"
         },
         {
-          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='projen'"
+          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='markmac,projen'"
         },
         {
-          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='projen'"
+          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='markmac,projen'"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @types/conventional-changelog-config-spec @types/fs-extra @types/glob @types/ini @types/jest @types/node @types/semver @types/yargs @typescript-eslint/eslint-plugin @typescript-eslint/parser all-contributors-cli eslint-config-prettier eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint jest jest-junit jsii jsii-diff jsii-docgen json-schema markmac npm-check-updates prettier standard-version ts-jest typescript @iarna/toml case chalk conventional-changelog-config-spec fs-extra glob ini semver shx xmlbuilder2 yaml yargs"
+          "exec": "yarn upgrade @types/conventional-changelog-config-spec @types/fs-extra @types/glob @types/ini @types/jest @types/node @types/semver @types/yargs @typescript-eslint/eslint-plugin @typescript-eslint/parser all-contributors-cli eslint-config-prettier eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint jest jest-junit jsii jsii-diff jsii-docgen json-schema npm-check-updates prettier standard-version ts-jest typescript @iarna/toml case chalk conventional-changelog-config-spec fs-extra glob ini semver shx xmlbuilder2 yaml yargs"
         },
         {
           "exec": "/bin/bash ./projen.bash"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -51,7 +51,7 @@ const project = new cdk.JsiiProject({
   ],
 
   depsUpgradeOptions: {
-    exclude: ["markmac"]
+    exclude: ["markmac"],
   },
 
   projenDevDependency: false, // because I am projen

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -51,6 +51,7 @@ const project = new cdk.JsiiProject({
   ],
 
   depsUpgradeOptions: {
+    // markmac depends on projen, we are excluding it here to avoid a circular update loop
     exclude: ["markmac"],
   },
 

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -1,5 +1,4 @@
-const { cdk, github, JsonFile, TextFile } = require("./lib");
-const { workflows } = require("./lib/github");
+const { cdk, JsonFile, TextFile } = require("./lib");
 
 const project = new cdk.JsiiProject({
   name: "projen",
@@ -50,6 +49,10 @@ const project = new cdk.JsiiProject({
     "markmac",
     "all-contributors-cli",
   ],
+
+  depsUpgradeOptions: {
+    exclude: ["markmac"]
+  },
 
   projenDevDependency: false, // because I am projen
   releaseToNpm: true,


### PR DESCRIPTION
Also removed unused imports in .projenrc.js.

Not sure if there's another way to resolve the linked issue, but I think not having publish a new version every day would be nice.

If it would be better to disable markmac from auto updating projen instead then this PR can be closed.

fixes #1553 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.