### PR TITLE
fix(typescript): aligns typescript and ts-node default versions

### DIFF
--- a/src/typescript/projenrc.ts
+++ b/src/typescript/projenrc.ts
@@ -45,7 +45,7 @@ export class Projenrc extends Component {
     // this is the task projen executes when running `projen` without a
     // specific task (if this task is not defined, projen falls back to
     // running "node .projenrc.js").
-    project.addDevDeps("ts-node@^9");
+    project.addDevDeps("ts-node");
 
     // we use "tsconfig.dev.json" here to allow projen source files to reside
     // anywhere in the project tree.


### PR DESCRIPTION
TypeScript projects using `projenrcTs` specify `typescript` and `ts-node@^9` as dev dependencies by default. The misalignment between the two makes `ts-node` fail to execute `synth`.

This PR simply removes the semver notation from `ts-node`, so new projects are created specifying the latest stable (and supposedly compatible) release of both as dev dependencies.

Fixes: #1880 
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.