### PR TITLE
fix(publisher): add manual publish condition

### DIFF
--- a/src/release/publisher.ts
+++ b/src/release/publisher.ts
@@ -212,6 +212,7 @@ export class Publisher extends Component {
         PROJECT_CHANGELOG_FILE: projectChangelogFile ?? "",
         VERSION_FILE: versionFile,
       },
+      condition: '! git log --oneline -1 | grep -q "chore(release):"',
     });
     if (projectChangelogFile) {
       publishTask.builtin("release/update-changelog");


### PR DESCRIPTION
Adding a condition to the git publish command, which performs
the same check as the bump command. If the last commit was a release
commit, it doesn't make sense to try to publish again. Doing so
actually causes an error because bump is skipped which means there
is no version file to read.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.