### PR TITLE
chore: fix wrong documentation for projectfqn

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -2297,7 +2297,7 @@ static createProject(options: CreateProjectOptions): void
 
 * **options** (<code>[CreateProjectOptions](#projen-createprojectoptions)</code>)  *No description*
   * **dir** (<code>string</code>)  Directory that the project will be generated in. 
-  * **projectFqn** (<code>string</code>)  Fully-qualified name of the project type (usually formatted as `module.ProjectType`). 
+  * **projectFqn** (<code>string</code>)  Fully-qualified name of the project type (usually formatted as `projen.module.ProjectType`). 
   * **projectOptions** (<code>Map<string, any></code>)  Project options. 
   * **optionHints** (<code>[InitProjectOptionHints](#projen-initprojectoptionhints)</code>)  Should we render commented-out default options in the projenrc file? __*Default*__: InitProjectOptionHints.FEATURED
   * **post** (<code>boolean</code>)  Should we execute post synthesis hooks? __*Default*__: true
@@ -11702,7 +11702,7 @@ Name | Type | Description
 Name | Type | Description 
 -----|------|-------------
 **dir**🔹 | <code>string</code> | Directory that the project will be generated in.
-**projectFqn**🔹 | <code>string</code> | Fully-qualified name of the project type (usually formatted as `module.ProjectType`).
+**projectFqn**🔹 | <code>string</code> | Fully-qualified name of the project type (usually formatted as `projen.module.ProjectType`).
 **projectOptions**🔹 | <code>Map<string, any></code> | Project options.
 **optionHints**?🔹 | <code>[InitProjectOptionHints](#projen-initprojectoptionhints)</code> | Should we render commented-out default options in the projenrc file?<br/>__*Default*__: InitProjectOptionHints.FEATURED
 **post**?🔹 | <code>boolean</code> | Should we execute post synthesis hooks?<br/>__*Default*__: true

--- a/docs/programmatic-api.md
+++ b/docs/programmatic-api.md
@@ -11,7 +11,7 @@ const { Projects } = require('projen');
 
 Projects.createProject({
   dir: '/path/to/mydir',
-  projectFqn: 'projen.TypeScriptProject',
+  projectFqn: 'projen.typescript.TypeScriptProject',
   projectOptions: {
     name: 'my-test-project',
     defaultReleaseBranch: 'main',

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -12,8 +12,8 @@ export interface CreateProjectOptions {
 
   /**
    * Fully-qualified name of the project type (usually formatted
-   * as `module.ProjectType`).
-   * @example `projen.TypescriptProject`
+   * as `projen.module.ProjectType`).
+   * @example `projen.typescript.TypescriptProject`
    */
   readonly projectFqn: string;
 


### PR DESCRIPTION
Caused me needless pain when trying to use `CreateProject` API.

Excerpt from my local projen .jsii file.

![Screen Shot 2022-12-14 at 8 58 27 PM](https://user-images.githubusercontent.com/36202692/207754545-2d70a027-4d7a-4a56-b967-20fdd3eacf69.png)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

