### PR TITLE
feat(cdk8s): import an explicit k8s spec version

### DIFF
--- a/API.md
+++ b/API.md
@@ -4659,10 +4659,10 @@ new cdk8s.Cdk8sTypeScriptApp(options: Cdk8sTypeScriptAppOptions)
   * **cdk8sCliVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for CDK8s-cli. __*Default*__: false
   * **cdk8sImports** (<code>Array<string></code>)  Import additional specs. __*Default*__: no additional specs imported
   * **cdk8sPlusVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for cdk8s-plus-17. __*Default*__: false
-  * **cdk8sSpecVersion** (<code>string</code>)  Import a specific Kubernetes spec version. __*Default*__: Use the cdk8s default
   * **cdk8sVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for CDK8s. __*Default*__: false
   * **constructsVersion** (<code>string</code>)  constructs verion. __*Default*__: "3.2.34"
   * **constructsVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for constructs. __*Default*__: false
+  * **k8sSpecVersion** (<code>string</code>)  Import a specific Kubernetes spec version. __*Default*__: Use the cdk8s default
 
 
 
@@ -12245,7 +12245,6 @@ Name | Type | Description
 **cdk8sCliVersionPinning**?🔹 | <code>boolean</code> | Use pinned version instead of caret version for CDK8s-cli.<br/>__*Default*__: false
 **cdk8sImports**?🔹 | <code>Array<string></code> | Import additional specs.<br/>__*Default*__: no additional specs imported
 **cdk8sPlusVersionPinning**?🔹 | <code>boolean</code> | Use pinned version instead of caret version for cdk8s-plus-17.<br/>__*Default*__: false
