### PR TITLE
chore(javascript): reduce the scope of the upgrade dependencies token

### DIFF
--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -42,14 +42,12 @@ jobs:
     needs: upgrade
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     if: ${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: main
       - name: Download patch
         uses: actions/download-artifact@v3

--- a/src/javascript/upgrade-dependencies.ts
+++ b/src/javascript/upgrade-dependencies.ts
@@ -367,7 +367,6 @@ export class UpgradeDependencies extends Component {
     const steps: workflows.JobStep[] = [
       ...apiAccess.setupSteps,
       ...WorkflowActions.checkoutWithPatch({
-        token: apiAccess.tokenRef,
         ref: upgrade.ref,
       }),
       ...WorkflowActions.setGitIdentity(this.gitIdentity),
@@ -399,8 +398,7 @@ export class UpgradeDependencies extends Component {
         if: `\${{ needs.${upgrade.jobId}.outputs.${PATCH_CREATED_OUTPUT} }}`,
         needs: [upgrade.jobId],
         permissions: {
-          contents: workflows.JobPermission.WRITE,
-          pullRequests: workflows.JobPermission.WRITE,
+          contents: workflows.JobPermission.READ,
         },
         runsOn: runsOn ?? ["ubuntu-latest"],
         steps: steps,

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -681,14 +681,12 @@ jobs:
     needs: upgrade
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     if: \${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: master
       - name: Download patch
         uses: actions/download-artifact@v3
@@ -1826,14 +1824,12 @@ jobs:
     needs: upgrade
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     if: \${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
+        with: {}
       - name: Download patch
         uses: actions/download-artifact@v3
         with:
@@ -3021,14 +3017,12 @@ jobs:
     needs: upgrade
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     if: \${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
+        with: {}
       - name: Download patch
         uses: actions/download-artifact@v3
         with:
@@ -4073,14 +4067,12 @@ jobs:
     needs: upgrade
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     if: \${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: master
       - name: Download patch
         uses: actions/download-artifact@v3

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -536,14 +536,12 @@ jobs:
     needs: upgrade
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     if: \${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: main
       - name: Download patch
         uses: actions/download-artifact@v3

--- a/test/javascript/__snapshots__/node-project.test.ts.snap
+++ b/test/javascript/__snapshots__/node-project.test.ts.snap
@@ -6,8 +6,7 @@ Object {
   "name": "Create Pull Request",
   "needs": "upgrade",
   "permissions": Object {
-    "contents": "write",
-    "pull-requests": "write",
+    "contents": "read",
   },
   "runs-on": "ubuntu-latest",
   "steps": Array [
@@ -16,7 +15,6 @@ Object {
       "uses": "actions/checkout@v3",
       "with": Object {
         "ref": "main",
-        "token": "\${{ secrets.PROJEN_GITHUB_TOKEN }}",
       },
     },
     Object {

--- a/test/javascript/__snapshots__/upgrade-dependencies.test.ts.snap
+++ b/test/javascript/__snapshots__/upgrade-dependencies.test.ts.snap
@@ -41,14 +41,12 @@ jobs:
     needs: upgrade
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     if: \${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: main
       - name: Download patch
         uses: actions/download-artifact@v3
@@ -133,14 +131,12 @@ jobs:
     needs: upgrade
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     if: \${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: branch1
       - name: Download patch
         uses: actions/download-artifact@v3
@@ -225,14 +221,12 @@ jobs:
     needs: upgrade
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     if: \${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: branch2
       - name: Download patch
         uses: actions/download-artifact@v3
@@ -317,14 +311,12 @@ jobs:
     needs: upgrade
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     if: \${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: branch1
       - name: Download patch
         uses: actions/download-artifact@v3
@@ -409,14 +401,12 @@ jobs:
     needs: upgrade
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     if: \${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: branch2
       - name: Download patch
         uses: actions/download-artifact@v3
@@ -501,14 +491,12 @@ jobs:
     needs: upgrade
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     if: \${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: main
       - name: Download patch
         uses: actions/download-artifact@v3
@@ -593,14 +581,12 @@ jobs:
     needs: upgrade
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     if: \${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: branch1
       - name: Download patch
         uses: actions/download-artifact@v3
@@ -685,14 +671,12 @@ jobs:
     needs: upgrade
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     if: \${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: branch2
       - name: Download patch
         uses: actions/download-artifact@v3
@@ -777,14 +761,12 @@ jobs:
     needs: upgrade
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     if: \${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: main
       - name: Download patch
         uses: actions/download-artifact@v3
@@ -869,14 +851,12 @@ jobs:
     needs: upgrade
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     if: \${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: main
       - name: Download patch
         uses: actions/download-artifact@v3
@@ -959,14 +939,12 @@ jobs:
     needs: upgrade
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     if: \${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: main
       - name: Download patch
         uses: actions/download-artifact@v3
@@ -1051,8 +1029,7 @@ jobs:
     needs: upgrade
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     if: \${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Generate token
@@ -1064,7 +1041,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: \${{ steps.generate_token.outputs.token }}
           ref: main
       - name: Download patch
         uses: actions/download-artifact@v3

--- a/test/typescript/__snapshots__/typescript.test.ts.snap
+++ b/test/typescript/__snapshots__/typescript.test.ts.snap
@@ -466,14 +466,12 @@ jobs:
     needs: upgrade
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     if: \${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: main
       - name: Download patch
         uses: actions/download-artifact@v3

--- a/test/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-project.test.ts.snap
@@ -245,14 +245,12 @@ jobs:
     needs: upgrade
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     if: \${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: main
       - name: Download patch
         uses: actions/download-artifact@v3

--- a/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -171,14 +171,12 @@ jobs:
     needs: upgrade
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     if: \${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
+        with: {}
       - name: Download patch
         uses: actions/download-artifact@v3
         with:

--- a/test/web/__snapshots__/react-project.test.ts.snap
+++ b/test/web/__snapshots__/react-project.test.ts.snap
@@ -231,14 +231,12 @@ jobs:
     needs: upgrade
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     if: \${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: main
       - name: Download patch
         uses: actions/download-artifact@v3

--- a/test/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/react-ts-project.test.ts.snap
@@ -393,14 +393,12 @@ jobs:
     needs: upgrade
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     if: \${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
+        with: {}
       - name: Download patch
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
The second step of this workflow that handles opening the pull request
is unnecessarily broad. Because the `PROJEN_GITHUB_TOKEN` (or the
otherwise configured token) will have `contents:write` and
`pull-requests:write` and that token is the one that is used to actually
push the content and open the pull request (as part of the
`peter-evens/create-pull-request` action), the `GITHUB_TOKEN` can be
used exclusively to checkout the branch with `contents:read`.

This change reduces the permissions of the `GITHUB_TOKEN` to the minimal
amount required and also reduces the places the configured token is used
to creating the pull request.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.