### PR TITLE
fix(typescript): eslint task lints projenrcts

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -7017,6 +7017,7 @@ new javascript.Eslint(project: NodeProject, options: EslintOptions)
   * **fileExtensions** (<code>Array<string></code>)  File types that should be linted (e.g. [ ".js", ".ts" ]). __*Default*__: [".ts"]
   * **ignorePatterns** (<code>Array<string></code>)  List of file patterns that should not be linted, using the same syntax as .gitignore patterns. __*Default*__: [ '*.js', '*.d.ts', 'node_modules/', '*.generated.ts', 'coverage' ]
   * **lintProjenRc** (<code>boolean</code>)  Should we lint .projenrc.js. __*Default*__: true
+  * **lintProjenRcFile** (<code>string</code>)  Projenrc file to lint. __*Default*__: PROJEN_RC
   * **prettier** (<code>boolean</code>)  Enable prettier for code formatting. __*Default*__: false
   * **tsAlwaysTryTypes** (<code>boolean</code>)  Always try to resolve types under `<root>@types` directory even it doesn't contain any source code. __*Default*__: true
   * **tsconfigPath** (<code>string</code>)  Path to `tsconfig.json` which should be used by eslint. __*Default*__: "./tsconfig.json"
@@ -14972,7 +14973,8 @@ Name | Type | Description
 **devdirs**?🔹 | <code>Array<string></code> | Directories with source files that include tests and build tools.<br/>__*Default*__: []
 **fileExtensions**?🔹 | <code>Array<string></code> | File types that should be linted (e.g. [ ".js", ".ts" ]).<br/>__*Default*__: [".ts"]
 **ignorePatterns**?🔹 | <code>Array<string></code> | List of file patterns that should not be linted, using the same syntax as .gitignore patterns.<br/>__*Default*__: [ '*.js', '*.d.ts', 'node_modules/', '*.generated.ts', 'coverage' ]
-**lintProjenRc**?🔹 | <code>boolean</code> | Should we lint .projenrc.js.<br/>__*Default*__: true
+**lintProjenRc**?⚠️ | <code>boolean</code> | Should we lint .projenrc.js.<br/>__*Default*__: true
+**lintProjenRcFile**?🔹 | <code>string</code> | Projenrc file to lint.<br/>__*Default*__: PROJEN_RC
 **prettier**?🔹 | <code>boolean</code> | Enable prettier for code formatting.<br/>__*Default*__: false
 **tsAlwaysTryTypes**?🔹 | <code>boolean</code> | Always try to resolve types under `<root>@types` directory even it doesn't contain any source code.<br/>__*Default*__: true
 **tsconfigPath**?🔹 | <code>string</code> | Path to `tsconfig.json` which should be used by eslint.<br/>__*Default*__: "./tsconfig.json"

--- a/src/javascript/eslint.ts
+++ b/src/javascript/eslint.ts
@@ -39,8 +39,15 @@ export interface EslintOptions {
   readonly ignorePatterns?: string[];
 
   /**
+   * Projenrc file to lint. Use empty string to disable.
+   * @default PROJEN_RC
+   */
+  readonly lintProjenRcFile?: string;
+
+  /**
    * Should we lint .projenrc.js
    * @default true
+   * @deprecated use lintProjenRcFile instead
    */
   readonly lintProjenRc?: boolean;
 
@@ -150,6 +157,7 @@ export class Eslint extends Component {
     this._allowDevDeps = new Set((devdirs ?? []).map((dir) => `**/${dir}/**`));
 
     const lintProjenRc = options.lintProjenRc ?? true;
+    const lintProjenRcFile = options.lintProjenRcFile ?? PROJEN_RC;
 
     const eslint = project.addTask("eslint", {
       description: "Runs eslint against the codebase",
@@ -159,7 +167,7 @@ export class Eslint extends Component {
         "--fix",
         "--no-error-on-unmatched-pattern",
         ...dirs,
-        ...(lintProjenRc ? [PROJEN_RC] : []),
+        ...(lintProjenRc && lintProjenRcFile ? [lintProjenRcFile] : []),
       ].join(" "),
     });
 
@@ -296,7 +304,7 @@ export class Eslint extends Component {
     // Overrides for .projenrc.js
     this.overrides = [
       {
-        files: [PROJEN_RC],
+        files: [lintProjenRcFile || PROJEN_RC],
         rules: {
           "@typescript-eslint/no-require-imports": "off",
           "import/no-extraneous-dependencies": "off",
@@ -306,7 +314,7 @@ export class Eslint extends Component {
 
     this.ignorePatterns = options.ignorePatterns ?? [
       "*.js",
-      `!${PROJEN_RC}`,
+      `!${lintProjenRcFile || PROJEN_RC}`,
       "*.d.ts",
       "node_modules/",
       "*.generated.ts",

--- a/src/typescript/typescript.ts
+++ b/src/typescript/typescript.ts
@@ -318,12 +318,22 @@ export class TypeScriptProject extends NodeProject {
       }
     }
 
+    const projenrcTypeScript = options.projenrcTs ?? false;
+    if (projenrcTypeScript) {
+      new ProjenrcTs(this, options.projenrcTsOptions);
+    }
+
+    const projenRcFilename = projenrcTypeScript
+      ? options.projenrcTsOptions?.filename ?? ".projenrc.ts"
+      : undefined;
+
     if (options.eslint ?? true) {
       this.eslint = new Eslint(this, {
         tsconfigPath: `./${this.tsconfigDev.fileName}`,
         dirs: [this.srcdir],
         devdirs: [this.testdir, "build-tools"],
         fileExtensions: [".ts", ".tsx"],
+        lintProjenRcFile: projenRcFilename,
         ...options.eslintOptions,
       });
 
@@ -355,11 +365,6 @@ export class TypeScriptProject extends NodeProject {
 
     if (this.docgen) {
       new TypedocDocgen(this);
-    }
-
-    const projenrcTypeScript = options.projenrcTs ?? false;
-    if (projenrcTypeScript) {
-      new ProjenrcTs(this, options.projenrcTsOptions);
     }
   }
 

--- a/test/typescript/typescript.test.ts
+++ b/test/typescript/typescript.test.ts
@@ -166,6 +166,25 @@ test("projenrc.ts", () => {
   });
 });
 
+test("projenrc.ts linted by eslint task", () => {
+  const prj = new TypeScriptProject({
+    name: "test",
+    defaultReleaseBranch: "main",
+    projenrcTs: true,
+  });
+
+  const snapshot = synthSnapshot(prj);
+  expect(snapshot[".projen/tasks.json"].tasks.eslint).toStrictEqual({
+    description: "Runs eslint against the codebase",
+    name: "eslint",
+    steps: [
+      {
+        exec: "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools .projenrc.ts",
+      },
+    ],
+  });
+});
+
 test("upgrade task ignores pinned versions", () => {
   const prj = new TypeScriptProject({
     defaultReleaseBranch: "main",


### PR DESCRIPTION

fixes #1831 

BREAKING CHANGE: EslintOptions.lintProjenRc is now a string
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.