### PR TITLE
fix: resolve issue where generated import prefix is incorrect in .pro…

### DIFF
--- a/src/python/projenrc.ts
+++ b/src/python/projenrc.ts
@@ -119,9 +119,12 @@ export class Projenrc extends Component {
 }
 
 export function resolvePythonImportName(jsiiFqn: string, jsiiManifest: any) {
-  const moduleName = jsiiManifest.targets.python.module;
+  const moduleName = jsiiManifest?.targets?.python?.module;
+
   // Module name prefix should take precedence in the event moduleName !== fqn prefix
-  return [moduleName, ...jsiiFqn.split(".").slice(1)].join(".");
+  return moduleName
+    ? [moduleName, ...jsiiFqn.split(".").slice(1)].join(".")
+    : jsiiFqn;
 }
 
 function renderPythonOptions(

--- a/src/python/projenrc.ts
+++ b/src/python/projenrc.ts
@@ -98,9 +98,7 @@ export class Projenrc extends Component {
       bootstrap.args
     );
 
-    const moduleName = jsiiManifest.targets.python.module;
-    // Module name prefix should take precedence in the event moduleName !== fqn prefix
-    const importName = [moduleName, ...jsiiFqn.split(".").slice(1)].join(".");
+    const importName = resolvePythonImportName(jsiiFqn, jsiiManifest);
     emit(toPythonImport(importName));
 
     for (const fqn of imports) {
@@ -118,6 +116,12 @@ export class Projenrc extends Component {
       `Project definition file was created at ${pythonFile}`
     );
   }
+}
+
+export function resolvePythonImportName(jsiiFqn: string, jsiiManifest: any) {
+  const moduleName = jsiiManifest.targets.python.module;
+  // Module name prefix should take precedence in the event moduleName !== fqn prefix
+  return [moduleName, ...jsiiFqn.split(".").slice(1)].join(".");
 }
 
 function renderPythonOptions(

--- a/src/python/projenrc.ts
+++ b/src/python/projenrc.ts
@@ -98,7 +98,11 @@ export class Projenrc extends Component {
       bootstrap.args
     );
 
-    emit(toPythonImport(jsiiFqn));
+    const moduleName = jsiiManifest.targets.python.module;
+    // Module name prefix should take precedence in the event moduleName !== fqn prefix
+    const importName = [moduleName, ...jsiiFqn.split(".").slice(1)].join(".");
+    emit(toPythonImport(importName));
+
     for (const fqn of imports) {
       emit(toPythonImport(fqn));
     }

--- a/test/python/projenrc.test.ts
+++ b/test/python/projenrc.test.ts
@@ -1,6 +1,6 @@
 import { renderProjenInitOptions } from "../../src/javascript/render-options";
 import { ProjectType } from "../../src/project";
-import { Projenrc } from "../../src/python/projenrc";
+import { Projenrc, resolvePythonImportName } from "../../src/python/projenrc";
 import { synthSnapshot, TestProject } from "../util";
 
 test("projenrc.py support", () => {
@@ -49,4 +49,31 @@ test("javascript values are translated to python", () => {
 
   // THEN
   expect(synthSnapshot(project)[".projenrc.py"]).toMatchSnapshot();
+});
+
+test("ensure python import is correctly resolved", () => {
+  // GIVEN
+  const jsiiManifest: any = {
+    targets: {
+      python: {
+        module: "my_module",
+      },
+    },
+  };
+
+  const fqnInputToExpectedImportMap = {
+    "my-module.component": "my_module.component",
+    "my_module.component": "my_module.component",
+    "my_module.nested.component": "my_module.nested.component",
+  };
+
+  Object.entries(fqnInputToExpectedImportMap).forEach(
+    ([jsiiFqn, expectedImportName]) => {
+      // WHEN
+      const resolvedImportName = resolvePythonImportName(jsiiFqn, jsiiManifest);
+
+      // THEN
+      expect(resolvedImportName).toEqual(expectedImportName);
+    }
+  );
 });

--- a/test/python/projenrc.test.ts
+++ b/test/python/projenrc.test.ts
@@ -51,7 +51,7 @@ test("javascript values are translated to python", () => {
   expect(synthSnapshot(project)[".projenrc.py"]).toMatchSnapshot();
 });
 
-test("ensure python import is correctly resolved", () => {
+test("ensure python import is correctly resolved when python module exists", () => {
   // GIVEN
   const jsiiManifest: any = {
     targets: {
@@ -76,4 +76,16 @@ test("ensure python import is correctly resolved", () => {
       expect(resolvedImportName).toEqual(expectedImportName);
     }
   );
+});
+
+test("ensure python import is correctly resolved to jsiiFqn when python module is undefined", () => {
+  // GIVEN
+  const jsiiManifest: any = {};
+  const jsiiFqn = "my-module.component";
+
+  // WHEN
+  const resolvedImportName = resolvePythonImportName(jsiiFqn, jsiiManifest);
+
+  // THEN
+  expect(resolvedImportName).toEqual(jsiiFqn);
 });


### PR DESCRIPTION
I am seeing an error whereby the generated .projenrc.py does not have the correct module_name. The FQN is aws-prototyping-sdk... however the exported python moduleName is aws_prototyping_sdk.

This PR ensures that the declared module_name takes precedence.

Repro steps:

```
mkdir foo && cd foo
npx projen new --from aws-prototyping-sdk pdk-pipeline-py
npx projen # this will throw the error
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.