### PR TITLE
fix: jsii-pacmak is not included as dev dependency

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -99,6 +99,10 @@
       "type": "build"
     },
     {
+      "name": "jsii-pacmak",
+      "type": "build"
+    },
+    {
       "name": "json-schema",
       "type": "build"
     },

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -221,10 +221,7 @@
       "description": "Create go language bindings",
       "steps": [
         {
-          "exec": "jsii_version=$(node -p \"JSON.parse(fs.readFileSync('.jsii')).jsiiVersion.split(' ')[0]\")"
-        },
-        {
-          "exec": "npx jsii-pacmak@$jsii_version -v --target go"
+          "exec": "jsii-pacmak -v --target go"
         }
       ]
     },
@@ -233,10 +230,7 @@
       "description": "Create java language bindings",
       "steps": [
         {
-          "exec": "jsii_version=$(node -p \"JSON.parse(fs.readFileSync('.jsii')).jsiiVersion.split(' ')[0]\")"
-        },
-        {
-          "exec": "npx jsii-pacmak@$jsii_version -v --target java"
+          "exec": "jsii-pacmak -v --target java"
         }
       ]
     },
@@ -245,10 +239,7 @@
       "description": "Create js language bindings",
       "steps": [
         {
-          "exec": "jsii_version=$(node -p \"JSON.parse(fs.readFileSync('.jsii')).jsiiVersion.split(' ')[0]\")"
-        },
-        {
-          "exec": "npx jsii-pacmak@$jsii_version -v --target js"
+          "exec": "jsii-pacmak -v --target js"
         }
       ]
     },
@@ -257,10 +248,7 @@
       "description": "Create python language bindings",
       "steps": [
         {
-          "exec": "jsii_version=$(node -p \"JSON.parse(fs.readFileSync('.jsii')).jsiiVersion.split(' ')[0]\")"
-        },
-        {
-          "exec": "npx jsii-pacmak@$jsii_version -v --target python"
+          "exec": "jsii-pacmak -v --target python"
         }
       ]
     },
@@ -399,7 +387,7 @@
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @types/conventional-changelog-config-spec @types/fs-extra @types/glob @types/ini @types/jest @types/node @types/semver @types/yargs @typescript-eslint/eslint-plugin @typescript-eslint/parser all-contributors-cli esbuild eslint-config-prettier eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint jest jest-junit jsii jsii-diff jsii-docgen json-schema npm-check-updates prettier standard-version ts-jest typescript @iarna/toml case chalk conventional-changelog-config-spec fs-extra glob ini semver shx xmlbuilder2 yaml yargs"
+          "exec": "yarn upgrade @types/conventional-changelog-config-spec @types/fs-extra @types/glob @types/ini @types/jest @types/node @types/semver @types/yargs @typescript-eslint/eslint-plugin @typescript-eslint/parser all-contributors-cli esbuild eslint-config-prettier eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint jest jest-junit jsii jsii-diff jsii-docgen jsii-pacmak json-schema npm-check-updates prettier standard-version ts-jest typescript @iarna/toml case chalk conventional-changelog-config-spec fs-extra glob ini semver shx xmlbuilder2 yaml yargs"
         },
         {
           "exec": "/bin/bash ./projen.bash"

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "jsii": "^1.55.0",
     "jsii-diff": "^1.55.0",
     "jsii-docgen": "^1.8.110",
+    "jsii-pacmak": "^1.55.0",
     "json-schema": "^0.4.0",
     "markmac": "^0.1.146",
     "npm-check-updates": "^12",

--- a/src/cdk/jsii-project.ts
+++ b/src/cdk/jsii-project.ts
@@ -328,7 +328,7 @@ export class JsiiProject extends TypeScriptProject {
       this.addPackagingTarget("go", task);
     }
 
-    this.addDevDeps("jsii", "jsii-diff");
+    this.addDevDeps("jsii", "jsii-diff", "jsii-pacmak");
 
     this.gitignore.exclude(".jsii", "tsconfig.json");
     this.npmignore?.include(".jsii");
@@ -370,11 +370,7 @@ export class JsiiProject extends TypeScriptProject {
     const packageTask = this.tasks.addTask(`package:${language}`, {
       description: `Create ${language} language bindings`,
     });
-
-    packageTask.exec(
-      "jsii_version=$(node -p \"JSON.parse(fs.readFileSync('.jsii')).jsiiVersion.split(' ')[0]\")"
-    );
-    packageTask.exec(`npx jsii-pacmak@$jsii_version -v --target ${language}`);
+    packageTask.exec(`jsii-pacmak -v --target ${language}`);
     this.packageAllTask.spawn(packageTask);
     return packageTask;
   }

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -908,6 +908,10 @@ tsconfig.tsbuildinfo
         "type": "build",
       },
       Object {
+        "name": "jsii-pacmak",
+        "type": "build",
+      },
+      Object {
         "name": "json-schema",
         "type": "build",
       },
