### PR TITLE
feat: Adding notes about forcing release versions

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -35,6 +35,14 @@ It is also possible to release multiple major versions from the same branch. By 
 minMajorVersion: 1
 ```
 
+
+## Forcing Versions
+
+You may be adopting projen in a project that has already been published to previous versions. Projen uses tags to determine the version to start with
+before bumping according to the rules previously mentioned.
+
+You can force the base version number by adding a tag to your repo. For example, if the latest version of your project is 1.2.3, then add a tag to your trunk ('main') branch of `v1.2.3`. The next time the release workflow runs it will bump from version 1.2.3. As mentioned above, this is based on the conventional commits so on the next release you will either get 1.2.4 or 1.3.0.
+
 ## Release Branches
 
 Our release model is based on [trunk-based development](https://trunkbaseddevelopment.com/). This means that commits to the default 


### PR DESCRIPTION
I struggled in the beginning understanding how I could "catch up" a project that was taking on projen to get version numbers to match up, so I added a section about it.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.