### PR TITLE
fix: Pinning jestVersion to ^27 by default

### DIFF
--- a/src/javascript/jest.ts
+++ b/src/javascript/jest.ts
@@ -593,7 +593,7 @@ export class Jest {
 
     const jestDep = options.jestVersion
       ? `jest@${options.jestVersion}`
-      : "jest";
+      : "jest@^27"; // pinning at version 27 for now because of an issue: https://github.com/projen/projen/issues/1801
     project.addDevDeps(jestDep);
 
     this.jestConfig = options.jestConfig;

--- a/test/javascript/__snapshots__/node-project.test.ts.snap
+++ b/test/javascript/__snapshots__/node-project.test.ts.snap
@@ -195,7 +195,7 @@ git config user.email \\"github-actions@github.com\\"",
 exports[`node project can be ejected 1`] = `
 Object {
   "devDependencies": Object {
-    "jest": "*",
+    "jest": "^27",
     "jest-junit": "^13",
     "npm-check-updates": "^12",
     "standard-version": "^9",


### PR DESCRIPTION
fixes #1801 

This will pin the jestVersion to ^27 to resolve compat problems. This should be reverted in the future when ts-jest and jest become more compatible.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.