### PR TITLE
fix(javascript): jest cli doesn't have an`--all` argument

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -322,7 +322,7 @@
       "description": "Run tests",
       "steps": [
         {
-          "exec": "jest --passWithNoTests --all --coverageProvider=v8 --updateSnapshot"
+          "exec": "jest --passWithNoTests --coverageProvider=v8 --updateSnapshot"
         },
         {
           "spawn": "eslint"

--- a/src/javascript/jest.ts
+++ b/src/javascript/jest.ts
@@ -745,7 +745,7 @@ export class Jest {
   }
 
   private configureTestCommand(updateSnapshot: UpdateSnapshot) {
-    const jestOpts = ["--passWithNoTests", "--all", ...this.extraCliOptions];
+    const jestOpts = ["--passWithNoTests", ...this.extraCliOptions];
     const jestConfigOpts =
       this.file && this.file.path != "jest.config.json"
         ? ` -c ${this.file.path}`

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -1358,7 +1358,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "test",
         "steps": Array [
           Object {
-            "exec": "jest --passWithNoTests --all --coverageProvider=v8 --updateSnapshot",
+            "exec": "jest --passWithNoTests --coverageProvider=v8 --updateSnapshot",
           },
           Object {
             "spawn": "eslint",
@@ -2734,7 +2734,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "test",
         "steps": Array [
           Object {
-            "exec": "jest --passWithNoTests --all --updateSnapshot",
+            "exec": "jest --passWithNoTests --updateSnapshot",
           },
           Object {
             "spawn": "eslint",
@@ -4128,7 +4128,7 @@ tsconfig.tsbuildinfo
         "name": "test",
         "steps": Array [
           Object {
-            "exec": "jest --passWithNoTests --all --updateSnapshot",
+            "exec": "jest --passWithNoTests --updateSnapshot",
           },
           Object {
             "spawn": "eslint",
@@ -5372,7 +5372,7 @@ permissions-backup.acl
         "name": "test",
         "steps": Array [
           Object {
-            "exec": "jest --passWithNoTests --all --updateSnapshot",
+            "exec": "jest --passWithNoTests --updateSnapshot",
           },
         ],
       },

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -1019,7 +1019,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "test",
         "steps": Array [
           Object {
-            "exec": "jest --passWithNoTests --all --updateSnapshot",
+            "exec": "jest --passWithNoTests --updateSnapshot",
           },
           Object {
             "spawn": "eslint",

--- a/test/cdk8s/__snapshots__/integration-test.test.ts.snap
+++ b/test/cdk8s/__snapshots__/integration-test.test.ts.snap
@@ -75,7 +75,7 @@ Object {
   "name": "test",
   "steps": Array [
     Object {
-      "exec": "jest --passWithNoTests --all --updateSnapshot",
+      "exec": "jest --passWithNoTests --updateSnapshot",
     },
     Object {
       "spawn": "eslint",
@@ -105,7 +105,7 @@ Object {
   "name": "test",
   "steps": Array [
     Object {
-      "exec": "jest --passWithNoTests --all --updateSnapshot",
+      "exec": "jest --passWithNoTests --updateSnapshot",
     },
     Object {
       "spawn": "eslint",

--- a/test/typescript/__snapshots__/typescript.test.ts.snap
+++ b/test/typescript/__snapshots__/typescript.test.ts.snap
@@ -882,7 +882,7 @@ tsconfig.tsbuildinfo
         "name": "test",
         "steps": Array [
           Object {
-            "exec": "jest --passWithNoTests --all --updateSnapshot",
+            "exec": "jest --passWithNoTests --updateSnapshot",
           },
           Object {
             "spawn": "eslint",


### PR DESCRIPTION
This argument does not exist and hasn't existed since at least 22.x:

https://jestjs.io/docs/cli

https://archive.jestjs.io/docs/en/22.x/cli

This argument was added in Dec 2020 by a larger commit adding build tasks: 95112272c2b192144293c1064c77b2d8da354b8f

And before that, the whole file did not exist and the project has no mention of `--all`. So I cannot deduce the original reason for adding this argument.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.