### PR TITLE
fix: avoid updating snapshots in yarn test

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -322,7 +322,7 @@
       "description": "Run tests",
       "steps": [
         {
-          "exec": "jest --passWithNoTests --all --updateSnapshot --coverageProvider=v8"
+          "exec": "jest --passWithNoTests --all --coverageProvider=v8"
         },
         {
           "spawn": "eslint"
@@ -334,7 +334,7 @@
       "description": "Update jest snapshots",
       "steps": [
         {
-          "exec": "jest --updateSnapshot"
+          "exec": "jest --updateSnapshot --passWithNoTests --all --coverageProvider=v8"
         }
       ]
     },

--- a/src/javascript/jest.ts
+++ b/src/javascript/jest.ts
@@ -731,12 +731,6 @@ export class Jest {
         ? ` -c ${this.file.path}`
         : "";
 
-    // since our build & release workflows have anti-tamper protection, it is
-    // safe to always run tests with --updateSnapshot. if a snapshot changes,
-    // the `build` workflow will either fail (on forks) or push the update and
-    // `release` workflows will fail.
-    jestOpts.push("--updateSnapshot");
-
     // as recommended in the jest docs, node > 14 may use native v8 coverage collection
     // https://jestjs.io/docs/en/cli#--coverageproviderprovider
     if (
@@ -760,7 +754,7 @@ export class Jest {
     if (!testUpdate) {
       this.project.addTask("test:update", {
         description: "Update jest snapshots",
-        exec: `jest --updateSnapshot${jestConfigOpts}`,
+        exec: `jest --updateSnapshot ${jestOpts.join(" ")}${jestConfigOpts}`,
       });
     }
   }

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -1324,7 +1324,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "test",
         "steps": Array [
           Object {
-            "exec": "jest --passWithNoTests --all --updateSnapshot --coverageProvider=v8",
+            "exec": "jest --passWithNoTests --all --coverageProvider=v8",
           },
           Object {
             "spawn": "eslint",
@@ -1336,7 +1336,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "test:update",
         "steps": Array [
           Object {
-            "exec": "jest --updateSnapshot",
+            "exec": "jest --updateSnapshot --passWithNoTests --all --coverageProvider=v8",
           },
         ],
       },
@@ -2707,7 +2707,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "test",
         "steps": Array [
           Object {
-            "exec": "jest --passWithNoTests --all --updateSnapshot",
+            "exec": "jest --passWithNoTests --all",
           },
           Object {
             "spawn": "eslint",
@@ -2722,7 +2722,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "test:update",
         "steps": Array [
           Object {
-            "exec": "jest --updateSnapshot",
+            "exec": "jest --updateSnapshot --passWithNoTests --all",
           },
         ],
       },
@@ -4113,7 +4113,7 @@ tsconfig.tsbuildinfo
         "name": "test",
         "steps": Array [
           Object {
-            "exec": "jest --passWithNoTests --all --updateSnapshot",
+            "exec": "jest --passWithNoTests --all",
           },
           Object {
             "spawn": "eslint",
@@ -4128,7 +4128,7 @@ tsconfig.tsbuildinfo
         "name": "test:update",
         "steps": Array [
           Object {
-            "exec": "jest --updateSnapshot",
+            "exec": "jest --updateSnapshot --passWithNoTests --all",
           },
         ],
       },
@@ -5363,7 +5363,7 @@ junit.xml
         "name": "test",
         "steps": Array [
           Object {
-            "exec": "jest --passWithNoTests --all --updateSnapshot",
+            "exec": "jest --passWithNoTests --all",
           },
         ],
       },
@@ -5372,7 +5372,7 @@ junit.xml
         "name": "test:update",
         "steps": Array [
           Object {
-            "exec": "jest --updateSnapshot",
+            "exec": "jest --updateSnapshot --passWithNoTests --all",
           },
         ],
       },

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -997,7 +997,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "test",
         "steps": Array [
           Object {
-            "exec": "jest --passWithNoTests --all --updateSnapshot",
+            "exec": "jest --passWithNoTests --all",
           },
           Object {
             "spawn": "eslint",
@@ -1009,7 +1009,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "test:update",
         "steps": Array [
           Object {
-            "exec": "jest --updateSnapshot",
+            "exec": "jest --updateSnapshot --passWithNoTests --all",
           },
         ],
       },

--- a/test/cdk8s/__snapshots__/integration-test.test.ts.snap
+++ b/test/cdk8s/__snapshots__/integration-test.test.ts.snap
@@ -75,7 +75,7 @@ Object {
   "name": "test",
   "steps": Array [
     Object {
-      "exec": "jest --passWithNoTests --all --updateSnapshot",
+      "exec": "jest --passWithNoTests --all",
     },
     Object {
       "spawn": "eslint",
@@ -105,7 +105,7 @@ Object {
   "name": "test",
   "steps": Array [
     Object {
-      "exec": "jest --passWithNoTests --all --updateSnapshot",
+      "exec": "jest --passWithNoTests --all",
     },
     Object {
       "spawn": "eslint",

--- a/test/typescript/__snapshots__/typescript.test.ts.snap
+++ b/test/typescript/__snapshots__/typescript.test.ts.snap
@@ -874,7 +874,7 @@ tsconfig.tsbuildinfo
         "name": "test",
         "steps": Array [
           Object {
-            "exec": "jest --passWithNoTests --all --updateSnapshot",
+            "exec": "jest --passWithNoTests --all",
           },
           Object {
             "spawn": "eslint",
@@ -886,7 +886,7 @@ tsconfig.tsbuildinfo
         "name": "test:update",
         "steps": Array [
           Object {
-            "exec": "jest --updateSnapshot",
+            "exec": "jest --updateSnapshot --passWithNoTests --all",
           },
         ],
       },


### PR DESCRIPTION
fixes https://github.com/projen/projen/issues/1144

## Description

* As a lot of users is noticing, updating snapshot in task "test" is a unexpected behavior and it should be separated as "test:update"
* I believe that snapshot should not be updated in the `buildWorkflow`, but would try to keep the current behavior to avoid breaking changes

## Fix

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.