-**cdk8sSpecVersion**?🔹 | <code>string</code> | Import a specific Kubernetes spec version.<br/>__*Default*__: Use the cdk8s default
 **cdk8sVersionPinning**?🔹 | <code>boolean</code> | Use pinned version instead of caret version for CDK8s.<br/>__*Default*__: false
 **clobber**?🔹 | <code>boolean</code> | Add a `clobber` task which resets the repo to origin.<br/>__*Default*__: true
 **codeArtifactOptions**?🔹 | <code>[javascript.CodeArtifactOptions](#projen-javascript-codeartifactoptions)</code> | Options for publishing npm package to AWS CodeArtifact.<br/>__*Default*__: undefined
@@ -12278,6 +12277,7 @@ Name | Type | Description
 **jest**?🔹 | <code>boolean</code> | Setup jest unit tests.<br/>__*Default*__: true
 **jestOptions**?🔹 | <code>[javascript.JestOptions](#projen-javascript-jestoptions)</code> | Jest options.<br/>__*Default*__: default options
 **jsiiReleaseVersion**?🔹 | <code>string</code> | Version requirement of `jsii-release` which is used to publish modules to npm.<br/>__*Default*__: "latest"
+**k8sSpecVersion**?🔹 | <code>string</code> | Import a specific Kubernetes spec version.<br/>__*Default*__: Use the cdk8s default
 **keywords**?🔹 | <code>Array<string></code> | Keywords to include in `package.json`.<br/>__*Optional*__
 **libdir**?🔹 | <code>string</code> | Typescript  artifacts output directory.<br/>__*Default*__: "lib"
 **license**?🔹 | <code>string</code> | License's SPDX identifier.<br/>__*Default*__: "Apache-2.0"

--- a/API.md
+++ b/API.md
@@ -4655,11 +4655,11 @@ new cdk8s.Cdk8sTypeScriptApp(options: Cdk8sTypeScriptAppOptions)
   * **typescriptVersion** (<code>string</code>)  TypeScript version to use. __*Default*__: "latest"
   * **cdk8sVersion** (<code>string</code>)  Minimum target version this library is tested against. 
   * **appEntrypoint** (<code>string</code>)  The CDK8s app's entrypoint (relative to the source directory, which is "src" by default). __*Default*__: "main.ts"
-  * **cdk8sApiVersion** (<code>string</code>)  Import a specific Kubernetes API version. __*Default*__: Use the cdk8s default
   * **cdk8sCliVersion** (<code>string</code>)  cdk8s-cli version. __*Default*__: "cdk8sVersion"
   * **cdk8sCliVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for CDK8s-cli. __*Default*__: false
   * **cdk8sImports** (<code>Array<string></code>)  Import additional specs. __*Default*__: no additional specs imported
   * **cdk8sPlusVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for cdk8s-plus-17. __*Default*__: false
+  * **cdk8sSpecVersion** (<code>string</code>)  Import a specific Kubernetes spec version. __*Default*__: Use the cdk8s default
   * **cdk8sVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for CDK8s. __*Default*__: false
   * **constructsVersion** (<code>string</code>)  constructs verion. __*Default*__: "3.2.34"
   * **constructsVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for constructs. __*Default*__: false
@@ -12241,11 +12241,11 @@ Name | Type | Description
 **buildWorkflow**?🔹 | <code>boolean</code> | Define a GitHub workflow for building PRs.<br/>__*Default*__: true if not a subproject
 **bundledDeps**?🔹 | <code>Array<string></code> | List of dependencies to bundle into this module.<br/>__*Optional*__
 **bundlerOptions**?🔹 | <code>[javascript.BundlerOptions](#projen-javascript-bundleroptions)</code> | Options for `Bundler`.<br/>__*Optional*__
-**cdk8sApiVersion**?🔹 | <code>string</code> | Import a specific Kubernetes API version.<br/>__*Default*__: Use the cdk8s default
 **cdk8sCliVersion**?🔹 | <code>string</code> | cdk8s-cli version.<br/>__*Default*__: "cdk8sVersion"
 **cdk8sCliVersionPinning**?🔹 | <code>boolean</code> | Use pinned version instead of caret version for CDK8s-cli.<br/>__*Default*__: false
 **cdk8sImports**?🔹 | <code>Array<string></code> | Import additional specs.<br/>__*Default*__: no additional specs imported
 **cdk8sPlusVersionPinning**?🔹 | <code>boolean</code> | Use pinned version instead of caret version for cdk8s-plus-17.<br/>__*Default*__: false
+**cdk8sSpecVersion**?🔹 | <code>string</code> | Import a specific Kubernetes spec version.<br/>__*Default*__: Use the cdk8s default
 **cdk8sVersionPinning**?🔹 | <code>boolean</code> | Use pinned version instead of caret version for CDK8s.<br/>__*Default*__: false
 **clobber**?🔹 | <code>boolean</code> | Add a `clobber` task which resets the repo to origin.<br/>__*Default*__: true
 **codeArtifactOptions**?🔹 | <code>[javascript.CodeArtifactOptions](#projen-javascript-codeartifactoptions)</code> | Options for publishing npm package to AWS CodeArtifact.<br/>__*Default*__: undefined

--- a/API.md
+++ b/API.md
@@ -4655,6 +4655,7 @@ new cdk8s.Cdk8sTypeScriptApp(options: Cdk8sTypeScriptAppOptions)
   * **typescriptVersion** (<code>string</code>)  TypeScript version to use. __*Default*__: "latest"
   * **cdk8sVersion** (<code>string</code>)  Minimum target version this library is tested against. 
   * **appEntrypoint** (<code>string</code>)  The CDK8s app's entrypoint (relative to the source directory, which is "src" by default). __*Default*__: "main.ts"
+  * **cdk8sApiVersion** (<code>string</code>)  Import a specific Kubernetes API version. __*Default*__: Use the cdk8s default
   * **cdk8sCliVersion** (<code>string</code>)  cdk8s-cli version. __*Default*__: "cdk8sVersion"
   * **cdk8sCliVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for CDK8s-cli. __*Default*__: false
   * **cdk8sImports** (<code>Array<string></code>)  Import additional specs. __*Default*__: no additional specs imported
@@ -12240,6 +12241,7 @@ Name | Type | Description
 **buildWorkflow**?🔹 | <code>boolean</code> | Define a GitHub workflow for building PRs.<br/>__*Default*__: true if not a subproject
 **bundledDeps**?🔹 | <code>Array<string></code> | List of dependencies to bundle into this module.<br/>__*Optional*__
 **bundlerOptions**?🔹 | <code>[javascript.BundlerOptions](#projen-javascript-bundleroptions)</code> | Options for `Bundler`.<br/>__*Optional*__
+**cdk8sApiVersion**?🔹 | <code>string</code> | Import a specific Kubernetes API version.<br/>__*Default*__: Use the cdk8s default
 **cdk8sCliVersion**?🔹 | <code>string</code> | cdk8s-cli version.<br/>__*Default*__: "cdk8sVersion"
 **cdk8sCliVersionPinning**?🔹 | <code>boolean</code> | Use pinned version instead of caret version for CDK8s-cli.<br/>__*Default*__: false
 **cdk8sImports**?🔹 | <code>Array<string></code> | Import additional specs.<br/>__*Default*__: no additional specs imported

--- a/src/cdk8s/cdk8s-app-ts.ts
+++ b/src/cdk8s/cdk8s-app-ts.ts
@@ -190,7 +190,7 @@ export class Cdk8sTypeScriptApp extends TypeScriptAppProject {
     this.postCompileTask.spawn(synth);
 
     const cdk8sImports = options.cdk8sImports ?? [];
-    const cdk8sSpec = options.k8sSpecVersion
+    const k8sSpec = options.k8sSpecVersion
       ? `k8s@${options.k8sSpecVersion}`
       : "k8s";
 
@@ -201,7 +201,7 @@ export class Cdk8sTypeScriptApp extends TypeScriptAppProject {
       obj: {
         language: "typescript",
         app: `node lib/${appEntrypointName}`,
-        imports: [cdk8sSpec, ...cdk8sImports],
+        imports: [k8sSpec, ...cdk8sImports],
       },
     });
 

--- a/src/cdk8s/cdk8s-app-ts.ts
+++ b/src/cdk8s/cdk8s-app-ts.ts
@@ -194,13 +194,14 @@ export class Cdk8sTypeScriptApp extends TypeScriptAppProject {
       ? `k8s@${options.k8sSpecVersion}`
       : "k8s";
 
-    const appEntrypointName = path.basename(this.appEntrypoint, ".ts") + ".js";
+    const appEntrypointBaseName = path.basename(this.appEntrypoint, ".ts");
+
     new YamlFile(this, "cdk8s.yaml", {
       committed: true,
       editGitignore: true,
       obj: {
         language: "typescript",
-        app: `node lib/${appEntrypointName}`,
+        app: `node lib/${appEntrypointBaseName}.js`,
         imports: [k8sSpec, ...cdk8sImports],
       },
     });

--- a/src/cdk8s/cdk8s-app-ts.ts
+++ b/src/cdk8s/cdk8s-app-ts.ts
@@ -175,10 +175,17 @@ export class Cdk8sTypeScriptApp extends TypeScriptAppProject {
 
     const importTask = this.addTask("import", {
       description: "Imports API objects to your app by generating constructs.",
-      exec: "cdk8s import -o src/imports",
     });
 
-    for (const importSpec of options.cdk8sImports ?? []) {
+    const cdk8sImports = options.cdk8sImports ?? [];
+
+    // Import cdk8s' default spec unless the user specifies the k8s version in
+    // `cdk8sImports`.
+    if (!cdk8sImports.some((spec) => spec.startsWith("k8s@"))) {
+      importTask.exec(`cdk8s import -o src/imports`);
+    }
+
+    for (const importSpec of cdk8sImports) {
       importTask.exec(`cdk8s import ${importSpec} -o src/imports`);
     }
 

--- a/src/cdk8s/cdk8s-app-ts.ts
+++ b/src/cdk8s/cdk8s-app-ts.ts
@@ -13,6 +13,13 @@ export interface Cdk8sTypeScriptAppOptions extends TypeScriptProjectOptions {
   readonly cdk8sVersion: string;
 
   /**
+   * Import a specific Kubernetes API version
+   *
+   * @default - Use the cdk8s default
+   */
+  readonly cdk8sApiVersion?: string;
+
+  /**
    * Import additional specs
    *
    * @default - no additional specs imported
@@ -173,19 +180,16 @@ export class Cdk8sTypeScriptApp extends TypeScriptAppProject {
       exec: "cdk8s synth",
     });
 
+    const k8sSpec = options.cdk8sApiVersion
+      ? `k8s@${options.cdk8sApiVersion}`
+      : "k8s";
+
     const importTask = this.addTask("import", {
       description: "Imports API objects to your app by generating constructs.",
+      exec: `cdk8s import ${k8sSpec} -o src/imports`,
     });
 
-    const cdk8sImports = options.cdk8sImports ?? [];
-
-    // Import cdk8s' default spec unless the user specifies the k8s version in
-    // `cdk8sImports`.
-    if (!cdk8sImports.some((spec) => spec.startsWith("k8s@"))) {
-      importTask.exec(`cdk8s import -o src/imports`);
-    }
-
-    for (const importSpec of cdk8sImports) {
+    for (const importSpec of options.cdk8sImports ?? []) {
       importTask.exec(`cdk8s import ${importSpec} -o src/imports`);
     }
 

--- a/src/cdk8s/cdk8s-app-ts.ts
+++ b/src/cdk8s/cdk8s-app-ts.ts
@@ -18,7 +18,7 @@ export interface Cdk8sTypeScriptAppOptions extends TypeScriptProjectOptions {
    *
    * @default - Use the cdk8s default
    */
-  readonly cdk8sSpecVersion?: string;
+  readonly k8sSpecVersion?: string;
 
   /**
    * Import additional specs
@@ -190,8 +190,8 @@ export class Cdk8sTypeScriptApp extends TypeScriptAppProject {
     this.postCompileTask.spawn(synth);
 
     const cdk8sImports = options.cdk8sImports ?? [];
-    const cdk8sSpec = options.cdk8sSpecVersion
-      ? `k8s@${options.cdk8sSpecVersion}`
+    const cdk8sSpec = options.k8sSpecVersion
+      ? `k8s@${options.k8sSpecVersion}`
       : "k8s";
 
     const appEntrypointName = path.basename(this.appEntrypoint, ".ts") + ".js";

--- a/test/__snapshots__/inventory.test.ts.snap
+++ b/test/__snapshots__/inventory.test.ts.snap
@@ -6721,23 +6721,6 @@ Array [
         "switch": "bundler-options",
       },
       Object {
-        "default": "- Use the cdk8s default",
-        "docs": "Import a specific Kubernetes API version.",
-        "featured": false,
-        "fullType": Object {
-          "primitive": "string",
-        },
-        "jsonLike": true,
-        "name": "cdk8sApiVersion",
-        "optional": true,
-        "parent": "Cdk8sTypeScriptAppOptions",
-        "path": Array [
-          "cdk8sApiVersion",
-        ],
-        "simpleType": "string",
-        "switch": "cdk8s-api-version",
-      },
-      Object {
         "default": "\\"cdk8sVersion\\"",
         "docs": "cdk8s-cli version.",
         "featured": false,
@@ -6809,6 +6792,23 @@ Array [
         ],
         "simpleType": "boolean",
         "switch": "cdk8s-plus-version-pinning",
+      },
+      Object {
+        "default": "- Use the cdk8s default",
+        "docs": "Import a specific Kubernetes spec version.",
+        "featured": false,
+        "fullType": Object {
+          "primitive": "string",
+        },
+        "jsonLike": true,
+        "name": "cdk8sSpecVersion",
+        "optional": true,
+        "parent": "Cdk8sTypeScriptAppOptions",
+        "path": Array [
+          "cdk8sSpecVersion",
+        ],
+        "simpleType": "string",
+        "switch": "cdk8s-spec-version",
       },
       Object {
         "default": "\\"1.0.0-beta.10\\"",

--- a/test/__snapshots__/inventory.test.ts.snap
+++ b/test/__snapshots__/inventory.test.ts.snap
@@ -6794,23 +6794,6 @@ Array [
         "switch": "cdk8s-plus-version-pinning",
       },
       Object {
-        "default": "- Use the cdk8s default",
-        "docs": "Import a specific Kubernetes spec version.",
-        "featured": false,
-        "fullType": Object {
-          "primitive": "string",
-        },
-        "jsonLike": true,
-        "name": "cdk8sSpecVersion",
-        "optional": true,
-        "parent": "Cdk8sTypeScriptAppOptions",
-        "path": Array [
-          "cdk8sSpecVersion",
-        ],
-        "simpleType": "string",
-        "switch": "cdk8s-spec-version",
-      },
-      Object {
         "default": "\\"1.0.0-beta.10\\"",
         "docs": "Minimum target version this library is tested against.",
         "featured": true,
@@ -7409,6 +7392,23 @@ Array [
         ],
         "simpleType": "string",
         "switch": "jsii-release-version",
+      },
+      Object {
+        "default": "- Use the cdk8s default",
+        "docs": "Import a specific Kubernetes spec version.",
+        "featured": false,
+        "fullType": Object {
+          "primitive": "string",
+        },
+        "jsonLike": true,
+        "name": "k8sSpecVersion",
+        "optional": true,
+        "parent": "Cdk8sTypeScriptAppOptions",
+        "path": Array [
+          "k8sSpecVersion",
+        ],
+        "simpleType": "string",
+        "switch": "k8s-spec-version",
       },
       Object {
         "docs": "Keywords to include in \`package.json\`.",

--- a/test/__snapshots__/inventory.test.ts.snap
+++ b/test/__snapshots__/inventory.test.ts.snap
@@ -6721,6 +6721,23 @@ Array [
         "switch": "bundler-options",
       },
       Object {
+        "default": "- Use the cdk8s default",
+        "docs": "Import a specific Kubernetes API version.",
+        "featured": false,
+        "fullType": Object {
+          "primitive": "string",
+        },
+        "jsonLike": true,
+        "name": "cdk8sApiVersion",
+        "optional": true,
+        "parent": "Cdk8sTypeScriptAppOptions",
+        "path": Array [
+          "cdk8sApiVersion",
+        ],
+        "simpleType": "string",
+        "switch": "cdk8s-api-version",
+      },
+      Object {
         "default": "\\"cdk8sVersion\\"",
         "docs": "cdk8s-cli version.",
         "featured": false,

--- a/test/cdk8s-app-project-ts.test.ts
+++ b/test/cdk8s-app-project-ts.test.ts
@@ -59,7 +59,7 @@ test("adding cdk8sImports", () => {
     defaultReleaseBranch: "main",
     releaseWorkflow: true,
     constructsVersion: "3.3.75",
-    cdk8sSpecVersion: "1.20.0",
+    k8sSpecVersion: "1.20.0",
     cdk8sImports: ["github:crossplane/crossplane@0.14.0"],
   });
 

--- a/test/cdk8s-app-project-ts.test.ts
+++ b/test/cdk8s-app-project-ts.test.ts
@@ -64,6 +64,27 @@ test("adding cdk8sImports", () => {
   ]);
 });
 
+test("adding an explicit k8s version to cdk8sImports", () => {
+  const project = new Cdk8sTypeScriptApp({
+    cdk8sVersion: "1.0.0-beta.18",
+    name: "project",
+    defaultReleaseBranch: "main",
+    releaseWorkflow: true,
+    constructsVersion: "3.3.75",
+    cdk8sImports: ["k8s@1.20.0"],
+  });
+
+  // WHEN
+  const output = synthSnapshot(project);
+
+  // THEN
+  expect(output[".projen/tasks.json"].tasks.import.steps).toStrictEqual([
+    {
+      exec: "cdk8s import k8s@1.20.0 -o src/imports",
+    },
+  ]);
+});
+
 test("constructs version undefined", () => {
   const project = new Cdk8sTypeScriptApp({
     cdk8sVersion: "1.0.0-beta.11",

--- a/test/cdk8s-app-project-ts.test.ts
+++ b/test/cdk8s-app-project-ts.test.ts
@@ -25,7 +25,7 @@ test("test if cdk8s synth is possible", () => {
   // expect an import task
   expect(output[".projen/tasks.json"].tasks.import.steps).toStrictEqual([
     {
-      exec: "cdk8s import -o src/imports",
+      exec: "cdk8s import k8s -o src/imports",
     },
   ]);
 
@@ -56,7 +56,7 @@ test("adding cdk8sImports", () => {
   // THEN
   expect(output[".projen/tasks.json"].tasks.import.steps).toStrictEqual([
     {
-      exec: "cdk8s import -o src/imports",
+      exec: "cdk8s import k8s -o src/imports",
     },
     {
       exec: "cdk8s import github:crossplane/crossplane@0.14.0 -o src/imports",
@@ -71,7 +71,7 @@ test("adding an explicit k8s version to cdk8sImports", () => {
     defaultReleaseBranch: "main",
     releaseWorkflow: true,
     constructsVersion: "3.3.75",
-    cdk8sImports: ["k8s@1.20.0"],
+    cdk8sApiVersion: "1.20.0",
   });
 
   // WHEN

--- a/test/cdk8s-app-project-ts.test.ts
+++ b/test/cdk8s-app-project-ts.test.ts
@@ -1,4 +1,5 @@
 import { Cdk8sTypeScriptApp } from "../src/cdk8s";
+import { YamlFile } from "../src/yaml";
 import { synthSnapshot } from "./util";
 
 test("test if cdk8s synth is possible", () => {
@@ -25,8 +26,19 @@ test("test if cdk8s synth is possible", () => {
   // expect an import task
   expect(output[".projen/tasks.json"].tasks.import.steps).toStrictEqual([
     {
-      exec: "cdk8s import k8s -o src/imports",
+      exec: "cdk8s import -o src/imports",
     },
+  ]);
+
+  // expect cdk8s.yaml to contain the k8s import
+  expect(output["cdk8s.yaml"].split("\n")).toStrictEqual([
+    `# ${YamlFile.PROJEN_MARKER}`,
+    "",
+    "language: typescript",
+    "app: node lib/main.js",
+    "imports:",
+    "  - k8s",
+    "",
   ]);
 
   // expect postcompile step to contain synth
@@ -47,6 +59,7 @@ test("adding cdk8sImports", () => {
     defaultReleaseBranch: "main",
     releaseWorkflow: true,
     constructsVersion: "3.3.75",
+    cdk8sSpecVersion: "1.20.0",
     cdk8sImports: ["github:crossplane/crossplane@0.14.0"],
   });
 
@@ -56,32 +69,18 @@ test("adding cdk8sImports", () => {
   // THEN
   expect(output[".projen/tasks.json"].tasks.import.steps).toStrictEqual([
     {
-      exec: "cdk8s import k8s -o src/imports",
-    },
-    {
-      exec: "cdk8s import github:crossplane/crossplane@0.14.0 -o src/imports",
+      exec: "cdk8s import -o src/imports",
     },
   ]);
-});
-
-test("adding an explicit k8s version to cdk8sImports", () => {
-  const project = new Cdk8sTypeScriptApp({
-    cdk8sVersion: "1.0.0-beta.18",
-    name: "project",
-    defaultReleaseBranch: "main",
-    releaseWorkflow: true,
-    constructsVersion: "3.3.75",
-    cdk8sApiVersion: "1.20.0",
-  });
-
-  // WHEN
-  const output = synthSnapshot(project);
-
-  // THEN
-  expect(output[".projen/tasks.json"].tasks.import.steps).toStrictEqual([
-    {
-      exec: "cdk8s import k8s@1.20.0 -o src/imports",
-    },
+  expect(output["cdk8s.yaml"].split("\n")).toStrictEqual([
+    `# ${YamlFile.PROJEN_MARKER}`,
+    "",
+    "language: typescript",
+    "app: node lib/main.js",
+    "imports:",
+    "  - k8s@1.20.0",
+    "  - github:crossplane/crossplane@0.14.0",
+    "",
   ]);
 });
 


### PR DESCRIPTION
Allows users to specify the `k8s` version to import.

Fixes #1557 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.