### PR TITLE
feat: add `addPreBuildSteps` API to build workflow

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -4418,6 +4418,28 @@ addPostBuildSteps(...steps: JobStep[]): void
 
 
 
+#### addPreBuildSteps(...steps)🔹 <a id="projen-build-buildworkflow-addprebuildsteps"></a>
+
+Adds steps that are executed before the build.
+
+```ts
+addPreBuildSteps(...steps: JobStep[]): void
+```
+
+* **steps** (<code>[github.workflows.JobStep](#projen-github-workflows-jobstep)</code>)  The job steps.
+  * **continueOnError** (<code>boolean</code>)  Prevents a job from failing when a step fails. __*Optional*__
+  * **env** (<code>Map<string, string></code>)  Sets environment variables for steps to use in the runner environment. __*Optional*__
+  * **id** (<code>string</code>)  A unique identifier for the step. __*Optional*__
+  * **if** (<code>string</code>)  You can use the if conditional to prevent a job from running unless a condition is met. __*Optional*__
+  * **name** (<code>string</code>)  A name for your step to display on GitHub. __*Optional*__
+  * **run** (<code>string</code>)  Runs command-line programs using the operating system's shell. __*Optional*__
+  * **timeoutMinutes** (<code>number</code>)  The maximum number of minutes to run the step before killing the process. __*Optional*__
+  * **uses** (<code>string</code>)  Selects an action to run as part of a step in your job. __*Optional*__
+  * **with** (<code>Map<string, any></code>)  A map of the input parameters defined by the action. __*Optional*__
+
+
+
+
 
 
 ## class AutoDiscoverBase 🔹 <a id="projen-cdk-autodiscoverbase"></a>

--- a/src/build/build-workflow.ts
+++ b/src/build/build-workflow.ts
@@ -172,6 +172,14 @@ export class BuildWorkflow extends Component {
   }
 
   /**
+   * Adds steps that are executed before the build.
+   * @param steps The job steps
+   */
+  public addPreBuildSteps(...steps: JobStep[]): void {
+    this.preBuildSteps.push(...steps);
+  }
+
+  /**
    * Adds steps that are executed after the build.
    * @param steps The job steps
    */

--- a/test/javascript/node-project.test.ts
+++ b/test/javascript/node-project.test.ts
@@ -561,6 +561,41 @@ test("extend github release workflow", () => {
   );
 });
 
+describe("extend github build workflow", () => {
+  let project: TestNodeProject;
+  beforeEach(() => {
+    project = new TestNodeProject();
+  });
+
+  test("addPostBuildSteps", () => {
+    // WHEN
+    project.buildWorkflow!.addPostBuildSteps({
+      name: "hello-world",
+      run: "echo 'hello world'",
+    });
+
+    // THEN
+    const workflow = synthSnapshot(project)[".github/workflows/build.yml"];
+    expect(workflow).toContain(
+      "- name: build\n        run: npx projen build\n      - name: hello-world\n        run: echo 'hello world'"
+    );
+  });
+
+  test("addPreBuildSteps", () => {
+    // WHEN
+    project.buildWorkflow!.addPreBuildSteps({
+      name: "hello-world",
+      run: "echo 'hello world'",
+    });
+
+    // THEN
+    const workflow = synthSnapshot(project)[".github/workflows/build.yml"];
+    expect(workflow).toContain(
+      "- name: hello-world\n        run: echo 'hello world'\n      - name: build\n        run: npx projen build"
+    );
+  });
+});
+
 describe("scripts", () => {
   test("addTask and setScript", () => {
     const p = new TestNodeProject();


### PR DESCRIPTION
Exposing pre-build steps on the build workflow. `BuildWorkflow` has a property called `preBuildSteps` so I think this API was unnecessarily omitted.

In addition to `addPostBuildSteps`, `BuildWorkflow` also has APIs for `addPostBuildJob` and `addPostBuildJobTask`, but I can't see a use case for needing to add Jobs pre-build so I did not add the corresponding `pre` APIs.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.