### PR TITLE
feat(publisher): use `publib` instead of `jsii-release`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Collect js Artifact
         run: mv .repo/dist dist
       - name: Release
-        run: npx -p jsii-release@latest jsii-release-npm
+        run: npx -p publib@latest publib-npm
         env:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
@@ -155,7 +155,7 @@ jobs:
       - name: Collect java Artifact
         run: mv .repo/dist dist
       - name: Release
-        run: npx -p jsii-release@latest jsii-release-maven
+        run: npx -p publib@latest publib-maven
         env:
           MAVEN_ENDPOINT: https://s01.oss.sonatype.org
           MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
@@ -205,7 +205,7 @@ jobs:
       - name: Collect python Artifact
         run: mv .repo/dist dist
       - name: Release
-        run: npx -p jsii-release@latest jsii-release-pypi
+        run: npx -p publib@latest publib-pypi
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
@@ -251,7 +251,7 @@ jobs:
       - name: Collect go Artifact
         run: mv .repo/dist dist
       - name: Release
-        run: npx -p jsii-release@latest jsii-release-golang
+        run: npx -p publib@latest publib-golang
         env:
           GIT_USER_NAME: github-actions
           GIT_USER_EMAIL: github-actions@github.com

--- a/src/release/publisher.ts
+++ b/src/release/publisher.ts
@@ -1,4 +1,3 @@
-import { JSII_TOOLCHAIN } from "../cdk/consts";
 import { Component } from "../component";
 import {
   BUILD_ARTIFACT_NAME,
@@ -15,11 +14,18 @@ import { defaultNpmToken } from "../javascript/node-package";
 import { Project } from "../project";
 import { BranchOptions } from "./release";
 
-const JSII_RELEASE_VERSION = "latest";
+const PUBLIB_VERSION = "latest";
 const GITHUB_PACKAGES_REGISTRY = "npm.pkg.github.com";
 const ARTIFACTS_DOWNLOAD_DIR = "dist";
 const GITHUB_PACKAGES_MAVEN_REPOSITORY = "https://maven.pkg.github.com";
 const AWS_CODEARTIFACT_REGISTRY_REGEX = /.codeartifact.*.amazonaws.com/;
+const PUBLIB_TOOLCHAIN = {
+  js: {},
+  java: { java: { version: "11.x" } },
+  python: { python: { version: "3.x" } },
+  go: { go: { version: "^1.16.0" } },
+  dotnet: { dotnet: { version: "3.x" } },
+};
 
 /**
  * Options for `Publisher`.
@@ -44,16 +50,21 @@ export interface PublisherOptions {
    * `go` (GitHub), `dotnet` (NuGet), `java` (Maven), `js` (npm), `python`
    * (PyPI).
    *
-   * @see https://github.com/aws/jsii-release
+   * @see https://github.com/aws/publib
    */
   readonly artifactName: string;
 
   /**
-   * Version requirement for `jsii-release`.
+   * @deprecated use `publibVersion` instead
+   */
+  readonly jsiiReleaseVersion?: string;
+
+  /**
+   * Version requirement for `publib`.
    *
    * @default "latest"
    */
-  readonly jsiiReleaseVersion?: string;
+ readonly publibVersion?: string;
 
   /**
    * Create an issue when a publish task fails.
@@ -97,13 +108,16 @@ export interface PublisherOptions {
 /**
  * Implements GitHub jobs for publishing modules to package managers.
  *
- * Under the hood, it uses https://github.com/aws/jsii-release
+ * Under the hood, it uses https://github.com/aws/publib
  */
 export class Publisher extends Component {
   public readonly buildJobId: string;
   public readonly artifactName: string;
-  public readonly jsiiReleaseVersion: string;
+  public readonly publibVersion: string;
   public readonly condition?: string;
+
+  /** @deprecated use `publibVersion` */
+  public readonly jsiiReleaseVersion: string;
 
   private readonly failureIssue: boolean;
   private readonly failureIssueLabel: string;
@@ -122,8 +136,8 @@ export class Publisher extends Component {
 
     this.buildJobId = options.buildJobId;
     this.artifactName = options.artifactName;
-    this.jsiiReleaseVersion =
-      options.jsiiReleaseVersion ?? JSII_RELEASE_VERSION;
+    this.publibVersion = options.publibVersion ?? options.jsiiReleaseVersion ?? PUBLIB_VERSION;
+    this.jsiiReleaseVersion = this.publibVersion;;
     this.condition = options.condition;
     this.dryRun = options.dryRun ?? false;
 
@@ -284,9 +298,9 @@ export class Publisher extends Component {
 
       return {
         name: "npm",
-        publishTools: JSII_TOOLCHAIN.js,
+        publishTools: PUBLIB_TOOLCHAIN.js,
         prePublishSteps: options.prePublishSteps ?? [],
-        run: this.jsiiReleaseCommand("jsii-release-npm"),
+        run: this.publibCommand("publib-npm"),
         registryName: "npm",
         env: {
           NPM_DIST_TAG: branchOptions.npmDistTag ?? options.distTag ?? "latest",
@@ -327,9 +341,9 @@ export class Publisher extends Component {
     this.addPublishJob(
       (_branch, _branchOptions): PublishJobOptions => ({
         name: "nuget",
-        publishTools: JSII_TOOLCHAIN.dotnet,
+        publishTools: PUBLIB_TOOLCHAIN.dotnet,
         prePublishSteps: options.prePublishSteps ?? [],
-        run: this.jsiiReleaseCommand("jsii-release-nuget"),
+        run: this.publibCommand("publib-nuget"),
         registryName: "NuGet Gallery",
         workflowEnv: {
           NUGET_API_KEY: secret(options.nugetApiKeySecret ?? "NUGET_API_KEY"),
@@ -361,9 +375,9 @@ export class Publisher extends Component {
       (_branch, _branchOptions): PublishJobOptions => ({
         name: "maven",
         registryName: "Maven Central",
-        publishTools: JSII_TOOLCHAIN.java,
+        publishTools: PUBLIB_TOOLCHAIN.java,
         prePublishSteps: options.prePublishSteps ?? [],
-        run: this.jsiiReleaseCommand("jsii-release-maven"),
+        run: this.publibCommand("publib-maven"),
         env: {
           MAVEN_ENDPOINT: options.mavenEndpoint,
           MAVEN_SERVER_ID: mavenServerId,
@@ -411,9 +425,9 @@ export class Publisher extends Component {
       (_branch, _branchOptions): PublishJobOptions => ({
         name: "pypi",
         registryName: "PyPI",
-        publishTools: JSII_TOOLCHAIN.python,
+        publishTools: PUBLIB_TOOLCHAIN.python,
         prePublishSteps: options.prePublishSteps ?? [],
-        run: this.jsiiReleaseCommand("jsii-release-pypi"),
+        run: this.publibCommand("publib-pypi"),
         env: {
           TWINE_REPOSITORY_URL: options.twineRegistryUrl,
         },
@@ -437,9 +451,9 @@ export class Publisher extends Component {
     this.addPublishJob(
       (_branch, _branchOptions): PublishJobOptions => ({
         name: "golang",
-        publishTools: JSII_TOOLCHAIN.go,
+        publishTools: PUBLIB_TOOLCHAIN.go,
         prePublishSteps: options.prePublishSteps ?? [],
-        run: this.jsiiReleaseCommand("jsii-release-golang"),
+        run: this.publibCommand("publib-golang"),
         registryName: "GitHub Go Module Repository",
         env: {
           GITHUB_REPO: options.githubRepo,
@@ -512,7 +526,7 @@ export class Publisher extends Component {
           uses: "actions/download-artifact@v2",
           with: {
             name: BUILD_ARTIFACT_NAME,
-            path: ARTIFACTS_DOWNLOAD_DIR, // this must be "dist" for jsii-release
+            path: ARTIFACTS_DOWNLOAD_DIR, // this must be "dist" for publib
           },
         },
         ...opts.prePublishSteps,
@@ -570,8 +584,8 @@ export class Publisher extends Component {
     });
   }
 
-  private jsiiReleaseCommand(command: string) {
-    return `npx -p jsii-release@${this.jsiiReleaseVersion} ${command}`;
+  private publibCommand(command: string) {
+    return `npx -p publib@${this.publibVersion} ${command}`;
   }
 }
 
@@ -807,7 +821,7 @@ export interface MavenPublishOptions extends CommonPublishOptions {
    * it. This is used to sign your Maven
    * packages. See instructions.
    *
-   * @see https://github.com/aws/jsii-release#maven
+   * @see https://github.com/aws/publib#maven
    * @default "MAVEN_GPG_PRIVATE_KEY" or not set when using GitHub Packages
    */
   readonly mavenGpgPrivateKeySecret?: string;
@@ -816,7 +830,7 @@ export interface MavenPublishOptions extends CommonPublishOptions {
    * GitHub secret name which contains the GPG private key or file that includes
    * it. This is used to sign your Maven packages. See instructions.
    *
-   * @see https://github.com/aws/jsii-release#maven
+   * @see https://github.com/aws/publib#maven
    * @default "MAVEN_GPG_PRIVATE_KEY_PASSPHRASE" or not set when using GitHub Packages
    */
   readonly mavenGpgPrivateKeyPassphrase?: string;

--- a/src/release/release.ts
+++ b/src/release/release.ts
@@ -55,7 +55,7 @@ export interface ReleaseProjectOptions {
   readonly workflowContainerImage?: string;
 
   /**
-   * Version requirement of `jsii-release` which is used to publish modules to npm.
+   * Version requirement of `publib` which is used to publish modules to npm.
    * @default "latest"
    */
   readonly jsiiReleaseVersion?: string;

--- a/test/cdk/jsii.test.ts
+++ b/test/cdk/jsii.test.ts
@@ -71,14 +71,12 @@ describe("maven repository options", () => {
       ],
       steps: [
         { exec: 'test "$(git branch --show-current)" = "master"' },
-        { exec: "npx -p jsii-release@latest jsii-release-maven" },
+        { exec: "npx -p publib@latest publib-maven" },
       ],
     });
 
     const workflow = outdir[".github/workflows/release.yml"];
-    expect(workflow).toContain(
-      "run: npx -p jsii-release@latest jsii-release-maven"
-    );
+    expect(workflow).toContain("run: npx -p publib@latest publib-maven");
     expect(workflow).toContain("MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}");
     expect(workflow).not.toContainEqual("MAVEN_SERVER_ID");
     expect(workflow).not.toContainEqual("MAVEN_REPOSITORY_URL");
@@ -119,14 +117,12 @@ describe("maven repository options", () => {
       ],
       steps: [
         { exec: 'test "$(git branch --show-current)" = "master"' },
-        { exec: "npx -p jsii-release@latest jsii-release-maven" },
+        { exec: "npx -p publib@latest publib-maven" },
       ],
     });
 
     const workflow = outdir[".github/workflows/release.yml"];
-    expect(workflow).toContain(
-      "run: npx -p jsii-release@latest jsii-release-maven"
-    );
+    expect(workflow).toContain("run: npx -p publib@latest publib-maven");
     expect(workflow).toContain("MAVEN_ENDPOINT: https://s01.oss.sonatype.org");
     expect(workflow).toContain("MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}");
     expect(workflow).not.toContainEqual("MAVEN_SERVER_ID");
@@ -163,7 +159,7 @@ describe("maven repository options", () => {
       requiredEnv: ["MAVEN_PASSWORD", "MAVEN_USERNAME"],
       steps: [
         { exec: 'test "$(git branch --show-current)" = "master"' },
-        { exec: "npx -p jsii-release@latest jsii-release-maven" },
+        { exec: "npx -p publib@latest publib-maven" },
       ],
     });
 


### PR DESCRIPTION
The `jsii-release` package was renamed to `publib`, so there’s that.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.