### PR TITLE
feat(publisher): match first changelog entry

### DIFF
--- a/src/release/update-changelog.ts
+++ b/src/release/update-changelog.ts
@@ -58,7 +58,7 @@ export async function updateChangelog(
   }
 
   const inputChangelogContent = await readFile(inputChangelog, "utf-8");
-  const changelogVersionSearchPattern = `[${version}]`;
+  const changelogVersionSearchPattern = `${version}`;
 
   if (!inputChangelogContent.includes(changelogVersionSearchPattern)) {
     throw new Error(

--- a/test/release/update-changelog.test.ts
+++ b/test/release/update-changelog.test.ts
@@ -44,6 +44,17 @@ test("adds a new changelog if missing", async () => {
   expect(result.projectChangelogContent.length).toBeGreaterThan(0);
 });
 
+test("matches first changelog entry missing brackets around the version", async () => {
+  const result = await testUpdateChangelog({
+    testOptions: {
+      inputChangelogContent: `## ${DEFAULT_VERSION} (2021-09-04)`,
+    },
+  });
+
+  expect(result.commits[0]).toMatch(`chore(release): ${DEFAULT_VERSION}`);
+  expect(result.lastCommitContent).toMatch(/.*CHANGELOG\.md.*/g);
+});
+
 test("duplicate release tag update is idempotent", async () => {
   const result1 = await testUpdateChangelog();
   const result2 = await testUpdateChangelog({


### PR DESCRIPTION
The first ever changelog entry created by standard-version
doesn't link to a diff because none exists yet. For that
reason there are no markdown link brackets around the
version, which was causing the first manual release to
fail.

Closes #1749

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.