### PR TITLE
fix: release task bumps to wrong version when majorVersion is 0

### DIFF
--- a/src/release/bump-version.task.ts
+++ b/src/release/bump-version.task.ts
@@ -15,6 +15,7 @@
  * - RELEASE_TAG_PREFIX: (optional) a prefix to apply to the release tag
  *
  */
+import * as logging from "../logging";
 import { bump, BumpOptions } from "./bump-version";
 
 const versionFile = process.env.OUTFILE;
@@ -59,6 +60,7 @@ const opts: BumpOptions = {
   // doesn't work with long customization
   versionrcOptions: JSON.parse(versionrcOptions ?? "{}"),
 };
+logging.debug(opts);
 
 bump(process.cwd(), opts).catch((e: Error) => {
   console.log(e.stack);

--- a/src/release/bump-version.ts
+++ b/src/release/bump-version.ts
@@ -245,7 +245,8 @@ function determineLatestTag(options: LatestTagOptions): {
   const { cwd, major, prerelease, prefix } = options;
 
   // filter only tags for this prefix and major version if specified (start with "vNN.").
-  const prefixFilter = major ? `${prefix}v${major}.*` : `${prefix}v*`;
+  const prefixFilter =
+    major !== undefined ? `${prefix}v${major}.*` : `${prefix}v*`;
 
   const listGitTags = [
     "git",

--- a/test/release/bump.test.ts
+++ b/test/release/bump.test.ts
@@ -123,6 +123,24 @@ test("select latest with major", async () => {
   expect(result10.tag).toStrictEqual("v10.21.1");
 });
 
+test("bump with major equal to 0", async () => {
+  const commits = [
+    { message: "first version", tag: "v0.1.0" },
+    { message: "second version", tag: "v0.1.1" },
+    { message: "stable branch", tag: "v1.0.0" },
+    { message: "fix: bug" },
+  ];
+
+  const result1 = await testBump({
+    options: { majorVersion: 0 },
+    commits: commits,
+  });
+
+  expect(result1.version).toEqual("0.1.2");
+  expect(result1.bumpfile).toEqual("0.1.2");
+  expect(result1.tag).toStrictEqual("v0.1.2");
+});
+
 test("already tagged version is not bumped again", async () => {
   const result = await testBump({
     commits: [


### PR DESCRIPTION
Fixes #1584

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.