### PR TITLE
feat(awscdk): custom Lambda runtimes

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -4481,6 +4481,19 @@ The runtime for the AWS Lambda function.
 __Submodule__: awscdk
 
 
+### Initializer
+
+
+
+
+```ts
+new awscdk.LambdaRuntime(functionRuntime: string, esbuildTarget: string)
+```
+
+* **functionRuntime** (<code>string</code>)  The Node.js runtime to use.
+* **esbuildTarget** (<code>string</code>)  The esbuild setting to use.
+
+
 
 ### Properties
 
@@ -4489,7 +4502,7 @@ Name | Type | Description
 -----|------|-------------
 **esbuildPlatform**🔹 | <code>string</code> | <span></span>
 **esbuildTarget**🔹 | <code>string</code> | The esbuild setting to use.
-**functionRuntime**🔹 | <code>string</code> | The aws-lambda.Runtime member name to use.
+**functionRuntime**🔹 | <code>string</code> | The Node.js runtime to use.
 *static* **NODEJS_10_X**🔹 | <code>[awscdk.LambdaRuntime](#projen-awscdk-lambdaruntime)</code> | Node.js 10.x.
 *static* **NODEJS_12_X**🔹 | <code>[awscdk.LambdaRuntime](#projen-awscdk-lambdaruntime)</code> | Node.js 12.x.
 *static* **NODEJS_14_X**🔹 | <code>[awscdk.LambdaRuntime](#projen-awscdk-lambdaruntime)</code> | Node.js 14.x.

--- a/src/awscdk/lambda-extension.ts
+++ b/src/awscdk/lambda-extension.ts
@@ -206,7 +206,9 @@ class LambdaLayerConstruct extends SourceCode {
 
     src.open("compatibleRuntimes: [");
     for (const runtime of options.compatibleRuntimes) {
-      src.line(`lambda.Runtime.${runtime.functionRuntime},`);
+      src.line(
+        `new lambda.Runtime('${runtime.functionRuntime}', lambda.RuntimeFamily.NODEJS),`
+      );
     }
     src.close("],");
 

--- a/src/awscdk/lambda-function.ts
+++ b/src/awscdk/lambda-function.ts
@@ -249,7 +249,9 @@ export class LambdaFunction extends Component {
     src.open("super(scope, id, {");
     src.line(`description: '${convertToPosixPath(entrypoint)}',`);
     src.line("...props,");
-    src.line(`runtime: lambda.Runtime.${runtime.functionRuntime},`);
+    src.line(
+      `runtime: new lambda.Runtime('${runtime.functionRuntime}', lambda.RuntimeFamily.NODEJS),`
+    );
     src.line("handler: 'index.handler',");
     src.line(
       `code: lambda.Code.fromAsset(path.join(__dirname, '${convertToPosixPath(
@@ -287,7 +289,7 @@ export class LambdaRuntime {
    * Node.js 10.x
    */
   public static readonly NODEJS_10_X = new LambdaRuntime(
-    "NODEJS_10_X",
+    "nodejs10.x",
     "node10"
   );
 
@@ -295,7 +297,7 @@ export class LambdaRuntime {
    * Node.js 12.x
    */
   public static readonly NODEJS_12_X = new LambdaRuntime(
-    "NODEJS_12_X",
+    "nodejs12.x",
     "node12"
   );
 
@@ -303,7 +305,7 @@ export class LambdaRuntime {
    * Node.js 14.x
    */
   public static readonly NODEJS_14_X = new LambdaRuntime(
-    "NODEJS_14_X",
+    "nodejs14.x",
     "node14"
   );
 
@@ -311,15 +313,15 @@ export class LambdaRuntime {
    * Node.js 16.x
    */
   public static readonly NODEJS_16_X = new LambdaRuntime(
-    "NODEJS_16_X",
+    "nodejs16.x",
     "node16"
   );
 
   public readonly esbuildPlatform = "node";
 
-  private constructor(
+  public constructor(
     /**
-     * The aws-lambda.Runtime member name to use.
+     * The Node.js runtime to use
      */
     public readonly functionRuntime: string,
 

--- a/test/awscdk/__snapshots__/lambda-extension.test.ts.snap
+++ b/test/awscdk/__snapshots__/lambda-extension.test.ts.snap
@@ -21,9 +21,9 @@ export class ExampleLayerVersion extends lambda.LayerVersion {
       description: 'Provides a Lambda Extension \`example\` from src/example.lambda-extension.ts',
       ...props,
       compatibleRuntimes: [
-        lambda.Runtime.NODEJS_12_X,
-        lambda.Runtime.NODEJS_14_X,
-        lambda.Runtime.NODEJS_16_X,
+        new lambda.Runtime('nodejs12.x', lambda.RuntimeFamily.NODEJS),
+        new lambda.Runtime('nodejs14.x', lambda.RuntimeFamily.NODEJS),
+        new lambda.Runtime('nodejs16.x', lambda.RuntimeFamily.NODEJS),
       ],
       code: lambda.Code.fromAsset(path.join(__dirname,
         '../assets/example.lambda-extension')),

--- a/test/awscdk/__snapshots__/lambda-function.test.ts.snap
+++ b/test/awscdk/__snapshots__/lambda-function.test.ts.snap
@@ -21,7 +21,7 @@ export class HelloFunction extends cloudfront.experimental.EdgeFunction {
     super(scope, id, {
       description: 'src/hello.edge-lambda.ts',
       ...props,
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: new lambda.Runtime('nodejs14.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../assets/hello.edge-lambda')),
     });
@@ -49,7 +49,7 @@ export class HelloFunction extends lambda.Function {
     super(scope, id, {
       description: 'src/hello.lambda.ts',
       ...props,
-      runtime: lambda.Runtime.NODEJS_12_X,
+      runtime: new lambda.Runtime('nodejs12.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../assets/hello.lambda')),
     });
@@ -78,7 +78,7 @@ export class WorldFunction extends lambda.Function {
     super(scope, id, {
       description: 'src/subdir/world.lambda.ts',
       ...props,
-      runtime: lambda.Runtime.NODEJS_12_X,
+      runtime: new lambda.Runtime('nodejs12.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../../assets/subdir/world.lambda')),
     });
@@ -107,7 +107,7 @@ export class JangyFunction extends lambda.Function {
     super(scope, id, {
       description: 'src/subdir/jangy.lambda.ts',
       ...props,
-      runtime: lambda.Runtime.NODEJS_12_X,
+      runtime: new lambda.Runtime('nodejs12.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../../assets/subdir/jangy.lambda')),
     });
@@ -226,7 +226,7 @@ export class HelloFunction extends lambda.Function {
     super(scope, id, {
       description: 'src/hello.lambda.ts',
       ...props,
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: new lambda.Runtime('nodejs14.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../my-assets/hello.lambda')),
     });
@@ -257,7 +257,7 @@ export class HelloFunction extends lambda.Function {
     super(scope, id, {
       description: 'src/hello.lambda.ts',
       ...props,
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: new lambda.Runtime('nodejs14.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../assets/hello.lambda')),
     });
@@ -286,7 +286,7 @@ export class HelloFunction extends lambda.Function {
     super(scope, id, {
       description: 'src/hello.lambda.ts',
       ...props,
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: new lambda.Runtime('nodejs14.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../assets/hello.lambda')),
     });
@@ -315,7 +315,7 @@ export class WorldFunction extends lambda.Function {
     super(scope, id, {
       description: 'src/world.lambda.ts',
       ...props,
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: new lambda.Runtime('nodejs14.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../assets/world.lambda')),
     });

--- a/test/awscdk/lambda-extension.test.ts
+++ b/test/awscdk/lambda-extension.test.ts
@@ -49,8 +49,12 @@ test("simplest LambdaExtension cdk v2", () => {
     "export interface ExampleLayerVersionProps"
   );
   expect(generatedSource).toContain("export class ExampleLayerVersion");
-  expect(generatedSource).toContain("Runtime.NODEJS_12_X");
-  expect(generatedSource).toContain("Runtime.NODEJS_14_X");
+  expect(generatedSource).toContain(
+    "new lambda.Runtime('nodejs12.x', lambda.RuntimeFamily.NODEJS)"
+  );
+  expect(generatedSource).toContain(
+    "new lambda.Runtime('nodejs14.x', lambda.RuntimeFamily.NODEJS)"
+  );
   expect(generatedSource).toMatchSnapshot();
 });
 
@@ -108,9 +112,15 @@ test("changing compatible runtimes", () => {
   );
 
   const generatedSource = snapshot["src/example-layer-version.ts"];
-  expect(generatedSource).toContain("Runtime.NODEJS_10_X");
-  expect(generatedSource).toContain("Runtime.NODEJS_12_X");
-  expect(generatedSource).toContain("Runtime.NODEJS_14_X");
+  expect(generatedSource).toContain(
+    "new lambda.Runtime('nodejs10.x', lambda.RuntimeFamily.NODEJS)"
+  );
+  expect(generatedSource).toContain(
+    "new lambda.Runtime('nodejs12.x', lambda.RuntimeFamily.NODEJS)"
+  );
+  expect(generatedSource).toContain(
+    "new lambda.Runtime('nodejs14.x', lambda.RuntimeFamily.NODEJS)"
+  );
 });
 
 test("bundler options", () => {

--- a/test/awscdk/lambda-function.test.ts
+++ b/test/awscdk/lambda-function.test.ts
@@ -117,7 +117,9 @@ test("runtime can be used to customize the lambda runtime and esbuild target", (
   const snapshot = Testing.synth(project);
   const generatedSource = snapshot["src/hello-function.ts"];
   const tasks = snapshot[".projen/tasks.json"].tasks;
-  expect(generatedSource).toContain("runtime: lambda.Runtime.NODEJS_12_X,");
+  expect(generatedSource).toContain(
+    "runtime: new lambda.Runtime('nodejs12.x', lambda.RuntimeFamily.NODEJS),"
+  );
   expect(tasks["bundle:hello.lambda"]).toEqual({
     description: "Create a JavaScript bundle from src/hello.lambda.ts",
     name: "bundle:hello.lambda",


### PR DESCRIPTION
Allow to use custom Lambda runtimes for bundled functions.

Remove the "coupling" with the enum from `aws-cdk-lib.aws_lambda`
so the runtime can be updated to a newer runtime without having to
update the minimum version of the AWS CDK to depend on.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.