### PR TITLE
chore(github)!: upgrade versions of workflow actions to `setup-python` and `setup-dotnet`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14.18.0
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - name: Download build artifacts
@@ -202,7 +202,7 @@ jobs:
       contents: read
     if: "! needs.build.outputs.self_mutation_happened"
     steps:
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - uses: actions/setup-go@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,7 +205,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14.18.0
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - name: Download build artifacts

--- a/src/github/workflows.ts
+++ b/src/github/workflows.ts
@@ -328,7 +328,7 @@ function setupTools(tools: workflows.Tools) {
 
   if (tools.python) {
     steps.push({
-      uses: "actions/setup-python@v3",
+      uses: "actions/setup-python@v4",
       with: { "python-version": tools.python.version },
     });
   }
@@ -342,7 +342,7 @@ function setupTools(tools: workflows.Tools) {
 
   if (tools.dotnet) {
     steps.push({
-      uses: "actions/setup-dotnet@v2",
+      uses: "actions/setup-dotnet@v3",
       with: { "dotnet-version": tools.dotnet.version },
     });
   }

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -402,7 +402,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14.0.0
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - name: Download build artifacts
@@ -610,7 +610,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14.0.0
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - name: Download build artifacts

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -1771,7 +1771,7 @@ Object {
       },
     },
     Object {
-      "uses": "actions/setup-dotnet@v2",
+      "uses": "actions/setup-dotnet@v3",
       "with": Object {
         "dotnet-version": "3.x",
       },
@@ -1833,7 +1833,7 @@ Object {
       },
     },
     Object {
-      "uses": "actions/setup-python@v3",
+      "uses": "actions/setup-python@v4",
       "with": Object {
         "python-version": "3.x",
       },
@@ -1893,7 +1893,7 @@ Object {
       },
     },
     Object {
-      "uses": "actions/setup-dotnet@v2",
+      "uses": "actions/setup-dotnet@v3",
       "with": Object {
         "dotnet-version": "3.x",
       },
@@ -2096,7 +2096,7 @@ Object {
       },
     },
     Object {
-      "uses": "actions/setup-python@v3",
+      "uses": "actions/setup-python@v4",
       "with": Object {
         "python-version": "3.x",
       },
@@ -2544,7 +2544,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14.x
-      - uses: actions/setup-dotnet@v2
+      - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
       - name: Download build artifacts
@@ -2687,7 +2687,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14.x
-      - uses: actions/setup-dotnet@v2
+      - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
       - name: Download build artifacts

--- a/test/release/__snapshots__/release.test.ts.snap
+++ b/test/release/__snapshots__/release.test.ts.snap
@@ -1871,7 +1871,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14.x
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - name: Download build artifacts
@@ -1999,7 +1999,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14.x
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - name: Download build artifacts
@@ -2841,7 +2841,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14.x
-      - uses: actions/setup-dotnet@v2
+      - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
       - name: Download build artifacts
@@ -4130,7 +4130,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14.x
-      - uses: actions/setup-dotnet@v2
+      - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
       - name: Download build artifacts
@@ -4156,7 +4156,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14.x
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - name: Download build artifacts


### PR DESCRIPTION
BREAKING CHANGE: If you have customized the `package-python` or `package-dotnet` jobs of the release workflow, please review the changes for the release of the respective action.

actions/setup-python@v4: https://github.com/actions/setup-python/releases/tag/v4.0.0
actions/setup-dotnet@v3: https://github.com/actions/setup-dotnet/releases/tag/v3.0.0

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.