### PR TITLE
fix(jsii-docgen): annotate output as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,6 +22,7 @@
 /.projen/files.json linguist-generated
 /.projen/tasks.json linguist-generated
 /.vscode/launch.json linguist-generated
+/docs/api/API.md linguist-generated
 /LICENSE linguist-generated
 /package.json linguist-generated
 /projen.bash linguist-generated

--- a/src/cdk/jsii-docgen.ts
+++ b/src/cdk/jsii-docgen.ts
@@ -31,5 +31,6 @@ export class JsiiDocgen {
     // spawn docgen after compilation (requires the .jsii manifest).
     project.postCompileTask.spawn(docgen);
     project.gitignore.include(`/${filePath}`);
+    project.annotateGenerated(`/${filePath}`);
   }
 }

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -250,6 +250,7 @@ Object {
 /.projen/deps.json linguist-generated
 /.projen/files.json linguist-generated
 /.projen/tasks.json linguist-generated
+/API.md linguist-generated
 /LICENSE linguist-generated
 /package.json linguist-generated
 /tsconfig.dev.json linguist-generated
@@ -2157,6 +2158,7 @@ Object {
 /.projen/deps.json linguist-generated
 /.projen/files.json linguist-generated
 /.projen/tasks.json linguist-generated
+/API.md linguist-generated
 /LICENSE linguist-generated
 /package.json linguist-generated
 /tsconfig.dev.json linguist-generated


### PR DESCRIPTION
The API.md file generated by jsii-docgen is machine-generated, so it should be annotated as such in PR diffs.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.