### PR TITLE
fix(typedoc): updated typedoc dependency when using doc generation in typescript projects

### DIFF
--- a/src/typescript/typescript-typedoc.ts
+++ b/src/typescript/typescript-typedoc.ts
@@ -5,7 +5,7 @@ import { TypeScriptProject } from "../typescript";
  */
 export class TypedocDocgen {
   constructor(project: TypeScriptProject) {
-    project.addDevDeps("typedoc@^0.21.4");
+    project.addDevDeps("typedoc");
 
     const docgen = project.addTask("docgen", {
       description: `Generate TypeScript API reference ${project.docsDirectory}`,


### PR DESCRIPTION


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.