### PR TITLE
chore: fix tests failing locally if git gpgsign is configured

### DIFF
--- a/test/release/bump.test.ts
+++ b/test/release/bump.test.ts
@@ -256,6 +256,7 @@ async function testBump(
   git('config user.email "you@example.com"');
   git('config user.name "Your Name"');
   git("config commit.gpgsign false");
+  git("config tag.gpgsign false");
 
   const commit = async (message: string) => {
     await writeFile(join(workdir, "dummy.txt"), message);

--- a/test/release/tag.test.ts
+++ b/test/release/tag.test.ts
@@ -65,6 +65,7 @@ async function testTag(opts: TestTagOpts = {}) {
   git('config user.email "you@example.com"');
   git('config user.name "Your Name"');
   git("config commit.gpgsign false");
+  git("config tag.gpgsign false");
   await writeFile(
     join(workdir, opts.testOptions?.releaseTagPath || "", releaseTagFile),
     releaseTag

--- a/test/util.ts
+++ b/test/util.ts
@@ -93,6 +93,8 @@ export function withProjectDir(
       shell("git remote add origin git@boom.com:foo/bar.git");
       shell('git config user.name "My User Name"');
       shell('git config user.email "my@user.email.com"');
+      shell("git config commit.gpgsign false");
+      shell("git config tag.gpgsign false");
     } else if (process.env.CI) {
       // if "git" is set to "false", we still want to make sure global user is defined
       // (relevant in CI context)


### PR DESCRIPTION
When running locally, one might have `tag.gpgsign` configured which causes these tests to hang on an open editor/expecting user input. This change disables tag signing as we already do for commits

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.