### PR TITLE
fix: remove refactor prefix from docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,8 +118,7 @@ npm utility.
 ## Making a pull request
 
 - Commit title and message (and PR title and description) must adhere to [conventionalcommits](https://www.conventionalcommits.org).
-  - The title must begin with `feat(module): title`, `fix(module): title`,
-    `refactor(module): title` or `chore(module): title`, where the module refers
+  - The title must begin with `feat(module): title`, `fix(module): title` or `chore(module): title`, where the module refers
     to the projects or components that the change centers on.
     The module can be omitted, so "feat: title" is okay as well.
   - Title should be lowercase.


### PR DESCRIPTION
Wasn't sure what's the source of truth, but according to the [GHA workflow, `refactor` is not allowed](https://github.com/projen/projen/blob/main/.github/workflows/pull-request-lint.yml#L24-L27) for semantic commits.
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.