### PR TITLE
fix(awscdk): fix pytest import path

### DIFF
--- a/src/awscdk/awscdk-pytest-sample.ts
+++ b/src/awscdk/awscdk-pytest-sample.ts
@@ -13,7 +13,7 @@ export class AwsCdkPytestSample extends Component {
           "from aws_cdk import App",
           "from aws_cdk.assertions import Template",
           "",
-          `from ${project.moduleName}.my_stack import MyStack`,
+          `from ${project.moduleName}.main import MyStack`,
           "",
           "@pytest.fixture(scope='module')",
           "def template():",


### PR DESCRIPTION
The python app file being generated by awscdk-app-py is main.py but the test_example.py is trying to import from my_stack, causing the first build to fail. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.