### PR TITLE
chore: pin yaml in projen

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -181,6 +181,7 @@
     },
     {
       "name": "yaml",
+      "version": "2.0.0",
       "type": "bundled"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -374,19 +374,19 @@
           "exec": "yarn upgrade npm-check-updates"
         },
         {
-          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='markmac'"
+          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='yaml,markmac'"
         },
         {
-          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='markmac'"
+          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='yaml,markmac'"
         },
         {
-          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='markmac'"
+          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='yaml,markmac'"
         },
         {
-          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='markmac'"
+          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='yaml,markmac'"
         },
         {
-          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='markmac'"
+          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='yaml,markmac'"
         },
         {
           "exec": "yarn install --check-files"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -27,7 +27,7 @@ const project = new cdk.JsiiProject({
 
   bundledDeps: [
     "conventional-changelog-config-spec",
-    "yaml",
+    "yaml@2.0.0",
     "fs-extra",
     "yargs",
     "case",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "semver": "^7.3.7",
     "shx": "^0.3.4",
     "xmlbuilder2": "^2.4.1",
-    "yaml": "^2.0.1",
+    "yaml": "2.0.0",
     "yargs": "^16.2.0"
   },
   "bundledDependencies": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -6442,15 +6442,15 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
+yaml@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.0.0.tgz#cbc588ad58e0cd924cd3f5f2b1a9485103048e25"
+  integrity sha512-JbfdlHKGP2Ik9IHylzWlGd4pPK++EU46/IxMykphS2ZKw7a7h+dHNmcXObLgpRDriBY+rpWslldikckX8oruWQ==
+
 yaml@^1.10.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
-
-yaml@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.0.1.tgz#71886d6021f3da28169dbefde78d4dd0f8d83650"
-  integrity sha512-1NpAYQ3wjzIlMs0mgdBmYzLkFgWBIWrzYVDYfrixhoFNNgJ444/jT2kUT2sicRbJES3oQYRZugjB6Ro8SjKeFg==
 
 yargs-parser@20.x, yargs-parser@^20.2.2, yargs-parser@^20.2.3:
   version "20.2.9"


### PR DESCRIPTION
The new version of yaml (2.1.0) uses some types that are not supported in TypeScript 3.9, so projen fails to compile if we upgrade to it. Pin to the existing version for now.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.