### PR TITLE
feat: Add read permissions for all useres

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -76,9 +76,9 @@ export function getFilePermissions(options: WriteFileOptions): string {
   const readonly = options.readonly ?? false;
   const executable = options.executable ?? false;
   if (readonly && executable) {
-    return "500";
+    return "544";
   } else if (readonly) {
-    return "400";
+    return "444";
   } else if (executable) {
     return "755";
   } else {

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -232,10 +232,10 @@ test("dedupArray", () => {
 test("getFilePermissions", () => {
   expect(getFilePermissions({})).toEqual("644");
   expect(getFilePermissions({ readonly: true, executable: true })).toEqual(
-    "500"
+    "544"
   );
   expect(getFilePermissions({ readonly: true, executable: false })).toEqual(
-    "400"
+    "444"
   );
   expect(getFilePermissions({ readonly: false, executable: true })).toEqual(
     "755"


### PR DESCRIPTION
# About
- Updated getFilePermissions() to grant read permissions for all users on the same machine.
- closes #1137 

# Testing 
 - Updated util tests
 - Manually tested by creating new Projen project via symlink (npm link).

# Notes
 - This will only add read permissions to newly generated files (mostly in new projects). 
 - Change does not update the file permissions of previously generated files.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.