### PR TITLE
chore(projects): Set environment variable in VM when creating new project

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -2291,6 +2291,10 @@ At the moment, it also generates a `.projenrc.js` file with the same code
 that was just executed. In the future, this will also be done by the project
 type, so we can easily support multiple languages of projenrc.
 
+An environment variable (PROJEN_CREATE_PROJECT=true) is set within the VM
+so that custom project types can detect whether the current synthesis is the
+result of a new project creation (and take additional steps accordingly)
+
 ```ts
 static createProject(options: CreateProjectOptions): void
 ```

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -64,6 +64,10 @@ export class Projects {
    * At the moment, it also generates a `.projenrc.js` file with the same code
    * that was just executed. In the future, this will also be done by the project
    * type, so we can easily support multiple languages of projenrc.
+   *
+   * An environment variable (PROJEN_CREATE_PROJECT=true) is set within the VM
+   * so that custom project types can detect whether the current synthesis is the
+   * result of a new project creation (and take additional steps accordingly)
    */
   public static createProject(options: CreateProjectOptions) {
     createProject(options);
@@ -122,6 +126,7 @@ function createProject(opts: CreateProjectOptions) {
   const synth = opts.synth ?? true;
   const postSynth = opts.post ?? true;
   process.env.PROJEN_DISABLE_POST = (!postSynth).toString();
+  process.env.PROJEN_CREATE_PROJECT = "true";
   vm.runInContext(
     [initProjectCode, synth ? `${varName}.synth();` : ""].join("\n"),
     ctx


### PR DESCRIPTION
Currently it's not really possible for external project types to distinguish between when a project is being created versus routine synth's. 

Being aware of this can be useful for certain types of project customizations, especially given external projects' limited ability to customize the "projen new ..." experience. 

This PR sets an environment variable (`PROJEN_CREATE_PROJECT=true`) in the VM used to create the project, thus allowing external project types to be aware of the nature of the current synthesis.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
