### PR TITLE
chore(docs): fix imports in GitHub example

### DIFF
--- a/docs/github.md
+++ b/docs/github.md
@@ -49,7 +49,7 @@ Add the App ID as a secret to your repo under the name `PROJEN_APP_ID` and the p
 Then, configure your projenrc file to use the GitHub app for API access:
 
 ```ts
-const { NodeProject } = require('projen/javascript');
+const { github, javascript } = require('projen');
 
 const project = new javascript.NodeProject({
   // ...other options


### PR DESCRIPTION
There's a minor issue with the module imports in the example presented on the GitHub component documentation page; this PR aims to correct the issue.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.