### PR TITLE
fix: build breaks after update of @types/semver

### DIFF
--- a/src/util/semver.ts
+++ b/src/util/semver.ts
@@ -90,7 +90,7 @@ export function toReleaseVersion(
   assemblyVersion: string,
   target: TargetName
 ): string {
-  const version = parse(assemblyVersion, { includePrerelease: true });
+  const version = parse(assemblyVersion);
   if (version == null) {
     throw new Error(
       `Unable to parse the provided assembly version: "${assemblyVersion}"`


### PR DESCRIPTION
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61586 introduces stricter types for the `semver` package, which in turn caused https://github.com/projen/projen/pull/2028 to fail the build when attempting to update `@types/semver` to the latest version.

This fix removes the parameter that is not compatible with the new types. The parameter is unused by the respective code in `semver` and we are not exposing the returned semver object, so this is a safe change.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.