### PR TITLE
fix: update version of npm-check-updates

### DIFF
--- a/src/javascript/upgrade-dependencies.ts
+++ b/src/javascript/upgrade-dependencies.ts
@@ -124,7 +124,7 @@ export class UpgradeDependencies extends Component {
       options.workflowOptions?.gitIdentity ?? DEFAULT_GITHUB_ACTIONS_USER;
     this.postBuildSteps = [];
     this.containerOptions = options.workflowOptions?.container;
-    project.addDevDeps("npm-check-updates@^12");
+    project.addDevDeps("npm-check-updates@^14");
 
     this.postUpgradeTask =
       project.tasks.tryFind("post-upgrade") ??


### PR DESCRIPTION
Updates the major version of npm-check-updates installed for projects
using the upgrade dependencies github actions. This should mitigate a
CVE related to a transitive dependency on `Got<11.8,5`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.