@@ -1281,10 +1285,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package:java",
         "steps": Array [
           Object {
-            "exec": "jsii_version=$(node -p \\"JSON.parse(fs.readFileSync('.jsii')).jsiiVersion.split(' ')[0]\\")",
-          },
-          Object {
-            "exec": "npx jsii-pacmak@$jsii_version -v --target java",
+            "exec": "jsii-pacmak -v --target java",
           },
         ],
       },
@@ -1293,10 +1294,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package:js",
         "steps": Array [
           Object {
-            "exec": "jsii_version=$(node -p \\"JSON.parse(fs.readFileSync('.jsii')).jsiiVersion.split(' ')[0]\\")",
-          },
-          Object {
-            "exec": "npx jsii-pacmak@$jsii_version -v --target js",
+            "exec": "jsii-pacmak -v --target js",
           },
         ],
       },
@@ -1305,10 +1303,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package:python",
         "steps": Array [
           Object {
-            "exec": "jsii_version=$(node -p \\"JSON.parse(fs.readFileSync('.jsii')).jsiiVersion.split(' ')[0]\\")",
-          },
-          Object {
-            "exec": "npx jsii-pacmak@$jsii_version -v --target python",
+            "exec": "jsii-pacmak -v --target python",
           },
         ],
       },
@@ -1758,6 +1753,7 @@ project.synth();
       "jsii": "*",
       "jsii-diff": "*",
       "jsii-docgen": "*",
+      "jsii-pacmak": "*",
       "json-schema": "*",
       "npm-check-updates": "^12",
       "projen": "*",
@@ -2486,6 +2482,10 @@ tsconfig.tsbuildinfo
         "type": "build",
       },
       Object {
+        "name": "jsii-pacmak",
+        "type": "build",
+      },
+      Object {
         "name": "json-schema",
         "type": "build",
       },
@@ -2704,10 +2704,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package:dotnet",
         "steps": Array [
           Object {
-            "exec": "jsii_version=$(node -p \\"JSON.parse(fs.readFileSync('.jsii')).jsiiVersion.split(' ')[0]\\")",
-          },
-          Object {
-            "exec": "npx jsii-pacmak@$jsii_version -v --target dotnet",
+            "exec": "jsii-pacmak -v --target dotnet",
           },
         ],
       },
@@ -2716,10 +2713,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package:java",
         "steps": Array [
           Object {
-            "exec": "jsii_version=$(node -p \\"JSON.parse(fs.readFileSync('.jsii')).jsiiVersion.split(' ')[0]\\")",
-          },
-          Object {
-            "exec": "npx jsii-pacmak@$jsii_version -v --target java",
+            "exec": "jsii-pacmak -v --target java",
           },
         ],
       },
@@ -2728,10 +2722,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package:js",
         "steps": Array [
           Object {
-            "exec": "jsii_version=$(node -p \\"JSON.parse(fs.readFileSync('.jsii')).jsiiVersion.split(' ')[0]\\")",
-          },
-          Object {
-            "exec": "npx jsii-pacmak@$jsii_version -v --target js",
+            "exec": "jsii-pacmak -v --target js",
           },
         ],
       },
@@ -2740,10 +2731,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package:python",
         "steps": Array [
           Object {
-            "exec": "jsii_version=$(node -p \\"JSON.parse(fs.readFileSync('.jsii')).jsiiVersion.split(' ')[0]\\")",
-          },
-          Object {
-            "exec": "npx jsii-pacmak@$jsii_version -v --target python",
+            "exec": "jsii-pacmak -v --target python",
           },
         ],
       },
