### PR TITLE
fix(release): rsync repo to artifact dir manual

### DIFF
--- a/src/release/release.ts
+++ b/src/release/release.ts
@@ -508,6 +508,16 @@ export class Release extends Component {
     releaseTask.exec(`rm -fr ${this.artifactsDirectory}`);
     releaseTask.spawn(this.version.bumpTask);
     releaseTask.spawn(this.buildTask);
+
+    if (this.releaseTrigger.isManual) {
+      const copyRepoToArtifactsDirectory = [
+        `rsync -a . .repo --exclude .git --exclude node_modules`,
+        `rm -rf ${this.artifactsDirectory}`,
+        `mv .repo ${this.artifactsDirectory}`,
+      ].join(" && ");
+      releaseTask.exec(copyRepoToArtifactsDirectory);
+    }
+
     releaseTask.spawn(this.version.unbumpTask);
 
     // anti-tamper check (fails if there were changes to committed files)
@@ -518,13 +528,16 @@ export class Release extends Component {
       const publishTask = this.publisher.publishToGit({
         changelogFile: path.posix.join(
           this.artifactsDirectory,
+          this.artifactsDirectory,
           this.version.changelogFileName
         ),
         versionFile: path.posix.join(
           this.artifactsDirectory,
+          this.artifactsDirectory,
           this.version.versionFileName
         ),
         releaseTagFile: path.posix.join(
+          this.artifactsDirectory,
           this.artifactsDirectory,
           this.version.releaseTagFileName
         ),


### PR DESCRIPTION
Copy the repo content to the artifacts directory after build
but before unbump. The reason for this is that after unbump
occurs, if you want to manually publish an artifact you can't
because the version has already been reset. Copying the full
repo into the artifacts directory allows folks doing manual
releases to cd into the artifacts directory, then perform
publish commands successfully.

This is technically redundant of what occurs for CI in the JSII
project, but for manual release, we do it always, so that there's
always a repo in a state capable of being packaged (for JSII)
or released (for standard node apps/modules).

Closes #1938

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.