### PR TITLE
fix: use posix paths for autodiscovered lambda entrypoints

### DIFF
--- a/src/cdk/auto-discover-base.ts
+++ b/src/cdk/auto-discover-base.ts
@@ -1,4 +1,4 @@
-import { join } from "path";
+import * as path from "path";
 import * as glob from "glob";
 import { Component } from "../component";
 import { Project } from "../project";
@@ -36,11 +36,11 @@ export abstract class AutoDiscoverBase extends Component {
   constructor(project: Project, options: AutoDiscoverBaseOptions) {
     super(project);
 
-    const cwd = join(this.project.outdir, options.projectdir);
+    const cwd = path.posix.join(this.project.outdir, options.projectdir);
 
     this.entrypoints = glob
       .sync(`**/*${options.extension}`, { cwd })
-      .map((p) => join(options.projectdir, p));
+      .map((p) => path.posix.join(options.projectdir, p));
   }
 }
 


### PR DESCRIPTION
Fixes #2344

Autodiscovered lambdas use back-slashes in their entrypoints when generated on Windows. This causes the generated github workflows to fail. Forcing posix path format for entrypoints fixes the workflows while still being compatible with esbuild on Windows.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.