@@ -2823,7 +2811,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
             "exec": "yarn install --check-files",
           },
           Object {
-            "exec": "yarn upgrade @types/follow-redirects @types/jest @types/json-stable-stringify @types/node @types/yaml @typescript-eslint/eslint-plugin @typescript-eslint/parser constructs eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit jsii jsii-diff jsii-docgen json-schema json-schema-to-typescript npm-check-updates ts-jest typescript fast-json-patch follow-redirects json-stable-stringify yaml constructs",
+            "exec": "yarn upgrade @types/follow-redirects @types/jest @types/json-stable-stringify @types/node @types/yaml @typescript-eslint/eslint-plugin @typescript-eslint/parser constructs eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit jsii jsii-diff jsii-docgen jsii-pacmak json-schema json-schema-to-typescript npm-check-updates ts-jest typescript fast-json-patch follow-redirects json-stable-stringify yaml constructs",
           },
           Object {
             "exec": "npx projen",
@@ -3323,6 +3311,7 @@ project.synth();
       "jsii": "*",
       "jsii-diff": "*",
       "jsii-docgen": "*",
+      "jsii-pacmak": "*",
       "json-schema": "*",
       "json-schema-to-typescript": "*",
       "npm-check-updates": "^12",

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -6,10 +6,7 @@ Object {
   "name": "package:dotnet",
   "steps": Array [
     Object {
-      "exec": "jsii_version=$(node -p \\"JSON.parse(fs.readFileSync('.jsii')).jsiiVersion.split(' ')[0]\\")",
-    },
-    Object {
-      "exec": "npx jsii-pacmak@$jsii_version -v --target dotnet",
+      "exec": "jsii-pacmak -v --target dotnet",
     },
   ],
 }
@@ -21,10 +18,7 @@ Object {
   "name": "package:go",
   "steps": Array [
     Object {
-      "exec": "jsii_version=$(node -p \\"JSON.parse(fs.readFileSync('.jsii')).jsiiVersion.split(' ')[0]\\")",
-    },
-    Object {
-      "exec": "npx jsii-pacmak@$jsii_version -v --target go",
+      "exec": "jsii-pacmak -v --target go",
     },
   ],
 }
@@ -36,10 +30,7 @@ Object {
   "name": "package:java",
   "steps": Array [
     Object {
-      "exec": "jsii_version=$(node -p \\"JSON.parse(fs.readFileSync('.jsii')).jsiiVersion.split(' ')[0]\\")",
-    },
-    Object {
-      "exec": "npx jsii-pacmak@$jsii_version -v --target java",
+      "exec": "jsii-pacmak -v --target java",
     },
   ],
 }
@@ -51,10 +42,7 @@ Object {
   "name": "package:js",
   "steps": Array [
     Object {
-      "exec": "jsii_version=$(node -p \\"JSON.parse(fs.readFileSync('.jsii')).jsiiVersion.split(' ')[0]\\")",
-    },
-    Object {
-      "exec": "npx jsii-pacmak@$jsii_version -v --target js",
+      "exec": "jsii-pacmak -v --target js",
     },
   ],
 }
@@ -66,10 +54,7 @@ Object {
   "name": "package:python",
   "steps": Array [
     Object {
-      "exec": "jsii_version=$(node -p \\"JSON.parse(fs.readFileSync('.jsii')).jsiiVersion.split(' ')[0]\\")",
-    },
-    Object {
-      "exec": "npx jsii-pacmak@$jsii_version -v --target python",
+      "exec": "jsii-pacmak -v --target python",
     },
   ],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -555,7 +555,7 @@
     chalk "^4.1.2"
     semver "^7.3.5"
 
-"@jsii/spec@^1.30.0", "@jsii/spec@^1.55.0":
+"@jsii/spec@1.55.0", "@jsii/spec@^1.30.0", "@jsii/spec@^1.55.0":
   version "1.55.0"
   resolved "https://registry.yarnpkg.com/@jsii/spec/-/spec-1.55.0.tgz#c0838b3f401eca0849c359bf2b62ef7b2b39202b"
   integrity sha512-MsmAmi9+2s8p5jSypYFDTufkO2iAUWK7Ngq+btGDM6bMyQgqInMKNQcPcZAgWuwUCOU0ne/oYMVIbCR2njjAGA==
@@ -951,6 +951,11 @@
   dependencies:
     "@typescript-eslint/types" "5.14.0"
     eslint-visitor-keys "^3.0.0"
+
+"@xmldom/xmldom@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.1.tgz#70c239275fc6d6a84e41b9a8d623a93c0d59b6b4"
+  integrity sha512-4wOae+5N2RZ+CZXd9ZKwkaDi55IxrSTOjHpxTvQQ4fomtOJmqVxbmICA9jE1jvnqNhpfgz8cnfFagG86wV/xLQ==
 
 JSONStream@^1.0.4:
   version "1.3.5"
@@ -1385,7 +1390,7 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-camelcase@^6.2.0:
+camelcase@^6.2.0, camelcase@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
@@ -1506,10 +1511,24 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
+clone@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
+
+codemaker@^1.55.0:
+  version "1.55.0"
+  resolved "https://registry.yarnpkg.com/codemaker/-/codemaker-1.55.0.tgz#902dbf5384d16823c7e2fc7e94a5ae632b1c7b22"
+  integrity sha512-oVCJ3PUqkMf65pS8TtstLSn5AAGmuDTfrjlZjG8qOcOMHvG/w12iJ4ZlJt/wULaAqlYh9bTemXaGIzT5YbX43A==
+  dependencies:
+    camelcase "^6.3.0"
+    decamelize "^5.0.1"
+    fs-extra "^9.1.0"
 
 collect-v8-coverage@^1.0.0:
   version "1.0.1"
@@ -1561,6 +1580,16 @@ commander@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.0.0.tgz#86d58f24ee98126568936bd1d3574e0308a99a40"
   integrity sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw==
+
+commonmark@^0.30.0:
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/commonmark/-/commonmark-0.30.0.tgz#38811dc7bbf0f59d277ae09054d4d73a332f2e45"
+  integrity sha512-j1yoUo4gxPND1JWV9xj5ELih0yMv1iCWDG6eEQIPLSWLxzCXiFoyS7kvB+WwU+tZMf4snwJMMtaubV0laFpiBA==
+  dependencies:
+    entities "~2.0"
+    mdurl "~1.0.1"
+    minimist ">=1.2.2"
+    string.prototype.repeat "^0.2.0"
 
 compare-func@^2.0.0:
   version "2.0.0"
@@ -1875,6 +1904,11 @@ decamelize@^1.1.0, decamelize@^1.2.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
+decamelize@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-5.0.1.tgz#db11a92e58c741ef339fb0a2868d8a06a9a7b1e9"
+  integrity sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==
+
 decimal.js@^10.2.1:
   version "10.3.1"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.3.1.tgz#d8c3a444a9c6774ba60ca6ad7261c3a94fd5e783"
@@ -2061,6 +2095,11 @@ end-of-stream@^1.1.0:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
+
+entities@~2.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
+  integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
 
 env-paths@^2.2.0:
   version "2.2.1"
@@ -2515,7 +2554,7 @@ fast-diff@^1.1.2:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
-fast-glob@^3.2.9:
+fast-glob@^3.2.11, fast-glob@^3.2.9:
   version "3.2.11"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
   integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
@@ -3927,6 +3966,25 @@ jsii-docgen@^1.8.110:
     jsii-reflect "^1.30.0"
     yargs "^16.2.0"
 
+jsii-pacmak@^1.55.0:
+  version "1.55.0"
+  resolved "https://registry.yarnpkg.com/jsii-pacmak/-/jsii-pacmak-1.55.0.tgz#b8b448ca6dd5319becbe4ba87f383e22fc4bf393"
+  integrity sha512-2i1VQVGQIC0JUSryw9gV2VqcMNbR/KLQOwsfNb7gTs6qKccR5Pmf4eXuIC+HxpyIiecu1UeEbToz5q8fMdVcig==
+  dependencies:
+    "@jsii/check-node" "1.55.0"
+    "@jsii/spec" "^1.55.0"
+    clone "^2.1.2"
+    codemaker "^1.55.0"
+    commonmark "^0.30.0"
+    escape-string-regexp "^4.0.0"
+    fs-extra "^9.1.0"
+    jsii-reflect "^1.55.0"
+    jsii-rosetta "^1.55.0"
+    semver "^7.3.5"
+    spdx-license-list "^6.4.0"
+    xmlbuilder "^15.1.1"
+    yargs "^16.2.0"
+
 jsii-reflect@^1.30.0, jsii-reflect@^1.55.0:
   version "1.55.0"
   resolved "https://registry.yarnpkg.com/jsii-reflect/-/jsii-reflect-1.55.0.tgz#0f9dadf1092a33970d9bdfa327a2580a27da1390"
@@ -3939,7 +3997,26 @@ jsii-reflect@^1.30.0, jsii-reflect@^1.55.0:
     oo-ascii-tree "^1.55.0"
     yargs "^16.2.0"
 
-jsii@^1.55.0:
+jsii-rosetta@^1.55.0:
+  version "1.55.0"
+  resolved "https://registry.yarnpkg.com/jsii-rosetta/-/jsii-rosetta-1.55.0.tgz#9c78d152204600cf70ad5006a61246e020f6fdbb"
+  integrity sha512-LOw8i5ypoJ8A2D24Za3fIWeiNbPa6q0wuLuu0LAr+VWvu4f2A5A9SJfzsB39CXwDVKjrAVVvCy83Fgdv3/2VFw==
+  dependencies:
+    "@jsii/check-node" "1.55.0"
+    "@jsii/spec" "1.55.0"
+    "@xmldom/xmldom" "^0.8.1"
+    commonmark "^0.30.0"
+    fast-glob "^3.2.11"
+    fs-extra "^9.1.0"
+    jsii "1.55.0"
+    semver "^7.3.5"
+    semver-intersect "^1.4.0"
+    sort-json "^2.0.1"
+    typescript "~3.9.10"
+    workerpool "^6.2.0"
+    yargs "^16.2.0"
+
+jsii@1.55.0, jsii@^1.55.0:
   version "1.55.0"
   resolved "https://registry.yarnpkg.com/jsii/-/jsii-1.55.0.tgz#b8f98d68e70ed1d7344d8e14034879074fef3937"
   integrity sha512-OpY67STJMTqF/pQRYMXx8xaA1lCnKoQCnraB043tkx6F3reyUNzlIzSIkQIgTEFoBa/OEYANHdtHJCfw6Y3nzA==
@@ -4255,6 +4332,11 @@ markmac@^0.1.146:
   resolved "https://registry.yarnpkg.com/markmac/-/markmac-0.1.146.tgz#4f49011d29af198829b9a930ea8fb4a84a3f69c5"
   integrity sha512-r3XAXdCf9EuMeocSc3PENuw8jcWXyLy4J7cWyklEzzwc6e/mXRuU7F+ixbhNld+rdb68MQlCB68p9KgogAdcsA==
 
+mdurl@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
+  integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
+
 meow@^8.0.0:
   version "8.1.2"
   resolved "https://registry.yarnpkg.com/meow/-/meow-8.1.2.tgz#bcbe45bda0ee1729d350c03cffc8395a36c4e897"
@@ -4340,7 +4422,7 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
+minimist@>=1.2.2, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -5605,6 +5687,11 @@ string-length@^4.0.1:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
+string.prototype.repeat@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.repeat/-/string.prototype.repeat-0.2.0.tgz#aba36de08dcee6a5a337d49b2ea1da1b28fc0ecf"
+  integrity sha1-q6Nt4I3O5qWjN9SbLqHaGyj8Ds8=
+
 string.prototype.trimend@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz#e75ae90c2942c63504686c18b287b4a0b1a45f80"
@@ -6187,6 +6274,11 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
+workerpool@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.0.tgz#827d93c9ba23ee2019c3ffaff5c27fccea289e8b"
+  integrity sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==
+
 wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
@@ -6250,6 +6342,11 @@ xmlbuilder2@^2.4.1:
     "@oozcitak/util" "8.3.8"
     "@types/node" "*"
     js-yaml "3.14.0"
+
+xmlbuilder@^15.1.1:
+  version "15.1.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-15.1.1.tgz#9dcdce49eea66d8d10b42cae94a79c3c8d0c2ec5"
+  integrity sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Sometimes while doing a local build, I encounter the build hanging because the relevant version of jsii-pacmak hasn't been installed:

```
👾 package-all » package:js | npx jsii-pacmak@$jsii_version -v --target js
Need to install the following packages:
  jsii-pacmak
Ok to proceed? (y)
```

Instead let's just add it as a dev dependency outright.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.