### PR TITLE
feat(awscdk): add lambda runtime nodejs16.x

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -4427,6 +4427,7 @@ Name | Type | Description
 *static* **NODEJS_10_X**🔹 | <code>[awscdk.LambdaRuntime](#projen-awscdk-lambdaruntime)</code> | Node.js 10.x.
 *static* **NODEJS_12_X**🔹 | <code>[awscdk.LambdaRuntime](#projen-awscdk-lambdaruntime)</code> | Node.js 12.x.
 *static* **NODEJS_14_X**🔹 | <code>[awscdk.LambdaRuntime](#projen-awscdk-lambdaruntime)</code> | Node.js 14.x.
+*static* **NODEJS_16_X**🔹 | <code>[awscdk.LambdaRuntime](#projen-awscdk-lambdaruntime)</code> | Node.js 16.x.
 
 
 

--- a/src/awscdk/lambda-extension.ts
+++ b/src/awscdk/lambda-extension.ts
@@ -97,6 +97,7 @@ export class LambdaExtension extends Component {
     }
 
     const compatibleRuntimes = options.compatibleRuntimes ?? [
+      LambdaRuntime.NODEJS_16_X,
       LambdaRuntime.NODEJS_14_X,
       LambdaRuntime.NODEJS_12_X,
     ];

--- a/src/awscdk/lambda-function.ts
+++ b/src/awscdk/lambda-function.ts
@@ -307,6 +307,14 @@ export class LambdaRuntime {
     "node14"
   );
 
+  /**
+   * Node.js 16.x
+   */
+  public static readonly NODEJS_16_X = new LambdaRuntime(
+    "NODEJS_16_X",
+    "node16"
+  );
+
   public readonly esbuildPlatform = "node";
 
   private constructor(

--- a/test/awscdk/__snapshots__/lambda-extension.test.ts.snap
+++ b/test/awscdk/__snapshots__/lambda-extension.test.ts.snap
@@ -23,6 +23,7 @@ export class ExampleLayerVersion extends lambda.LayerVersion {
       compatibleRuntimes: [
         lambda.Runtime.NODEJS_12_X,
         lambda.Runtime.NODEJS_14_X,
+        lambda.Runtime.NODEJS_16_X,
       ],
       code: lambda.Code.fromAsset(path.join(__dirname,
         '../assets/example.lambda-extension')),


### PR DESCRIPTION
Added NodeJS Lambda Runtime 16.x to be able to use them for [AWS Lambda Functions](https://projen.io/awscdk.html#aws-lambda-functions) (its possible to use them since [aws-cdk v2.24.0](https://github.com/aws/aws-cdk/releases/tag/v2.24.0), [blogpost](https://aws.amazon.com/de/blogs/compute/node-js-16-x-runtime-now-available-in-aws-lambda/).
Tested the changes in my local project.
I've tried to keep as less changes as possible. 

Let me know if something is off and should be fixed

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.