### PR TITLE
fix(upgrade-dependencies): upgrade task cannot be overwritten

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -7868,7 +7868,7 @@ Add steps to execute a successful build.
 addPostBuildSteps(...steps: JobStep[]): void
 ```
 
-* **steps** (<code>[github.workflows.JobStep](#projen-github-workflows-jobstep)</code>)  worklfow steps.
+* **steps** (<code>[github.workflows.JobStep](#projen-github-workflows-jobstep)</code>)  workflow steps.
   * **continueOnError** (<code>boolean</code>)  Prevents a job from failing when a step fails. __*Optional*__
   * **env** (<code>Map<string, string></code>)  Sets environment variables for steps to use in the runner environment. __*Optional*__
   * **id** (<code>string</code>)  A unique identifier for the step. __*Optional*__

--- a/test/upgrade-dependencies.test.ts
+++ b/test/upgrade-dependencies.test.ts
@@ -59,6 +59,20 @@ test("upgrades command includes only included packages", () => {
   expect(tasks.upgrade.steps[6].exec).toStrictEqual(`yarn upgrade ${deps}`);
 });
 
+test("upgrade task can be overwritten", () => {
+  const project = createProject({
+    depsUpgrade: true,
+  });
+
+  project.removeTask("upgrade");
+  const newTask = project.addTask("upgrade");
+  newTask.exec("echo 'hello world'");
+
+  const tasks = synthSnapshot(project)[TaskRuntime.MANIFEST_FILE].tasks;
+
+  expect(tasks.upgrade.steps[0].exec).toStrictEqual(`echo 'hello world'`);
+});
+
 test("default options", () => {
   const project = createProject({
     projenUpgradeSecret: "PROJEN_SECRET",


### PR DESCRIPTION
Small change that moves the `createTask` step of `UpgradeDependencies` into the constructor, so that it is added during project instantiation. This allows the task to be overwritten with `project.removeTask()` per the error message:
```
Error: A task with the name upgrade already exists. To override it, call removeTask first and then create the new task.
```
This previously did not work, as the error was actually being thrown by the `UpgradeDependencies.createTask()` function during the pre-synth step. I considered instead adding error handling during this step, but could not decide whether silently not creating a task if one already existed or throwing an error with a clearer message would be a better behaviour, and decided on this approach instead.

Also includes a couple of non-breaking typo fixes.

fixes #1129 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.