### PR TITLE
fix: addPostBuildJobTask options are required

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -4486,7 +4486,7 @@ addPostBuildJobCommands(id: string, commands: Array<string>, options?: AddPostBu
 
 
 
-#### addPostBuildJobTask(task, options)🔹 <a id="projen-build-buildworkflow-addpostbuildjobtask"></a>
+#### addPostBuildJobTask(task, options?)🔹 <a id="projen-build-buildworkflow-addpostbuildjobtask"></a>
 
 Run a task as a job within the build workflow which is executed after the build job succeeded.
 
@@ -4498,7 +4498,7 @@ self-mutate, the branch will either be updated or the build will fail (in
 forks), so there is no point in executing the post-build job.
 
 ```ts
-addPostBuildJobTask(task: Task, options: AddPostBuildJobTaskOptions): void
+addPostBuildJobTask(task: Task, options?: AddPostBuildJobTaskOptions): void
 ```
 
 * **task** (<code>[Task](#projen-task)</code>)  *No description*

--- a/src/build/build-workflow.ts
+++ b/src/build/build-workflow.ts
@@ -231,7 +231,10 @@ export class BuildWorkflow extends Component {
    *
    * @param options Specify tools and other options
    */
-  public addPostBuildJobTask(task: Task, options: AddPostBuildJobTaskOptions) {
+  public addPostBuildJobTask(
+    task: Task,
+    options: AddPostBuildJobTaskOptions = {}
+  ) {
     this.addPostBuildJobCommands(
       `post-build-${task.name}`,
       [`${this.project.projenCommand} ${task.name}`],


### PR DESCRIPTION
Since all of the options are optional, we can provide a default value so that passing an options object is not required.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.