### PR TITLE
chore: pull out generic `Step` from `JobStep`

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -4405,15 +4405,15 @@ addPostBuildSteps(...steps: JobStep[]): void
 ```
 
 * **steps** (<code>[github.workflows.JobStep](#projen-github-workflows-jobstep)</code>)  The job steps.
-  * **continueOnError** (<code>boolean</code>)  Prevents a job from failing when a step fails. __*Optional*__
   * **env** (<code>Map<string, string></code>)  Sets environment variables for steps to use in the runner environment. __*Optional*__
   * **id** (<code>string</code>)  A unique identifier for the step. __*Optional*__
   * **if** (<code>string</code>)  You can use the if conditional to prevent a job from running unless a condition is met. __*Optional*__
   * **name** (<code>string</code>)  A name for your step to display on GitHub. __*Optional*__
   * **run** (<code>string</code>)  Runs command-line programs using the operating system's shell. __*Optional*__
-  * **timeoutMinutes** (<code>number</code>)  The maximum number of minutes to run the step before killing the process. __*Optional*__
   * **uses** (<code>string</code>)  Selects an action to run as part of a step in your job. __*Optional*__
   * **with** (<code>Map<string, any></code>)  A map of the input parameters defined by the action. __*Optional*__
+  * **continueOnError** (<code>boolean</code>)  Prevents a job from failing when a step fails. __*Optional*__
+  * **timeoutMinutes** (<code>number</code>)  The maximum number of minutes to run the step before killing the process. __*Optional*__
 
 
 
@@ -8095,15 +8095,15 @@ addPostBuildSteps(...steps: JobStep[]): void
 ```
 
 * **steps** (<code>[github.workflows.JobStep](#projen-github-workflows-jobstep)</code>)  workflow steps.
-  * **continueOnError** (<code>boolean</code>)  Prevents a job from failing when a step fails. __*Optional*__
   * **env** (<code>Map<string, string></code>)  Sets environment variables for steps to use in the runner environment. __*Optional*__
   * **id** (<code>string</code>)  A unique identifier for the step. __*Optional*__
   * **if** (<code>string</code>)  You can use the if conditional to prevent a job from running unless a condition is met. __*Optional*__
   * **name** (<code>string</code>)  A name for your step to display on GitHub. __*Optional*__
   * **run** (<code>string</code>)  Runs command-line programs using the operating system's shell. __*Optional*__
-  * **timeoutMinutes** (<code>number</code>)  The maximum number of minutes to run the step before killing the process. __*Optional*__
   * **uses** (<code>string</code>)  Selects an action to run as part of a step in your job. __*Optional*__
   * **with** (<code>Map<string, any></code>)  A map of the input parameters defined by the action. __*Optional*__
+  * **continueOnError** (<code>boolean</code>)  Prevents a job from failing when a step fails. __*Optional*__
+  * **timeoutMinutes** (<code>number</code>)  The maximum number of minutes to run the step before killing the process. __*Optional*__
 
 
 
@@ -8845,15 +8845,15 @@ addGitHubPrePublishingSteps(...steps: JobStep[]): void
 ```
 
 * **steps** (<code>[github.workflows.JobStep](#projen-github-workflows-jobstep)</code>)  The steps.
-  * **continueOnError** (<code>boolean</code>)  Prevents a job from failing when a step fails. __*Optional*__
   * **env** (<code>Map<string, string></code>)  Sets environment variables for steps to use in the runner environment. __*Optional*__
   * **id** (<code>string</code>)  A unique identifier for the step. __*Optional*__
   * **if** (<code>string</code>)  You can use the if conditional to prevent a job from running unless a condition is met. __*Optional*__
   * **name** (<code>string</code>)  A name for your step to display on GitHub. __*Optional*__
   * **run** (<code>string</code>)  Runs command-line programs using the operating system's shell. __*Optional*__
-  * **timeoutMinutes** (<code>number</code>)  The maximum number of minutes to run the step before killing the process. __*Optional*__
   * **uses** (<code>string</code>)  Selects an action to run as part of a step in your job. __*Optional*__
   * **with** (<code>Map<string, any></code>)  A map of the input parameters defined by the action. __*Optional*__
+  * **continueOnError** (<code>boolean</code>)  Prevents a job from failing when a step fails. __*Optional*__
+  * **timeoutMinutes** (<code>number</code>)  The maximum number of minutes to run the step before killing the process. __*Optional*__
 
 
 

--- a/src/github/workflows-model.ts
+++ b/src/github/workflows-model.ts
@@ -258,9 +258,9 @@ export interface RunSettings {
 }
 
 /**
- * A job step.
+ * A generic step
  */
-export interface JobStep {
+export interface Step {
   /**
    * A unique identifier for the step. You can use the id to reference the
    * step in contexts.
@@ -306,7 +306,12 @@ export interface JobStep {
    * You can also set environment variables for the entire workflow or a job.
    */
   readonly env?: Record<string, string>;
+}
 
+/**
+ * A job step
+ */
+export interface JobStep extends Step {
   /**
    * Prevents a job from failing when a step fails. Set to true to allow a job
    * to pass when this step fails.


### PR DESCRIPTION
This doesn't change the API, but moves generic `Step` properties out of `JobStep`. This is necessary because the [syntax](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions) for Action Metadata steps is ever so slightly different than a job step.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.