### PR TITLE
feat(github): allow JobMatrix to accept values other than string

### DIFF
--- a/src/github/workflows-model.ts
+++ b/src/github/workflows-model.ts
@@ -349,7 +349,7 @@ export interface JobStrategy {
   readonly maxParallel?: number;
 }
 
-type JobMatrixValue = string | boolean | number
+type JobMatrixValue = string | boolean | number;
 
 /**
  * A job matrix.

--- a/src/github/workflows-model.ts
+++ b/src/github/workflows-model.ts
@@ -349,6 +349,8 @@ export interface JobStrategy {
   readonly maxParallel?: number;
 }
 
+type JobMatrixValue = string | boolean | number
+
 /**
  * A job matrix.
  */
@@ -361,7 +363,7 @@ export interface JobMatrix {
    * matrix.os property as the value of the runs-on keyword to create a job
    * for each operating system.
    */
-  readonly domain?: Record<string, string[]>;
+  readonly domain?: Record<string, JobMatrixValue[]>;
 
   /**
    * You can add additional configuration options to a build matrix job that
@@ -369,14 +371,14 @@ export interface JobMatrix {
    * when the job that uses windows-latest and version 8 of node runs, you can
    * use include to specify that additional option.
    */
-  readonly include?: Array<Record<string, string>>;
+  readonly include?: Array<Record<string, JobMatrixValue>>;
 
   /**
    * You can remove a specific configurations defined in the build matrix
    * using the exclude option. Using exclude removes a job defined by the
    * build matrix.
    */
-  readonly exclude?: Array<Record<string, string>>;
+  readonly exclude?: Array<Record<string, JobMatrixValue>>;
 }
 
 /**


### PR DESCRIPTION
Adding this feature to allow setting the JobMetrix values to other primitive data types rather than string. For instance, I want to set the session length for AWS assume role github action which is a number. This is comming as a value from matrix.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.