### PR TITLE
feat(awscdk): allow integration test path metadata

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -2975,6 +2975,7 @@ new awscdk.AutoDiscover(project: Project, options: AutoDiscoverOptions)
   * **srcdir** (<code>string</code>)  Project source tree (relative to project output directory). 
   * **lambdaOptions** (<code>[awscdk.LambdaFunctionCommonOptions](#projen-awscdk-lambdafunctioncommonoptions)</code>)  Options for auto-discovery of AWS Lambda functions. __*Optional*__
   * **testdir** (<code>string</code>)  Test source tree. 
+  * **integrationTestOptions** (<code>[awscdk.IntegrationTestCommonOptions](#projen-awscdk-integrationtestcommonoptions)</code>)  Options for integration tests. __*Optional*__
   * **integrationTestAutoDiscover** (<code>boolean</code>)  Auto-discover integration tests. __*Default*__: true
   * **lambdaAutoDiscover** (<code>boolean</code>)  Auto-discover lambda functions. __*Default*__: true
 
@@ -3966,6 +3967,7 @@ new awscdk.IntegrationTest(project: Project, options: IntegrationTestOptions)
 * **project** (<code>[Project](#projen-project)</code>)  *No description*
 * **options** (<code>[awscdk.IntegrationTestOptions](#projen-awscdk-integrationtestoptions)</code>)  *No description*
   * **destroyAfterDeploy** (<code>boolean</code>)  Destroy the test app after a successful deployment. __*Default*__: true
+  * **pathMetadata** (<code>boolean</code>)  Enables path metadata. __*Default*__: false
   * **entrypoint** (<code>string</code>)  A path from the project root directory to a TypeScript file which contains the integration test app. 
   * **tsconfigPath** (<code>string</code>)  The path of the tsconfig.json file to use when running integration test cdk apps. 
   * **name** (<code>string</code>)  Name of the integration test. __*Default*__: Derived from the entrypoint filename.
@@ -4006,6 +4008,7 @@ new awscdk.IntegrationTestAutoDiscover(project: Project, options: IntegrationTes
   * **cdkDeps** (<code>[awscdk.AwsCdkDeps](#projen-awscdk-awscdkdeps)</code>)  AWS CDK dependency manager. 
   * **tsconfigPath** (<code>string</code>)  Path to the tsconfig file to use for integration tests. 
   * **testdir** (<code>string</code>)  Test source tree. 
+  * **integrationTestOptions** (<code>[awscdk.IntegrationTestCommonOptions](#projen-awscdk-integrationtestcommonoptions)</code>)  Options for integration tests. __*Optional*__
 
 
 
@@ -11349,6 +11352,7 @@ Name | Type | Description
 **testdir**🔹 | <code>string</code> | Test source tree.
 **tsconfigPath**🔹 | <code>string</code> | Path to the tsconfig file to use for integration tests.
 **integrationTestAutoDiscover**?🔹 | <code>boolean</code> | Auto-discover integration tests.<br/>__*Default*__: true
+**integrationTestOptions**?🔹 | <code>[awscdk.IntegrationTestCommonOptions](#projen-awscdk-integrationtestcommonoptions)</code> | Options for integration tests.<br/>__*Optional*__
 **lambdaAutoDiscover**?🔹 | <code>boolean</code> | Auto-discover lambda functions.<br/>__*Default*__: true
 **lambdaOptions**?🔹 | <code>[awscdk.LambdaFunctionCommonOptions](#projen-awscdk-lambdafunctioncommonoptions)</code> | Options for auto-discovery of AWS Lambda functions.<br/>__*Optional*__
 
@@ -12025,6 +12029,7 @@ Name | Type | Description
 **cdkDeps**🔹 | <code>[awscdk.AwsCdkDeps](#projen-awscdk-awscdkdeps)</code> | AWS CDK dependency manager.
 **testdir**🔹 | <code>string</code> | Test source tree.
 **tsconfigPath**🔹 | <code>string</code> | Path to the tsconfig file to use for integration tests.
+**integrationTestOptions**?🔹 | <code>[awscdk.IntegrationTestCommonOptions](#projen-awscdk-integrationtestcommonoptions)</code> | Options for integration tests.<br/>__*Optional*__
 
 
 
@@ -12038,6 +12043,7 @@ Name | Type | Description
 Name | Type | Description 
 -----|------|-------------
 **destroyAfterDeploy**?🔹 | <code>boolean</code> | Destroy the test app after a successful deployment.<br/>__*Default*__: true
+**pathMetadata**?🔹 | <code>boolean</code> | Enables path metadata.<br/>__*Default*__: false
 
 
 
@@ -12055,6 +12061,7 @@ Name | Type | Description
 **tsconfigPath**🔹 | <code>string</code> | The path of the tsconfig.json file to use when running integration test cdk apps.
 **destroyAfterDeploy**?🔹 | <code>boolean</code> | Destroy the test app after a successful deployment.<br/>__*Default*__: true
 **name**?🔹 | <code>string</code> | Name of the integration test.<br/>__*Default*__: Derived from the entrypoint filename.
+**pathMetadata**?🔹 | <code>boolean</code> | Enables path metadata.<br/>__*Default*__: false
 **stacks**?🔹 | <code>Array<string></code> | A list of stacks within the integration test to deploy/destroy.<br/>__*Default*__: ["**"]
 
 

--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -3967,7 +3967,7 @@ new awscdk.IntegrationTest(project: Project, options: IntegrationTestOptions)
 * **project** (<code>[Project](#projen-project)</code>)  *No description*
 * **options** (<code>[awscdk.IntegrationTestOptions](#projen-awscdk-integrationtestoptions)</code>)  *No description*
   * **destroyAfterDeploy** (<code>boolean</code>)  Destroy the test app after a successful deployment. __*Default*__: true
-  * **pathMetadata** (<code>boolean</code>)  Enables path metadata. __*Default*__: false
+  * **pathMetadata** (<code>boolean</code>)  Enables path metadata, adding `aws:cdk:path`, with the defining construct's path, to the CloudFormation metadata for each synthesized resource. __*Default*__: false
   * **entrypoint** (<code>string</code>)  A path from the project root directory to a TypeScript file which contains the integration test app. 
   * **tsconfigPath** (<code>string</code>)  The path of the tsconfig.json file to use when running integration test cdk apps. 
   * **name** (<code>string</code>)  Name of the integration test. __*Default*__: Derived from the entrypoint filename.
@@ -12043,7 +12043,7 @@ Name | Type | Description
 Name | Type | Description 
 -----|------|-------------
 **destroyAfterDeploy**?🔹 | <code>boolean</code> | Destroy the test app after a successful deployment.<br/>__*Default*__: true
-**pathMetadata**?🔹 | <code>boolean</code> | Enables path metadata.<br/>__*Default*__: false
+**pathMetadata**?🔹 | <code>boolean</code> | Enables path metadata, adding `aws:cdk:path`, with the defining construct's path, to the CloudFormation metadata for each synthesized resource.<br/>__*Default*__: false
 
 
 
@@ -12061,7 +12061,7 @@ Name | Type | Description
 **tsconfigPath**🔹 | <code>string</code> | The path of the tsconfig.json file to use when running integration test cdk apps.
 **destroyAfterDeploy**?🔹 | <code>boolean</code> | Destroy the test app after a successful deployment.<br/>__*Default*__: true
 **name**?🔹 | <code>string</code> | Name of the integration test.<br/>__*Default*__: Derived from the entrypoint filename.
-**pathMetadata**?🔹 | <code>boolean</code> | Enables path metadata.<br/>__*Default*__: false
+**pathMetadata**?🔹 | <code>boolean</code> | Enables path metadata, adding `aws:cdk:path`, with the defining construct's path, to the CloudFormation metadata for each synthesized resource.<br/>__*Default*__: false
 **stacks**?🔹 | <code>Array<string></code> | A list of stacks within the integration test to deploy/destroy.<br/>__*Default*__: ["**"]
 
 

--- a/src/awscdk/auto-discover.ts
+++ b/src/awscdk/auto-discover.ts
@@ -6,7 +6,10 @@ import {
 import { Component } from "../component";
 import { Project } from "../project";
 import { AwsCdkDeps } from "./awscdk-deps";
-import { IntegrationTest } from "./integration-test";
+import {
+  IntegrationTest,
+  IntegrationTestCommonOptions,
+} from "./integration-test";
 import { TYPESCRIPT_LAMBDA_EXT } from "./internal";
 import { LambdaFunction, LambdaFunctionCommonOptions } from "./lambda-function";
 
@@ -30,7 +33,12 @@ export interface AutoDiscoverCommonOptions {
  */
 export interface IntegrationTestAutoDiscoverOptions
   extends AutoDiscoverCommonOptions,
-    IntegrationTestAutoDiscoverBaseOptions {}
+    IntegrationTestAutoDiscoverBaseOptions {
+  /**
+   * Options for integration tests.
+   */
+  readonly integrationTestOptions?: IntegrationTestCommonOptions;
+}
 
 /**
  * Creates integration tests from entry points discovered in the test tree.
@@ -44,6 +52,7 @@ export class IntegrationTestAutoDiscover extends IntegrationTestAutoDiscoverBase
         entrypoint,
         cdkDeps: options.cdkDeps,
         tsconfigPath: options.tsconfigPath,
+        ...options.integrationTestOptions,
       });
     }
   }
@@ -127,6 +136,7 @@ export class AutoDiscover extends Component {
         cdkDeps: options.cdkDeps,
         testdir: options.testdir,
         tsconfigPath: options.tsconfigPath,
+        integrationTestOptions: options.integrationTestOptions,
       });
     }
   }

--- a/src/awscdk/integration-test.ts
+++ b/src/awscdk/integration-test.ts
@@ -15,8 +15,8 @@ export interface IntegrationTestCommonOptions {
   readonly destroyAfterDeploy?: boolean;
 
   /**
-   * Enables path metadata
-   *
+   * Enables path metadata, adding `aws:cdk:path` with the defining construct's
+   * path to the CloudFormation metadata for each synthesized resource.
    * @default false
    */
   readonly pathMetadata?: boolean;

--- a/src/awscdk/integration-test.ts
+++ b/src/awscdk/integration-test.ts
@@ -15,8 +15,8 @@ export interface IntegrationTestCommonOptions {
   readonly destroyAfterDeploy?: boolean;
 
   /**
-   * Enables path metadata, adding `aws:cdk:path` with the defining construct's
-   * path to the CloudFormation metadata for each synthesized resource.
+   * Enables path metadata, adding `aws:cdk:path`, with the defining construct's
+   * path, to the CloudFormation metadata for each synthesized resource.
    * @default false
    */
   readonly pathMetadata?: boolean;

--- a/src/awscdk/integration-test.ts
+++ b/src/awscdk/integration-test.ts
@@ -13,6 +13,13 @@ export interface IntegrationTestCommonOptions {
    * @default true
    */
   readonly destroyAfterDeploy?: boolean;
+
+  /**
+   * Enables path metadata
+   *
+   * @default false
+   */
+  readonly pathMetadata?: boolean;
 }
 
 /**
@@ -69,9 +76,13 @@ export class IntegrationTest extends IntegrationTestBase {
       `--app "${app}"`,
       "--no-version-reporting",
       // don't inject cloudformation metadata into template
-      "--no-path-metadata",
       "--no-asset-metadata",
     ];
+
+    const pathMetadata = options.pathMetadata ?? false;
+    if (!pathMetadata) {
+      opts.push("--no-path-metadata");
+    }
 
     if (options.cdkDeps.cdkMajorVersion === 1) {
       // add all feature flags

--- a/test/awscdk/__snapshots__/integration-test.test.ts.snap
+++ b/test/awscdk/__snapshots__/integration-test.test.ts.snap
@@ -93,54 +93,6 @@ Object {
 }
 `;
 
-exports[`enabling path metadata 1`] = `
-Object {
-  "description": "deploy integration test 'my-stage' and capture snapshot",
-  "name": "integ:my-stage:deploy",
-  "steps": Array [
-    Object {
-      "exec": "rm -fr test/.tmp/my-stage.integ/deploy.cdk.out",
-    },
-    Object {
-      "exec": "cdk deploy --app \\"ts-node -P tsconfig.dev.json test/my-stage.myinteg.ts\\" --no-version-reporting --no-asset-metadata 'my-stage/*' --require-approval=never -o test/.tmp/my-stage.integ/deploy.cdk.out",
-    },
-    Object {
-      "exec": "rm -fr test/my-stage.integ.snapshot",
-    },
-    Object {
-      "exec": "mv test/.tmp/my-stage.integ/deploy.cdk.out test/my-stage.integ.snapshot",
-    },
-    Object {
-      "spawn": "integ:my-stage:destroy",
-    },
-  ],
-}
-`;
-
-exports[`enabling path metadata 2`] = `
-Object {
-  "description": "update snapshot for integration test \\"my-stage\\"",
-  "name": "integ:my-stage:snapshot",
-  "steps": Array [
-    Object {
-      "exec": "cdk synth --app \\"ts-node -P tsconfig.dev.json test/my-stage.myinteg.ts\\" --no-version-reporting --no-asset-metadata -o test/my-stage.integ.snapshot > /dev/null",
-    },
-  ],
-}
-`;
-
-exports[`enabling path metadata 3`] = `
-Object {
-  "description": "watch integration test 'my-stage' (without updating snapshots)",
-  "name": "integ:my-stage:watch",
-  "steps": Array [
-    Object {
-      "exec": "cdk watch --app \\"ts-node -P tsconfig.dev.json test/my-stage.myinteg.ts\\" --no-version-reporting --no-asset-metadata 'my-stage/*' -o test/.tmp/my-stage.integ/deploy.cdk.out",
-    },
-  ],
-}
-`;
-
 exports[`synthesizing an integration test containing a multi-stack stage 1`] = `
 Object {
   "description": "deploy integration test 'my-stage' and capture snapshot",

--- a/test/awscdk/__snapshots__/integration-test.test.ts.snap
+++ b/test/awscdk/__snapshots__/integration-test.test.ts.snap
@@ -9,7 +9,7 @@ Object {
       "exec": "[ -d \\"test/foo.integ.snapshot\\" ] || (echo \\"No snapshot available for integration test 'foo'. Run 'projen integ:foo:deploy' to capture.\\" && exit 1)",
     },
     Object {
-      "exec": "cdk synth --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata --context aws-cdk:enableDiffNoFail=true --context @aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId=true --context @aws-cdk/core:enableStackNameDuplicates=true --context @aws-cdk/core:stackRelativeExports=true --context @aws-cdk/aws-ecr-assets:dockerIgnoreSupport=true --context @aws-cdk/aws-secretsmanager:parseOwnedSecretName=true --context @aws-cdk/aws-kms:defaultKeyPolicies=true --context @aws-cdk/aws-s3:grantWriteWithoutAcl=true --context @aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount=true --context @aws-cdk/aws-rds:lowercaseDbIdentifier=true --context @aws-cdk/aws-efs:defaultEncryptionAtRest=true --context @aws-cdk/aws-lambda:recognizeVersionProps=true --context @aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021=true --context @aws-cdk/core:newStyleStackSynthesis=true -o test/.tmp/foo.integ/assert.cdk.out > /dev/null",
+      "exec": "cdk synth --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-asset-metadata --no-path-metadata --context aws-cdk:enableDiffNoFail=true --context @aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId=true --context @aws-cdk/core:enableStackNameDuplicates=true --context @aws-cdk/core:stackRelativeExports=true --context @aws-cdk/aws-ecr-assets:dockerIgnoreSupport=true --context @aws-cdk/aws-secretsmanager:parseOwnedSecretName=true --context @aws-cdk/aws-kms:defaultKeyPolicies=true --context @aws-cdk/aws-s3:grantWriteWithoutAcl=true --context @aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount=true --context @aws-cdk/aws-rds:lowercaseDbIdentifier=true --context @aws-cdk/aws-efs:defaultEncryptionAtRest=true --context @aws-cdk/aws-lambda:recognizeVersionProps=true --context @aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021=true --context @aws-cdk/core:newStyleStackSynthesis=true -o test/.tmp/foo.integ/assert.cdk.out > /dev/null",
     },
     Object {
       "exec": "diff -r -x asset.* -x cdk.out -x manifest.json -x tree.json test/foo.integ.snapshot/ test/.tmp/foo.integ/assert.cdk.out/",
@@ -27,7 +27,7 @@ Object {
       "exec": "rm -fr test/.tmp/foo.integ/deploy.cdk.out",
     },
     Object {
-      "exec": "cdk deploy --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata --context aws-cdk:enableDiffNoFail=true --context @aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId=true --context @aws-cdk/core:enableStackNameDuplicates=true --context @aws-cdk/core:stackRelativeExports=true --context @aws-cdk/aws-ecr-assets:dockerIgnoreSupport=true --context @aws-cdk/aws-secretsmanager:parseOwnedSecretName=true --context @aws-cdk/aws-kms:defaultKeyPolicies=true --context @aws-cdk/aws-s3:grantWriteWithoutAcl=true --context @aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount=true --context @aws-cdk/aws-rds:lowercaseDbIdentifier=true --context @aws-cdk/aws-efs:defaultEncryptionAtRest=true --context @aws-cdk/aws-lambda:recognizeVersionProps=true --context @aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021=true --context @aws-cdk/core:newStyleStackSynthesis=true '**' --require-approval=never -o test/.tmp/foo.integ/deploy.cdk.out",
+      "exec": "cdk deploy --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-asset-metadata --no-path-metadata --context aws-cdk:enableDiffNoFail=true --context @aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId=true --context @aws-cdk/core:enableStackNameDuplicates=true --context @aws-cdk/core:stackRelativeExports=true --context @aws-cdk/aws-ecr-assets:dockerIgnoreSupport=true --context @aws-cdk/aws-secretsmanager:parseOwnedSecretName=true --context @aws-cdk/aws-kms:defaultKeyPolicies=true --context @aws-cdk/aws-s3:grantWriteWithoutAcl=true --context @aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount=true --context @aws-cdk/aws-rds:lowercaseDbIdentifier=true --context @aws-cdk/aws-efs:defaultEncryptionAtRest=true --context @aws-cdk/aws-lambda:recognizeVersionProps=true --context @aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021=true --context @aws-cdk/core:newStyleStackSynthesis=true '**' --require-approval=never -o test/.tmp/foo.integ/deploy.cdk.out",
     },
     Object {
       "exec": "rm -fr test/foo.integ.snapshot",
@@ -60,7 +60,7 @@ Object {
   "name": "integ:foo:snapshot",
   "steps": Array [
     Object {
-      "exec": "cdk synth --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata --context aws-cdk:enableDiffNoFail=true --context @aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId=true --context @aws-cdk/core:enableStackNameDuplicates=true --context @aws-cdk/core:stackRelativeExports=true --context @aws-cdk/aws-ecr-assets:dockerIgnoreSupport=true --context @aws-cdk/aws-secretsmanager:parseOwnedSecretName=true --context @aws-cdk/aws-kms:defaultKeyPolicies=true --context @aws-cdk/aws-s3:grantWriteWithoutAcl=true --context @aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount=true --context @aws-cdk/aws-rds:lowercaseDbIdentifier=true --context @aws-cdk/aws-efs:defaultEncryptionAtRest=true --context @aws-cdk/aws-lambda:recognizeVersionProps=true --context @aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021=true --context @aws-cdk/core:newStyleStackSynthesis=true -o test/foo.integ.snapshot > /dev/null",
+      "exec": "cdk synth --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-asset-metadata --no-path-metadata --context aws-cdk:enableDiffNoFail=true --context @aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId=true --context @aws-cdk/core:enableStackNameDuplicates=true --context @aws-cdk/core:stackRelativeExports=true --context @aws-cdk/aws-ecr-assets:dockerIgnoreSupport=true --context @aws-cdk/aws-secretsmanager:parseOwnedSecretName=true --context @aws-cdk/aws-kms:defaultKeyPolicies=true --context @aws-cdk/aws-s3:grantWriteWithoutAcl=true --context @aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount=true --context @aws-cdk/aws-rds:lowercaseDbIdentifier=true --context @aws-cdk/aws-efs:defaultEncryptionAtRest=true --context @aws-cdk/aws-lambda:recognizeVersionProps=true --context @aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021=true --context @aws-cdk/core:newStyleStackSynthesis=true -o test/foo.integ.snapshot > /dev/null",
     },
   ],
 }
@@ -72,7 +72,7 @@ Object {
   "name": "integ:foo:watch",
   "steps": Array [
     Object {
-      "exec": "cdk watch --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata --context aws-cdk:enableDiffNoFail=true --context @aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId=true --context @aws-cdk/core:enableStackNameDuplicates=true --context @aws-cdk/core:stackRelativeExports=true --context @aws-cdk/aws-ecr-assets:dockerIgnoreSupport=true --context @aws-cdk/aws-secretsmanager:parseOwnedSecretName=true --context @aws-cdk/aws-kms:defaultKeyPolicies=true --context @aws-cdk/aws-s3:grantWriteWithoutAcl=true --context @aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount=true --context @aws-cdk/aws-rds:lowercaseDbIdentifier=true --context @aws-cdk/aws-efs:defaultEncryptionAtRest=true --context @aws-cdk/aws-lambda:recognizeVersionProps=true --context @aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021=true --context @aws-cdk/core:newStyleStackSynthesis=true '**' -o test/.tmp/foo.integ/deploy.cdk.out",
+      "exec": "cdk watch --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-asset-metadata --no-path-metadata --context aws-cdk:enableDiffNoFail=true --context @aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId=true --context @aws-cdk/core:enableStackNameDuplicates=true --context @aws-cdk/core:stackRelativeExports=true --context @aws-cdk/aws-ecr-assets:dockerIgnoreSupport=true --context @aws-cdk/aws-secretsmanager:parseOwnedSecretName=true --context @aws-cdk/aws-kms:defaultKeyPolicies=true --context @aws-cdk/aws-s3:grantWriteWithoutAcl=true --context @aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount=true --context @aws-cdk/aws-rds:lowercaseDbIdentifier=true --context @aws-cdk/aws-efs:defaultEncryptionAtRest=true --context @aws-cdk/aws-lambda:recognizeVersionProps=true --context @aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021=true --context @aws-cdk/core:newStyleStackSynthesis=true '**' -o test/.tmp/foo.integ/deploy.cdk.out",
     },
   ],
 }
@@ -93,6 +93,54 @@ Object {
 }
 `;
 
+exports[`enabling path metadata 1`] = `
+Object {
+  "description": "deploy integration test 'my-stage' and capture snapshot",
+  "name": "integ:my-stage:deploy",
+  "steps": Array [
+    Object {
+      "exec": "rm -fr test/.tmp/my-stage.integ/deploy.cdk.out",
+    },
+    Object {
+      "exec": "cdk deploy --app \\"ts-node -P tsconfig.dev.json test/my-stage.myinteg.ts\\" --no-version-reporting --no-asset-metadata 'my-stage/*' --require-approval=never -o test/.tmp/my-stage.integ/deploy.cdk.out",
+    },
+    Object {
+      "exec": "rm -fr test/my-stage.integ.snapshot",
+    },
+    Object {
+      "exec": "mv test/.tmp/my-stage.integ/deploy.cdk.out test/my-stage.integ.snapshot",
+    },
+    Object {
+      "spawn": "integ:my-stage:destroy",
+    },
+  ],
+}
+`;
+
+exports[`enabling path metadata 2`] = `
+Object {
+  "description": "update snapshot for integration test \\"my-stage\\"",
+  "name": "integ:my-stage:snapshot",
+  "steps": Array [
+    Object {
+      "exec": "cdk synth --app \\"ts-node -P tsconfig.dev.json test/my-stage.myinteg.ts\\" --no-version-reporting --no-asset-metadata -o test/my-stage.integ.snapshot > /dev/null",
+    },
+  ],
+}
+`;
+
+exports[`enabling path metadata 3`] = `
+Object {
+  "description": "watch integration test 'my-stage' (without updating snapshots)",
+  "name": "integ:my-stage:watch",
+  "steps": Array [
+    Object {
+      "exec": "cdk watch --app \\"ts-node -P tsconfig.dev.json test/my-stage.myinteg.ts\\" --no-version-reporting --no-asset-metadata 'my-stage/*' -o test/.tmp/my-stage.integ/deploy.cdk.out",
+    },
+  ],
+}
+`;
+
 exports[`synthesizing an integration test containing a multi-stack stage 1`] = `
 Object {
   "description": "deploy integration test 'my-stage' and capture snapshot",
@@ -102,7 +150,7 @@ Object {
       "exec": "rm -fr test/.tmp/my-stage.integ/deploy.cdk.out",
     },
     Object {
-      "exec": "cdk deploy --app \\"ts-node -P tsconfig.dev.json test/my-stage.myinteg.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata 'my-stage/*' --require-approval=never -o test/.tmp/my-stage.integ/deploy.cdk.out",
+      "exec": "cdk deploy --app \\"ts-node -P tsconfig.dev.json test/my-stage.myinteg.ts\\" --no-version-reporting --no-asset-metadata --no-path-metadata 'my-stage/*' --require-approval=never -o test/.tmp/my-stage.integ/deploy.cdk.out",
     },
     Object {
       "exec": "rm -fr test/my-stage.integ.snapshot",
@@ -123,7 +171,7 @@ Object {
   "name": "integ:my-stage:snapshot",
   "steps": Array [
     Object {
-      "exec": "cdk synth --app \\"ts-node -P tsconfig.dev.json test/my-stage.myinteg.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata -o test/my-stage.integ.snapshot > /dev/null",
+      "exec": "cdk synth --app \\"ts-node -P tsconfig.dev.json test/my-stage.myinteg.ts\\" --no-version-reporting --no-asset-metadata --no-path-metadata -o test/my-stage.integ.snapshot > /dev/null",
     },
   ],
 }
@@ -135,7 +183,7 @@ Object {
   "name": "integ:my-stage:watch",
   "steps": Array [
     Object {
-      "exec": "cdk watch --app \\"ts-node -P tsconfig.dev.json test/my-stage.myinteg.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata 'my-stage/*' -o test/.tmp/my-stage.integ/deploy.cdk.out",
+      "exec": "cdk watch --app \\"ts-node -P tsconfig.dev.json test/my-stage.myinteg.ts\\" --no-version-reporting --no-asset-metadata --no-path-metadata 'my-stage/*' -o test/.tmp/my-stage.integ/deploy.cdk.out",
     },
   ],
 }
@@ -150,7 +198,7 @@ Object {
       "exec": "rm -fr test/.tmp/foo.integ/deploy.cdk.out",
     },
     Object {
-      "exec": "cdk deploy --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata '**' --require-approval=never -o test/.tmp/foo.integ/deploy.cdk.out",
+      "exec": "cdk deploy --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-asset-metadata --no-path-metadata '**' --require-approval=never -o test/.tmp/foo.integ/deploy.cdk.out",
     },
     Object {
       "exec": "rm -fr test/foo.integ.snapshot",
@@ -171,7 +219,7 @@ Object {
   "name": "integ:foo:snapshot",
   "steps": Array [
     Object {
-      "exec": "cdk synth --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata -o test/foo.integ.snapshot > /dev/null",
+      "exec": "cdk synth --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-asset-metadata --no-path-metadata -o test/foo.integ.snapshot > /dev/null",
     },
   ],
 }
@@ -183,7 +231,7 @@ Object {
   "name": "integ:foo:watch",
   "steps": Array [
     Object {
-      "exec": "cdk watch --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-path-metadata --no-asset-metadata '**' -o test/.tmp/foo.integ/deploy.cdk.out",
+      "exec": "cdk watch --app \\"ts-node -P tsconfig.dev.json test/foo.integ.ts\\" --no-version-reporting --no-asset-metadata --no-path-metadata '**' -o test/.tmp/foo.integ/deploy.cdk.out",
     },
   ],
 }

--- a/test/awscdk/integration-test.test.ts
+++ b/test/awscdk/integration-test.test.ts
@@ -219,12 +219,26 @@ test("enabling path metadata", () => {
   const output = Testing.synth(project);
 
   expect(
-    output[".projen/tasks.json"].tasks["integ:my-stage:deploy"]
-  ).toMatchSnapshot();
+    output[".projen/tasks.json"].tasks["integ:my-stage:deploy"].steps
+  ).not.toEqual(
+    expect.arrayContaining([
+      { exec: expect.stringContaining("--no-path-metadata") },
+    ])
+  );
+
   expect(
-    output[".projen/tasks.json"].tasks["integ:my-stage:snapshot"]
-  ).toMatchSnapshot();
+    output[".projen/tasks.json"].tasks["integ:my-stage:snapshot"].steps
+  ).not.toEqual(
+    expect.arrayContaining([
+      { exec: expect.stringContaining("--no-path-metadata") },
+    ])
+  );
+
   expect(
-    output[".projen/tasks.json"].tasks["integ:my-stage:watch"]
-  ).toMatchSnapshot();
+    output[".projen/tasks.json"].tasks["integ:my-stage:watch"].steps
+  ).not.toEqual(
+    expect.arrayContaining([
+      { exec: expect.stringContaining("--no-path-metadata") },
+    ])
+  );
 });

--- a/test/awscdk/integration-test.test.ts
+++ b/test/awscdk/integration-test.test.ts
@@ -196,3 +196,35 @@ test("synthesizing an integration test containing a multi-stack stage", () => {
     output[".projen/tasks.json"].tasks["integ:my-stage:watch"]
   ).toMatchSnapshot();
 });
+
+test("enabling path metadata", () => {
+  // GIVEN
+  const project = new awscdk.AwsCdkTypeScriptApp({
+    name: "test",
+    defaultReleaseBranch: "main",
+    cdkVersion: "2.3.1",
+  });
+
+  // WHEN
+  new awscdk.IntegrationTest(project, {
+    name: "my-stage",
+    entrypoint: "test/my-stage.myinteg.ts",
+    stacks: ["my-stage/*"],
+    tsconfigPath: project.tsconfigDev.fileName,
+    cdkDeps: project.cdkDeps,
+    pathMetadata: true,
+  });
+
+  // THEN
+  const output = Testing.synth(project);
+
+  expect(
+    output[".projen/tasks.json"].tasks["integ:my-stage:deploy"]
+  ).toMatchSnapshot();
+  expect(
+    output[".projen/tasks.json"].tasks["integ:my-stage:snapshot"]
+  ).toMatchSnapshot();
+  expect(
+    output[".projen/tasks.json"].tasks["integ:my-stage:watch"]
+  ).toMatchSnapshot();
+});


### PR DESCRIPTION
Adds a `pathMetadata` option to IntegrationTest and the integration test options to auto-discover classes so that users can enable path metadata for their integration tests.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
