### PR TITLE
fix: resolve issue with option fqns in java when they do not exist in…

### DIFF
--- a/src/java/projenrc.ts
+++ b/src/java/projenrc.ts
@@ -150,10 +150,9 @@ export class Projenrc extends Component {
 
     const optionFqns: Record<string, string> = {};
     for (const option of bootstrap.type.options) {
-      if (option.fqn) {
-        optionFqns[option.name] = toJavaFullTypeName(
-          jsiiManifest.types[option.fqn]
-        );
+      const fqnType = jsiiManifest.types[option.fqn];
+      if (option.fqn && fqnType) {
+        optionFqns[option.name] = toJavaFullTypeName(fqnType);
       }
     }
 

--- a/src/java/projenrc.ts
+++ b/src/java/projenrc.ts
@@ -191,11 +191,16 @@ export class Projenrc extends Component {
   }
 }
 
-export function generateJavaOptionNames(options: ProjectOption[], jsiiManifest: any) {
+export function generateJavaOptionNames(
+  options: ProjectOption[],
+  jsiiManifest: any
+) {
   const optionFqns: Record<string, string> = {};
   for (const option of options) {
     if (option.fqn && jsiiManifest.types[option.fqn]) {
-      optionFqns[option.name] = toJavaFullTypeName(jsiiManifest.types[option.fqn]);
+      optionFqns[option.name] = toJavaFullTypeName(
+        jsiiManifest.types[option.fqn]
+      );
     }
   }
 

--- a/src/java/projenrc.ts
+++ b/src/java/projenrc.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirpSync, writeFileSync } from "fs-extra";
 import { PROJEN_VERSION } from "../common";
 import { Component } from "../component";
 import { DependencyType } from "../dependencies";
-import { readJsiiManifest } from "../inventory";
+import { ProjectOption, readJsiiManifest } from "../inventory";
 import { Project } from "../project";
 import { Pom } from "./pom";
 
@@ -148,13 +148,10 @@ export class Projenrc extends Component {
       emit("}");
     };
 
-    const optionFqns: Record<string, string> = {};
-    for (const option of bootstrap.type.options) {
-      const fqnType = jsiiManifest.types[option.fqn];
-      if (option.fqn && fqnType) {
-        optionFqns[option.name] = toJavaFullTypeName(fqnType);
-      }
-    }
+    const optionFqns: Record<string, string> = generateJavaOptionNames(
+      bootstrap.type.options,
+      jsiiManifest
+    );
 
     if (javaPackage.length > 0) {
       emit(`package ${javaPackage.join(".")};`);
@@ -192,6 +189,17 @@ export class Projenrc extends Component {
       `Project definition file was created at ${javaFile}`
     );
   }
+}
+
+export function generateJavaOptionNames(options: ProjectOption[], jsiiManifest: any) {
+  const optionFqns: Record<string, string> = {};
+  for (const option of options) {
+    if (option.fqn && jsiiManifest.types[option.fqn]) {
+      optionFqns[option.name] = toJavaFullTypeName(jsiiManifest.types[option.fqn]);
+    }
+  }
+
+  return optionFqns;
 }
 
 function renderJavaOptions(

--- a/test/java/projenrc.test.ts
+++ b/test/java/projenrc.test.ts
@@ -2,6 +2,8 @@ import { Pom } from "../../src/java";
 import { Projenrc } from "../../src/java/projenrc";
 import { renderProjenInitOptions } from "../../src/javascript/render-options";
 import { synthSnapshot, TestProject } from "../util";
+import { generateJavaOptionNames } from "../../lib/java";
+import { ProjectOption } from "../../lib/inventory";
 
 test("projenrc.java support", () => {
   // GIVEN
@@ -77,4 +79,45 @@ test("generate projenrc in java", () => {
   expect(
     synthSnapshot(project)["src/test/java/projenrc.java"]
   ).toMatchSnapshot();
+});
+
+test("assert unknown manifest type doesn't throw", () => {
+  // GIVEN
+  const options: ProjectOption[] = [
+    {
+      fqn: "unknown.fqn",
+      path: [],
+      name: "unknownFqn",
+      simpleType: "",
+      switch: "",
+      fullType: {},
+      parent: "",
+    },
+    {
+      fqn: "known.fqn",
+      path: [],
+      name: "knownFqn",
+      simpleType: "",
+      switch: "",
+      fullType: {},
+      parent: "",
+    },
+  ];
+
+  const jsiiManifest: any = {
+    types: {
+      "known.fqn": {
+        namespace: "known_namespace",
+        name: "component",
+      },
+    },
+  };
+
+  // WHEN
+  const optionNames = generateJavaOptionNames(options, jsiiManifest);
+
+  // THEN
+  const optionNameKeys = Object.keys(optionNames);
+  expect(optionNameKeys.length).toEqual(1);
+  expect(optionNames[optionNameKeys[0]]).toEqual("known_namespace.component");
 });

--- a/test/java/projenrc.test.ts
+++ b/test/java/projenrc.test.ts
@@ -1,9 +1,9 @@
+import { ProjectOption } from "../../lib/inventory";
+import { generateJavaOptionNames } from "../../lib/java";
 import { Pom } from "../../src/java";
 import { Projenrc } from "../../src/java/projenrc";
 import { renderProjenInitOptions } from "../../src/javascript/render-options";
 import { synthSnapshot, TestProject } from "../util";
-import { generateJavaOptionNames } from "../../lib/java";
-import { ProjectOption } from "../../lib/inventory";
 
 test("projenrc.java support", () => {
   // GIVEN


### PR DESCRIPTION
This PR resolves an issue whereby the Java projenrc synthesizer was throwing an error when fqns couldn't be resolved to a type in the jsii manifest.

```
return [jsiiType.namespace, jsiiType.name].filter((x) => x).join(".");
                     ^
TypeError: Cannot read property 'namespace' of undefined
```

The use case for this happening is I have a custom project type that extends JavaProject. As part of the bootstrap options iterator, it tries to resolve projen specific fqns i.e: projen.github.* into types within the .jsii manifest which I generate as part of my package. Given projen types are not bundled as part of my .jsii file, this will error out as above.

I am not sure if this is related, but I did notice the projen submodules were all empty in my .jsii file as shown below:

`"projen": {
      "submodules": {
        "projen.awscdk": {},
        "projen.build": {},
        "projen.cdk": {},
        "projen.cdk8s": {},
        "projen.cdktf": {},
        "projen.github": {},
        "projen.github.workflows": {},
        "projen.gitlab": {},
        "projen.java": {},
        "projen.javascript": {},
        "projen.python": {},
        "projen.release": {},
        "projen.typescript": {},
        "projen.vscode": {},
        "projen.web": {}
      }`

Repro steps:

```
mkdir foo && cd foo
npx projen new --from aws-prototyping-sdk pdk-pipeline-java
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.