### PR TITLE
fix(node-project): code artifact login command

### DIFF
--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -920,9 +920,8 @@ export class NodePackage extends Component {
         { exec: "which aws" }, // check that AWS CLI is installed
         ...this.scopedPackagesOptions.map((scopedPackagesOption) => {
           const { registryUrl, scope } = scopedPackagesOption;
-          const { domain, region, accountId } =
+          const { domain, region, accountId, registry } =
             extractCodeArtifactDetails(registryUrl);
-          const registry = registryUrl.replace(/^https:\/\//, "");
           // reference: https://docs.aws.amazon.com/codeartifact/latest/ug/npm-auth.html
           const commands = [
             `npm config set ${scope}:registry ${registryUrl}`,

--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -920,14 +920,15 @@ export class NodePackage extends Component {
         { exec: "which aws" }, // check that AWS CLI is installed
         ...this.scopedPackagesOptions.map((scopedPackagesOption) => {
           const { registryUrl, scope } = scopedPackagesOption;
-          const { domain, repository, region, accountId } =
+          const { domain, region, accountId } =
             extractCodeArtifactDetails(registryUrl);
+          const registry = registryUrl.replace(/^https:\/\//, "");
           // reference: https://docs.aws.amazon.com/codeartifact/latest/ug/npm-auth.html
           const commands = [
             `npm config set ${scope}:registry ${registryUrl}`,
-            `CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${domain} --repository ${repository} --region ${region} --domain-owner ${accountId})`,
-            `npm config set //${registryUrl}:_authToken=$CODEARTIFACT_AUTH_TOKEN`,
-            `npm config set //${registryUrl}:always-auth=true`,
+            `CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${domain} --region ${region} --domain-owner ${accountId} --query authorizationToken --output text)`,
+            `npm config set //${registry}:_authToken=$CODEARTIFACT_AUTH_TOKEN`,
+            `npm config set //${registry}:always-auth=true`,
           ];
           return {
             exec: commands.join("; "),

--- a/src/javascript/util.ts
+++ b/src/javascript/util.ts
@@ -17,7 +17,7 @@ export function renderBundleName(entrypoint: string) {
  * Regex for AWS CodeArtifact registry
  */
 export const codeArtifactRegex =
-  /^https:\/\/(?<domain>[^\.]+)-(?<accountId>\d{12})\.d\.codeartifact\.(?<region>[^\.]+).*\.amazonaws\.com\/.*\/(?<repository>\w+)\//;
+  /^https:\/\/(?<registry>(?<domain>[^\.]+)-(?<accountId>\d{12})\.d\.codeartifact\.(?<region>[^\.]+).*\.amazonaws\.com\/.*\/(?<repository>\w+)\/)/;
 
 /**
  * gets AWS details from the Code Artifact registry URL
@@ -28,8 +28,8 @@ export const codeArtifactRegex =
 export function extractCodeArtifactDetails(registryUrl: string) {
   const match = registryUrl.match(codeArtifactRegex);
   if (match?.groups) {
-    const { domain, accountId, region, repository } = match.groups;
-    return { domain, accountId, region, repository };
+    const { domain, accountId, region, repository, registry } = match.groups;
+    return { domain, accountId, region, repository, registry };
   }
   throw new Error("Could not get CodeArtifact details from npm Registry");
 }

--- a/src/javascript/util.ts
+++ b/src/javascript/util.ts
@@ -17,7 +17,7 @@ export function renderBundleName(entrypoint: string) {
  * Regex for AWS CodeArtifact registry
  */
 export const codeArtifactRegex =
-  /^https:\/\/(?<domain>[^\.]+)-(?<accountId>\d{12})\.d\.codeartifact\.(?<region>[^\.]+).*\.amazonaws\.com\/.*\/(?<repository>\w+)/;
+  /^https:\/\/(?<domain>[^\.]+)-(?<accountId>\d{12})\.d\.codeartifact\.(?<region>[^\.]+).*\.amazonaws\.com\/.*\/(?<repository>\w+)\//;
 
 /**
  * gets AWS details from the Code Artifact registry URL

--- a/test/javascript/node-project.test.ts
+++ b/test/javascript/node-project.test.ts
@@ -873,7 +873,8 @@ describe("scoped private packages", () => {
   const scope = "@stub-scope";
   const defaultAccessKeyIdSecret = "AWS_ACCESS_KEY_ID";
   const defaultSecretAccessKeySecret = "AWS_SECRET_ACCESS_KEY";
-  const registryUrl = `https://${domain}-${accountId}.d.codeartifact.${region}.amazonaws.com/npm/${repository}/`;
+  const registry = `${domain}-${accountId}.d.codeartifact.${region}.amazonaws.com/npm/${repository}/`;
+  const registryUrl = `https://${registry}`;
 
   test("adds AWS Code Artifact Login step prior to install to build workflow", () => {
     const project = new TestNodeProject({
@@ -1096,7 +1097,7 @@ describe("scoped private packages", () => {
           exec: "which aws",
         },
         {
-          exec: `npm config set ${scope}:registry ${registryUrl}; CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${domain} --repository ${repository} --region ${region} --domain-owner ${accountId}); npm config set //${registryUrl}:_authToken=$CODEARTIFACT_AUTH_TOKEN; npm config set //${registryUrl}:always-auth=true`,
+          exec: `npm config set ${scope}:registry ${registryUrl}; CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${domain} --region ${region} --domain-owner ${accountId} --query authorizationToken --output text); npm config set //${registry}:_authToken=$CODEARTIFACT_AUTH_TOKEN; npm config set //${registry}:always-auth=true`,
         },
       ],
     });
@@ -1108,7 +1109,8 @@ describe("scoped private packages", () => {
     const region2 = "my-region-2";
     const repository2 = "MyRepository2";
     const scope2 = "@stub-scope-2";
-    const registryUrl2 = `https://${domain2}-${accountId2}.d.codeartifact.${region2}.amazonaws.com/npm/${repository2}/`;
+    const registry2 = `${domain2}-${accountId2}.d.codeartifact.${region2}.amazonaws.com/npm/${repository2}/`;
+    const registryUrl2 = `https://${registry2}`;
     const project = new TestNodeProject({
       scopedPackagesOptions: [
         {
@@ -1132,10 +1134,10 @@ describe("scoped private packages", () => {
           exec: "which aws",
         },
         {
-          exec: `npm config set ${scope}:registry ${registryUrl}; CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${domain} --repository ${repository} --region ${region} --domain-owner ${accountId}); npm config set //${registryUrl}:_authToken=$CODEARTIFACT_AUTH_TOKEN; npm config set //${registryUrl}:always-auth=true`,
+          exec: `npm config set ${scope}:registry ${registryUrl}; CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${domain} --region ${region} --domain-owner ${accountId} --query authorizationToken --output text); npm config set //${registry}:_authToken=$CODEARTIFACT_AUTH_TOKEN; npm config set //${registry}:always-auth=true`,
         },
         {
-          exec: `npm config set ${scope2}:registry ${registryUrl2}; CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${domain2} --repository ${repository2} --region ${region2} --domain-owner ${accountId2}); npm config set //${registryUrl2}:_authToken=$CODEARTIFACT_AUTH_TOKEN; npm config set //${registryUrl2}:always-auth=true`,
+          exec: `npm config set ${scope2}:registry ${registryUrl2}; CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${domain2} --region ${region2} --domain-owner ${accountId2} --query authorizationToken --output text); npm config set //${registry2}:_authToken=$CODEARTIFACT_AUTH_TOKEN; npm config set //${registry2}:always-auth=true`,
         },
       ],
     });


### PR DESCRIPTION
Added validation to include trailing slash in the `registryUrl`

Fixed `ca:login` task by:

- Removed `repository` parameter from aws call
- Removed https:// from registryUrl used in npm config

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.