### PR TITLE
fix(github): correct secret name for GithubCredentials docs

### DIFF
--- a/src/github/github-credentials.ts
+++ b/src/github/github-credentials.ts
@@ -45,7 +45,8 @@ export class GithubCredentials {
    * can be specified here.
    *
    * @see https://docs.github.com/en/developers/apps/building-github-apps/creating-a-github-app
-   * @default - app id stored in "PROJEN_GITHUB_TOKEN" and private key stored in "PROJEN_APP_PRIVATE_KEY"
+   * @see https://projen.io/github.html#github-app
+   * @default - app id stored in "PROJEN_APP_ID" and private key stored in "PROJEN_APP_PRIVATE_KEY"
    */
   public static fromApp(options: GithubCredentialsAppOptions = {}) {
     const appIdSecret = options.appIdSecret ?? "PROJEN_APP_ID";


### PR DESCRIPTION
Fixes an error in the docs for GithubCredentials so it shows the right secret name for `PROJEN_APP_ID`.

Fixes #2147

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.