### PR TITLE
feat(release): add option to set the minimal major version

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -3225,7 +3225,7 @@ new awscdk.AwsCdkConstructLibrary(options: AwsCdkConstructLibraryOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
-  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: No minimum version is being enforced
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -3859,7 +3859,7 @@ new awscdk.AwsCdkTypeScriptApp(options: AwsCdkTypeScriptAppOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
-  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: No minimum version is being enforced
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -4167,7 +4167,7 @@ new awscdk.ConstructLibraryAws(options: AwsCdkConstructLibraryOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
-  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: No minimum version is being enforced
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -4784,7 +4784,7 @@ new cdk.ConstructLibrary(options: ConstructLibraryOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
-  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: No minimum version is being enforced
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -5039,7 +5039,7 @@ new cdk.JsiiProject(options: JsiiProjectOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
-  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: No minimum version is being enforced
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -5446,7 +5446,7 @@ new cdk8s.Cdk8sTypeScriptApp(options: Cdk8sTypeScriptAppOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
-  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: No minimum version is being enforced
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -5626,7 +5626,7 @@ new cdk8s.ConstructLibraryCdk8s(options: ConstructLibraryCdk8sOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
-  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: No minimum version is being enforced
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -5864,7 +5864,7 @@ new cdktf.ConstructLibraryCdktf(options: ConstructLibraryCdktfOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
-  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: No minimum version is being enforced
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -8084,7 +8084,7 @@ new javascript.NodeProject(options: NodeProjectOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
-  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: No minimum version is being enforced
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -9609,7 +9609,7 @@ new release.Release(project: GitHubProject, options: ReleaseOptions)
 * **options** (<code>[release.ReleaseOptions](#projen-release-releaseoptions)</code>)  *No description*
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
-  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: No minimum version is being enforced
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -9902,7 +9902,7 @@ new typescript.TypeScriptAppProject(options: TypeScriptProjectOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
-  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: No minimum version is being enforced
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -10055,7 +10055,7 @@ new typescript.TypeScriptLibraryProject(options: TypeScriptProjectOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
-  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: No minimum version is being enforced
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -10208,7 +10208,7 @@ new typescript.TypeScriptProject(options: TypeScriptProjectOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
-  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: No minimum version is being enforced
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -10606,7 +10606,7 @@ new web.NextJsProject(options: NextJsProjectOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
-  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: No minimum version is being enforced
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -10757,7 +10757,7 @@ new web.NextJsTypeScriptProject(options: NextJsTypeScriptProjectOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
-  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: No minimum version is being enforced
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -10980,7 +10980,7 @@ new web.ReactProject(options: ReactProjectOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
-  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: No minimum version is being enforced
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -11173,7 +11173,7 @@ new web.ReactTypeScriptProject(options: ReactTypeScriptProjectOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
-  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: No minimum version is being enforced
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -12334,7 +12334,7 @@ Name | Type | Description
 **maxNodeVersion**?🔹 | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
-**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: No minimum version is being enforced
 **minNodeVersion**?🔹 | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?🔹 | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?🔹 | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.
@@ -12711,7 +12711,7 @@ Name | Type | Description
 **maxNodeVersion**?🔹 | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
-**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: No minimum version is being enforced
 **minNodeVersion**?🔹 | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?🔹 | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?🔹 | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.
@@ -12918,7 +12918,7 @@ Name | Type | Description
 **maxNodeVersion**?⚠️ | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
-**minMajorVersion**?⚠️ | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
+**minMajorVersion**?⚠️ | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: No minimum version is being enforced
 **minNodeVersion**?⚠️ | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?⚠️ | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?⚠️ | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.
@@ -13325,7 +13325,7 @@ Name | Type | Description
 **maxNodeVersion**?🔹 | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
-**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: No minimum version is being enforced
 **minNodeVersion**?🔹 | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?🔹 | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?🔹 | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.
@@ -13590,7 +13590,7 @@ Name | Type | Description
 **maxNodeVersion**?🔹 | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
-**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: No minimum version is being enforced
 **minNodeVersion**?🔹 | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?🔹 | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?🔹 | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.
@@ -13926,7 +13926,7 @@ Name | Type | Description
 **maxNodeVersion**?🔹 | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
-**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: No minimum version is being enforced
 **minNodeVersion**?🔹 | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?🔹 | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?🔹 | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.
@@ -14084,7 +14084,7 @@ Name | Type | Description
 **maxNodeVersion**?🔹 | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
-**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: No minimum version is being enforced
 **minNodeVersion**?🔹 | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?🔹 | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?🔹 | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.
@@ -14273,7 +14273,7 @@ Name | Type | Description
 **maxNodeVersion**?🔹 | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
-**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: No minimum version is being enforced
 **minNodeVersion**?🔹 | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?🔹 | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?🔹 | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.
@@ -16171,7 +16171,7 @@ Name | Type | Description
 **maxNodeVersion**?🔹 | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
-**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: No minimum version is being enforced
 **minNodeVersion**?🔹 | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?🔹 | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?🔹 | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.
@@ -17167,7 +17167,7 @@ Name | Type | Description
 **githubRelease**?🔹 | <code>boolean</code> | Create a GitHub release for each release.<br/>__*Default*__: true
 **jsiiReleaseVersion**?🔹 | <code>string</code> | Version requirement of `publib` which is used to publish modules to npm.<br/>__*Default*__: "latest"
 **majorVersion**?🔹 | <code>number</code> | Major version to release from the default branch.<br/>__*Default*__: Major version is not enforced.
-**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: No minimum version is being enforced
 **npmDistTag**?🔹 | <code>string</code> | The npmDistTag to use when publishing from the default branch.<br/>__*Default*__: "latest"
 **postBuildSteps**?🔹 | <code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code> | Steps to execute after build as part of the release workflow.<br/>__*Default*__: []
 **prerelease**?🔹 | <code>string</code> | Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre").<br/>__*Default*__: normal semantic versions
@@ -17199,7 +17199,7 @@ Name | Type | Description
 -----|------|-------------
 **jsiiReleaseVersion**?🔹 | <code>string</code> | Version requirement of `publib` which is used to publish modules to npm.<br/>__*Default*__: "latest"
 **majorVersion**?🔹 | <code>number</code> | Major version to release from the default branch.<br/>__*Default*__: Major version is not enforced.
-**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: No minimum version is being enforced
 **npmDistTag**?🔹 | <code>string</code> | The npmDistTag to use when publishing from the default branch.<br/>__*Default*__: "latest"
 **postBuildSteps**?🔹 | <code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code> | Steps to execute after build as part of the release workflow.<br/>__*Default*__: []
 **prerelease**?🔹 | <code>string</code> | Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre").<br/>__*Default*__: normal semantic versions
@@ -17314,7 +17314,7 @@ Name | Type | Description
 **maxNodeVersion**?⚠️ | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
-**minMajorVersion**?⚠️ | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
+**minMajorVersion**?⚠️ | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: No minimum version is being enforced
 **minNodeVersion**?⚠️ | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?⚠️ | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?⚠️ | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.
@@ -17457,7 +17457,7 @@ Name | Type | Description
 **maxNodeVersion**?🔹 | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
-**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: No minimum version is being enforced
 **minNodeVersion**?🔹 | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?🔹 | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?🔹 | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.
@@ -17698,7 +17698,7 @@ Name | Type | Description
 **maxNodeVersion**?🔹 | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
-**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: No minimum version is being enforced
 **minNodeVersion**?🔹 | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?🔹 | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?🔹 | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.
@@ -17836,7 +17836,7 @@ Name | Type | Description
 **maxNodeVersion**?🔹 | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
-**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: No minimum version is being enforced
 **minNodeVersion**?🔹 | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?🔹 | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?🔹 | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.
@@ -18002,7 +18002,7 @@ Name | Type | Description
 **maxNodeVersion**?🔹 | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
-**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: No minimum version is being enforced
 **minNodeVersion**?🔹 | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?🔹 | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?🔹 | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.
@@ -18169,7 +18169,7 @@ Name | Type | Description
 **maxNodeVersion**?🔹 | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
-**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: No minimum version is being enforced
 **minNodeVersion**?🔹 | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?🔹 | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?🔹 | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.

--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -3225,6 +3225,7 @@ new awscdk.AwsCdkConstructLibrary(options: AwsCdkConstructLibraryOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -3858,6 +3859,7 @@ new awscdk.AwsCdkTypeScriptApp(options: AwsCdkTypeScriptAppOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -4165,6 +4167,7 @@ new awscdk.ConstructLibraryAws(options: AwsCdkConstructLibraryOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -4781,6 +4784,7 @@ new cdk.ConstructLibrary(options: ConstructLibraryOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -5035,6 +5039,7 @@ new cdk.JsiiProject(options: JsiiProjectOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -5441,6 +5446,7 @@ new cdk8s.Cdk8sTypeScriptApp(options: Cdk8sTypeScriptAppOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -5620,6 +5626,7 @@ new cdk8s.ConstructLibraryCdk8s(options: ConstructLibraryCdk8sOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -5857,6 +5864,7 @@ new cdktf.ConstructLibraryCdktf(options: ConstructLibraryCdktfOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -8076,6 +8084,7 @@ new javascript.NodeProject(options: NodeProjectOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -9600,6 +9609,7 @@ new release.Release(project: GitHubProject, options: ReleaseOptions)
 * **options** (<code>[release.ReleaseOptions](#projen-release-releaseoptions)</code>)  *No description*
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -9653,6 +9663,7 @@ addBranch(branch: string, options: BranchOptions): void
 * **branch** (<code>string</code>)  The branch to monitor (e.g. `main`, `v2.x`).
 * **options** (<code>[release.BranchOptions](#projen-release-branchoptions)</code>)  Branch definition.
   * **majorVersion** (<code>number</code>)  The major versions released from this branch. 
+  * **minMajorVersion** (<code>number</code>)  The minimum major version to release. __*Optional*__
   * **npmDistTag** (<code>string</code>)  The npm distribution tag to use for this branch. __*Default*__: "latest"
   * **prerelease** (<code>string</code>)  Bump the version as a pre-release tag. __*Default*__: normal releases
   * **tagPrefix** (<code>string</code>)  Automatically add the given prefix to release tags. Useful if you are releasing on multiple branches with overlapping version numbers. __*Default*__: no prefix
@@ -9891,6 +9902,7 @@ new typescript.TypeScriptAppProject(options: TypeScriptProjectOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -10043,6 +10055,7 @@ new typescript.TypeScriptLibraryProject(options: TypeScriptProjectOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -10195,6 +10208,7 @@ new typescript.TypeScriptProject(options: TypeScriptProjectOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -10592,6 +10606,7 @@ new web.NextJsProject(options: NextJsProjectOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -10742,6 +10757,7 @@ new web.NextJsTypeScriptProject(options: NextJsTypeScriptProjectOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -10964,6 +10980,7 @@ new web.ReactProject(options: ReactProjectOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -11156,6 +11173,7 @@ new web.ReactTypeScriptProject(options: ReactTypeScriptProjectOptions)
   * **stability** (<code>string</code>)  Package's Stability. __*Optional*__
   * **jsiiReleaseVersion** (<code>string</code>)  Version requirement of `publib` which is used to publish modules to npm. __*Default*__: "latest"
   * **majorVersion** (<code>number</code>)  Major version to release from the default branch. __*Default*__: Major version is not enforced.
+  * **minMajorVersion** (<code>number</code>)  Minimal Major version to release. __*Default*__: start releasing with major version 0
   * **npmDistTag** (<code>string</code>)  The npmDistTag to use when publishing from the default branch. __*Default*__: "latest"
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build as part of the release workflow. __*Default*__: []
   * **prerelease** (<code>string</code>)  Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre"). __*Default*__: normal semantic versions
@@ -12316,6 +12334,7 @@ Name | Type | Description
 **maxNodeVersion**?🔹 | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
 **minNodeVersion**?🔹 | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?🔹 | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?🔹 | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.
@@ -12692,6 +12711,7 @@ Name | Type | Description
 **maxNodeVersion**?🔹 | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
 **minNodeVersion**?🔹 | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?🔹 | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?🔹 | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.
@@ -12898,6 +12918,7 @@ Name | Type | Description
 **maxNodeVersion**?⚠️ | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
+**minMajorVersion**?⚠️ | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
 **minNodeVersion**?⚠️ | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?⚠️ | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?⚠️ | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.
@@ -13304,6 +13325,7 @@ Name | Type | Description
 **maxNodeVersion**?🔹 | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
 **minNodeVersion**?🔹 | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?🔹 | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?🔹 | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.
@@ -13568,6 +13590,7 @@ Name | Type | Description
 **maxNodeVersion**?🔹 | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
 **minNodeVersion**?🔹 | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?🔹 | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?🔹 | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.
@@ -13903,6 +13926,7 @@ Name | Type | Description
 **maxNodeVersion**?🔹 | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
 **minNodeVersion**?🔹 | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?🔹 | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?🔹 | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.
@@ -14060,6 +14084,7 @@ Name | Type | Description
 **maxNodeVersion**?🔹 | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
 **minNodeVersion**?🔹 | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?🔹 | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?🔹 | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.
@@ -14248,6 +14273,7 @@ Name | Type | Description
 **maxNodeVersion**?🔹 | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
 **minNodeVersion**?🔹 | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?🔹 | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?🔹 | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.
@@ -16145,6 +16171,7 @@ Name | Type | Description
 **maxNodeVersion**?🔹 | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
 **minNodeVersion**?🔹 | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?🔹 | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?🔹 | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.
@@ -16825,6 +16852,7 @@ Options for a release branch.
 Name | Type | Description 
 -----|------|-------------
 **majorVersion**🔹 | <code>number</code> | The major versions released from this branch.
+**minMajorVersion**?🔹 | <code>number</code> | The minimum major version to release.<br/>__*Optional*__
 **npmDistTag**?🔹 | <code>string</code> | The npm distribution tag to use for this branch.<br/>__*Default*__: "latest"
 **prerelease**?🔹 | <code>string</code> | Bump the version as a pre-release tag.<br/>__*Default*__: normal releases
 **tagPrefix**?🔹 | <code>string</code> | Automatically add the given prefix to release tags. Useful if you are releasing on multiple branches with overlapping version numbers.<br/>__*Default*__: no prefix
@@ -17139,6 +17167,7 @@ Name | Type | Description
 **githubRelease**?🔹 | <code>boolean</code> | Create a GitHub release for each release.<br/>__*Default*__: true
 **jsiiReleaseVersion**?🔹 | <code>string</code> | Version requirement of `publib` which is used to publish modules to npm.<br/>__*Default*__: "latest"
 **majorVersion**?🔹 | <code>number</code> | Major version to release from the default branch.<br/>__*Default*__: Major version is not enforced.
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
 **npmDistTag**?🔹 | <code>string</code> | The npmDistTag to use when publishing from the default branch.<br/>__*Default*__: "latest"
 **postBuildSteps**?🔹 | <code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code> | Steps to execute after build as part of the release workflow.<br/>__*Default*__: []
 **prerelease**?🔹 | <code>string</code> | Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre").<br/>__*Default*__: normal semantic versions
@@ -17170,6 +17199,7 @@ Name | Type | Description
 -----|------|-------------
 **jsiiReleaseVersion**?🔹 | <code>string</code> | Version requirement of `publib` which is used to publish modules to npm.<br/>__*Default*__: "latest"
 **majorVersion**?🔹 | <code>number</code> | Major version to release from the default branch.<br/>__*Default*__: Major version is not enforced.
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
 **npmDistTag**?🔹 | <code>string</code> | The npmDistTag to use when publishing from the default branch.<br/>__*Default*__: "latest"
 **postBuildSteps**?🔹 | <code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code> | Steps to execute after build as part of the release workflow.<br/>__*Default*__: []
 **prerelease**?🔹 | <code>string</code> | Bump versions from the default branch as pre-releases (e.g. "beta", "alpha", "pre").<br/>__*Default*__: normal semantic versions
@@ -17284,6 +17314,7 @@ Name | Type | Description
 **maxNodeVersion**?⚠️ | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
+**minMajorVersion**?⚠️ | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
 **minNodeVersion**?⚠️ | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?⚠️ | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?⚠️ | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.
@@ -17426,6 +17457,7 @@ Name | Type | Description
 **maxNodeVersion**?🔹 | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
 **minNodeVersion**?🔹 | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?🔹 | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?🔹 | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.
@@ -17666,6 +17698,7 @@ Name | Type | Description
 **maxNodeVersion**?🔹 | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
 **minNodeVersion**?🔹 | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?🔹 | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?🔹 | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.
@@ -17803,6 +17836,7 @@ Name | Type | Description
 **maxNodeVersion**?🔹 | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
 **minNodeVersion**?🔹 | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?🔹 | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?🔹 | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.
@@ -17968,6 +18002,7 @@ Name | Type | Description
 **maxNodeVersion**?🔹 | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
 **minNodeVersion**?🔹 | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?🔹 | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?🔹 | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.
@@ -18134,6 +18169,7 @@ Name | Type | Description
 **maxNodeVersion**?🔹 | <code>string</code> | Minimum node.js version to require via `engines` (inclusive).<br/>__*Default*__: no max
 **mergify**?⚠️ | <code>boolean</code> | Whether mergify should be enabled on this repository or not.<br/>__*Default*__: true
 **mergifyOptions**?⚠️ | <code>[github.MergifyOptions](#projen-github-mergifyoptions)</code> | Options for mergify.<br/>__*Default*__: default options
+**minMajorVersion**?🔹 | <code>number</code> | Minimal Major version to release.<br/>__*Default*__: start releasing with major version 0
 **minNodeVersion**?🔹 | <code>string</code> | Minimum Node.js version to require via package.json `engines` (inclusive).<br/>__*Default*__: no "engines" specified
 **mutableBuild**?🔹 | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
 **npmAccess**?🔹 | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | Access level of the npm package.<br/>__*Default*__: for scoped packages (e.g. `foo@bar`), the default is `NpmAccess.RESTRICTED`, for non-scoped packages, the default is `NpmAccess.PUBLIC`.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -29,6 +29,12 @@ For example:
 tagPrefix: 'stable/'
 ```
 
+It is also possible to release multiple major versions from the same branch. By adding a `!` to your commit message you can indicate a breaking change, thus triggering a major version change. If you start out with the `0` major version a breaking change in this pre-stable version will lead to the minor version increasing. You can set the `minMajorVersion` to `1` so that breaking changes increase the major version.
+
+```js
+minMajorVersion: 1
+```
+
 ## Release Branches
 
 Our release model is based on [trunk-based development](https://trunkbaseddevelopment.com/). This means that commits to the default 

--- a/src/release/bump-version.task.ts
+++ b/src/release/bump-version.task.ts
@@ -11,6 +11,7 @@
  * - PRERELEASE: (optional) a prerelease tag to use (e.g. "beta")
  * - MAJOR: major version number NN to filter (tags are filtered by "vNN."
  *   prefix). if not specified, the last major version is selected
+ * - MIN_MAJOR: minimum major version number to use
  * - CHANGELOG: name of changelog file to create
  * - RELEASE_TAG_PREFIX: (optional) a prefix to apply to the release tag
  *
@@ -21,6 +22,7 @@ import { bump, BumpOptions } from "./bump-version";
 const versionFile = process.env.OUTFILE;
 const prerelease = process.env.PRERELEASE;
 const major = process.env.MAJOR;
+const minMajor = process.env.MIN_MAJOR;
 const changelog = process.env.CHANGELOG;
 const bumpFile = process.env.BUMPFILE;
 const releaseTagFile = process.env.RELEASETAG;
@@ -49,10 +51,17 @@ if (Number.isNaN(majorVersion)) {
   throw new Error(`MAJOR must be a number: ${majorVersion}`);
 }
 
+const minMajorVersion =
+  minMajor == null || minMajor === "" ? undefined : parseInt(minMajor);
+if (Number.isNaN(minMajorVersion)) {
+  throw new Error(`minMajor must be a number: ${minMajorVersion}`);
+}
+
 const opts: BumpOptions = {
   versionFile: versionFile,
   changelog: changelog,
   majorVersion: majorVersion,
+  minMajorVersion: minMajorVersion,
   prerelease: prerelease,
   bumpFile: bumpFile,
   releaseTagFile: releaseTagFile,

--- a/src/release/bump-version.ts
+++ b/src/release/bump-version.ts
@@ -39,7 +39,7 @@ export interface BumpOptions {
    *
    * Can not be set together with `majorVersion`.
    *
-   * @default - start releasing with major version 0
+   * @default - No minimum version is being enforced
    */
   readonly minMajorVersion?: number;
 

--- a/src/release/bump-version.ts
+++ b/src/release/bump-version.ts
@@ -25,9 +25,23 @@ export interface BumpOptions {
    * Defines the major version line. This is used to select the latest version
    * and also enforce that new major versions are not released accidentally.
    *
+   * Can not be set together with `minMajorVersion`.
+   *
    * @default - any version is supported
    */
   readonly majorVersion?: number;
+
+  /**
+   * Defines the minimal major version. This is used if you want to start with
+   * a specific major version, and increment from there on.
+   * This can be useful to set to 1, as breaking changes before the 1.x major
+   * release are not incrementing the major version number.
+   *
+   * Can not be set together with `majorVersion`.
+   *
+   * @default - start releasing with major version 0
+   */
+  readonly minMajorVersion?: number;
 
   /**
    * The name of a file which will include the output version number (a text file).
@@ -73,10 +87,16 @@ export async function bump(cwd: string, options: BumpOptions) {
   const versionFile = join(cwd, options.versionFile);
   const prerelease = options.prerelease;
   const major = options.majorVersion;
+  const minMajorVersion = options.minMajorVersion;
   const prefix = options.tagPrefix ?? "";
   const bumpFile = join(cwd, options.bumpFile);
   const changelogFile = join(cwd, options.changelog);
   const releaseTagFile = join(cwd, options.releaseTagFile);
+  if (major && minMajorVersion) {
+    throw new Error(
+      `minMajorVersion and majorVersion cannot be used together.`
+    );
+  }
 
   await mkdirp(dirname(bumpFile));
   await mkdirp(dirname(changelogFile));
@@ -133,6 +153,13 @@ export async function bump(cwd: string, options: BumpOptions) {
   }
   if (prefix) {
     cmd.push(`--tag-prefix ${prefix}v`);
+  }
+  if (minMajorVersion) {
+    const [majorVersion] = latestVersion.split(".");
+    const majorVersionNumber = parseInt(majorVersion, 10);
+    if (majorVersionNumber < minMajorVersion) {
+      cmd.push(`--release-as ${minMajorVersion}.0.0`);
+    }
   }
 
   exec(cmd.join(" "), { cwd });

--- a/src/release/release.ts
+++ b/src/release/release.ts
@@ -79,6 +79,19 @@ export interface ReleaseProjectOptions {
   readonly majorVersion?: number;
 
   /**
+   * Minimal Major version to release
+   *
+   *
+   * This can be useful to set to 1, as breaking changes before the 1.x major
+   * release are not incrementing the major version number.
+   *
+   * Can not be set together with `majorVersion`.
+   *
+   * @default - start releasing with major version 0
+   */
+  readonly minMajorVersion?: number;
+
+  /**
    * Bump versions from the default branch as pre-releases (e.g. "beta",
    * "alpha", "pre").
    *
@@ -345,6 +358,7 @@ export class Release extends Component {
     this.defaultBranch = this._addBranch(options.branch, {
       prerelease: options.prerelease,
       majorVersion: options.majorVersion,
+      minMajorVersion: options.minMajorVersion,
       workflowName: options.releaseWorkflowName ?? "release",
       tagPrefix: options.releaseTagPrefix,
       npmDistTag: options.npmDistTag,
@@ -613,6 +627,11 @@ export interface BranchOptions {
    * The major versions released from this branch.
    */
   readonly majorVersion: number;
+
+  /**
+   * The minimum major version to release.
+   */
+  readonly minMajorVersion?: number;
 
   /**
    * Bump the version as a pre-release tag.

--- a/src/release/release.ts
+++ b/src/release/release.ts
@@ -87,7 +87,7 @@ export interface ReleaseProjectOptions {
    *
    * Can not be set together with `majorVersion`.
    *
-   * @default - start releasing with major version 0
+   * @default - No minimum version is being enforced
    */
   readonly minMajorVersion?: number;
 

--- a/test/__snapshots__/inventory.test.ts.snap
+++ b/test/__snapshots__/inventory.test.ts.snap
@@ -3662,6 +3662,23 @@ Array [
         "switch": "mergify-options",
       },
       Object {
+        "default": "- start releasing with major version 0",
+        "docs": "Minimal Major version to release.",
+        "featured": false,
+        "fullType": Object {
+          "primitive": "number",
+        },
+        "jsonLike": true,
+        "name": "minMajorVersion",
+        "optional": true,
+        "parent": "ReleaseProjectOptions",
+        "path": Array [
+          "minMajorVersion",
+        ],
+        "simpleType": "number",
+        "switch": "min-major-version",
+      },
+      Object {
         "default": "- no \\"engines\\" specified",
         "docs": "Minimum Node.js version to require via package.json \`engines\` (inclusive).",
         "featured": false,
@@ -6449,6 +6466,23 @@ Array [
         ],
         "simpleType": "MergifyOptions",
         "switch": "mergify-options",
+      },
+      Object {
+        "default": "- start releasing with major version 0",
+        "docs": "Minimal Major version to release.",
+        "featured": false,
+        "fullType": Object {
+          "primitive": "number",
+        },
+        "jsonLike": true,
+        "name": "minMajorVersion",
+        "optional": true,
+        "parent": "ReleaseProjectOptions",
+        "path": Array [
+          "minMajorVersion",
+        ],
+        "simpleType": "number",
+        "switch": "min-major-version",
       },
       Object {
         "default": "- no \\"engines\\" specified",
@@ -10317,6 +10351,23 @@ Array [
         "switch": "mergify-options",
       },
       Object {
+        "default": "- start releasing with major version 0",
+        "docs": "Minimal Major version to release.",
+        "featured": false,
+        "fullType": Object {
+          "primitive": "number",
+        },
+        "jsonLike": true,
+        "name": "minMajorVersion",
+        "optional": true,
+        "parent": "ReleaseProjectOptions",
+        "path": Array [
+          "minMajorVersion",
+        ],
+        "simpleType": "number",
+        "switch": "min-major-version",
+      },
+      Object {
         "default": "- no \\"engines\\" specified",
         "docs": "Minimum Node.js version to require via package.json \`engines\` (inclusive).",
         "featured": false,
@@ -12908,6 +12959,23 @@ Array [
         ],
         "simpleType": "MergifyOptions",
         "switch": "mergify-options",
+      },
+      Object {
+        "default": "- start releasing with major version 0",
+        "docs": "Minimal Major version to release.",
+        "featured": false,
+        "fullType": Object {
+          "primitive": "number",
+        },
+        "jsonLike": true,
+        "name": "minMajorVersion",
+        "optional": true,
+        "parent": "ReleaseProjectOptions",
+        "path": Array [
+          "minMajorVersion",
+        ],
+        "simpleType": "number",
+        "switch": "min-major-version",
       },
       Object {
         "default": "- no \\"engines\\" specified",
@@ -15559,6 +15627,23 @@ Array [
         ],
         "simpleType": "MergifyOptions",
         "switch": "mergify-options",
+      },
+      Object {
+        "default": "- start releasing with major version 0",
+        "docs": "Minimal Major version to release.",
+        "featured": false,
+        "fullType": Object {
+          "primitive": "number",
+        },
+        "jsonLike": true,
+        "name": "minMajorVersion",
+        "optional": true,
+        "parent": "ReleaseProjectOptions",
+        "path": Array [
+          "minMajorVersion",
+        ],
+        "simpleType": "number",
+        "switch": "min-major-version",
       },
       Object {
         "default": "- no \\"engines\\" specified",
@@ -18940,6 +19025,23 @@ Array [
         "switch": "mergify-options",
       },
       Object {
+        "default": "- start releasing with major version 0",
+        "docs": "Minimal Major version to release.",
+        "featured": false,
+        "fullType": Object {
+          "primitive": "number",
+        },
+        "jsonLike": true,
+        "name": "minMajorVersion",
+        "optional": true,
+        "parent": "ReleaseProjectOptions",
+        "path": Array [
+          "minMajorVersion",
+        ],
+        "simpleType": "number",
+        "switch": "min-major-version",
+      },
+      Object {
         "default": "- no \\"engines\\" specified",
         "docs": "Minimum Node.js version to require via package.json \`engines\` (inclusive).",
         "featured": false,
@@ -21313,6 +21415,23 @@ Array [
         "switch": "mergify-options",
       },
       Object {
+        "default": "- start releasing with major version 0",
+        "docs": "Minimal Major version to release.",
+        "featured": false,
+        "fullType": Object {
+          "primitive": "number",
+        },
+        "jsonLike": true,
+        "name": "minMajorVersion",
+        "optional": true,
+        "parent": "ReleaseProjectOptions",
+        "path": Array [
+          "minMajorVersion",
+        ],
+        "simpleType": "number",
+        "switch": "min-major-version",
+      },
+      Object {
         "default": "- no \\"engines\\" specified",
         "docs": "Minimum Node.js version to require via package.json \`engines\` (inclusive).",
         "featured": false,
@@ -23574,6 +23693,23 @@ Array [
         "switch": "mergify-options",
       },
       Object {
+        "default": "- start releasing with major version 0",
+        "docs": "Minimal Major version to release.",
+        "featured": false,
+        "fullType": Object {
+          "primitive": "number",
+        },
+        "jsonLike": true,
+        "name": "minMajorVersion",
+        "optional": true,
+        "parent": "ReleaseProjectOptions",
+        "path": Array [
+          "minMajorVersion",
+        ],
+        "simpleType": "number",
+        "switch": "min-major-version",
+      },
+      Object {
         "default": "- no \\"engines\\" specified",
         "docs": "Minimum Node.js version to require via package.json \`engines\` (inclusive).",
         "featured": false,
@@ -25819,6 +25955,23 @@ Array [
         ],
         "simpleType": "MergifyOptions",
         "switch": "mergify-options",
+      },
+      Object {
+        "default": "- start releasing with major version 0",
+        "docs": "Minimal Major version to release.",
+        "featured": false,
+        "fullType": Object {
+          "primitive": "number",
+        },
+        "jsonLike": true,
+        "name": "minMajorVersion",
+        "optional": true,
+        "parent": "ReleaseProjectOptions",
+        "path": Array [
+          "minMajorVersion",
+        ],
+        "simpleType": "number",
+        "switch": "min-major-version",
       },
       Object {
         "default": "- no \\"engines\\" specified",
@@ -28984,6 +29137,23 @@ Array [
         "switch": "mergify-options",
       },
       Object {
+        "default": "- start releasing with major version 0",
+        "docs": "Minimal Major version to release.",
+        "featured": false,
+        "fullType": Object {
+          "primitive": "number",
+        },
+        "jsonLike": true,
+        "name": "minMajorVersion",
+        "optional": true,
+        "parent": "ReleaseProjectOptions",
+        "path": Array [
+          "minMajorVersion",
+        ],
+        "simpleType": "number",
+        "switch": "min-major-version",
+      },
+      Object {
         "default": "- no \\"engines\\" specified",
         "docs": "Minimum Node.js version to require via package.json \`engines\` (inclusive).",
         "featured": false,
@@ -31231,6 +31401,23 @@ Array [
         ],
         "simpleType": "MergifyOptions",
         "switch": "mergify-options",
+      },
+      Object {
+        "default": "- start releasing with major version 0",
+        "docs": "Minimal Major version to release.",
+        "featured": false,
+        "fullType": Object {
+          "primitive": "number",
+        },
+        "jsonLike": true,
+        "name": "minMajorVersion",
+        "optional": true,
+        "parent": "ReleaseProjectOptions",
+        "path": Array [
+          "minMajorVersion",
+        ],
+        "simpleType": "number",
+        "switch": "min-major-version",
       },
       Object {
         "default": "- no \\"engines\\" specified",
@@ -33606,6 +33793,23 @@ Array [
         "switch": "mergify-options",
       },
       Object {
+        "default": "- start releasing with major version 0",
+        "docs": "Minimal Major version to release.",
+        "featured": false,
+        "fullType": Object {
+          "primitive": "number",
+        },
+        "jsonLike": true,
+        "name": "minMajorVersion",
+        "optional": true,
+        "parent": "ReleaseProjectOptions",
+        "path": Array [
+          "minMajorVersion",
+        ],
+        "simpleType": "number",
+        "switch": "min-major-version",
+      },
+      Object {
         "default": "- no \\"engines\\" specified",
         "docs": "Minimum Node.js version to require via package.json \`engines\` (inclusive).",
         "featured": false,
@@ -35955,6 +36159,23 @@ Array [
         ],
         "simpleType": "MergifyOptions",
         "switch": "mergify-options",
+      },
+      Object {
+        "default": "- start releasing with major version 0",
+        "docs": "Minimal Major version to release.",
+        "featured": false,
+        "fullType": Object {
+          "primitive": "number",
+        },
+        "jsonLike": true,
+        "name": "minMajorVersion",
+        "optional": true,
+        "parent": "ReleaseProjectOptions",
+        "path": Array [
+          "minMajorVersion",
+        ],
+        "simpleType": "number",
+        "switch": "min-major-version",
       },
       Object {
         "default": "- no \\"engines\\" specified",

--- a/test/__snapshots__/inventory.test.ts.snap
+++ b/test/__snapshots__/inventory.test.ts.snap
@@ -3662,7 +3662,7 @@ Array [
         "switch": "mergify-options",
       },
       Object {
-        "default": "- start releasing with major version 0",
+        "default": "- No minimum version is being enforced",
         "docs": "Minimal Major version to release.",
         "featured": false,
         "fullType": Object {
@@ -6468,7 +6468,7 @@ Array [
         "switch": "mergify-options",
       },
       Object {
-        "default": "- start releasing with major version 0",
+        "default": "- No minimum version is being enforced",
         "docs": "Minimal Major version to release.",
         "featured": false,
         "fullType": Object {
@@ -10351,7 +10351,7 @@ Array [
         "switch": "mergify-options",
       },
       Object {
-        "default": "- start releasing with major version 0",
+        "default": "- No minimum version is being enforced",
         "docs": "Minimal Major version to release.",
         "featured": false,
         "fullType": Object {
@@ -12961,7 +12961,7 @@ Array [
         "switch": "mergify-options",
       },
       Object {
-        "default": "- start releasing with major version 0",
+        "default": "- No minimum version is being enforced",
         "docs": "Minimal Major version to release.",
         "featured": false,
         "fullType": Object {
@@ -15629,7 +15629,7 @@ Array [
         "switch": "mergify-options",
       },
       Object {
-        "default": "- start releasing with major version 0",
+        "default": "- No minimum version is being enforced",
         "docs": "Minimal Major version to release.",
         "featured": false,
         "fullType": Object {
@@ -19025,7 +19025,7 @@ Array [
         "switch": "mergify-options",
       },
       Object {
-        "default": "- start releasing with major version 0",
+        "default": "- No minimum version is being enforced",
         "docs": "Minimal Major version to release.",
         "featured": false,
         "fullType": Object {
@@ -21415,7 +21415,7 @@ Array [
         "switch": "mergify-options",
       },
       Object {
-        "default": "- start releasing with major version 0",
+        "default": "- No minimum version is being enforced",
         "docs": "Minimal Major version to release.",
         "featured": false,
         "fullType": Object {
@@ -23693,7 +23693,7 @@ Array [
         "switch": "mergify-options",
       },
       Object {
-        "default": "- start releasing with major version 0",
+        "default": "- No minimum version is being enforced",
         "docs": "Minimal Major version to release.",
         "featured": false,
         "fullType": Object {
@@ -25957,7 +25957,7 @@ Array [
         "switch": "mergify-options",
       },
       Object {
-        "default": "- start releasing with major version 0",
+        "default": "- No minimum version is being enforced",
         "docs": "Minimal Major version to release.",
         "featured": false,
         "fullType": Object {
@@ -29137,7 +29137,7 @@ Array [
         "switch": "mergify-options",
       },
       Object {
-        "default": "- start releasing with major version 0",
+        "default": "- No minimum version is being enforced",
         "docs": "Minimal Major version to release.",
         "featured": false,
         "fullType": Object {
@@ -31403,7 +31403,7 @@ Array [
         "switch": "mergify-options",
       },
       Object {
-        "default": "- start releasing with major version 0",
+        "default": "- No minimum version is being enforced",
         "docs": "Minimal Major version to release.",
         "featured": false,
         "fullType": Object {
@@ -33793,7 +33793,7 @@ Array [
         "switch": "mergify-options",
       },
       Object {
-        "default": "- start releasing with major version 0",
+        "default": "- No minimum version is being enforced",
         "docs": "Minimal Major version to release.",
         "featured": false,
         "fullType": Object {
@@ -36161,7 +36161,7 @@ Array [
         "switch": "mergify-options",
       },
       Object {
-        "default": "- start releasing with major version 0",
+        "default": "- No minimum version is being enforced",
         "docs": "Minimal Major version to release.",
         "featured": false,
         "fullType": Object {

--- a/test/release/bump.test.ts
+++ b/test/release/bump.test.ts
@@ -214,6 +214,17 @@ test("minMajorVersion keeps release version if version is equal", async () => {
   expect(result.tag).toStrictEqual("v1.2.4");
 });
 
+test("minMajorVersion has no effect if version is higher", async () => {
+  const result = await testBump({
+    options: { minMajorVersion: 1 },
+    commits: [{ message: "v2", tag: "v2.3.3" }, { message: "commit2" }],
+  });
+  expect(result.version).toStrictEqual("2.3.4");
+  expect(result.changelog.includes("## [2.3.4]")).toBeTruthy();
+  expect(result.bumpfile).toStrictEqual("2.3.4");
+  expect(result.tag).toStrictEqual("v2.3.4");
+});
+
 test("minMajorVersion throws if set together with majorVersion", async () => {
   await expect(
     testBump({

--- a/test/release/bump.test.ts
+++ b/test/release/bump.test.ts
@@ -192,6 +192,37 @@ test("customization to versionrc reflects to changelog", async () => {
   await expect(result.changelog).toContain("testCompareUrl");
 });
 
+test("minMajorVersion increases major version if current release is lower", async () => {
+  const result = await testBump({
+    options: { minMajorVersion: 1 },
+    commits: [{ message: "v0", tag: "v0.1.2" }, { message: "commit2" }],
+  });
+  expect(result.version).toStrictEqual("1.0.0");
+  expect(result.changelog.includes("## [1.0.0]")).toBeTruthy();
+  expect(result.bumpfile).toStrictEqual("1.0.0");
+  expect(result.tag).toStrictEqual("v1.0.0");
+});
+
+test("minMajorVersion keeps release version if version is equal", async () => {
+  const result = await testBump({
+    options: { minMajorVersion: 1 },
+    commits: [{ message: "v1", tag: "v1.2.3" }, { message: "commit2" }],
+  });
+  expect(result.version).toStrictEqual("1.2.4");
+  expect(result.changelog.includes("## [1.2.4]")).toBeTruthy();
+  expect(result.bumpfile).toStrictEqual("1.2.4");
+  expect(result.tag).toStrictEqual("v1.2.4");
+});
+
+test("minMajorVersion throws if set together with majorVersion", async () => {
+  await expect(
+    testBump({
+      options: { minMajorVersion: 1, majorVersion: 1 },
+      commits: [{ message: "v0", tag: "v0.1.2" }, { message: "commit2" }],
+    })
+  ).rejects.toThrow(/minMajorVersion and majorVersion cannot be used together/);
+});
+
 //----------------------------------------------------------------------------------------------------------------------------------
 
 async function testBump(


### PR DESCRIPTION
This new option is really convenient when you have a generated project that is self updating like the cdktf pre-built providers. With the current setup it's impossible to increase the major version without manual intervention. Since breaking changes in a 0.x version only result in a minor version increase there is no way to get to a higher major version.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.