### PR TITLE
feat: `tryRemoveFile` escape hatch

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -871,7 +871,7 @@ addVolume(volume: IDockerComposeVolumeBinding): void
 
 __Extends__: [Component](#projen-component)
 __Implemented by__: [github.PullRequestTemplate](#projen-github-pullrequesttemplate), [python.RequirementsFile](#projen-python-requirementsfile), [python.SetupPy](#projen-python-setuppy), [web.ReactTypeDef](#projen-web-reacttypedef), [GitAttributesFile](#projen-gitattributesfile), [IgnoreFile](#projen-ignorefile), [IniFile](#projen-inifile), [JsonFile](#projen-jsonfile), [License](#projen-license), [Makefile](#projen-makefile), [TextFile](#projen-textfile), [TomlFile](#projen-tomlfile), [XmlFile](#projen-xmlfile), [YamlFile](#projen-yamlfile)
-__Obtainable from__: [Project](#projen-project).[tryFindFile](#projen-project#projen-project-tryfindfile)()
+__Obtainable from__: [Project](#projen-project).[tryFindFile](#projen-project#projen-project-tryfindfile)(), [Project](#projen-project).[tryRemoveFile](#projen-project#projen-project-tryremovefile)()
 
 ### Initializer
 
@@ -1948,6 +1948,19 @@ tryFindObjectFile(filePath: string): ObjectFile
 
 __Returns__:
 * <code>[ObjectFile](#projen-objectfile)</code>
+
+#### tryRemoveFile(filePath)🔹 <a id="projen-project-tryremovefile"></a>
+
+
+
+```ts
+tryRemoveFile(filePath: string): FileBase
+```
+
+* **filePath** (<code>string</code>)  *No description*
+
+__Returns__:
+* <code>[FileBase](#projen-filebase)</code>
 
 
 

--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -1951,13 +1951,13 @@ __Returns__:
 
 #### tryRemoveFile(filePath)🔹 <a id="projen-project-tryremovefile"></a>
 
-
+Finds a file at the specified relative path within this project and removes it.
 
 ```ts
 tryRemoveFile(filePath: string): FileBase
 ```
 
-* **filePath** (<code>string</code>)  *No description*
+* **filePath** (<code>string</code>)  The file path.
 
 __Returns__:
 * <code>[FileBase](#projen-filebase)</code>

--- a/docs/escape-hatches.md
+++ b/docs/escape-hatches.md
@@ -25,3 +25,22 @@ packageJson.addDeletionOverride('author.organization');
 // Use array indices to override specific array elements
 packageJson.addOverride('bundledDependencies.3', 'react');
 ```
+
+## Removing files
+
+You can remove a file from the project through `tryRemoveFile` method on the
+`Project` class.
+
+```ts
+new TextFile(project, "hello.txt", { lines: "original" });
+
+project.tryRemoveFile("hello.txt");
+
+new TextFile(project, "hello.txt", { lines: "better" });
+```
+
+> Note: It's recommended that this used carefully since removing files may be
+unexpected for users depending on where it's used. For example, if you created a
+component named `MyFancyGitIgnore` and had it remove any existing `.gitignore`
+files in the project, then users may be surprised when customizations for their
+existing `.gitignore` file are nullified.

--- a/src/project.ts
+++ b/src/project.ts
@@ -385,8 +385,9 @@ export class Project {
       ? filePath
       : path.resolve(this.outdir, filePath);
     const isFile = (c: Component): c is FileBase => c instanceof FileBase;
-    const index = this._components
-      .findIndex(c => isFile(c) && c.absolutePath === absolute);
+    const index = this._components.findIndex(
+      (c) => isFile(c) && c.absolutePath === absolute
+    );
 
     if (index !== -1) {
       return this._components.splice(index, 1)[0] as FileBase;

--- a/src/project.ts
+++ b/src/project.ts
@@ -372,6 +372,37 @@ export class Project {
   }
 
   /**
+   * Finds a file at the specified relative path within this project and removes
+   * it.
+   *
+   * @param filePath The file path. If this path is relative, it will be
+   * resolved from the root of _this_ project.
+   * @returns a `FileBase` if the file was found and removed, or undefined if
+   * the file was not found.
+   */
+  public tryRemoveFile(filePath: string): FileBase | undefined {
+    const absolute = path.isAbsolute(filePath)
+      ? filePath
+      : path.resolve(this.outdir, filePath);
+    const isFile = (c: Component): c is FileBase => c instanceof FileBase;
+    const index = this._components
+      .findIndex(c => isFile(c) && c.absolutePath === absolute);
+
+    if (index !== -1) {
+      return this._components.splice(index, 1)[0] as FileBase;
+    }
+
+    for (const child of this.subprojects) {
+      const file = child.tryRemoveFile(absolute);
+      if (file) {
+        return file;
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
    * Prints a "tip" message during synthesis.
    * @param message The message
    * @deprecated - use `project.logger.info(message)` to show messages during synthesis

--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import { JsonFile, Project, TextFile } from "../src";
+import { JsonFile, Project, Testing, TextFile } from "../src";
 import { TestProject } from "./util";
 
 test("file paths are relative to the project outdir", () => {
@@ -30,7 +30,7 @@ test("all files added to the project can be enumerated", () => {
   exp("your/file/me.json");
 });
 
-test("findFile() can be used to find a file either absolute or relative path", () => {
+test("tryFindFile() can be used to find a file either absolute or relative path", () => {
   // GIVEN
   const p = new TestProject();
   const file = new JsonFile(p, "your/file/me.json", { obj: {} });
@@ -44,7 +44,7 @@ test("findFile() can be used to find a file either absolute or relative path", (
   expect(result2 === file).toBeTruthy();
 });
 
-test("findFile() will also look up files in subprojects", () => {
+test("tryFindFile() will also look up files in subprojects", () => {
   // GIVEN
   const p = new TestProject();
   const child = new Project({
@@ -61,6 +61,75 @@ test("findFile() will also look up files in subprojects", () => {
   // THEN
   expect(result1 === fchild).toBeTruthy();
   expect(result2 === fchild).toBeTruthy();
+});
+
+test("tryRemoveFile() can be used to remove a file with a relative path", () => {
+  // GIVEN
+  const p = new TestProject();
+  const file = new JsonFile(p, "your/file/me.json", { obj: {} });
+
+  // WHEN
+  const result1 = p.tryRemoveFile("your/file/me.json");
+  const result2 = p.tryRemoveFile("your/file/me.json");
+
+  // THEN
+  const outdir = Testing.synth(p);
+  expect(outdir["your/file/me.json"]).toBeUndefined();
+  expect(result1 === file).toBeTruthy();
+  expect(result2).toBeUndefined();
+});
+
+test("tryRemoveFile() can be used to remove a file with an absolute path", () => {
+  // GIVEN
+  const p = new TestProject();
+  const file = new JsonFile(p, "your/file/me.json", { obj: {} });
+
+  // WHEN
+  const result1 = p.tryRemoveFile(path.resolve(p.outdir, "your/file/me.json"));
+  const result2 = p.tryRemoveFile(path.resolve(p.outdir, "your/file/me.json"));
+
+  // THEN
+  const outdir = Testing.synth(p);
+  expect(outdir["your/file/me.json"]).toBeUndefined();
+  expect(result1 === file).toBeTruthy();
+  expect(result2).toBeUndefined();
+});
+
+test("tryRemoveFile() will also remove a file in a subproject", () => {
+  // GIVEN
+  const p = new TestProject();
+  const child = new Project({
+    name: "foobar",
+    parent: p,
+    outdir: "subproject/foo/bar",
+  });
+  const fchild = new TextFile(child, "fchild.txt");
+
+  // WHEN
+  const result1 = p.tryRemoveFile("subproject/foo/bar/fchild.txt");
+  const result2 = p.tryRemoveFile("subproject/foo/bar/fchild.txt");
+
+  // THEN
+  const outdir = Testing.synth(p);
+  expect(outdir["subproject/foo/bar/fchild.txt"]).toBeUndefined();
+  expect(result1 === fchild).toBeTruthy();
+  expect(result2).toBeUndefined();
+});
+
+test("tryRemoveFile() can be used to override an existing file", () => {
+  // GIVEN
+  const p = new TestProject();
+  new TextFile(p, "your/file/me.txt", { lines: ["original"] });
+
+  // WHEN
+  p.tryRemoveFile("your/file/me.txt");
+  const newFile = new TextFile(p, "your/file/me.txt", { lines: ["better"] });
+  const result = p.tryFindFile("your/file/me.txt");
+
+  // THEN
+  const outdir = Testing.synth(p);
+  expect(outdir["your/file/me.txt"]).toContain("better");
+  expect(result === newFile).toBeTruthy();
 });
 
 test("autoApprove is configured", () => {


### PR DESCRIPTION
Adds an escape hatch method to all projects that allows removing files.

In the future, if projen uses the `constructs` programing model, this probably won't be needed since constructs have their own `node.tryRemoveChild` method - but for now this should be able to substitute for most use cases.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.