### PR TITLE
fix(release)!: existing tags for prerelease not respected

### DIFF
--- a/src/release/bump-version.ts
+++ b/src/release/bump-version.ts
@@ -291,9 +291,12 @@ function determineLatestTag(options: LatestTagOptions): {
 
   let tags = stdout?.split("\n");
 
-  // if "pre" is set, filter versions that end with "-PRE.ddd".
-  if (prerelease) {
-    tags = tags.filter((x) => new RegExp(`-${prerelease}\.[0-9]+$`).test(x));
+  // if prerelease is set and there are existing prerelease tags, filter versions that end with "-PRE.ddd".
+  const prereleaseTags = tags.filter((x) =>
+    new RegExp(`-${prerelease}\.[0-9]+$`).test(x)
+  );
+  if (prerelease && prereleaseTags.length > 0) {
+    tags = prereleaseTags;
   }
 
   tags = tags.filter((x) => x);

--- a/test/release/bump.test.ts
+++ b/test/release/bump.test.ts
@@ -124,6 +124,24 @@ test("select latest with major", async () => {
   expect(result10.tag).toStrictEqual("v10.21.1");
 });
 
+test("select latest, with prerelease", async () => {
+  const result = await testBump({
+    options: {
+      prerelease: "beta",
+    },
+    commits: [
+      { message: "first version", tag: "v1.1.0" },
+      { message: "feat: new feature" },
+    ],
+  });
+
+  expect(result.version).toEqual("1.2.0-beta.0");
+  expect(result.changelog.includes("Features")).toBeTruthy();
+  expect(result.changelog.includes("new feature")).toBeTruthy();
+  expect(result.bumpfile).toStrictEqual("1.2.0-beta.0");
+  expect(result.tag).toStrictEqual("v1.2.0-beta.0");
+});
+
 test("bump with major equal to 0", async () => {
   const commits = [
     { message: "first version", tag: "v0.1.0" },


### PR DESCRIPTION
This change fixes the behavior of the bump task when a prerelease suffix is set, there are not yet any prerelease tags, but there are other normal tags for the current major version. The current behavior results in "first release" behavior. What should happen, and what this change implements, is a correct semver increment into a new prerelease.

For example,

Given
- A major version of `1`
- a previous tag of `1.2.0`
- a new `feat` commit
- a `prerelease` setting of `beta`

Previously a bump would have resulted in `1.0.0-beta.0`.
Now a bump will result in `1.3.0-beta.0`, as expected.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.