### PR TITLE
feat(pom): support adding phase to plugin execution

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -16105,6 +16105,7 @@ Name | Type | Description
 -----|------|-------------
 **goals**🔹 | <code>Array<string></code> | Which Maven goals this plugin should be associated with.
 **id**🔹 | <code>string</code> | The ID.
+**phase**?🔹 | <code>string</code> | The phase in which the plugin should execute.<br/>__*Optional*__
 
 
 

--- a/src/java/pom.ts
+++ b/src/java/pom.ts
@@ -345,6 +345,11 @@ export interface PluginExecution {
    * Which Maven goals this plugin should be associated with.
    */
   readonly goals: string[];
+
+  /**
+   * The phase in which the plugin should execute.
+   */
+  readonly phase?: string;
 }
 
 /**
@@ -384,6 +389,7 @@ function pluginConfig(options: PluginOptions = {}) {
       execution: {
         id: e.id,
         goals: e.goals.map((goal) => ({ goal })),
+        phase: e.phase,
       },
     })),
   };

--- a/test/java/__snapshots__/pom.test.ts.snap
+++ b/test/java/__snapshots__/pom.test.ts.snap
@@ -53,6 +53,23 @@ exports[`addPlugin() 1`] = `
                 </dependencies>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.2</version>
+                <configuration>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>shade-task</id>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>3.0.0</version>

--- a/test/java/pom.test.ts
+++ b/test/java/pom.test.ts
@@ -66,6 +66,19 @@ test("addPlugin()", () => {
     },
   });
 
+  pom.addPlugin("org.apache.maven.plugins/maven-shade-plugin@3.2.2", {
+    configuration: {
+      createDependencyReducedPom: false,
+    },
+    executions: [
+      {
+        id: "shade-task",
+        phase: "package",
+        goals: ["shade"],
+      },
+    ],
+  });
+
   // alteratively
   pom.project.deps.addDependency(
     "org.codehaus.mojo/exec-maven-plugin@3.0.0",


### PR DESCRIPTION
I'd like to be able to build a lambda deployment package using a `JavaProject`. For this I need to use the `maven-shade-plugin` as mentioned here: https://docs.aws.amazon.com/lambda/latest/dg/java-package.html

The plugin execution needs `<phase>package</phase>` in order to run as part of the build. This PR allows this to be optionally specified.

See also: https://maven.apache.org/guides/mini/guide-configuring-plugins.html#Using_the_executions_Tag

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.