### PR TITLE
fix(nextjs): default node versions for Next.js are out-of-date

### DIFF
--- a/src/web/next.ts
+++ b/src/web/next.ts
@@ -76,7 +76,8 @@ export class NextJsProject extends NodeProject {
   constructor(options: NextJsProjectOptions) {
     super({
       jest: false,
-      minNodeVersion: "12.13.0", // https://tailwindcss.com/docs/installation
+      minNodeVersion: "12.22.0", // https://nextjs.org/docs#system-requirements
+      workflowNodeVersion: "14.x",
       ...options,
     });
 
@@ -125,8 +126,9 @@ export class NextJsTypeScriptProject extends TypeScriptAppProject {
     const defaultOptions = {
       srcdir: "pages",
       eslint: false,
-      minNodeVersion: "12.13.0", // https://tailwindcss.com/docs/installation
+      minNodeVersion: "12.22.0", // https://nextjs.org/docs#system-requirements
       jest: false,
+      workflowNodeVersion: "14.x",
       tsconfig: {
         include: ["**/*.ts", "**/*.tsx"],
         compilerOptions: {

--- a/test/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-project.test.ts.snap
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 12.13.0
+          node-version: 14.x
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -157,7 +157,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 12.13.0
+          node-version: 14.x
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -181,7 +181,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.13.0
+          node-version: 14.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -217,7 +217,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 12.13.0
+          node-version: 14.x
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -876,7 +876,7 @@ pull_request_rules:
       "standard-version": "^9",
     },
     "engines": Object {
-      "node": ">= 12.13.0",
+      "node": ">= 12.22.0",
     },
     "license": "Apache-2.0",
     "main": "lib/index.js",

--- a/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 12.13.0
+          node-version: 14.x
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -150,7 +150,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 12.13.0
+          node-version: 14.x
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -783,7 +783,7 @@ tsconfig.tsbuildinfo
       "typescript": "*",
     },
     "engines": Object {
-      "node": ">= 12.13.0",
+      "node": ">= 12.22.0",
     },
     "license": "Apache-2.0",
     "name": "test-nextjs-project",


### PR DESCRIPTION
Updates `minNodeVersion` according to current Next.js requirements
Changes `workflowNodeVersion` to use the oldest version still supported by Node.js

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.