### PR TITLE
fix(awscdk-construct): new project fails to build

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -19,6 +19,7 @@
     },
     {
       "name": "@types/jest",
+      "version": "^27",
       "type": "build"
     },
     {
@@ -78,12 +79,13 @@
       "type": "build"
     },
     {
-      "name": "jest",
+      "name": "jest-junit",
+      "version": "^13",
       "type": "build"
     },
     {
-      "name": "jest-junit",
-      "version": "^13",
+      "name": "jest",
+      "version": "^27",
       "type": "build"
     },
     {
@@ -130,6 +132,7 @@
     },
     {
       "name": "ts-jest",
+      "version": "^27",
       "type": "build"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -392,7 +392,7 @@
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @types/conventional-changelog-config-spec @types/fs-extra @types/glob @types/ini @types/jest @types/node @types/semver @types/yargs @typescript-eslint/eslint-plugin @typescript-eslint/parser all-contributors-cli esbuild eslint-config-prettier eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint jest jest-junit jsii jsii-diff jsii-docgen jsii-pacmak json-schema json5 npm-check-updates prettier standard-version ts-jest typescript @iarna/toml case chalk conventional-changelog-config-spec fs-extra glob ini semver shx xmlbuilder2 yaml yargs"
+          "exec": "yarn upgrade @types/conventional-changelog-config-spec @types/fs-extra @types/glob @types/ini @types/jest @types/node @types/semver @types/yargs @typescript-eslint/eslint-plugin @typescript-eslint/parser all-contributors-cli esbuild eslint-config-prettier eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint jest-junit jest jsii jsii-diff jsii-docgen jsii-pacmak json-schema json5 npm-check-updates prettier standard-version ts-jest typescript @iarna/toml case chalk conventional-changelog-config-spec fs-extra glob ini semver shx xmlbuilder2 yaml yargs"
         },
         {
           "exec": "/bin/bash ./projen.bash"

--- a/src/cdk/jsii-project.ts
+++ b/src/cdk/jsii-project.ts
@@ -8,6 +8,7 @@ import {
   PyPiPublishOptions,
 } from "../release";
 import { TypeScriptProject, TypeScriptProjectOptions } from "../typescript";
+import { deepMerge } from "../util";
 import { JsiiPacmakTarget, JSII_TOOLCHAIN } from "./consts";
 import { JsiiDocgen } from "./jsii-docgen";
 
@@ -155,16 +156,30 @@ export class JsiiProject extends TypeScriptProject {
 
   constructor(options: JsiiProjectOptions) {
     const { authorEmail, authorUrl } = parseAuthorAddress(options);
-    super({
+
+    const defaultOptions = {
       repository: options.repositoryUrl,
       authorName: options.author,
       authorEmail,
       authorUrl,
-      ...options,
+      jestOptions: {
+        jestVersion: "^27",
+      },
+    };
+
+    const forcedOptions = {
       releaseToNpm: false, // we have a jsii release workflow
       disableTsconfig: true, // jsii generates its own tsconfig.json
       docgen: false, // we use jsii-docgen here so disable typescript docgen
-    });
+    };
+
+    const mergedOptions = deepMerge([
+      defaultOptions,
+      options,
+      forcedOptions,
+    ]) as TypeScriptProjectOptions;
+
+    super(mergedOptions);
 
     const srcdir = this.srcdir;
     const libdir = this.libdir;

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -816,6 +816,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/jest",
         "type": "build",
+        "version": "^27",
       },
       Object {
         "name": "@types/node",
@@ -854,13 +855,14 @@ tsconfig.tsbuildinfo
         "version": "^8",
       },
       Object {
-        "name": "jest",
-        "type": "build",
-      },
-      Object {
         "name": "jest-junit",
         "type": "build",
         "version": "^13",
+      },
+      Object {
+        "name": "jest",
+        "type": "build",
+        "version": "^27",
       },
       Object {
         "name": "jsii",
@@ -899,6 +901,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "ts-jest",
         "type": "build",
+        "version": "^27",
       },
       Object {
         "name": "typescript",
@@ -1710,7 +1713,7 @@ project.synth();
     "description": "Watching your CDK apps since 2019",
     "devDependencies": Object {
       "@aws-cdk/assert": "^1.75.0",
-      "@types/jest": "*",
+      "@types/jest": "^27",
       "@types/node": "^14",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
@@ -1719,7 +1722,7 @@ project.synth();
       "eslint-import-resolver-node": "*",
       "eslint-import-resolver-typescript": "*",
       "eslint-plugin-import": "*",
-      "jest": "*",
+      "jest": "^27",
       "jest-junit": "^13",
       "jsii": "*",
       "jsii-diff": "*",
@@ -1729,7 +1732,7 @@ project.synth();
       "npm-check-updates": "^12",
       "projen": "*",
       "standard-version": "^9",
-      "ts-jest": "*",
+      "ts-jest": "^27",
       "typescript": "*",
     },
     "engines": Object {
@@ -2356,6 +2359,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/jest",
         "type": "build",
+        "version": "^27",
       },
       Object {
         "name": "@types/json-stable-stringify",
@@ -2402,13 +2406,14 @@ tsconfig.tsbuildinfo
         "version": "^8",
       },
       Object {
-        "name": "jest",
-        "type": "build",
-      },
-      Object {
         "name": "jest-junit",
         "type": "build",
         "version": "^13",
+      },
+      Object {
+        "name": "jest",
+        "type": "build",
+        "version": "^27",
       },
       Object {
         "name": "jsii",
@@ -2446,6 +2451,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "ts-jest",
         "type": "build",
+        "version": "^27",
       },
       Object {
         "name": "typescript",
@@ -3202,7 +3208,7 @@ project.synth();
     "description": "Cloud Development Kit for Kubernetes",
     "devDependencies": Object {
       "@types/follow-redirects": "*",
-      "@types/jest": "*",
+      "@types/jest": "^27",
       "@types/json-stable-stringify": "*",
       "@types/node": "^12",
       "@types/yaml": "*",
@@ -3213,7 +3219,7 @@ project.synth();
       "eslint-import-resolver-node": "*",
       "eslint-import-resolver-typescript": "*",
       "eslint-plugin-import": "*",
-      "jest": "*",
+      "jest": "^27",
       "jest-junit": "^13",
       "jsii": "*",
       "jsii-diff": "*",
@@ -3223,7 +3229,7 @@ project.synth();
       "json-schema-to-typescript": "*",
       "npm-check-updates": "^12",
       "projen": "*",
-      "ts-jest": "*",
+      "ts-jest": "^27",
       "typescript": "*",
     },
     "engines": Object {


### PR DESCRIPTION
Fixes #1964

I tested the changes by creating a new awscdk-construct project in a new directory following the instructions here: https://github.com/projen/projen/blob/main/CONTRIBUTING.md#testing-against-local-projects

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.