### PR TITLE
chore: remove bump files from npm tarball

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -195,7 +195,7 @@
       "description": "Creates the distribution package",
       "steps": [
         {
-          "exec": "if [ ! -z ${CI} ]; then mkdir -p dist && rsync -a . dist --exclude .git --exclude node_modules; else /bin/bash ./projen.bash package-all; fi"
+          "exec": "if [ ! -z ${CI} ]; then rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist; else /bin/bash ./projen.bash package-all; fi"
         }
       ]
     },

--- a/src/cdk/jsii-project.ts
+++ b/src/cdk/jsii-project.ts
@@ -201,8 +201,9 @@ export class JsiiProject extends TypeScriptProject {
     // in jsii we consider the entire repo (post build) as the build artifact
     // which is then used to create the language bindings in separate jobs.
     const prepareRepoForCI = [
-      `mkdir -p ${this.artifactsDirectory}`,
-      `rsync -a . ${this.artifactsDirectory} --exclude .git --exclude node_modules`,
+      `rsync -a . .repo --exclude .git --exclude node_modules`,
+      `rm -rf ${this.artifactsDirectory}`,
+      `mv .repo ${this.artifactsDirectory}`,
     ].join(" && ");
 
     // when running inside CI we just prepare the repo for packaging, which

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -1230,7 +1230,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": Array [
           Object {
-            "exec": "if [ ! -z \${CI} ]; then mkdir -p dist && rsync -a . dist --exclude .git --exclude node_modules; else npx projen package-all; fi",
+            "exec": "if [ ! -z \${CI} ]; then rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist; else npx projen package-all; fi",
           },
         ],
       },
@@ -2621,7 +2621,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": Array [
           Object {
-            "exec": "if [ ! -z \${CI} ]; then mkdir -p dist && rsync -a . dist --exclude .git --exclude node_modules; else npx projen package-all; fi",
+            "exec": "if [ ! -z \${CI} ]; then rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist; else npx projen package-all; fi",
           },
         ],
       },


### PR DESCRIPTION
Currently, the `package` task for jsii projects running in CI environments does the following:

```console
rsync -a . dist --exclude .git --exclude node_modules
```

It does this to prepare the `dist` directory for subsequent `package:${lang}` in the GitHub workflow. (More details [here](https://github.com/projen/projen/pull/1631))

The problem is that when this command is executed, the `dist` directory is not empty, it contains:

- `releasetag.txt`
- `version.txt`
- `changelog.md`

These are created in the `bump` task. This in turn creates a weird structure after the `rsync` is executed:

```console
dist/
├─ releasetag.txt // duplicated and misplaced
├─ version.txt // duplicated and misplaced
├─ changelog.md // duplicated and misplaced
├─ package.json
├─ lib/
├─ dist/
│  ├─ releasetag.txt
│  ├─ version.txt
│  ├─ changelog.md
```

Eventually the misplaced files end up in the published tarball. Its not horrible, but also undesirable. 

This PR fixes this quirk by `rsync`ing into an intermediary directory before populating the `dist` folder.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.