### PR TITLE
chore: projen new command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ npx projen new PROJECT-TYPE
 Currently supported project types (use `npx projen new` without a type for a
 full list):
 
-**Built-in:** (run `npx projen <type>`)
+**Built-in:** (run `npx projen new <type>`)
 
 <!-- <macro exec="node ./scripts/readme-projects.js"> -->
 * [awscdk-app-java](https://projen.io/api/API.html#projen-awscdk-awscdkjavaapp) - AWS CDK app in Java.
@@ -83,7 +83,7 @@ full list):
 * [typescript-app](https://projen.io/api/API.html#projen-typescript-typescriptappproject) - TypeScript app.
 <!-- </macro> -->
 
-**External:** (run `npx projen --from <type>`)
+**External:** (run `npx projen new --from <type>`)
 
 * [projen-github-action-typescript](https://github.com/projen/projen-github-action-typescript/blob/main/API.md) - GitHub Action in TypeScript project.
 


### PR DESCRIPTION
We need to run `npx projen new <type>` instead of `npx projen <type>` to initialize a project.

Sorry, I'm not sure what is an appropriate title for this PR so it would be great if you could fix it. 🙏 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.