### PR TITLE
feat(github): add new job permissions

### DIFF
--- a/src/github/workflows-model.ts
+++ b/src/github/workflows-model.ts
@@ -192,8 +192,11 @@ export interface JobPermissions {
   readonly checks?: JobPermission;
   readonly contents?: JobPermission;
   readonly deployments?: JobPermission;
+  readonly idToken?: JobPermission;
   readonly issues?: JobPermission;
+  readonly discussions?: JobPermission;
   readonly packages?: JobPermission;
+  readonly pages?: JobPermission;
   readonly pullRequests?: JobPermission;
   readonly repositoryProjects?: JobPermission;
   readonly securityEvents?: JobPermission;


### PR DESCRIPTION
Add missing job permissions.

The available scopes are listed here: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.