### PR TITLE
fix: restore ability to lint files in projenrc src directory

### DIFF
--- a/src/typescript/typescript.ts
+++ b/src/typescript/typescript.ts
@@ -319,25 +319,31 @@ export class TypeScriptProject extends NodeProject {
     }
 
     const projenrcTypeScript = options.projenrcTs ?? false;
-    if (projenrcTypeScript) {
-      new ProjenrcTs(this, options.projenrcTsOptions);
-    }
 
     const projenRcFilename = projenrcTypeScript
       ? options.projenrcTsOptions?.filename ?? ".projenrc.ts"
       : undefined;
 
     if (options.eslint ?? true) {
+      const devdirs = [this.testdir, "build-tools"];
+      if (projenrcTypeScript) {
+        devdirs.push(options.projenrcTsOptions?.projenCodeDir ?? "projenrc");
+      }
+
       this.eslint = new Eslint(this, {
         tsconfigPath: `./${this.tsconfigDev.fileName}`,
         dirs: [this.srcdir],
-        devdirs: [this.testdir, "build-tools"],
+        devdirs,
         fileExtensions: [".ts", ".tsx"],
         lintProjenRcFile: projenRcFilename,
         ...options.eslintOptions,
       });
 
       this.tsconfigEslint = this.tsconfigDev;
+    }
+
+    if (projenrcTypeScript) {
+      new ProjenrcTs(this, options.projenrcTsOptions);
     }
 
     const tsver = options.typescriptVersion

--- a/test/typescript/typescript.test.ts
+++ b/test/typescript/typescript.test.ts
@@ -166,7 +166,7 @@ test("projenrc.ts", () => {
   });
 });
 
-test("projenrc.ts linted by eslint task", () => {
+test("eslint configured to support .projenrc.ts and projenrc src dir", () => {
   const prj = new TypeScriptProject({
     name: "test",
     defaultReleaseBranch: "main",
@@ -179,9 +179,26 @@ test("projenrc.ts linted by eslint task", () => {
     name: "eslint",
     steps: [
       {
-        exec: "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools .projenrc.ts",
+        exec: "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools projenrc .projenrc.ts",
       },
     ],
+  });
+  expect(snapshot[".eslintrc.json"]).toMatchObject({
+    ignorePatterns: expect.arrayContaining([
+      "!.projenrc.ts",
+      "!projenrc/**/*.ts",
+    ]),
+    rules: expect.objectContaining({
+      "import/no-extraneous-dependencies": [
+        "error",
+        expect.objectContaining({
+          devDependencies: expect.arrayContaining([
+            ".projenrc.ts",
+            "projenrc/**/*.ts",
+          ]),
+        }),
+      ],
+    }),
   });
 });
 


### PR DESCRIPTION
Closes #1903 

The change in #1832 inadvertently removed required configuration for files on `projenrc` to be linted. This change restores that config by once again creating the `ProjenrcTs` component _after_  the `Eslint` component. It also adds `projenrc` as a `testDir`, so files will be linted by the eslint task.


This PR is aiming to resolve #1903 with minimal changes. I felt that the current implementation of the `Eslint` component is mixing responsibilities a bit (is it aware of projen, how much is it aware?) and makes some assumptions about what it thinks it knows about projen. **tl;dr I didn't really want to get into it.** But please let me know if you do want me to!


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.