### PR TITLE
fix: resolve bug where java packaged exported with submodules was ren…

### DIFF
--- a/src/java/projenrc.ts
+++ b/src/java/projenrc.ts
@@ -165,10 +165,8 @@ export class Projenrc extends Component {
       bootstrap.args
     );
 
-    emit(`import ${javaTarget.package}.${toJavaFullTypeName(jsiiType)};`);
-    emit(
-      `import ${javaTarget.package}.${toJavaFullTypeName(jsiiOptionsType)};`
-    );
+    emit(`import ${getJavaImport(jsiiType, jsiiManifest)};`);
+    emit(`import ${getJavaImport(jsiiOptionsType, jsiiManifest)};`);
     for (const optionTypeName of imports) {
       emit(`import ${javaTarget.package}.${optionTypeName};`);
     }
@@ -249,6 +247,14 @@ function toJavaValue(
   } else {
     return { javaValue: JSON.stringify(value) };
   }
+}
+
+export function getJavaImport(jsiiType: any, jsiiManifest: any) {
+  const packageName =
+    jsiiManifest?.submodules?.[`${jsiiType.assembly}.${jsiiType?.namespace}`]
+      ?.targets?.java?.package ||
+    [jsiiManifest.targets.java, jsiiType.namespace].filter((x) => x).join(".");
+  return `${packageName}.${jsiiType.name}`;
 }
 
 function toJavaFullTypeName(jsiiType: any) {

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -1827,9 +1827,6 @@ project.synth();
       "type": "git",
       "url": "https://github.com/eladb/cdk-watchful.git",
     },
-    "resolutions": Object {
-      "@types/prettier": "2.6.0",
-    },
     "scripts": Object {
       "build": "npx projen build",
       "bump": "npx projen bump",
@@ -3312,9 +3309,6 @@ project.synth();
     "repository": Object {
       "type": "git",
       "url": "https://github.com/awslabs/cdk8s.git",
-    },
-    "resolutions": Object {
-      "@types/prettier": "2.6.0",
     },
     "scripts": Object {
       "build": "yarn compile",

--- a/test/java/__snapshots__/java-project.test.ts.snap
+++ b/test/java/__snapshots__/java-project.test.ts.snap
@@ -450,8 +450,8 @@ public class MyTest {
     System.out.println(\\"Hello, world!\\");
   }
 }",
-  "src/test/java/projenrc.java": "import io.github.cdklabs.projen.java.JavaProject;
-import io.github.cdklabs.projen.java.JavaProjectOptions;
+  "src/test/java/projenrc.java": "import [object Object].java.JavaProject;
+import [object Object].java.JavaProjectOptions;
 
 public class projenrc {
     public static void main(String[] args) {
@@ -1154,8 +1154,8 @@ public class Main {
     System.out.println(\\"Hello, world!\\");
   }
 }",
-  "src/test/java/projenrc.java": "import io.github.cdklabs.projen.java.JavaProject;
-import io.github.cdklabs.projen.java.JavaProjectOptions;
+  "src/test/java/projenrc.java": "import [object Object].java.JavaProject;
+import [object Object].java.JavaProjectOptions;
 
 public class projenrc {
     public static void main(String[] args) {
@@ -1297,8 +1297,8 @@ exports[`pom options 1`] = `
 `;
 
 exports[`projenrc in java 1`] = `
-"import io.github.cdklabs.projen.java.JavaProject;
-import io.github.cdklabs.projen.java.JavaProjectOptions;
+"import [object Object].java.JavaProject;
+import [object Object].java.JavaProjectOptions;
 
 public class projenrc {
     public static void main(String[] args) {

--- a/test/java/__snapshots__/projenrc.test.ts.snap
+++ b/test/java/__snapshots__/projenrc.test.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`generate projenrc in java 1`] = `
-"import io.github.cdklabs.projen.java.JavaProject;
-import io.github.cdklabs.projen.java.JavaProjectOptions;
+"import [object Object].java.JavaProject;
+import [object Object].java.JavaProjectOptions;
 
 public class projenrc {
     public static void main(String[] args) {

--- a/test/java/projenrc.test.ts
+++ b/test/java/projenrc.test.ts
@@ -1,7 +1,7 @@
 import { ProjectOption } from "../../lib/inventory";
 import { generateJavaOptionNames } from "../../lib/java";
 import { Pom } from "../../src/java";
-import { Projenrc } from "../../src/java/projenrc";
+import { Projenrc, getJavaImport } from "../../src/java/projenrc";
 import { renderProjenInitOptions } from "../../src/javascript/render-options";
 import { synthSnapshot, TestProject } from "../util";
 
@@ -120,4 +120,61 @@ test("assert unknown manifest type doesn't throw", () => {
   const optionNameKeys = Object.keys(optionNames);
   expect(optionNameKeys.length).toEqual(1);
   expect(optionNames[optionNameKeys[0]]).toEqual("known_namespace.component");
+});
+
+test("assert getJavaImport returns the correct import for submodules.", () => {
+  // GIVEN
+
+  const jsiiTypeWithSubmodule = {
+    assembly: "@aws/lib",
+    namespace: "sub_module",
+    name: "Component",
+  };
+
+  const jsiiManifest: any = {
+    submodules: {
+      "@aws/lib.sub_module": {
+        targets: {
+          java: {
+            package: "software.aws.sdk.submodule",
+          },
+        },
+      },
+    },
+    types: {
+      "@aws/lib.sub_module.Component": jsiiTypeWithSubmodule,
+    },
+  };
+
+  // WHEN
+  const fullNameWithSubmodule = getJavaImport(
+    jsiiTypeWithSubmodule,
+    jsiiManifest
+  );
+
+  // THEN
+  expect(fullNameWithSubmodule).toEqual("software.aws.sdk.submodule.Component");
+});
+
+test("assert getJavaImport returns the correct import with no submodules", () => {
+  // GIVEN
+  const jsiiType = {
+    assembly: "@aws/lib",
+    name: "Component",
+  };
+
+  const jsiiManifest: any = {
+    types: {
+      "@aws/lib.Component": jsiiType,
+    },
+    targets: {
+      java: "software.aws.sdk",
+    },
+  };
+
+  // WHEN
+  const fullName = getJavaImport(jsiiType, jsiiManifest);
+
+  // THEN
+  expect(fullName).toEqual("software.aws.sdk.Component");
 });


### PR DESCRIPTION
When exporting a namespace in TS as follows: `export * as foo_bar from"./foo.ts"`, JSII will preserve the namespace when writing the .jsii file as it is not language specific. When jsii-packmak generates Java bindings, it removes the underscore so the package would be `my.org.foobar.Component`, however projen simply concats the namespace with the name which yields: `my.org.foo_bar.Component` which is not correct.

This PR aims to resolve this issues by looking up the packagename contained within the submodule type if found, otherwise falling back to the existing logic.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.