### PR TITLE
fix: update NODE Lambda runtimes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,10 +15,12 @@ The following tools need to be installed to develop on projen locally.
 - [Node]
 - [Yarn]
 - [Maven]
+- [Go]
 
-[Node]: https://nodejs.org/en/download/
-[Yarn]: https://yarnpkg.com/en/docs/install
-[Maven]: https://maven.apache.org/install
+[node]: https://nodejs.org/en/download/
+[yarn]: https://yarnpkg.com/en/docs/install
+[maven]: https://maven.apache.org/install
+[go]: https://go.dev/doc/install
 
 ## Getting Started
 
@@ -99,7 +101,7 @@ $ yarn link projen
 $ pj
 ```
 
-From now on, running `pj` in this session will use the local development version of 
+From now on, running `pj` in this session will use the local development version of
 projen instead of the latest one from npm.
 
 ```console
@@ -115,20 +117,20 @@ npm utility.
 
 ## Making a pull request
 
-* Commit title and message (and PR title and description) must adhere to [conventionalcommits](https://www.conventionalcommits.org).
-  * The title must begin with `feat(module): title`, `fix(module): title`,
-  `refactor(module): title` or `chore(module): title`, where the module refers
-  to the projects or components that the change centers on.
-  The module can be omitted, so "feat: title" is okay as well.
-  * Title should be lowercase.
-  * No period at the end of the title.
-* Commit message should describe _motivation_. Think about your code reviewers and what information they need in
+- Commit title and message (and PR title and description) must adhere to [conventionalcommits](https://www.conventionalcommits.org).
+  - The title must begin with `feat(module): title`, `fix(module): title`,
+    `refactor(module): title` or `chore(module): title`, where the module refers
+    to the projects or components that the change centers on.
+    The module can be omitted, so "feat: title" is okay as well.
+  - Title should be lowercase.
+  - No period at the end of the title.
+- Commit message should describe _motivation_. Think about your code reviewers and what information they need in
   order to understand what you did. If it's a big commit (hopefully not), try to provide some good entry points so
   it will be easier to follow.
-* Commit message should indicate which issues are fixed: `fixes #<issue>` or `closes #<issue>`.
-* Shout out to collaborators.
-* If not obvious (i.e. from unit tests), describe how you verified that your change works.
-* If this commit includes breaking changes, they must be listed at the end in the following format (notice how multiple breaking changes should be formatted):
+- Commit message should indicate which issues are fixed: `fixes #<issue>` or `closes #<issue>`.
+- Shout out to collaborators.
+- If not obvious (i.e. from unit tests), describe how you verified that your change works.
+- If this commit includes breaking changes, they must be listed at the end in the following format (notice how multiple breaking changes should be formatted):
 
 ```
 BREAKING CHANGE: Description of what broke and how to achieve this behavior now

--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -4767,10 +4767,10 @@ Name | Type | Description
 **esbuildPlatform**🔹 | <code>string</code> | <span></span>
 **esbuildTarget**🔹 | <code>string</code> | The esbuild setting to use.
 **functionRuntime**🔹 | <code>string</code> | The Node.js runtime to use.
-*static* **NODEJS_10_X**🔹 | <code>[awscdk.LambdaRuntime](#projen-awscdk-lambdaruntime)</code> | Node.js 10.x.
 *static* **NODEJS_12_X**🔹 | <code>[awscdk.LambdaRuntime](#projen-awscdk-lambdaruntime)</code> | Node.js 12.x.
 *static* **NODEJS_14_X**🔹 | <code>[awscdk.LambdaRuntime](#projen-awscdk-lambdaruntime)</code> | Node.js 14.x.
 *static* **NODEJS_16_X**🔹 | <code>[awscdk.LambdaRuntime](#projen-awscdk-lambdaruntime)</code> | Node.js 16.x.
+*static* **NODEJS_18_X**🔹 | <code>[awscdk.LambdaRuntime](#projen-awscdk-lambdaruntime)</code> | Node.js 18.x.
 
 
 

--- a/src/awscdk/lambda-function.ts
+++ b/src/awscdk/lambda-function.ts
@@ -288,14 +288,6 @@ export class LambdaFunction extends Component {
  */
 export class LambdaRuntime {
   /**
-   * Node.js 10.x
-   */
-  public static readonly NODEJS_10_X = new LambdaRuntime(
-    "nodejs10.x",
-    "node10"
-  );
-
-  /**
    * Node.js 12.x
    */
   public static readonly NODEJS_12_X = new LambdaRuntime(
@@ -317,6 +309,14 @@ export class LambdaRuntime {
   public static readonly NODEJS_16_X = new LambdaRuntime(
     "nodejs16.x",
     "node16"
+  );
+
+  /**
+   * Node.js 18.x
+   */
+  public static readonly NODEJS_18_X = new LambdaRuntime(
+    "nodejs18.x",
+    "node18"
   );
 
   public readonly esbuildPlatform = "node";

--- a/test/awscdk/awscdk-app.test.ts
+++ b/test/awscdk/awscdk-app.test.ts
@@ -47,7 +47,7 @@ describe("lambda functions", () => {
       cdkVersion: "1.100.0",
       libdir: "liblib",
       lambdaOptions: {
-        runtime: LambdaRuntime.NODEJS_10_X,
+        runtime: LambdaRuntime.NODEJS_18_X,
         bundlingOptions: {
           externals: ["foo", "bar"],
         },
@@ -61,7 +61,7 @@ describe("lambda functions", () => {
       snapshot[".projen/tasks.json"].tasks["bundle:my.lambda"].steps
     ).toStrictEqual([
       {
-        exec: 'esbuild --bundle src/my.lambda.ts --target="node10" --platform="node" --outfile="assets/my.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:foo --external:bar',
+        exec: 'esbuild --bundle src/my.lambda.ts --target="node18" --platform="node" --outfile="assets/my.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:foo --external:bar',
       },
     ]);
   });

--- a/test/awscdk/awscdk-construct.test.ts
+++ b/test/awscdk/awscdk-construct.test.ts
@@ -175,7 +175,7 @@ describe("lambda functions", () => {
         assetsDir: "resources",
       },
       lambdaOptions: {
-        runtime: awscdk.LambdaRuntime.NODEJS_10_X,
+        runtime: awscdk.LambdaRuntime.NODEJS_18_X,
         bundlingOptions: {
           externals: ["foo", "bar"],
           sourcemap: true,
@@ -190,7 +190,7 @@ describe("lambda functions", () => {
       snapshot[".projen/tasks.json"].tasks["bundle:my.lambda"].steps
     ).toStrictEqual([
       {
-        exec: 'esbuild --bundle src/my.lambda.ts --target="node10" --platform="node" --outfile="resources/my.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:foo --external:bar --sourcemap',
+        exec: 'esbuild --bundle src/my.lambda.ts --target="node18" --platform="node" --outfile="resources/my.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:foo --external:bar --sourcemap',
       },
     ]);
   });

--- a/test/awscdk/lambda-extension.test.ts
+++ b/test/awscdk/lambda-extension.test.ts
@@ -93,9 +93,10 @@ test("changing compatible runtimes", () => {
     cdkDeps: cdkDepsForProject(project),
     entrypoint: "src/example.lambda-extension.ts",
     compatibleRuntimes: [
+      LambdaRuntime.NODEJS_18_X,
+      LambdaRuntime.NODEJS_16_X,
       LambdaRuntime.NODEJS_14_X,
       LambdaRuntime.NODEJS_12_X,
-      LambdaRuntime.NODEJS_10_X,
     ],
   });
 
@@ -108,18 +109,21 @@ test("changing compatible runtimes", () => {
 
   expect(bundleTaskExec).toContain(
     // It picked the lowest compatible runtime
-    '--target="node10"'
+    '--target="node12"'
   );
 
   const generatedSource = snapshot["src/example-layer-version.ts"];
-  expect(generatedSource).toContain(
-    "new lambda.Runtime('nodejs10.x', lambda.RuntimeFamily.NODEJS)"
-  );
   expect(generatedSource).toContain(
     "new lambda.Runtime('nodejs12.x', lambda.RuntimeFamily.NODEJS)"
   );
   expect(generatedSource).toContain(
     "new lambda.Runtime('nodejs14.x', lambda.RuntimeFamily.NODEJS)"
+  );
+  expect(generatedSource).toContain(
+    "new lambda.Runtime('nodejs16.x', lambda.RuntimeFamily.NODEJS)"
+  );
+  expect(generatedSource).toContain(
+    "new lambda.Runtime('nodejs18.x', lambda.RuntimeFamily.NODEJS)"
   );
 });
 


### PR DESCRIPTION
Updates to LambdaRuntime to deprecate NODEJS_10_X and inclusion of NODEJS_18_X

https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

All tests pass and tested with project using NODEJS_18_X.

Inclusion of Go in CONTRIBUTING guidelines as build failed before installing Go.  

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.