### PR TITLE
chore: fix confusing error messages

### DIFF
--- a/src/javascript/node-project.ts
+++ b/src/javascript/node-project.ts
@@ -589,7 +589,9 @@ export class NodeProject extends GitHubProject {
     } else {
       // validate that no release options are selected if the release workflow is disabled.
       if (options.releaseToNpm) {
-        throw new Error('"releaseToNpm" is not supported if "release" is not set');
+        throw new Error(
+          '"releaseToNpm" is not supported if "release" is not set'
+        );
       }
 
       if (options.releaseEveryCommit) {
@@ -599,7 +601,9 @@ export class NodeProject extends GitHubProject {
       }
 
       if (options.releaseSchedule) {
-        throw new Error('"releaseSchedule" is not supported if "release" is not set');
+        throw new Error(
+          '"releaseSchedule" is not supported if "release" is not set'
+        );
       }
     }
 

--- a/src/javascript/node-project.ts
+++ b/src/javascript/node-project.ts
@@ -589,17 +589,17 @@ export class NodeProject extends GitHubProject {
     } else {
       // validate that no release options are selected if the release workflow is disabled.
       if (options.releaseToNpm) {
-        throw new Error('"releaseToNpm" is not supported for APP projects');
+        throw new Error('"releaseToNpm" is not supported if "release" is not set');
       }
 
       if (options.releaseEveryCommit) {
         throw new Error(
-          '"releaseEveryCommit" is not supported for APP projects'
+          '"releaseEveryCommit" is not supported if "release" is not set'
         );
       }
 
       if (options.releaseSchedule) {
-        throw new Error('"releaseSchedule" is not supported for APP projects');
+        throw new Error('"releaseSchedule" is not supported if "release" is not set');
       }
     }
 


### PR DESCRIPTION
When switching on `releaseToNpm` I got a confusing error message
saying I wasn't allowed to. The error message did not match the
actual reason.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.