### PR TITLE
chore: display --projenrc-ts option when running projen new command

### DIFF
--- a/src/cli/cmds/new.ts
+++ b/src/cli/cmds/new.ts
@@ -25,6 +25,11 @@ class Command implements yargs.CommandModule {
       default: true,
       desc: "Synthesize after creating .projenrc.js",
     });
+    args.option("projenrc-ts", {
+      type: "boolean",
+      default: false,
+      desc: "Create a .projenrc.ts file",
+    });
     args.option("comments", {
       type: "boolean",
       default: true,


### PR DESCRIPTION
The command `--projenrc-ts` creates the configuration file in typescript format but today this option does not appear when executing `projen new`

This change will make this option appear in the Options

```console
...
Options:
      --post         Run post-synthesis steps such as installing dependencies. Use --no-post to skip
                                                                                               [boolean] [default: true]
  -w, --watch        Keep running and resynthesize when projenrc changes                      [boolean] [default: false]
      --debug        Debug logs                                                               [boolean] [default: false]
      --rc           path to .projenrc.js file         [string] [default: "/home/marciocadev/empty/.projenrc.js"]
      --help         Show help                                                                                 [boolean]
      --synth        Synthesize after creating .projenrc.js                                    [boolean] [default: true]
      --projenrc-ts  Create a .projenrc.ts file                                               [boolean] [default: false]
      --comments     Include commented out options in .projenrc.js (use --no-comments to disable)
                                                                                               [boolean] [default: true]
  -f, --from         External jsii npm module to create project from. Supports any package spec supported by npm (such
                     as "my-pack@^2.0")                                                                         [string]
      --git          Run `git init` and create an initial commit (use --no-git to disable)     [boolean] [default: true]
...
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.