### PR TITLE
fix(awscdk-app-ts,cdk8s-app-ts): use ts-node default versions

### DIFF
--- a/src/awscdk/awscdk-app-ts.ts
+++ b/src/awscdk/awscdk-app-ts.ts
@@ -160,7 +160,7 @@ export class AwsCdkTypeScriptApp extends TypeScriptAppProject {
       this.tsconfig.exclude.push(this.cdkConfig.cdkout);
     }
 
-    this.addDevDeps("ts-node@^9");
+    this.addDevDeps("ts-node");
     if (options.sampleCode ?? true) {
       new SampleCode(this, this.cdkDeps.cdkMajorVersion);
     }

--- a/src/cdk8s/cdk8s-app-ts.ts
+++ b/src/cdk8s/cdk8s-app-ts.ts
@@ -179,7 +179,7 @@ export class Cdk8sTypeScriptApp extends TypeScriptAppProject {
       `constructs@${this.constructsVersion}`
     );
     this.addDevDeps(
-      "ts-node@^9",
+      "ts-node",
       `cdk8s-cli@${this.cdk8sCliVersion}`,
       `cdk8s@${this.cdk8sVersion}`,
       `constructs@${this.constructsVersion}`


### PR DESCRIPTION
Addition to #1881

#1880 is still present in `awscdk-app-ts` and `cdk8s-app-ts` apps

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.