### PR TITLE
feat: warn users if CDK v1 deps are installed in a CDK v2 project

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -3370,6 +3370,18 @@ addV1DevDependencies(...deps: string[]): void
 
 
 
+#### preSynthesize()🔹 <a id="projen-awscdk-awscdkdeps-presynthesize"></a>
+
+Called before synthesis.
+
+```ts
+preSynthesize(): void
+```
+
+
+
+
+
 #### protected packageNames()🔹 <a id="projen-awscdk-awscdkdeps-packagenames"></a>
 
 Return a configuration object with information about package naming in various languages.

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -62,7 +62,9 @@ export class Logger extends Component {
     }
 
     if (level <= maxLevel) {
-      const color = this.colorForLogLevel(level);
+      const color =
+        this.colorForLogLevel(level) ??
+        ((...values: string[]): string => values.join(" "));
       const prefix = this.usePrefix ? `[${this.project.name}] ` : "";
       console.error(`${ICON} ${prefix}${color(...text)}`);
     }


### PR DESCRIPTION
Proactively help users avoid errors by logging a warning if a CDK v1 dep has been added to the projenrc file of a CDK v2 project.

projen doesn't have a notion of "Annotations" like AWS CDK, so for now this warning is logged during the preSynthesize hook, at which point most dependencies should have been to the project's `Dependencies`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.