### PR TITLE
feat(cdk): allow user to pass arguments to deploy and destroy tasks

### DIFF
--- a/src/awscdk/cdk-tasks.ts
+++ b/src/awscdk/cdk-tasks.ts
@@ -53,11 +53,13 @@ export class CdkTasks extends Component {
     this.deploy = project.addTask("deploy", {
       description: "Deploys your CDK app to the AWS cloud",
       exec: "cdk deploy",
+      receiveArgs: true,
     });
 
     this.destroy = project.addTask("destroy", {
       description: "Destroys your cdk app in the AWS cloud",
       exec: "cdk destroy",
+      receiveArgs: true,
     });
 
     this.diff = project.addTask("diff", {


### PR DESCRIPTION
Allow user to pass arguments to CDK deploy and destroy tasks — e.g. stack name 
or `--all` are commonly used.

`projen deploy my-stack` 🎉 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
