### PR TITLE
fix(react-ts): `@types/express` (4.17.14) and `@types/express-serve-static-core` (4.17.31) break compilation

### DIFF
--- a/src/web/react.ts
+++ b/src/web/react.ts
@@ -176,13 +176,12 @@ export class ReactTypeScriptProject extends TypeScriptAppProject {
         sourceDir: path.join(__dirname, "..", "..", "assets", "web", "react"),
       });
     }
-    
+
     this.package.addPackageResolutions(
       // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/62300
-      '@types/express@4.17.13',
-      '@types/express-serve-static-core@4.17.30',      
+      "@types/express@4.17.13",
+      "@types/express-serve-static-core@4.17.30"
     );
-    
   }
 }
 

--- a/src/web/react.ts
+++ b/src/web/react.ts
@@ -176,6 +176,13 @@ export class ReactTypeScriptProject extends TypeScriptAppProject {
         sourceDir: path.join(__dirname, "..", "..", "assets", "web", "react"),
       });
     }
+    
+    this.package.addPackageResolutions(
+      // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/62300
+      '@types/express@4.17.13',
+      '@types/express-serve-static-core@4.17.30',      
+    );
+    
   }
 }
 

--- a/test/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/react-ts-project.test.ts.snap
@@ -1054,6 +1054,8 @@ tsconfig.tsbuildinfo
     "license": "Apache-2.0",
     "name": "test-nextjs-project",
     "resolutions": Object {
+      "@types/express": "4.17.13",
+      "@types/express-serve-static-core": "4.17.30",
       "@types/responselike": "1.0.0",
       "got": "12.3.1",
     },


### PR DESCRIPTION
See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/62300

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.