### PR TITLE
feat(typescript): support `noImplicitOverride`

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -17073,6 +17073,7 @@ Name | Type | Description
 **noEmitOnError**?🔹 | <code>boolean</code> | Do not emit compiler output files like JavaScript source code, source-maps or declarations if any errors were reported.<br/>__*Default*__: true
 **noFallthroughCasesInSwitch**?🔹 | <code>boolean</code> | Report errors for fallthrough cases in switch statements.<br/>__*Default*__: true
 **noImplicitAny**?🔹 | <code>boolean</code> | In some cases where no type annotations are present, TypeScript will fall back to a type of any for a variable when it cannot infer the type.<br/>__*Default*__: true
+**noImplicitOverride**?🔹 | <code>boolean</code> | Using `noImplicitOverride`, you can ensure that sub-classes never go out of sync as they are required to explicitly declare that they are overriding a member using the `override` keyword.<br/>__*Default*__: false
 **noImplicitReturns**?🔹 | <code>boolean</code> | When enabled, TypeScript will check all code paths in a function to ensure they return a value.<br/>__*Default*__: true
 **noImplicitThis**?🔹 | <code>boolean</code> | Raise error on ‘this’ expressions with an implied ‘any’ type.<br/>__*Default*__: true
 **noPropertyAccessFromIndexSignature**?🔹 | <code>boolean</code> | Raise error on use of the dot syntax to access fields which are not defined.<br/>__*Default*__: true

--- a/src/javascript/typescript-config.ts
+++ b/src/javascript/typescript-config.ts
@@ -266,6 +266,17 @@ export interface TypeScriptCompilerOptions {
   readonly noImplicitAny?: boolean;
 
   /**
+   * Using `noImplicitOverride`, you can ensure that sub-classes never go out of sync as
+   * they are required to explicitly declare that they are overriding a member using the
+   * `override` keyword. This also improves readability of the programmer's intent.
+   *
+   * Available with TypeScript 4.3 and newer.
+   *
+   * @default false
+   */
+  readonly noImplicitOverride?: boolean;
+
+  /**
    * When enabled, TypeScript will check all code paths in a function to ensure they
    * return a value.
    *


### PR DESCRIPTION
Allows to require use of the `override` keyword to indicate that a member overrides a declaration from a parent type, improving code readability and providing additional protection against typos and rename churn.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.