### PR TITLE
fix: no-floating-promises

### DIFF
--- a/src/web/react.ts
+++ b/src/web/react.ts
@@ -427,20 +427,20 @@ class ReactSampleCode extends Component {
     const reportWebVitalsJs = [
       "import { ReportHandler } from 'web-vitals';",
       "",
-      "const reportWebVitals = (onPerfEntry?: ReportHandler) => {
-      "  if (onPerfEntry && onPerfEntry instanceof Function) {
-      "    import('web-vitals').then(
-      "      ({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
-      "        getCLS(onPerfEntry);
-      "        getFID(onPerfEntry);
-      "        getFCP(onPerfEntry);
-      "        getLCP(onPerfEntry);
-      "        getTTFB(onPerfEntry);
-      "      },
-      "      () => {}
-      "    );
-      "  }
-      "};
+      "const reportWebVitals = (onPerfEntry?: ReportHandler) => {",
+      "  if (onPerfEntry && onPerfEntry instanceof Function) {",
+      "    import('web-vitals').then(",
+      "      ({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {",
+      "        getCLS(onPerfEntry);",
+      "        getFID(onPerfEntry);",
+      "        getFCP(onPerfEntry);",
+      "        getLCP(onPerfEntry);",
+      "        getTTFB(onPerfEntry);",
+      "      },",
+      "      () => {}",
+      "    );",
+      "  }",
+      "};",
       "",
       "export default reportWebVitals;",
     ];

--- a/src/web/react.ts
+++ b/src/web/react.ts
@@ -427,17 +427,20 @@ class ReactSampleCode extends Component {
     const reportWebVitalsJs = [
       "import { ReportHandler } from 'web-vitals';",
       "",
-      "const reportWebVitals = (onPerfEntry?: ReportHandler) => {",
-      "  if (onPerfEntry && onPerfEntry instanceof Function) {",
-      "    import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {",
-      "      getCLS(onPerfEntry);",
-      "      getFID(onPerfEntry);",
-      "      getFCP(onPerfEntry);",
-      "      getLCP(onPerfEntry);",
-      "      getTTFB(onPerfEntry);",
-      "    });",
-      "  }",
-      "}",
+      "const reportWebVitals = (onPerfEntry?: ReportHandler) => {
+      "  if (onPerfEntry && onPerfEntry instanceof Function) {
+      "    import('web-vitals').then(
+      "      ({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
+      "        getCLS(onPerfEntry);
+      "        getFID(onPerfEntry);
+      "        getFCP(onPerfEntry);
+      "        getLCP(onPerfEntry);
+      "        getTTFB(onPerfEntry);
+      "      },
+      "      () => {}
+      "    );
+      "  }
+      "};
       "",
       "export default reportWebVitals;",
     ];

--- a/test/web/__snapshots__/react-project.test.ts.snap
+++ b/test/web/__snapshots__/react-project.test.ts.snap
@@ -1130,15 +1130,18 @@ reportWebVitals();
 
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
-    import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
-      getCLS(onPerfEntry);
-      getFID(onPerfEntry);
-      getFCP(onPerfEntry);
-      getLCP(onPerfEntry);
-      getTTFB(onPerfEntry);
-    });
+    import('web-vitals').then(
+      ({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
+        getCLS(onPerfEntry);
+        getFID(onPerfEntry);
+        getFCP(onPerfEntry);
+        getLCP(onPerfEntry);
+        getTTFB(onPerfEntry);
+      },
+      () => {}
+    );
   }
-}
+};
 
 export default reportWebVitals;",
   "src/setupTests.js": "// jest-dom adds custom jest matchers for asserting on DOM nodes.

--- a/test/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/react-ts-project.test.ts.snap
@@ -1048,15 +1048,18 @@ reportWebVitals();
 
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
-    import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
-      getCLS(onPerfEntry);
-      getFID(onPerfEntry);
-      getFCP(onPerfEntry);
-      getLCP(onPerfEntry);
-      getTTFB(onPerfEntry);
-    });
+    import('web-vitals').then(
+      ({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
+        getCLS(onPerfEntry);
+        getFID(onPerfEntry);
+        getFCP(onPerfEntry);
+        getLCP(onPerfEntry);
+        getTTFB(onPerfEntry);
+      },
+      () => {}
+    );
   }
-}
+};
 
 export default reportWebVitals;",
   "src/setupTests.ts": "// jest-dom adds custom jest matchers for asserting on DOM nodes.


### PR DESCRIPTION
Using `yarn eslint` I noticed a rule break defined here https://github.com/projen/projen/blob/main/.eslintrc.json#L95

https://typescript-eslint.io/rules/no-floating-promises/

```
Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the `void` operator.eslint[@typescript-eslint/no-floating-promises](https://typescript-eslint.io/rules/no-floating-promises)
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.