### PR TITLE
fix: cannot create `PythonProject` with `.projenrc.js`

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -3576,7 +3576,7 @@ new awscdk.AwsCdkPythonApp(options: AwsCdkPythonAppOptions)
   * **devDeps** (<code>Array<string></code>)  List of dev dependencies for this project. __*Default*__: []
   * **pip** (<code>boolean</code>)  Use pip with a requirements.txt file to track project dependencies. __*Default*__: true
   * **poetry** (<code>boolean</code>)  Use poetry to manage your project dependencies, virtual environment, and (optional) packaging/publishing. __*Default*__: false
-  * **projenrcJs** (<code>boolean</code>)  Use projenrc in javascript. __*Default*__: true
+  * **projenrcJs** (<code>boolean</code>)  Use projenrc in javascript. __*Default*__: false
   * **projenrcJsOptions** (<code>[javascript.ProjenrcOptions](#projen-javascript-projenrcoptions)</code>)  Options related to projenrc in JavaScript. __*Default*__: default options
   * **projenrcPython** (<code>boolean</code>)  Use projenrc in Python. __*Default*__: true
   * **projenrcPythonOptions** (<code>[python.ProjenrcOptions](#projen-python-projenrcoptions)</code>)  Options related to projenrc in python. __*Default*__: default options
@@ -8528,7 +8528,7 @@ new python.PythonProject(options: PythonProjectOptions)
   * **devDeps** (<code>Array<string></code>)  List of dev dependencies for this project. __*Default*__: []
   * **pip** (<code>boolean</code>)  Use pip with a requirements.txt file to track project dependencies. __*Default*__: true
   * **poetry** (<code>boolean</code>)  Use poetry to manage your project dependencies, virtual environment, and (optional) packaging/publishing. __*Default*__: false
-  * **projenrcJs** (<code>boolean</code>)  Use projenrc in javascript. __*Default*__: true
+  * **projenrcJs** (<code>boolean</code>)  Use projenrc in javascript. __*Default*__: false
   * **projenrcJsOptions** (<code>[javascript.ProjenrcOptions](#projen-javascript-projenrcoptions)</code>)  Options related to projenrc in JavaScript. __*Default*__: default options
   * **projenrcPython** (<code>boolean</code>)  Use projenrc in Python. __*Default*__: true
   * **projenrcPythonOptions** (<code>[python.ProjenrcOptions](#projen-python-projenrcoptions)</code>)  Options related to projenrc in python. __*Default*__: default options
@@ -11982,7 +11982,7 @@ Name | Type | Description
 **projenCommand**?🔹 | <code>string</code> | The shell command to use in order to run the projen CLI.<br/>__*Default*__: "npx projen"
 **projenCredentials**?🔹 | <code>[github.GithubCredentials](#projen-github-githubcredentials)</code> | Choose a method of providing GitHub API access for projen workflows.<br/>__*Default*__: use a personal access token named PROJEN_GITHUB_TOKEN
 **projenTokenSecret**?⚠️ | <code>string</code> | The name of a secret which includes a GitHub Personal Access Token to be used by projen workflows.<br/>__*Default*__: "PROJEN_GITHUB_TOKEN"
-**projenrcJs**?🔹 | <code>boolean</code> | Use projenrc in javascript.<br/>__*Default*__: true
+**projenrcJs**?🔹 | <code>boolean</code> | Use projenrc in javascript.<br/>__*Default*__: false
 **projenrcJsOptions**?🔹 | <code>[javascript.ProjenrcOptions](#projen-javascript-projenrcoptions)</code> | Options related to projenrc in JavaScript.<br/>__*Default*__: default options
 **projenrcJson**?🔹 | <code>boolean</code> | Generate (once) .projenrc.json (in JSON). Set to `false` in order to disable .projenrc.json generation.<br/>__*Default*__: false
 **projenrcJsonOptions**?🔹 | <code>[ProjenrcOptions](#projen-projenrcoptions)</code> | Options for .projenrc.json.<br/>__*Default*__: default options
@@ -15637,7 +15637,7 @@ Name | Type | Description
 **projenCommand**?🔹 | <code>string</code> | The shell command to use in order to run the projen CLI.<br/>__*Default*__: "npx projen"
 **projenCredentials**?🔹 | <code>[github.GithubCredentials](#projen-github-githubcredentials)</code> | Choose a method of providing GitHub API access for projen workflows.<br/>__*Default*__: use a personal access token named PROJEN_GITHUB_TOKEN
 **projenTokenSecret**?⚠️ | <code>string</code> | The name of a secret which includes a GitHub Personal Access Token to be used by projen workflows.<br/>__*Default*__: "PROJEN_GITHUB_TOKEN"
-**projenrcJs**?🔹 | <code>boolean</code> | Use projenrc in javascript.<br/>__*Default*__: true
+**projenrcJs**?🔹 | <code>boolean</code> | Use projenrc in javascript.<br/>__*Default*__: false
 **projenrcJsOptions**?🔹 | <code>[javascript.ProjenrcOptions](#projen-javascript-projenrcoptions)</code> | Options related to projenrc in JavaScript.<br/>__*Default*__: default options
 **projenrcJson**?🔹 | <code>boolean</code> | Generate (once) .projenrc.json (in JSON). Set to `false` in order to disable .projenrc.json generation.<br/>__*Default*__: false
 **projenrcJsonOptions**?🔹 | <code>[ProjenrcOptions](#projen-projenrcoptions)</code> | Options for .projenrc.json.<br/>__*Default*__: default options

--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -3576,7 +3576,9 @@ new awscdk.AwsCdkPythonApp(options: AwsCdkPythonAppOptions)
   * **devDeps** (<code>Array<string></code>)  List of dev dependencies for this project. __*Default*__: []
   * **pip** (<code>boolean</code>)  Use pip with a requirements.txt file to track project dependencies. __*Default*__: true
   * **poetry** (<code>boolean</code>)  Use poetry to manage your project dependencies, virtual environment, and (optional) packaging/publishing. __*Default*__: false
-  * **projenrcPython** (<code>boolean</code>)  Use projenrc in python. __*Default*__: true
+  * **projenrcJs** (<code>boolean</code>)  Use projenrc in javascript. __*Default*__: true
+  * **projenrcJsOptions** (<code>[javascript.ProjenrcOptions](#projen-javascript-projenrcoptions)</code>)  Options related to projenrc in JavaScript. __*Default*__: default options
+  * **projenrcPython** (<code>boolean</code>)  Use projenrc in Python. __*Default*__: true
   * **projenrcPythonOptions** (<code>[python.ProjenrcOptions](#projen-python-projenrcoptions)</code>)  Options related to projenrc in python. __*Default*__: default options
   * **pytest** (<code>boolean</code>)  Include pytest tests. __*Default*__: true
   * **pytestOptions** (<code>[python.PytestOptions](#projen-python-pytestoptions)</code>)  pytest options. __*Default*__: defaults
@@ -8526,7 +8528,9 @@ new python.PythonProject(options: PythonProjectOptions)
   * **devDeps** (<code>Array<string></code>)  List of dev dependencies for this project. __*Default*__: []
   * **pip** (<code>boolean</code>)  Use pip with a requirements.txt file to track project dependencies. __*Default*__: true
   * **poetry** (<code>boolean</code>)  Use poetry to manage your project dependencies, virtual environment, and (optional) packaging/publishing. __*Default*__: false
-  * **projenrcPython** (<code>boolean</code>)  Use projenrc in python. __*Default*__: true
+  * **projenrcJs** (<code>boolean</code>)  Use projenrc in javascript. __*Default*__: true
+  * **projenrcJsOptions** (<code>[javascript.ProjenrcOptions](#projen-javascript-projenrcoptions)</code>)  Options related to projenrc in JavaScript. __*Default*__: default options
+  * **projenrcPython** (<code>boolean</code>)  Use projenrc in Python. __*Default*__: true
   * **projenrcPythonOptions** (<code>[python.ProjenrcOptions](#projen-python-projenrcoptions)</code>)  Options related to projenrc in python. __*Default*__: default options
   * **pytest** (<code>boolean</code>)  Include pytest tests. __*Default*__: true
   * **pytestOptions** (<code>[python.PytestOptions](#projen-python-pytestoptions)</code>)  pytest options. __*Default*__: defaults
@@ -11978,9 +11982,11 @@ Name | Type | Description
 **projenCommand**?🔹 | <code>string</code> | The shell command to use in order to run the projen CLI.<br/>__*Default*__: "npx projen"
 **projenCredentials**?🔹 | <code>[github.GithubCredentials](#projen-github-githubcredentials)</code> | Choose a method of providing GitHub API access for projen workflows.<br/>__*Default*__: use a personal access token named PROJEN_GITHUB_TOKEN
 **projenTokenSecret**?⚠️ | <code>string</code> | The name of a secret which includes a GitHub Personal Access Token to be used by projen workflows.<br/>__*Default*__: "PROJEN_GITHUB_TOKEN"
+**projenrcJs**?🔹 | <code>boolean</code> | Use projenrc in javascript.<br/>__*Default*__: true
+**projenrcJsOptions**?🔹 | <code>[javascript.ProjenrcOptions](#projen-javascript-projenrcoptions)</code> | Options related to projenrc in JavaScript.<br/>__*Default*__: default options
 **projenrcJson**?🔹 | <code>boolean</code> | Generate (once) .projenrc.json (in JSON). Set to `false` in order to disable .projenrc.json generation.<br/>__*Default*__: false
 **projenrcJsonOptions**?🔹 | <code>[ProjenrcOptions](#projen-projenrcoptions)</code> | Options for .projenrc.json.<br/>__*Default*__: default options
-**projenrcPython**?🔹 | <code>boolean</code> | Use projenrc in python.<br/>__*Default*__: true
+**projenrcPython**?🔹 | <code>boolean</code> | Use projenrc in Python.<br/>__*Default*__: true
 **projenrcPythonOptions**?🔹 | <code>[python.ProjenrcOptions](#projen-python-projenrcoptions)</code> | Options related to projenrc in python.<br/>__*Default*__: default options
 **pytest**?🔹 | <code>boolean</code> | Include pytest tests.<br/>__*Default*__: true
 **pytestOptions**?🔹 | <code>[python.PytestOptions](#projen-python-pytestoptions)</code> | pytest options.<br/>__*Default*__: defaults
@@ -15631,9 +15637,11 @@ Name | Type | Description
 **projenCommand**?🔹 | <code>string</code> | The shell command to use in order to run the projen CLI.<br/>__*Default*__: "npx projen"
 **projenCredentials**?🔹 | <code>[github.GithubCredentials](#projen-github-githubcredentials)</code> | Choose a method of providing GitHub API access for projen workflows.<br/>__*Default*__: use a personal access token named PROJEN_GITHUB_TOKEN
 **projenTokenSecret**?⚠️ | <code>string</code> | The name of a secret which includes a GitHub Personal Access Token to be used by projen workflows.<br/>__*Default*__: "PROJEN_GITHUB_TOKEN"
+**projenrcJs**?🔹 | <code>boolean</code> | Use projenrc in javascript.<br/>__*Default*__: true
+**projenrcJsOptions**?🔹 | <code>[javascript.ProjenrcOptions](#projen-javascript-projenrcoptions)</code> | Options related to projenrc in JavaScript.<br/>__*Default*__: default options
 **projenrcJson**?🔹 | <code>boolean</code> | Generate (once) .projenrc.json (in JSON). Set to `false` in order to disable .projenrc.json generation.<br/>__*Default*__: false
 **projenrcJsonOptions**?🔹 | <code>[ProjenrcOptions](#projen-projenrcoptions)</code> | Options for .projenrc.json.<br/>__*Default*__: default options
-**projenrcPython**?🔹 | <code>boolean</code> | Use projenrc in python.<br/>__*Default*__: true
+**projenrcPython**?🔹 | <code>boolean</code> | Use projenrc in Python.<br/>__*Default*__: true
 **projenrcPythonOptions**?🔹 | <code>[python.ProjenrcOptions](#projen-python-projenrcoptions)</code> | Options related to projenrc in python.<br/>__*Default*__: default options
 **pytest**?🔹 | <code>boolean</code> | Include pytest tests.<br/>__*Default*__: true
 **pytestOptions**?🔹 | <code>[python.PytestOptions](#projen-python-pytestoptions)</code> | pytest options.<br/>__*Default*__: defaults

--- a/src/python/python-project.ts
+++ b/src/python/python-project.ts
@@ -1,8 +1,15 @@
 import { GitHubProject, GitHubProjectOptions } from "../github";
+import {
+  Projenrc as ProjenrcJs,
+  ProjenrcOptions as ProjenrcJsOptions,
+} from "../javascript/projenrc";
 import { ProjectType } from "../project";
 import { Pip } from "./pip";
 import { Poetry } from "./poetry";
-import { Projenrc as ProjenrcPython, ProjenrcOptions } from "./projenrc";
+import {
+  Projenrc as ProjenrcPython,
+  ProjenrcOptions as ProjenrcPythonOptions,
+} from "./projenrc";
 import { Pytest, PytestOptions } from "./pytest";
 import { PytestSample } from "./pytest-sample";
 import { IPythonDeps } from "./python-deps";
@@ -121,9 +128,9 @@ export interface PythonProjectOptions
   readonly sample?: boolean;
 
   /**
-   * Use projenrc in python.
+   * Use projenrc in Python.
    *
-   * This will install `projen` as a python dependency and will add a `synth`
+   * This will install `projen` as a Python dependency and add a `synth`
    * task which will run `.projenrc.py`.
    *
    * @default true
@@ -134,7 +141,23 @@ export interface PythonProjectOptions
    * Options related to projenrc in python.
    * @default - default options
    */
-  readonly projenrcPythonOptions?: ProjenrcOptions;
+  readonly projenrcPythonOptions?: ProjenrcPythonOptions;
+
+  /**
+   * Use projenrc in javascript.
+   *
+   * This will install `projen` as a JavaScript dependency and add a `synth`
+   * task which will run `.projenrc.js`.
+   *
+   * @default true
+   */
+  readonly projenrcJs?: boolean;
+
+  /**
+   * Options related to projenrc in JavaScript.
+   * @default - default options
+   */
+  readonly projenrcJsOptions?: ProjenrcJsOptions;
 }
 
 /**
@@ -188,6 +211,10 @@ export class PythonProject extends GitHubProject {
 
     if (options.projenrcPython ?? true) {
       new ProjenrcPython(this, options.projenrcPythonOptions);
+    }
+
+    if (options.projenrcJs ?? false) {
+      new ProjenrcJs(this, options.projenrcJsOptions);
     }
 
     if (options.venv ?? true) {

--- a/src/python/python-project.ts
+++ b/src/python/python-project.ts
@@ -209,10 +209,16 @@ export class PythonProject extends GitHubProject {
     this.moduleName = options.moduleName;
     this.version = options.version;
 
-    const { anySelected, multipleSelected } = analyzeChoices(options.projenrcPython, options.projenrcJs, options.projenrcJson)
+    const { anySelected, multipleSelected } = analyzeChoices(
+      options.projenrcPython,
+      options.projenrcJs,
+      options.projenrcJson
+    );
 
     if (multipleSelected) {
-      throw new Error("Only one of projenrcPython, projenrcJs, and projenrcJson can be selected.");
+      throw new Error(
+        "Only one of projenrcPython, projenrcJs, and projenrcJson can be selected."
+      );
     }
 
     // default to projenrc.py if no other projenrc type was elected
@@ -494,7 +500,10 @@ export class PythonProject extends GitHubProject {
   }
 }
 
-function analyzeChoices(...bools: (boolean | undefined)[]): { anySelected: any; multipleSelected: any; } {
+function analyzeChoices(...bools: (boolean | undefined)[]): {
+  anySelected: any;
+  multipleSelected: any;
+} {
   let anySelected = false;
   let multipleSelected = false;
   for (const bool of bools) {

--- a/test/__snapshots__/inventory.test.ts.snap
+++ b/test/__snapshots__/inventory.test.ts.snap
@@ -1808,6 +1808,23 @@ Array [
         "switch": "projen-credentials",
       },
       Object {
+        "default": "true",
+        "docs": "Use projenrc in javascript.",
+        "featured": false,
+        "fullType": Object {
+          "primitive": "boolean",
+        },
+        "jsonLike": true,
+        "name": "projenrcJs",
+        "optional": true,
+        "parent": "PythonProjectOptions",
+        "path": Array [
+          "projenrcJs",
+        ],
+        "simpleType": "boolean",
+        "switch": "projenrc-js",
+      },
+      Object {
         "default": "false",
         "docs": "Generate (once) .projenrc.json (in JSON). Set to \`false\` in order to disable .projenrc.json generation.",
         "featured": false,
@@ -1844,8 +1861,27 @@ Array [
         "switch": "projenrc-json-options",
       },
       Object {
+        "default": "- default options",
+        "docs": "Options related to projenrc in JavaScript.",
+        "featured": false,
+        "fqn": "projen.javascript.ProjenrcOptions",
+        "fullType": Object {
+          "fqn": "projen.javascript.ProjenrcOptions",
+        },
+        "jsonLike": true,
+        "kind": "interface",
+        "name": "projenrcJsOptions",
+        "optional": true,
+        "parent": "PythonProjectOptions",
+        "path": Array [
+          "projenrcJsOptions",
+        ],
+        "simpleType": "ProjenrcOptions",
+        "switch": "projenrc-js-options",
+      },
+      Object {
         "default": "true",
-        "docs": "Use projenrc in python.",
+        "docs": "Use projenrc in Python.",
         "featured": false,
         "fullType": Object {
           "primitive": "boolean",
@@ -25939,6 +25975,23 @@ Array [
         "switch": "projen-credentials",
       },
       Object {
+        "default": "true",
+        "docs": "Use projenrc in javascript.",
+        "featured": false,
+        "fullType": Object {
+          "primitive": "boolean",
+        },
+        "jsonLike": true,
+        "name": "projenrcJs",
+        "optional": true,
+        "parent": "PythonProjectOptions",
+        "path": Array [
+          "projenrcJs",
+        ],
+        "simpleType": "boolean",
+        "switch": "projenrc-js",
+      },
+      Object {
         "default": "false",
         "docs": "Generate (once) .projenrc.json (in JSON). Set to \`false\` in order to disable .projenrc.json generation.",
         "featured": false,
@@ -25975,8 +26028,27 @@ Array [
         "switch": "projenrc-json-options",
       },
       Object {
+        "default": "- default options",
+        "docs": "Options related to projenrc in JavaScript.",
+        "featured": false,
+        "fqn": "projen.javascript.ProjenrcOptions",
+        "fullType": Object {
+          "fqn": "projen.javascript.ProjenrcOptions",
+        },
+        "jsonLike": true,
+        "kind": "interface",
+        "name": "projenrcJsOptions",
+        "optional": true,
+        "parent": "PythonProjectOptions",
+        "path": Array [
+          "projenrcJsOptions",
+        ],
+        "simpleType": "ProjenrcOptions",
+        "switch": "projenrc-js-options",
+      },
+      Object {
         "default": "true",
-        "docs": "Use projenrc in python.",
+        "docs": "Use projenrc in Python.",
         "featured": false,
         "fullType": Object {
           "primitive": "boolean",

--- a/test/__snapshots__/inventory.test.ts.snap
+++ b/test/__snapshots__/inventory.test.ts.snap
@@ -1808,7 +1808,7 @@ Array [
         "switch": "projen-credentials",
       },
       Object {
-        "default": "true",
+        "default": "false",
         "docs": "Use projenrc in javascript.",
         "featured": false,
         "fullType": Object {
@@ -25975,7 +25975,7 @@ Array [
         "switch": "projen-credentials",
       },
       Object {
-        "default": "true",
+        "default": "false",
         "docs": "Use projenrc in javascript.",
         "featured": false,
         "fullType": Object {

--- a/test/new.test.ts
+++ b/test/new.test.ts
@@ -261,11 +261,7 @@ test("projenrc-ts creates typescript projenrc", () => {
 
 test("python project includes .projenrc.py by default", () => {
   withProjectDir((projectdir) => {
-    execProjenCLI(projectdir, [
-      "new",
-      "python",
-      "--no-synth",
-    ]);
+    execProjenCLI(projectdir, ["new", "python", "--no-synth"]);
 
     const output = directorySnapshot(projectdir);
     expect(output[".projenrc.py"]).toBeDefined();
@@ -274,12 +270,7 @@ test("python project includes .projenrc.py by default", () => {
 
 test("python project can include .projenrc.js", () => {
   withProjectDir((projectdir) => {
-    execProjenCLI(projectdir, [
-      "new",
-      "python",
-      "--projenrc-js",
-      "--no-synth",
-    ]);
+    execProjenCLI(projectdir, ["new", "python", "--projenrc-js", "--no-synth"]);
 
     const output = directorySnapshot(projectdir);
     expect(output[".projenrc.py"]).toBeUndefined();

--- a/test/new.test.ts
+++ b/test/new.test.ts
@@ -259,6 +259,34 @@ test("projenrc-ts creates typescript projenrc", () => {
   });
 });
 
+test("python project includes .projenrc.py by default", () => {
+  withProjectDir((projectdir) => {
+    execProjenCLI(projectdir, [
+      "new",
+      "python",
+      "--no-synth",
+    ]);
+
+    const output = directorySnapshot(projectdir);
+    expect(output[".projenrc.py"]).toBeDefined();
+  });
+});
+
+test("python project can include .projenrc.js", () => {
+  withProjectDir((projectdir) => {
+    execProjenCLI(projectdir, [
+      "new",
+      "python",
+      "--projenrc-js",
+      "--no-synth",
+    ]);
+
+    const output = directorySnapshot(projectdir);
+    expect(output[".projenrc.py"]).toBeUndefined();
+    expect(output[".projenrc.js"]).toBeDefined();
+  });
+});
+
 // test("projen new node --outdir path/to/mydir", () => {
 //   withProjectDir((projectdir) => {
 //     // GIVEN

--- a/test/python/python-project.test.ts
+++ b/test/python/python-project.test.ts
@@ -43,10 +43,15 @@ test("pytest maxfailures", () => {
 });
 
 test("cannot specify multiple projenrc types", () => {
-  expect(() => new TestPythonProject({
-    projenrcPython: true,
-    projenrcJs: true,
-  })).toThrow(/Only one of projenrcPython, projenrcJs, and projenrcJson can be selected./)
+  expect(
+    () =>
+      new TestPythonProject({
+        projenrcPython: true,
+        projenrcJs: true,
+      })
+  ).toThrow(
+    /Only one of projenrcPython, projenrcJs, and projenrcJson can be selected./
+  );
 });
 
 class TestPythonProject extends PythonProject {

--- a/test/python/python-project.test.ts
+++ b/test/python/python-project.test.ts
@@ -42,6 +42,13 @@ test("pytest maxfailures", () => {
   ).toContain("--maxfail=3");
 });
 
+test("cannot specify multiple projenrc types", () => {
+  expect(() => new TestPythonProject({
+    projenrcPython: true,
+    projenrcJs: true,
+  })).toThrow(/Only one of projenrcPython, projenrcJs, and projenrcJson can be selected./)
+});
+
 class TestPythonProject extends PythonProject {
   constructor(options: Partial<PythonProjectOptions> = {}) {
     super({


### PR DESCRIPTION
Fixes #1807

To manage a PythonProject with a JavaScript projenrc file, the project will need to have these options configured:
```js
projenrcJs: true,
```

Or pass the option in the command line when creating the project, e.g. `npx projen new python --projenrc-js`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.