### PR TITLE
fix(python): creation of PythonProject with poetry

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -3989,7 +3989,7 @@ new awscdk.AwsCdkPythonApp(options: AwsCdkPythonAppOptions)
   * **moduleName** (<code>string</code>)  Name of the python package as used in imports and filenames. 
   * **deps** (<code>Array<string></code>)  List of runtime dependencies for this project. __*Default*__: []
   * **devDeps** (<code>Array<string></code>)  List of dev dependencies for this project. __*Default*__: []
-  * **pip** (<code>boolean</code>)  Use pip with a requirements.txt file to track project dependencies. __*Default*__: true
+  * **pip** (<code>boolean</code>)  Use pip with a requirements.txt file to track project dependencies. __*Default*__: true, unless poetry is true, then false
   * **poetry** (<code>boolean</code>)  Use poetry to manage your project dependencies, virtual environment, and (optional) packaging/publishing. __*Default*__: false
   * **projenrcJs** (<code>boolean</code>)  Use projenrc in javascript. __*Default*__: false
   * **projenrcJsOptions** (<code>[javascript.ProjenrcOptions](#projen-javascript-projenrcoptions)</code>)  Options related to projenrc in JavaScript. __*Default*__: default options
@@ -3998,8 +3998,8 @@ new awscdk.AwsCdkPythonApp(options: AwsCdkPythonAppOptions)
   * **pytest** (<code>boolean</code>)  Include pytest tests. __*Default*__: true
   * **pytestOptions** (<code>[python.PytestOptions](#projen-python-pytestoptions)</code>)  pytest options. __*Default*__: defaults
   * **sample** (<code>boolean</code>)  Include sample code and test if the relevant directories don't exist. __*Default*__: true
-  * **setuptools** (<code>boolean</code>)  Use setuptools with a setup.py script for packaging and publishing. __*Default*__: true if the project type is library
-  * **venv** (<code>boolean</code>)  Use venv to manage a virtual environment for installing dependencies inside. __*Default*__: true
+  * **setuptools** (<code>boolean</code>)  Use setuptools with a setup.py script for packaging and publishing. __*Default*__: true, unless poetry is true, then false
+  * **venv** (<code>boolean</code>)  Use venv to manage a virtual environment for installing dependencies inside. __*Default*__: true, unless poetry is true, then false
   * **venvOptions** (<code>[python.VenvOptions](#projen-python-venvoptions)</code>)  Venv options. __*Default*__: defaults
   * **buildCommand** (<code>string</code>)  A command to execute before synthesis. __*Default*__: no build command
   * **cdkout** (<code>string</code>)  cdk.out directory. __*Default*__: "cdk.out"
@@ -5597,7 +5597,7 @@ new cdk8s.Cdk8sPythonApp(options: Cdk8sPythonOptions)
   * **moduleName** (<code>string</code>)  Name of the python package as used in imports and filenames. 
   * **deps** (<code>Array<string></code>)  List of runtime dependencies for this project. __*Default*__: []
   * **devDeps** (<code>Array<string></code>)  List of dev dependencies for this project. __*Default*__: []
-  * **pip** (<code>boolean</code>)  Use pip with a requirements.txt file to track project dependencies. __*Default*__: true
+  * **pip** (<code>boolean</code>)  Use pip with a requirements.txt file to track project dependencies. __*Default*__: true, unless poetry is true, then false
   * **poetry** (<code>boolean</code>)  Use poetry to manage your project dependencies, virtual environment, and (optional) packaging/publishing. __*Default*__: false
   * **projenrcJs** (<code>boolean</code>)  Use projenrc in javascript. __*Default*__: false
   * **projenrcJsOptions** (<code>[javascript.ProjenrcOptions](#projen-javascript-projenrcoptions)</code>)  Options related to projenrc in JavaScript. __*Default*__: default options
@@ -5606,8 +5606,8 @@ new cdk8s.Cdk8sPythonApp(options: Cdk8sPythonOptions)
   * **pytest** (<code>boolean</code>)  Include pytest tests. __*Default*__: true
   * **pytestOptions** (<code>[python.PytestOptions](#projen-python-pytestoptions)</code>)  pytest options. __*Default*__: defaults
   * **sample** (<code>boolean</code>)  Include sample code and test if the relevant directories don't exist. __*Default*__: true
-  * **setuptools** (<code>boolean</code>)  Use setuptools with a setup.py script for packaging and publishing. __*Default*__: true if the project type is library
-  * **venv** (<code>boolean</code>)  Use venv to manage a virtual environment for installing dependencies inside. __*Default*__: true
+  * **setuptools** (<code>boolean</code>)  Use setuptools with a setup.py script for packaging and publishing. __*Default*__: true, unless poetry is true, then false
+  * **venv** (<code>boolean</code>)  Use venv to manage a virtual environment for installing dependencies inside. __*Default*__: true, unless poetry is true, then false
   * **venvOptions** (<code>[python.VenvOptions](#projen-python-venvoptions)</code>)  Venv options. __*Default*__: defaults
   * **cdk8sVersion** (<code>string</code>)  Minumum version of the cdk8s to depend on. 
   * **cdk8sCliVersion** (<code>string</code>)  Minumum version of the cdk8s-cli to depend on. __*Default*__: "2.0.28"
@@ -9377,7 +9377,7 @@ new python.PythonProject(options: PythonProjectOptions)
   * **moduleName** (<code>string</code>)  Name of the python package as used in imports and filenames. 
   * **deps** (<code>Array<string></code>)  List of runtime dependencies for this project. __*Default*__: []
   * **devDeps** (<code>Array<string></code>)  List of dev dependencies for this project. __*Default*__: []
-  * **pip** (<code>boolean</code>)  Use pip with a requirements.txt file to track project dependencies. __*Default*__: true
+  * **pip** (<code>boolean</code>)  Use pip with a requirements.txt file to track project dependencies. __*Default*__: true, unless poetry is true, then false
   * **poetry** (<code>boolean</code>)  Use poetry to manage your project dependencies, virtual environment, and (optional) packaging/publishing. __*Default*__: false
   * **projenrcJs** (<code>boolean</code>)  Use projenrc in javascript. __*Default*__: false
   * **projenrcJsOptions** (<code>[javascript.ProjenrcOptions](#projen-javascript-projenrcoptions)</code>)  Options related to projenrc in JavaScript. __*Default*__: default options
@@ -9386,8 +9386,8 @@ new python.PythonProject(options: PythonProjectOptions)
   * **pytest** (<code>boolean</code>)  Include pytest tests. __*Default*__: true
   * **pytestOptions** (<code>[python.PytestOptions](#projen-python-pytestoptions)</code>)  pytest options. __*Default*__: defaults
   * **sample** (<code>boolean</code>)  Include sample code and test if the relevant directories don't exist. __*Default*__: true
-  * **setuptools** (<code>boolean</code>)  Use setuptools with a setup.py script for packaging and publishing. __*Default*__: true if the project type is library
-  * **venv** (<code>boolean</code>)  Use venv to manage a virtual environment for installing dependencies inside. __*Default*__: true
+  * **setuptools** (<code>boolean</code>)  Use setuptools with a setup.py script for packaging and publishing. __*Default*__: true, unless poetry is true, then false
+  * **venv** (<code>boolean</code>)  Use venv to manage a virtual environment for installing dependencies inside. __*Default*__: true, unless poetry is true, then false
   * **venvOptions** (<code>[python.VenvOptions](#projen-python-venvoptions)</code>)  Venv options. __*Default*__: defaults
 
 
@@ -13029,7 +13029,7 @@ Name | Type | Description
 **outdir**?🔹 | <code>string</code> | The root directory of the project.<br/>__*Default*__: "."
 **packageName**?🔹 | <code>string</code> | Package name.<br/>__*Optional*__
 **parent**?🔹 | <code>[Project](#projen-project)</code> | The parent project, if this project is part of a bigger project.<br/>__*Optional*__
-**pip**?🔹 | <code>boolean</code> | Use pip with a requirements.txt file to track project dependencies.<br/>__*Default*__: true
+**pip**?🔹 | <code>boolean</code> | Use pip with a requirements.txt file to track project dependencies.<br/>__*Default*__: true, unless poetry is true, then false
 **poetry**?🔹 | <code>boolean</code> | Use poetry to manage your project dependencies, virtual environment, and (optional) packaging/publishing.<br/>__*Default*__: false
 **poetryOptions**?🔹 | <code>[python.PoetryPyprojectOptionsWithoutDeps](#projen-python-poetrypyprojectoptionswithoutdeps)</code> | Additional options to set for poetry if using poetry.<br/>__*Optional*__
 **projectType**?⚠️ | <code>[ProjectType](#projen-projecttype)</code> | Which type of project this is (library/app).<br/>__*Default*__: ProjectType.UNKNOWN
@@ -13050,11 +13050,11 @@ Name | Type | Description
 **requireApproval**?🔹 | <code>[awscdk.ApprovalLevel](#projen-awscdk-approvallevel)</code> | To protect you against unintended changes that affect your security posture, the AWS CDK Toolkit prompts you to approve security-related changes before deploying them.<br/>__*Default*__: ApprovalLevel.BROADENING
 **sample**?🔹 | <code>boolean</code> | Include sample code and test if the relevant directories don't exist.<br/>__*Default*__: true
 **setupConfig**?🔹 | <code>Map<string, any></code> | Additional fields to pass in the setup() function if using setuptools.<br/>__*Optional*__
-**setuptools**?🔹 | <code>boolean</code> | Use setuptools with a setup.py script for packaging and publishing.<br/>__*Default*__: true if the project type is library
+**setuptools**?🔹 | <code>boolean</code> | Use setuptools with a setup.py script for packaging and publishing.<br/>__*Default*__: true, unless poetry is true, then false
 **stale**?🔹 | <code>boolean</code> | Auto-close of stale issues and pull request.<br/>__*Default*__: false
 **staleOptions**?🔹 | <code>[github.StaleOptions](#projen-github-staleoptions)</code> | Auto-close stale issues and pull requests.<br/>__*Default*__: see defaults in `StaleOptions`
 **testdir**?🔹 | <code>string</code> | Python sources directory.<br/>__*Default*__: "tests"
-**venv**?🔹 | <code>boolean</code> | Use venv to manage a virtual environment for installing dependencies inside.<br/>__*Default*__: true
+**venv**?🔹 | <code>boolean</code> | Use venv to manage a virtual environment for installing dependencies inside.<br/>__*Default*__: true, unless poetry is true, then false
 **venvOptions**?🔹 | <code>[python.VenvOptions](#projen-python-venvoptions)</code> | Venv options.<br/>__*Default*__: defaults
 **vscode**?🔹 | <code>boolean</code> | Enable VSCode integration.<br/>__*Default*__: true
 **watchExcludes**?🔹 | <code>Array<string></code> | Glob patterns to exclude from `cdk watch`.<br/>__*Default*__: []
@@ -14274,7 +14274,7 @@ Name | Type | Description
 **outdir**?🔹 | <code>string</code> | The root directory of the project.<br/>__*Default*__: "."
 **packageName**?🔹 | <code>string</code> | Package name.<br/>__*Optional*__
 **parent**?🔹 | <code>[Project](#projen-project)</code> | The parent project, if this project is part of a bigger project.<br/>__*Optional*__
-**pip**?🔹 | <code>boolean</code> | Use pip with a requirements.txt file to track project dependencies.<br/>__*Default*__: true
+**pip**?🔹 | <code>boolean</code> | Use pip with a requirements.txt file to track project dependencies.<br/>__*Default*__: true, unless poetry is true, then false
 **poetry**?🔹 | <code>boolean</code> | Use poetry to manage your project dependencies, virtual environment, and (optional) packaging/publishing.<br/>__*Default*__: false
 **poetryOptions**?🔹 | <code>[python.PoetryPyprojectOptionsWithoutDeps](#projen-python-poetrypyprojectoptionswithoutdeps)</code> | Additional options to set for poetry if using poetry.<br/>__*Optional*__
 **projectType**?⚠️ | <code>[ProjectType](#projen-projecttype)</code> | Which type of project this is (library/app).<br/>__*Default*__: ProjectType.UNKNOWN
@@ -14294,10 +14294,10 @@ Name | Type | Description
 **renovatebotOptions**?🔹 | <code>[RenovatebotOptions](#projen-renovatebotoptions)</code> | Options for renovatebot.<br/>__*Default*__: default options
 **sample**?🔹 | <code>boolean</code> | Include sample code and test if the relevant directories don't exist.<br/>__*Default*__: true
 **setupConfig**?🔹 | <code>Map<string, any></code> | Additional fields to pass in the setup() function if using setuptools.<br/>__*Optional*__
-**setuptools**?🔹 | <code>boolean</code> | Use setuptools with a setup.py script for packaging and publishing.<br/>__*Default*__: true if the project type is library
+**setuptools**?🔹 | <code>boolean</code> | Use setuptools with a setup.py script for packaging and publishing.<br/>__*Default*__: true, unless poetry is true, then false
 **stale**?🔹 | <code>boolean</code> | Auto-close of stale issues and pull request.<br/>__*Default*__: false
 **staleOptions**?🔹 | <code>[github.StaleOptions](#projen-github-staleoptions)</code> | Auto-close stale issues and pull requests.<br/>__*Default*__: see defaults in `StaleOptions`
-**venv**?🔹 | <code>boolean</code> | Use venv to manage a virtual environment for installing dependencies inside.<br/>__*Default*__: true
+**venv**?🔹 | <code>boolean</code> | Use venv to manage a virtual environment for installing dependencies inside.<br/>__*Default*__: true, unless poetry is true, then false
 **venvOptions**?🔹 | <code>[python.VenvOptions](#projen-python-venvoptions)</code> | Venv options.<br/>__*Default*__: defaults
 **vscode**?🔹 | <code>boolean</code> | Enable VSCode integration.<br/>__*Default*__: true
 
@@ -17227,7 +17227,7 @@ Name | Type | Description
 **outdir**?🔹 | <code>string</code> | The root directory of the project.<br/>__*Default*__: "."
 **packageName**?🔹 | <code>string</code> | Package name.<br/>__*Optional*__
 **parent**?🔹 | <code>[Project](#projen-project)</code> | The parent project, if this project is part of a bigger project.<br/>__*Optional*__
-**pip**?🔹 | <code>boolean</code> | Use pip with a requirements.txt file to track project dependencies.<br/>__*Default*__: true
+**pip**?🔹 | <code>boolean</code> | Use pip with a requirements.txt file to track project dependencies.<br/>__*Default*__: true, unless poetry is true, then false
 **poetry**?🔹 | <code>boolean</code> | Use poetry to manage your project dependencies, virtual environment, and (optional) packaging/publishing.<br/>__*Default*__: false
 **poetryOptions**?🔹 | <code>[python.PoetryPyprojectOptionsWithoutDeps](#projen-python-poetrypyprojectoptionswithoutdeps)</code> | Additional options to set for poetry if using poetry.<br/>__*Optional*__
 **projectType**?⚠️ | <code>[ProjectType](#projen-projecttype)</code> | Which type of project this is (library/app).<br/>__*Default*__: ProjectType.UNKNOWN
@@ -17247,10 +17247,10 @@ Name | Type | Description
 **renovatebotOptions**?🔹 | <code>[RenovatebotOptions](#projen-renovatebotoptions)</code> | Options for renovatebot.<br/>__*Default*__: default options
 **sample**?🔹 | <code>boolean</code> | Include sample code and test if the relevant directories don't exist.<br/>__*Default*__: true
 **setupConfig**?🔹 | <code>Map<string, any></code> | Additional fields to pass in the setup() function if using setuptools.<br/>__*Optional*__
-**setuptools**?🔹 | <code>boolean</code> | Use setuptools with a setup.py script for packaging and publishing.<br/>__*Default*__: true if the project type is library
+**setuptools**?🔹 | <code>boolean</code> | Use setuptools with a setup.py script for packaging and publishing.<br/>__*Default*__: true, unless poetry is true, then false
 **stale**?🔹 | <code>boolean</code> | Auto-close of stale issues and pull request.<br/>__*Default*__: false
 **staleOptions**?🔹 | <code>[github.StaleOptions](#projen-github-staleoptions)</code> | Auto-close stale issues and pull requests.<br/>__*Default*__: see defaults in `StaleOptions`
-**venv**?🔹 | <code>boolean</code> | Use venv to manage a virtual environment for installing dependencies inside.<br/>__*Default*__: true
+**venv**?🔹 | <code>boolean</code> | Use venv to manage a virtual environment for installing dependencies inside.<br/>__*Default*__: true, unless poetry is true, then false
 **venvOptions**?🔹 | <code>[python.VenvOptions](#projen-python-venvoptions)</code> | Venv options.<br/>__*Default*__: defaults
 **vscode**?🔹 | <code>boolean</code> | Enable VSCode integration.<br/>__*Default*__: true
 

--- a/src/python/python-project.ts
+++ b/src/python/python-project.ts
@@ -102,6 +102,9 @@ export interface PythonProjectOptions
    * Use poetry to manage your project dependencies, virtual environment, and
    * (optional) packaging/publishing.
    *
+   * Please note that this feature is incompatible with pip, setuptools, and venv.
+   * If you set this option to true, then pip, setuptools, and venv will be set to false.
+   *
    * @default false
    * @featured
    */
@@ -222,6 +225,15 @@ export class PythonProject extends GitHubProject {
       );
     }
 
+    let poetry = options.poetry ?? false;
+    let pip = options.pip ?? true;
+    let venv = options.venv ?? true;
+    let setuptools = options.setuptools ?? this.projectType === ProjectType.LIB;
+    // If we select poetry, then pip/venv/setuptools must be set to false
+    if (options.poetry) {
+      pip = venv = setuptools = false;
+    }
+
     // default to projenrc.py if no other projenrc type was elected
     if (options.projenrcPython ?? !anySelected(rcFileTypeOptions)) {
       new ProjenrcPython(this, options.projenrcPythonOptions);
@@ -231,15 +243,15 @@ export class PythonProject extends GitHubProject {
       new ProjenrcJs(this, options.projenrcJsOptions);
     }
 
-    if (options.venv ?? true) {
+    if (venv) {
       this.envManager = new Venv(this, options.venvOptions);
     }
 
-    if (options.pip ?? true) {
+    if (pip) {
       this.depsManager = new Pip(this);
     }
 
-    if (options.setuptools ?? this.projectType === ProjectType.LIB) {
+    if (setuptools) {
       this.packagingManager = new Setuptools(this, {
         version: options.version,
         description: options.description,
@@ -262,8 +274,8 @@ export class PythonProject extends GitHubProject {
     //   this.envManager = this.depsManager;
     // }
 
-    if (options.poetry ?? false) {
-      const poetry = new Poetry(this, {
+    if (poetry) {
+      const poetryProject = new Poetry(this, {
         version: options.version,
         description: options.description,
         authorName: options.authorName,
@@ -276,9 +288,9 @@ export class PythonProject extends GitHubProject {
           ...options.poetryOptions,
         },
       });
-      this.depsManager = poetry;
-      this.envManager = poetry;
-      this.packagingManager = poetry;
+      this.depsManager = poetryProject;
+      this.envManager = poetryProject;
+      this.packagingManager = poetryProject;
     }
 
     if (!this.envManager) {
@@ -299,22 +311,19 @@ export class PythonProject extends GitHubProject {
       );
     }
 
-    if (Number(options.venv ?? true) + Number(options.poetry ?? false) > 1) {
+    if (Number(venv) + Number(poetry) > 1) {
       throw new Error(
         "More than one component has been chosen for managing the environment (venv, conda, pipenv, or poetry)"
       );
     }
 
-    if (Number(options.pip ?? true) + Number(options.poetry ?? false) > 1) {
+    if (Number(pip) + Number(poetry) > 1) {
       throw new Error(
         "More than one component has been chosen for managing dependencies (pip, conda, pipenv, or poetry)"
       );
     }
 
-    if (
-      Number(options.setuptools ?? true) + Number(options.poetry ?? false) >
-      1
-    ) {
+    if (Number(setuptools) + Number(poetry) > 1) {
       throw new Error(
         "More than one component has been chosen for managing packaging (setuptools or poetry)"
       );

--- a/src/python/python-project.ts
+++ b/src/python/python-project.ts
@@ -102,8 +102,8 @@ export interface PythonProjectOptions
    * Use poetry to manage your project dependencies, virtual environment, and
    * (optional) packaging/publishing.
    *
-   * Please note that this feature is incompatible with pip, setuptools, and venv.
-   * If you set this option to true, then pip, setuptools, and venv will be set to false.
+   * This feature is incompatible with pip, setuptools, or venv.
+   * If you set this option to `true`, then pip, setuptools, and venv must be set to `false`.
    *
    * @default false
    * @featured
@@ -230,6 +230,12 @@ export class PythonProject extends GitHubProject {
     const venv = options.venv ?? !poetry;
     const setuptools =
       options.setuptools ?? (!poetry && this.projectType === ProjectType.LIB);
+
+    if (poetry && (pip || venv || setuptools)) {
+      throw new Error(
+        "poetry is true - pip, venv, and setuptools must be undefined or false"
+      );
+    }
 
     // default to projenrc.py if no other projenrc type was elected
     if (options.projenrcPython ?? !anySelected(rcFileTypeOptions)) {

--- a/src/python/python-project.ts
+++ b/src/python/python-project.ts
@@ -71,7 +71,7 @@ export interface PythonProjectOptions
   /**
    * Use pip with a requirements.txt file to track project dependencies.
    *
-   * @default true
+   * @default - true, unless poetry is true, then false
    * @featured
    */
   readonly pip?: boolean;
@@ -79,7 +79,7 @@ export interface PythonProjectOptions
   /**
    * Use venv to manage a virtual environment for installing dependencies inside.
    *
-   * @default true
+   * @default - true, unless poetry is true, then false
    * @featured
    */
   readonly venv?: boolean;
@@ -93,7 +93,7 @@ export interface PythonProjectOptions
   /**
    * Use setuptools with a setup.py script for packaging and publishing.
    *
-   * @default - true if the project type is library
+   * @default - true, unless poetry is true, then false
    * @featured
    */
   readonly setuptools?: boolean;
@@ -228,7 +228,8 @@ export class PythonProject extends GitHubProject {
     const poetry = options.poetry ?? false;
     const pip = options.pip ?? !poetry;
     const venv = options.venv ?? !poetry;
-    const setuptools = options.setuptools ?? !poetry && this.projectType === ProjectType.LIB;
+    const setuptools =
+      options.setuptools ?? (!poetry && this.projectType === ProjectType.LIB);
 
     // default to projenrc.py if no other projenrc type was elected
     if (options.projenrcPython ?? !anySelected(rcFileTypeOptions)) {

--- a/src/python/python-project.ts
+++ b/src/python/python-project.ts
@@ -225,14 +225,10 @@ export class PythonProject extends GitHubProject {
       );
     }
 
-    let poetry = options.poetry ?? false;
-    let pip = options.pip ?? true;
-    let venv = options.venv ?? true;
-    let setuptools = options.setuptools ?? this.projectType === ProjectType.LIB;
-    // If we select poetry, then pip/venv/setuptools must be set to false
-    if (options.poetry) {
-      pip = venv = setuptools = false;
-    }
+    const poetry = options.poetry ?? false;
+    const pip = options.pip ?? !poetry;
+    const venv = options.venv ?? !poetry;
+    const setuptools = options.setuptools ?? !poetry && this.projectType === ProjectType.LIB;
 
     // default to projenrc.py if no other projenrc type was elected
     if (options.projenrcPython ?? !anySelected(rcFileTypeOptions)) {

--- a/test/__snapshots__/inventory.test.ts.snap
+++ b/test/__snapshots__/inventory.test.ts.snap
@@ -1786,7 +1786,7 @@ Array [
         "switch": "parent",
       },
       Object {
-        "default": "true",
+        "default": "- true, unless poetry is true, then false",
         "docs": "Use pip with a requirements.txt file to track project dependencies.",
         "featured": true,
         "fullType": Object {
@@ -2168,7 +2168,7 @@ Array [
         "switch": "setup-config",
       },
       Object {
-        "default": "- true if the project type is library",
+        "default": "- true, unless poetry is true, then false",
         "docs": "Use setuptools with a setup.py script for packaging and publishing.",
         "featured": true,
         "fullType": Object {
@@ -2238,7 +2238,7 @@ Array [
         "switch": "testdir",
       },
       Object {
-        "default": "true",
+        "default": "- true, unless poetry is true, then false",
         "docs": "Use venv to manage a virtual environment for installing dependencies inside.",
         "featured": true,
         "fullType": Object {
@@ -8705,7 +8705,7 @@ Array [
         "switch": "parent",
       },
       Object {
-        "default": "true",
+        "default": "- true, unless poetry is true, then false",
         "docs": "Use pip with a requirements.txt file to track project dependencies.",
         "featured": true,
         "fullType": Object {
@@ -9068,7 +9068,7 @@ Array [
         "switch": "setup-config",
       },
       Object {
-        "default": "- true if the project type is library",
+        "default": "- true, unless poetry is true, then false",
         "docs": "Use setuptools with a setup.py script for packaging and publishing.",
         "featured": true,
         "fullType": Object {
@@ -9121,7 +9121,7 @@ Array [
         "switch": "stale-options",
       },
       Object {
-        "default": "true",
+        "default": "- true, unless poetry is true, then false",
         "docs": "Use venv to manage a virtual environment for installing dependencies inside.",
         "featured": true,
         "fullType": Object {
@@ -28075,7 +28075,7 @@ Array [
         "switch": "parent",
       },
       Object {
-        "default": "true",
+        "default": "- true, unless poetry is true, then false",
         "docs": "Use pip with a requirements.txt file to track project dependencies.",
         "featured": true,
         "fullType": Object {
@@ -28438,7 +28438,7 @@ Array [
         "switch": "setup-config",
       },
       Object {
-        "default": "- true if the project type is library",
+        "default": "- true, unless poetry is true, then false",
         "docs": "Use setuptools with a setup.py script for packaging and publishing.",
         "featured": true,
         "fullType": Object {
@@ -28491,7 +28491,7 @@ Array [
         "switch": "stale-options",
       },
       Object {
-        "default": "true",
+        "default": "- true, unless poetry is true, then false",
         "docs": "Use venv to manage a virtual environment for installing dependencies inside.",
         "featured": true,
         "fullType": Object {

--- a/test/python/poetry.test.ts
+++ b/test/python/poetry.test.ts
@@ -22,6 +22,69 @@ test("poetry enabled", () => {
   expect(snapshot["pyproject.toml"]).toContain('python = "^3.7"'); // default python version
 });
 
+test("poetry and venv fails", () => {
+  expect(
+    () =>
+      new TestPythonProject({
+        poetry: true,
+        venv: true,
+        homepage: "http://www.example.com",
+        description: "a short project description",
+        license: "Apache-2.0",
+        classifiers: ["Development Status :: 4 - Beta"],
+      })
+  ).toThrowError();
+});
+
+test("poetry and pip fails", () => {
+  expect(
+    () =>
+      new TestPythonProject({
+        poetry: true,
+        pip: true,
+        homepage: "http://www.example.com",
+        description: "a short project description",
+        license: "Apache-2.0",
+        classifiers: ["Development Status :: 4 - Beta"],
+      })
+  ).toThrowError();
+});
+
+test("poetry and setuptools fails", () => {
+  expect(
+    () =>
+      new TestPythonProject({
+        poetry: true,
+        setuptools: true,
+        homepage: "http://www.example.com",
+        description: "a short project description",
+        license: "Apache-2.0",
+        classifiers: ["Development Status :: 4 - Beta"],
+      })
+  ).toThrowError();
+});
+
+test("poetry enabled", () => {
+  const p = new TestPythonProject({
+    poetry: true,
+    homepage: "http://www.example.com",
+    description: "a short project description",
+    license: "Apache-2.0",
+    classifiers: ["Development Status :: 4 - Beta"],
+  });
+
+  const snapshot = synthSnapshot(p);
+  expect(snapshot["pyproject.toml"]).toContain("First Last");
+  expect(snapshot["pyproject.toml"]).toContain("email@example.com");
+  expect(snapshot["pyproject.toml"]).toContain("http://www.example.com");
+  expect(snapshot["pyproject.toml"]).toContain("a short project description");
+  expect(snapshot["pyproject.toml"]).toContain("Apache-2.0");
+  expect(snapshot["pyproject.toml"]).toContain(
+    "Development Status :: 4 - Beta"
+  );
+  expect(snapshot["pyproject.toml"]).toContain('python = "^3.7"'); // default python version
+});
+
 test("poetry enabled with specified python version", () => {
   const p = new TestPythonProject({
     poetry: true,

--- a/test/python/poetry.test.ts
+++ b/test/python/poetry.test.ts
@@ -3,9 +3,6 @@ import { synthSnapshot } from "../util";
 
 test("poetry enabled", () => {
   const p = new TestPythonProject({
-    venv: false,
-    pip: false,
-    setuptools: false,
     poetry: true,
     homepage: "http://www.example.com",
     description: "a short project description",
@@ -27,9 +24,6 @@ test("poetry enabled", () => {
 
 test("poetry enabled with specified python version", () => {
   const p = new TestPythonProject({
-    venv: false,
-    pip: false,
-    setuptools: false,
     poetry: true,
     homepage: "http://www.example.com",
     description: "a short project description",
@@ -44,9 +38,6 @@ test("poetry enabled with specified python version", () => {
 
 test("poetry enabled with poetry-specific options", () => {
   const p = new TestPythonProject({
-    venv: false,
-    pip: false,
-    setuptools: false,
     poetry: true,
     homepage: "http://www.example.com",
     description: "a short project description",


### PR DESCRIPTION
Explicitly unsets pip, setuptools, and venv if poetry is set to true. This enables the creation of a PythonProject with the `--poetry true` flag.

Considered throwing errors if both poetry and pip were set to true, but opted instead to provide warnings in the interface instead. If there is a use case for poetry being set with one or more of pip, setuptools, and venv, we can re-evaluate this.

fixes #1863

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.