### PR TITLE
chore: deprecate node v12 support

### DIFF
--- a/docs/node.md
+++ b/docs/node.md
@@ -3,6 +3,18 @@
 This topic describes all the features of `NodeProject` projects and their
 derivatives.
 
+## Node versioning
+
+You can specify the minimum version of node that your project supports, and the version of node used in GitHub workflows:
+
+```js
+const project = new javascript.NodeProject({
+  // ...
+  minNodeVersion: '16.0.0',
+  workflowNodeVersion: '16.1.0', // defaults to minNodeVersion
+});
+```
+
 ## Development Workflow
 
 TODO

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,7 +1,7 @@
 import { resolve } from "path";
-import * as logging from "../logging";
 import * as yargs from "yargs";
 import { PROJEN_RC, PROJEN_VERSION } from "../common";
+import * as logging from "../logging";
 import { TaskRuntime } from "../task-runtime";
 import { getNodeMajorVersion } from "../util";
 import { synth } from "./synth";

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,7 +1,9 @@
 import { resolve } from "path";
+import * as logging from "../logging";
 import * as yargs from "yargs";
 import { PROJEN_RC, PROJEN_VERSION } from "../common";
 import { TaskRuntime } from "../task-runtime";
+import { getNodeMajorVersion } from "../util";
 import { synth } from "./synth";
 import { discoverTaskCommands } from "./tasks";
 
@@ -51,6 +53,13 @@ async function main() {
 
   if (args.debug) {
     process.env.DEBUG = "true";
+  }
+
+  const nodeVersion = getNodeMajorVersion();
+  if (nodeVersion && nodeVersion < 14) {
+    logging.warn(
+      `WARNING: You are using Node v${nodeVersion}, which reaches end of life on April 30, 2022. Support for EOL Node releases may be dropped by projen in the future. Please consider upgrading to Node >= 14 as soon as possible.`
+    );
   }
 
   // no command means synthesize

--- a/src/util.ts
+++ b/src/util.ts
@@ -380,3 +380,12 @@ function decamelize(s: string, sep: string = "_") {
     return s;
   }
 }
+
+export function getNodeMajorVersion(): number | undefined {
+  const match = process.version.match(/(\d+)\.(\d+)\.(\d+)/);
+  if (match) {
+    const [major,] = match.slice(1).map(x => parseInt(x));
+    return major;
+  }
+  return undefined;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -384,7 +384,7 @@ function decamelize(s: string, sep: string = "_") {
 export function getNodeMajorVersion(): number | undefined {
   const match = process.version.match(/(\d+)\.(\d+)\.(\d+)/);
   if (match) {
-    const [major,] = match.slice(1).map(x => parseInt(x));
+    const [major] = match.slice(1).map((x) => parseInt(x));
     return major;
   }
   return undefined;


### PR DESCRIPTION
Node v12 reaches end of life on April 30, 2022. This PR adds a warning that projen will be dropping support for old node releases.

We'll give this message a week to incubate before actually bumping the version we support (#1768).

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.