### PR TITLE
fix: Pin the version of ts-jest to 27

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -127,6 +127,7 @@
     },
     {
       "name": "ts-jest",
+      "version": "^27",
       "type": "build"
     },
     {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "npm-check-updates": "^12",
     "prettier": "^2.6.2",
     "standard-version": "^9",
-    "ts-jest": "^27.1.4",
+    "ts-jest": "^27",
     "typescript": "^3.9.10"
   },
   "dependencies": {

--- a/src/typescript/typescript.ts
+++ b/src/typescript/typescript.ts
@@ -417,7 +417,7 @@ export class TypeScriptProject extends NodeProject {
   }
 
   private addJestNoCompile(jest: Jest) {
-    this.addDevDeps("@types/jest", "ts-jest");
+    this.addDevDeps("@types/jest", "ts-jest@^27"); // pinning for now because of an issue: https://github.com/projen/projen/issues/1813
 
     jest.addTestMatch(`<rootDir>/${this.srcdir}/**/__tests__/**/*.ts?(x)`);
     jest.addTestMatch(

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -900,6 +900,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "ts-jest",
         "type": "build",
+        "version": "^27",
       },
       Object {
         "name": "typescript",
@@ -1730,7 +1731,7 @@ project.synth();
       "npm-check-updates": "^12",
       "projen": "*",
       "standard-version": "^9",
-      "ts-jest": "*",
+      "ts-jest": "^27",
       "typescript": "*",
     },
     "engines": Object {
@@ -2445,6 +2446,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "ts-jest",
         "type": "build",
+        "version": "^27",
       },
       Object {
         "name": "typescript",
@@ -3222,7 +3224,7 @@ project.synth();
       "json-schema-to-typescript": "*",
       "npm-check-updates": "^12",
       "projen": "*",
-      "ts-jest": "*",
+      "ts-jest": "^27",
       "typescript": "*",
     },
     "engines": Object {
@@ -3895,6 +3897,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "ts-jest",
         "type": "build",
+        "version": "^27",
       },
       Object {
         "name": "typescript",
@@ -4604,7 +4607,7 @@ project.synth();
       "json-schema": "*",
       "npm-check-updates": "^12",
       "projen": "*",
-      "ts-jest": "*",
+      "ts-jest": "^27",
       "typescript": "*",
     },
     "engines": Object {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5983,7 +5983,7 @@ trim-newlines@^3.0.0:
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
-ts-jest@^27.1.4:
+ts-jest@^27:
   version "27.1.4"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.1.4.tgz#84d42cf0f4e7157a52e7c64b1492c46330943e00"
   integrity sha512-qjkZlVPWVctAezwsOD1OPzbZ+k7zA5z3oxII4dGdZo5ggX/PL7kvwTM0pXTr10fAtbiVpJaL3bWd502zAhpgSQ==


### PR DESCRIPTION
Pins the version of `ts-jest` to `^27`, to fix an issue with auto-approve PRs having `jest` at 27 but `ts-jest` at 26, which causes build failures. 

Fixes #1813 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.