### PR TITLE
chore(awscdk): add integ-runner to CDK v1/v2 packages list

### DIFF
--- a/src/awscdk/awscdk-deps.ts
+++ b/src/awscdk/awscdk-deps.ts
@@ -399,6 +399,7 @@ const AWS_CDK_V1_V2_SCOPED_PACKAGES = [
   "@aws-cdk/cloud-assembly-schema",
   "@aws-cdk/assert",
   "@aws-cdk/cloudformation-diff",
+  "@aws-cdk/integ-runner",
 ];
 
 function determineFrameworkVersion(options: AwsCdkDepsOptions) {


### PR DESCRIPTION
The CDK team [recently](https://github.com/aws/aws-cdk/issues/21268#issuecomment-1267065439) started publishing the `integ-runner` package under both V1 and V2, so adding it here to eliminate inaccurate WARNING log messages during project synthesis.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.