### PR TITLE
feat(vscode): support VS Code workspace settings

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -131,6 +131,7 @@ Name|Description
 [vscode.DevContainer](#projen-vscode-devcontainer)|A development environment running VSCode in a container;
 [vscode.VsCode](#projen-vscode-vscode)|*No description*
 [vscode.VsCodeLaunchConfig](#projen-vscode-vscodelaunchconfig)|VSCode launch configuration file (launch.json), useful for enabling in-editor debugger.
+[vscode.VsCodeSettings](#projen-vscode-vscodesettings)|VS Code Workspace settings Source: https://code.visualstudio.com/docs/getstarted/settings#_workspace-settings.
 [web.NextComponent](#projen-web-nextcomponent)|*No description*
 [web.NextJsProject](#projen-web-nextjsproject)|Next.js project without TypeScript.
 [web.NextJsTypeScriptProject](#projen-web-nextjstypescriptproject)|Next.js project with TypeScript.
@@ -10632,6 +10633,7 @@ new vscode.VsCode(project: Project)
 Name | Type | Description 
 -----|------|-------------
 **launchConfiguration**🔹 | <code>[vscode.VsCodeLaunchConfig](#projen-vscode-vscodelaunchconfig)</code> | <span></span>
+**settings**🔹 | <code>[vscode.VsCodeSettings](#projen-vscode-vscodesettings)</code> | <span></span>
 
 
 
@@ -10690,6 +10692,60 @@ addConfiguration(cfg: VsCodeLaunchConfigurationEntry): void
   * **stopOnEntry** (<code>boolean</code>)  *No description* __*Optional*__
   * **url** (<code>string</code>)  *No description* __*Optional*__
   * **webRoot** (<code>string</code>)  *No description* __*Optional*__
+
+
+
+
+
+
+## class VsCodeSettings 🔹 <a id="projen-vscode-vscodesettings"></a>
+
+VS Code Workspace settings Source: https://code.visualstudio.com/docs/getstarted/settings#_workspace-settings.
+
+__Submodule__: vscode
+
+__Extends__: [Component](#projen-component)
+
+### Initializer
+
+
+
+
+```ts
+new vscode.VsCodeSettings(vscode: VsCode)
+```
+
+* **vscode** (<code>[vscode.VsCode](#projen-vscode-vscode)</code>)  *No description*
+
+
+### Methods
+
+
+#### addSetting(setting, value, language?)🔹 <a id="projen-vscode-vscodesettings-addsetting"></a>
+
+Adds a workspace setting.
+
+```ts
+addSetting(setting: string, value: any, language?: string): void
+```
+
+* **setting** (<code>string</code>)  The setting ID.
+* **value** (<code>any</code>)  The value of the setting.
+* **language** (<code>string</code>)  Scope the setting to a specific language.
+
+
+
+
+#### addSettings(settings, languages?)🔹 <a id="projen-vscode-vscodesettings-addsettings"></a>
+
+Adds a workspace setting.
+
+```ts
+addSettings(settings: Map<string, any>, languages?: string &#124; Array<string>): void
+```
+
+* **settings** (<code>Map<string, any></code>)  Array structure: [setting: string, value: any, languages?: string[]].
+* **languages** (<code>string &#124; Array<string></code>)  *No description*
 
 
 

--- a/src/vscode/index.ts
+++ b/src/vscode/index.ts
@@ -1,3 +1,4 @@
 export * from "./devcontainer";
 export * from "./launch-config";
+export * from "./settings";
 export * from "./vscode";

--- a/src/vscode/settings.ts
+++ b/src/vscode/settings.ts
@@ -1,0 +1,60 @@
+import { Component } from "../component";
+import { JsonFile } from "../json";
+import { VsCode } from "./vscode";
+
+/**
+ * VS Code Workspace settings
+ * Source: https://code.visualstudio.com/docs/getstarted/settings#_workspace-settings
+ */
+export class VsCodeSettings extends Component {
+  private readonly content: any;
+
+  constructor(vscode: VsCode) {
+    super(vscode.project);
+
+    this.content = {};
+
+    new JsonFile(vscode.project, ".vscode/settings.json", {
+      omitEmpty: false,
+      obj: this.content,
+    });
+  }
+
+  /**
+   * Adds a workspace setting
+   *
+   * @param setting The setting ID
+   * @param value The value of the setting
+   * @param language Scope the setting to a specific language
+   */
+  public addSetting(setting: string, value: unknown, language?: string) {
+    if (language) {
+      this.content[`[${language}]`] = this.content[`[${language}]`] ?? {};
+      this.content[`[${language}]`][setting] = value;
+    } else {
+      this.content[setting] = value;
+    }
+  }
+
+  /**
+   * Adds a workspace setting
+   *
+   * @param settings Array structure: [setting: string, value: any, languages?: string[]]
+   */
+  public addSettings(
+    settings: Record<string, unknown>,
+    languages?: string | string[]
+  ) {
+    if (Array.isArray(languages)) {
+      languages.forEach((language) => {
+        Object.entries(settings).forEach(([setting, value]) =>
+          this.addSetting(setting, value, language)
+        );
+      });
+    } else {
+      Object.entries(settings).forEach(([setting, value]) =>
+        this.addSetting(setting, value, languages)
+      );
+    }
+  }
+}

--- a/src/vscode/vscode.ts
+++ b/src/vscode/vscode.ts
@@ -1,9 +1,11 @@
 import { Component } from "../component";
 import { Project } from "../project";
 import { VsCodeLaunchConfig } from "./launch-config";
+import { VsCodeSettings } from "./settings";
 
 export class VsCode extends Component {
   private _launchConfig?: VsCodeLaunchConfig;
+  private _settings?: VsCodeSettings;
 
   constructor(project: Project) {
     super(project);
@@ -15,5 +17,13 @@ export class VsCode extends Component {
     }
 
     return this._launchConfig;
+  }
+
+  public get settings() {
+    if (!this._settings) {
+      this._settings = new VsCodeSettings(this);
+    }
+
+    return this._settings;
   }
 }

--- a/test/vscode/settings.test.ts
+++ b/test/vscode/settings.test.ts
@@ -1,0 +1,107 @@
+import { synthSnapshot, TestProject } from "../util";
+
+const VSCODE_SETTINGS_FILE = ".vscode/settings.json";
+
+test("no settings configured", () => {
+  // GIVEN
+  const project = new TestProject();
+
+  // WHEN
+  project.vscode?.settings;
+
+  // THEN
+  expect(synthSnapshot(project)).not.toHaveProperty(VSCODE_SETTINGS_FILE);
+});
+
+test("add single settings", () => {
+  // GIVEN
+  const project = new TestProject();
+
+  // WHEN
+  project.vscode?.settings.addSetting("files.autoSave", "afterDelay");
+  project.vscode?.settings.addSetting("editor.minimap.enabled", true);
+  project.vscode?.settings.addSetting("files.autoSaveDelay", 1000);
+  project.vscode?.settings.addSetting("editor.rulers", []);
+  project.vscode?.settings.addSetting("search.exclude", {
+    "**/node_modules": true,
+    "**/bower_components": true,
+  });
+  project.vscode?.settings.addSetting(
+    "editor.defaultFormatter",
+    "esbenp.prettier-vscode",
+    "javascript"
+  );
+  project.vscode?.settings.addSetting(
+    "editor.defaultFormatter",
+    "esbenp.prettier-vscode",
+    "typescript"
+  );
+
+  // THEN
+  const settings = synthSnapshot(project)[VSCODE_SETTINGS_FILE];
+
+  expect(settings).toStrictEqual({
+    "//": expect.anything(),
+    "files.autoSave": "afterDelay",
+    "editor.minimap.enabled": true,
+    "files.autoSaveDelay": 1000,
+    "editor.rulers": [],
+    "search.exclude": { "**/node_modules": true, "**/bower_components": true },
+    "[javascript]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode",
+    },
+    "[typescript]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode",
+    },
+  });
+});
+
+test("batch add settings", () => {
+  // GIVEN
+  const project = new TestProject();
+
+  // WHEN
+  project.vscode?.settings.addSettings({
+    "files.autoSave": "afterDelay",
+    "editor.minimap.enabled": true,
+    "files.autoSaveDelay": 1000,
+    "editor.rulers": [],
+    "search.exclude": { "**/node_modules": true, "**/bower_components": true },
+  });
+  project.vscode?.settings.addSettings(
+    {
+      "editor.defaultFormatter": "esbenp.prettier-vscode",
+      "eslint.format.enable": true,
+    },
+    ["javascript", "typescript"]
+  );
+  project.vscode?.settings.addSettings(
+    {
+      "python.formatting.provider": "black",
+    },
+    "python"
+  );
+
+  // THEN
+  const settings = synthSnapshot(project)[VSCODE_SETTINGS_FILE];
+
+  expect(settings).toStrictEqual({
+    "//": expect.anything(),
+    "files.autoSave": "afterDelay",
+    "editor.minimap.enabled": true,
+    "files.autoSaveDelay": 1000,
+    "editor.rulers": [],
+    "search.exclude": { "**/node_modules": true, "**/bower_components": true },
+    "[javascript]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode",
+      "eslint.format.enable": true,
+    },
+    "[typescript]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode",
+      "eslint.format.enable": true,
+    },
+    "[python]": {
+      "python.formatting.provider": "black",
+    },
+  });
+});


### PR DESCRIPTION
Settings keys languages are not further typed as there are A LOT of
them and plugins can add any new values to it.

Setting values are not typed as they are essentially of type JSON which is
difficult to express in TS and a jsii compatible way.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.