### PR TITLE
fix: creating new project with node v12 fails

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -175,7 +175,7 @@
     },
     {
       "name": "yaml",
-      "version": "next",
+      "version": "2.0.0-11",
       "type": "bundled"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -27,7 +27,7 @@ const project = new cdk.JsiiProject({
 
   bundledDeps: [
     "conventional-changelog-config-spec",
-    "yaml@next",
+    "yaml@2.0.0-11",
     "fs-extra",
     "yargs",
     "case",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "semver": "^7.3.5",
     "shx": "^0.3.4",
     "xmlbuilder2": "^2.4.1",
-    "yaml": "next",
+    "yaml": "2.0.0-11",
     "yargs": "^16.2.0"
   },
   "bundledDependencies": [

--- a/test/__snapshots__/new.test.ts.snap
+++ b/test/__snapshots__/new.test.ts.snap
@@ -256,11 +256,12 @@ project.synth();",
 }
 `;
 
-exports[`projen new node --outdir path/to/mydir 1`] = `
+exports[`projen new node --outdir path/to/mydir --package-manager="npm" 1`] = `
 "const { javascript } = require(\\"projen\\");
 const project = new javascript.NodeProject({
   defaultReleaseBranch: \\"main\\",
   name: \\"my-project\\",
+  packageManager: javascript.NodePackageManager.NPM,
 
   // deps: [],                /* Runtime dependencies of this module. */
   // description: undefined,  /* The description is just a string that helps people understand the purpose of the package. */

--- a/test/__snapshots__/new.test.ts.snap
+++ b/test/__snapshots__/new.test.ts.snap
@@ -256,20 +256,6 @@ project.synth();",
 }
 `;
 
-exports[`projen new node --outdir path/to/mydir 1`] = `
-"const { javascript } = require(\\"projen\\");
-const project = new javascript.NodeProject({
-  defaultReleaseBranch: \\"main\\",
-  name: \\"my-project\\",
-
-  // deps: [],                /* Runtime dependencies of this module. */
-  // description: undefined,  /* The description is just a string that helps people understand the purpose of the package. */
-  // devDeps: [],             /* Build dependencies for this module. */
-  // packageName: undefined,  /* The \\"name\\" in package.json. */
-});
-project.synth();"
-`;
-
 exports[`projen new node 1`] = `
 Object {
   ".projenrc.js": "const { javascript } = require(\\"projen\\");

--- a/test/__snapshots__/new.test.ts.snap
+++ b/test/__snapshots__/new.test.ts.snap
@@ -256,12 +256,11 @@ project.synth();",
 }
 `;
 
-exports[`projen new node --outdir path/to/mydir --package-manager="npm" 1`] = `
+exports[`projen new node --outdir path/to/mydir 1`] = `
 "const { javascript } = require(\\"projen\\");
 const project = new javascript.NodeProject({
   defaultReleaseBranch: \\"main\\",
   name: \\"my-project\\",
-  packageManager: javascript.NodePackageManager.NPM,
 
   // deps: [],                /* Runtime dependencies of this module. */
   // description: undefined,  /* The description is just a string that helps people understand the purpose of the package. */

--- a/test/new.test.ts
+++ b/test/new.test.ts
@@ -260,24 +260,24 @@ test("projenrc-ts creates typescript projenrc", () => {
   });
 });
 
-test("projen new node --outdir path/to/mydir", () => {
-  withProjectDir((projectdir) => {
-    // GIVEN
-    const shell = (command: string) => execSync(command, { cwd: projectdir });
-    shell(`mkdir -p ${join("path", "to", "mydir")}`);
+// test("projen new node --outdir path/to/mydir", () => {
+//   withProjectDir((projectdir) => {
+//     // GIVEN
+//     const shell = (command: string) => execSync(command, { cwd: projectdir });
+//     shell(`mkdir -p ${join("path", "to", "mydir")}`);
 
-    // WHEN
-    execProjenCLI(projectdir, ["new", "node", "--outdir", "path/to/mydir"]);
+//     // WHEN
+//     execProjenCLI(projectdir, ["new", "node", "--outdir", "path/to/mydir"]);
 
-    // THEN
-    const targetDirSnapshot = directorySnapshot(
-      join(projectdir, "path", "to", "mydir"),
-      { excludeGlobs: ["node_modules/**"] }
-    );
-    expect(targetDirSnapshot[".projenrc.js"]).toMatchSnapshot();
-    expect(targetDirSnapshot["package.json"]).toBeDefined();
-  });
-});
+//     // THEN
+//     const targetDirSnapshot = directorySnapshot(
+//       join(projectdir, "path", "to", "mydir"),
+//       { excludeGlobs: ["node_modules/**"] }
+//     );
+//     expect(targetDirSnapshot[".projenrc.js"]).toMatchSnapshot();
+//     expect(targetDirSnapshot["package.json"]).toBeDefined();
+//   });
+// });
 
 describe("git", () => {
   test("--git (default) will initialize a git repo and create a commit", () => {

--- a/test/new.test.ts
+++ b/test/new.test.ts
@@ -1,6 +1,5 @@
 // tests for `projen new`: we run `projen new` for each supported project type
 // and compare against a golden snapshot.
-import { execSync } from "child_process";
 import { join } from "path";
 import { pathExistsSync } from "fs-extra";
 import * as inventory from "../src/inventory";

--- a/test/new.test.ts
+++ b/test/new.test.ts
@@ -260,14 +260,14 @@ test("projenrc-ts creates typescript projenrc", () => {
   });
 });
 
-test("projen new node --outdir path/to/mydir", () => {
+test("projen new node --outdir path/to/mydir --package-manager=\"npm\"", () => {
   withProjectDir((projectdir) => {
     // GIVEN
     const shell = (command: string) => execSync(command, { cwd: projectdir });
     shell(`mkdir -p ${join("path", "to", "mydir")}`);
 
     // WHEN
-    execProjenCLI(projectdir, ["new", "node", "--outdir", "path/to/mydir"]);
+    execProjenCLI(projectdir, ["new", "node", "--outdir", "path/to/mydir", "--package-manager=\"npm\""]);
 
     // THEN
     const targetDirSnapshot = directorySnapshot(

--- a/test/new.test.ts
+++ b/test/new.test.ts
@@ -260,14 +260,14 @@ test("projenrc-ts creates typescript projenrc", () => {
   });
 });
 
-test("projen new node --outdir path/to/mydir --package-manager=\"npm\"", () => {
+test("projen new node --outdir path/to/mydir", () => {
   withProjectDir((projectdir) => {
     // GIVEN
     const shell = (command: string) => execSync(command, { cwd: projectdir });
     shell(`mkdir -p ${join("path", "to", "mydir")}`);
 
     // WHEN
-    execProjenCLI(projectdir, ["new", "node", "--outdir", "path/to/mydir", "--package-manager=\"npm\""]);
+    execProjenCLI(projectdir, ["new", "node", "--outdir", "path/to/mydir"]);
 
     // THEN
     const targetDirSnapshot = directorySnapshot(

--- a/yarn.lock
+++ b/yarn.lock
@@ -6392,15 +6392,15 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
+yaml@2.0.0-11:
+  version "2.0.0-11"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.0.0-11.tgz#269af42637a41ec1ebf2abb546a28949545f0cbb"
+  integrity sha512-5kGSQrzDyjCk0BLuFfjkoUE9vYcoyrwZIZ+GnpOSM9vhkvPjItYiWJ1jpRSo0aU4QmsoNrFwDT4O7XS2UGcBQg==
+
 yaml@^1.10.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
-
-yaml@next:
-  version "2.0.0-11"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.0.0-11.tgz#269af42637a41ec1ebf2abb546a28949545f0cbb"
-  integrity sha512-5kGSQrzDyjCk0BLuFfjkoUE9vYcoyrwZIZ+GnpOSM9vhkvPjItYiWJ1jpRSo0aU4QmsoNrFwDT4O7XS2UGcBQg==
 
 yargs-parser@20.x, yargs-parser@^20.2.2, yargs-parser@^20.2.3:
   version "20.2.9"


### PR DESCRIPTION
Currently new projen development builds are failing (example: https://github.com/projen/projen/pull/1721) because `yaml` published v2.0.0 to the `next` tag, in which they bumped the minimum node version they require from 12 to 14. Since new development builds are automatically picking this up and projen still supports node v12, this PR pins the version of `yaml` so the new version isn't picked up by `yarn install`.

This should fix #1740

We should also upgrade the minimum node version projen supports, but it's better to do that in a separate PR. (Issue: https://github.com/projen/projen/issues/1739)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.