### PR TITLE
feat(release): allow adding of publishing jobs in the projen file

### DIFF
--- a/src/release/publisher.ts
+++ b/src/release/publisher.ts
@@ -555,7 +555,7 @@ export class Publisher extends Component {
     );
   }
 
-  private addPublishJob(
+  public addPublishJob(
     factory: (
       branch: string,
       branchOptions: Partial<BranchOptions>


### PR DESCRIPTION
to be able to configure additional release jobs dynamically we need the addPublishingJob function publicly available

In a project I currently publish to a private npm registery and cannot use the publishToNpm generated job because the authentication requires additional steps so I can't place a ready to use token as a github secret. 

To still be able to publish I've created a new release job with the Release.addJob function. But I also use releaseBranches and want to use those branchOptions to dynamically create the job.  To be able to do this I need the addPublishJob to be usable in my .projenrc so we can add a jobFactory instead of a static job. 