### PR TITLE
feat(jest): convert Jest to Component

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -7879,6 +7879,7 @@ Installs the following npm scripts:.
 
 __Submodule__: javascript
 
+__Extends__: [Component](#projen-component)
 
 ### Initializer
 
@@ -7910,7 +7911,8 @@ new javascript.Jest(project: NodeProject, options?: JestOptions)
 Name | Type | Description 
 -----|------|-------------
 **config**🔹 | <code>any</code> | Escape hatch.
-**jestVersion**🔹 | <code>string</code> | <span></span>
+**jestVersion**🔹 | <code>string</code> | Jest version, including `@` symbol, like `@^29`.
+**file**?🔹 | <code>[JsonFile](#projen-jsonfile)</code> | Jest config file.<br/>__*Optional*__
 
 ### Methods
 
@@ -7979,6 +7981,19 @@ addWatchIgnorePattern(pattern: string): void
 
 
 
+
+#### *static* of(project)🔹 <a id="projen-javascript-jest-of"></a>
+
+Returns the singletone Jest component of a project or undefined if there is none.
+
+```ts
+static of(project: Project): Jest
+```
+
+* **project** (<code>[Project](#projen-project)</code>)  *No description*
+
+__Returns__:
+* <code>[javascript.Jest](#projen-javascript-jest)</code>
 
 
 


### PR DESCRIPTION
Contrary to ESLint, Prettier, and most of the other components `Jest` is not extending the `Component` class but just a generic class that can only be accessed via `project.jest` property (if set)

This PR proposes converting the `Jest` class into the `Component` subclass for the following benefits:
* unification of approach with Eslint, Prettier, Projenrc, and other components
* providing `Jest.of(project)` API to be in line with Eslint and Prettier components and simplify accessing/extending Jest from outside components
* Facilitates future [migration to Constructs](https://github.com/projen/projen/pull/1671/files#diff-02bcf880af61bcbdba8cd4974d4a8ac84d32fcc0d4f4fb08d05cc053d3176c42) if that hopefully will happen one day

Additional small fixes in this PR:
* adding Jest external config to npmignore
* exposing the `file` property as public following [TypescriptConfig component](https://github.com/projen/projen/blob/main/src/javascript/typescript-config.ts#L405) design and simplifying JSON patching to support more properties.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.