### PR TITLE
fix(jsii): run workflow setup steps for language jobs

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -8427,6 +8427,7 @@ Name | Type | Description
 **package**🔹 | <code>[javascript.NodePackage](#projen-javascript-nodepackage)</code> | API for managing the node package.
 **packageManager**⚠️ | <code>[javascript.NodePackageManager](#projen-javascript-nodepackagemanager)</code> | The package manager to use.
 **runScriptCommand**🔹 | <code>string</code> | The command to use to run scripts (e.g. `yarn run` or `npm run` depends on the package manager).
+**workflowBootstrapSteps**🔹 | <code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code> | <span></span>
 **autoMerge**?🔹 | <code>[github.AutoMerge](#projen-github-automerge)</code> | Component that sets up mergify for merging approved pull requests.<br/>__*Optional*__
 **buildWorkflow**?🔹 | <code>[build.BuildWorkflow](#projen-build-buildworkflow)</code> | The PR build GitHub workflow.<br/>__*Optional*__
 **buildWorkflowJobId**?🔹 | <code>string</code> | The job ID of the build workflow.<br/>__*Optional*__

--- a/src/cdk/jsii-project.ts
+++ b/src/cdk/jsii-project.ts
@@ -434,6 +434,8 @@ export class JsiiProject extends TypeScriptProject {
     // so we move the repo, create the artifact, and put it in the expected place.
     const prePublishSteps: Array<Step> = [];
 
+    prePublishSteps.push(...this.workflowBootstrapSteps);
+
     if (this.package.packageManager === NodePackageManager.PNPM) {
       prePublishSteps.push({
         name: "Setup pnpm",

--- a/src/javascript/node-project.ts
+++ b/src/javascript/node-project.ts
@@ -424,7 +424,7 @@ export class NodeProject extends GitHubProject {
    */
   public readonly upgradeWorkflow?: UpgradeDependencies;
 
-  private readonly workflowBootstrapSteps: JobStep[];
+  protected readonly workflowBootstrapSteps: JobStep[];
   private readonly workflowGitIdentity: GitIdentity;
   public readonly prettier?: Prettier;
 

--- a/test/cdk/jsii.test.ts
+++ b/test/cdk/jsii.test.ts
@@ -289,6 +289,36 @@ describe("publish to go", () => {
     );
   });
 
+  test("workflowBootstrap steps", () => {
+    const workflowBootstrapStep = {
+      id: "test_setup",
+      env: {
+        TEST: "TEST_VALUE",
+      },
+      name: "Workflow setup step",
+    };
+    const project = new JsiiProject({
+      authorAddress: "https://foo.bar",
+      authorUrl: "https://foo.bar",
+      repositoryUrl: "https://github.com/foo/bar.git",
+      author: "My Name",
+      name: "testproject",
+      defaultReleaseBranch: "main",
+      releaseToNpm: true,
+      publishTasks: true,
+      workflowBootstrapSteps: [workflowBootstrapStep],
+    });
+
+    const output = synthSnapshot(project);
+    const build = yaml.parse(output[".github/workflows/build.yml"]);
+    const release = yaml.parse(output[".github/workflows/release.yml"]);
+    expect(build.jobs.build.steps).toContainEqual(workflowBootstrapStep);
+    expect(release.jobs.release.steps).toContainEqual(workflowBootstrapStep);
+    expect(release.jobs.release_npm.steps).toContainEqual(
+      workflowBootstrapStep
+    );
+  });
+
   test("customizations", () => {
     const project = new JsiiProject({
       authorAddress: "https://foo.bar",


### PR DESCRIPTION
Fix #1799 #1006

Allow workflow setup steps to be used by extensions of node-project. 

This change will enable for example a step that sets NPM authentication for private repos before build and publish.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.