### PR TITLE
feat(eslint): support eslint config in yaml form

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -7055,6 +7055,7 @@ new javascript.Eslint(project: NodeProject, options: EslintOptions)
   * **prettier** (<code>boolean</code>)  Enable prettier for code formatting. __*Default*__: false
   * **tsAlwaysTryTypes** (<code>boolean</code>)  Always try to resolve types under `<root>@types` directory even it doesn't contain any source code. __*Default*__: true
   * **tsconfigPath** (<code>string</code>)  Path to `tsconfig.json` which should be used by eslint. __*Default*__: "./tsconfig.json"
+  * **yamlConfiguration** (<code>boolean</code>)  Write eslint configuration as YAML instead of JSON. __*Default*__: false
 
 
 
@@ -15036,6 +15037,7 @@ Name | Type | Description
 **prettier**?🔹 | <code>boolean</code> | Enable prettier for code formatting.<br/>__*Default*__: false
 **tsAlwaysTryTypes**?🔹 | <code>boolean</code> | Always try to resolve types under `<root>@types` directory even it doesn't contain any source code.<br/>__*Default*__: true
 **tsconfigPath**?🔹 | <code>string</code> | Path to `tsconfig.json` which should be used by eslint.<br/>__*Default*__: "./tsconfig.json"
+**yamlConfiguration**?🔹 | <code>boolean</code> | Write eslint configuration as YAML instead of JSON.<br/>__*Default*__: false
 
 
 

--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -7055,7 +7055,7 @@ new javascript.Eslint(project: NodeProject, options: EslintOptions)
   * **prettier** (<code>boolean</code>)  Enable prettier for code formatting. __*Default*__: false
   * **tsAlwaysTryTypes** (<code>boolean</code>)  Always try to resolve types under `<root>@types` directory even it doesn't contain any source code. __*Default*__: true
   * **tsconfigPath** (<code>string</code>)  Path to `tsconfig.json` which should be used by eslint. __*Default*__: "./tsconfig.json"
-  * **yamlConfiguration** (<code>boolean</code>)  Write eslint configuration as YAML instead of JSON. __*Default*__: false
+  * **yaml** (<code>boolean</code>)  Write eslint configuration as YAML instead of JSON. __*Default*__: false
 
 
 
@@ -15037,7 +15037,7 @@ Name | Type | Description
 **prettier**?🔹 | <code>boolean</code> | Enable prettier for code formatting.<br/>__*Default*__: false
 **tsAlwaysTryTypes**?🔹 | <code>boolean</code> | Always try to resolve types under `<root>@types` directory even it doesn't contain any source code.<br/>__*Default*__: true
 **tsconfigPath**?🔹 | <code>string</code> | Path to `tsconfig.json` which should be used by eslint.<br/>__*Default*__: "./tsconfig.json"
-**yamlConfiguration**?🔹 | <code>boolean</code> | Write eslint configuration as YAML instead of JSON.<br/>__*Default*__: false
+**yaml**?🔹 | <code>boolean</code> | Write eslint configuration as YAML instead of JSON.<br/>__*Default*__: false
 
 
 

--- a/src/javascript/eslint.ts
+++ b/src/javascript/eslint.ts
@@ -3,6 +3,7 @@ import { PROJEN_RC } from "../common";
 import { Component } from "../component";
 import { NodeProject } from "../javascript";
 import { JsonFile } from "../json";
+import { YamlFile } from "../yaml";
 import { Prettier } from "./prettier";
 
 export interface EslintOptions {
@@ -75,6 +76,12 @@ export interface EslintOptions {
    * @default true
    */
   readonly tsAlwaysTryTypes?: boolean;
+
+  /**
+   * Write eslint configuration as YAML instead of JSON
+   * @default false
+   */
+  readonly yamlConfiguration?: boolean;
 }
 
 /**
@@ -364,10 +371,17 @@ export class Eslint extends Component {
       overrides: this.overrides,
     };
 
-    new JsonFile(project, ".eslintrc.json", {
-      obj: this.config,
-      marker: false,
-    });
+    if (options.yamlConfiguration) {
+      new YamlFile(project, ".eslintrc.yml", {
+        obj: this.config,
+        marker: false,
+      });
+    } else {
+      new JsonFile(project, ".eslintrc.json", {
+        obj: this.config,
+        marker: false,
+      });
+    }
 
     // if the user enabled prettier explicitly _or_ if the project has a
     // `Prettier` component, we shall tweak our configuration accordingly.

--- a/src/javascript/eslint.ts
+++ b/src/javascript/eslint.ts
@@ -81,7 +81,7 @@ export interface EslintOptions {
    * Write eslint configuration as YAML instead of JSON
    * @default false
    */
-  readonly yamlConfiguration?: boolean;
+  readonly yaml?: boolean;
 }
 
 /**
@@ -371,7 +371,7 @@ export class Eslint extends Component {
       overrides: this.overrides,
     };
 
-    if (options.yamlConfiguration) {
+    if (options.yaml) {
       new YamlFile(project, ".eslintrc.yml", {
         obj: this.config,
         marker: false,

--- a/test/javascript/eslint.test.ts
+++ b/test/javascript/eslint.test.ts
@@ -129,3 +129,23 @@ test("if the prettier is configured, eslint is configured accordingly", () => {
     "prettier/prettier": ["error"],
   });
 });
+
+test("can output yml instead of json", () => {
+  // GIVEN
+  const project = new NodeProject({
+    name: "test",
+    defaultReleaseBranch: "main",
+    prettier: true,
+  });
+
+  // WHEN
+  new Eslint(project, {
+    dirs: ["src"],
+    yamlConfiguration: true,
+  });
+
+  // THEN
+  const output = synthSnapshot(project);
+  expect(output[".eslintrc.yml"]).toBeDefined();
+  expect(output[".eslintrc.json"]).toBeUndefined();
+});

--- a/test/javascript/eslint.test.ts
+++ b/test/javascript/eslint.test.ts
@@ -141,7 +141,7 @@ test("can output yml instead of json", () => {
   // WHEN
   new Eslint(project, {
     dirs: ["src"],
-    yamlConfiguration: true,
+    yaml: true,
   });
 
   // THEN


### PR DESCRIPTION
Adds a configuration option to the ESLint module to support writing the
configuration file as yml instead of json. Still writes as json by
default. ESLint natively supports yml configuration files and they're
nicer to work with. See
https://eslint.org/docs/user-guide/configuring/configuration-files

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.