### PR TITLE
feat: allow overwriting the checkout settings during build

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -4922,6 +4922,20 @@ Name | Type | Description
 ### Methods
 
 
+#### addCloneOptions(optionKey, optionValue)🔹 <a id="projen-build-buildworkflow-addcloneoptions"></a>
+
+Adds a clone option to the checkout step.
+
+```ts
+addCloneOptions(optionKey: string, optionValue: any): void
+```
+
+* **optionKey** (<code>string</code>)  *No description*
+* **optionValue** (<code>any</code>)  *No description*
+
+
+
+
 #### addPostBuildJob(id, job)🔹 <a id="projen-build-buildworkflow-addpostbuildjob"></a>
 
 Adds another job to the build workflow which is executed after the build job succeeded.

--- a/src/build/build-workflow.ts
+++ b/src/build/build-workflow.ts
@@ -116,6 +116,7 @@ export class BuildWorkflow extends Component {
   private readonly defaultRunners: string[] = ["ubuntu-latest"];
 
   private readonly _postBuildJobs: string[] = [];
+  private _cloneOptions: Record<string, any> = {};
 
   constructor(project: Project, options: BuildWorkflowOptions) {
     super(project);
@@ -322,6 +323,13 @@ export class BuildWorkflow extends Component {
     });
   }
 
+  /**
+   * Adds a clone option to the checkout step.
+   */
+  public addCloneOptions(optionKey: string, optionValue: any) {
+    this._cloneOptions[optionKey] = optionValue;
+  }
+
   private addSelfMutationJob(options: BuildWorkflowOptions) {
     this.workflow.addJob("self-mutation", {
       runsOn: options.runsOn ?? this.defaultRunners,
@@ -364,6 +372,7 @@ export class BuildWorkflow extends Component {
           ref: PULL_REQUEST_REF,
           repository: PULL_REQUEST_REPOSITORY,
           ...(this.github.downloadLfs ? { lfs: true } : {}),
+          ...this._cloneOptions,
         },
       },
 

--- a/test/github/workflows.test.ts
+++ b/test/github/workflows.test.ts
@@ -1,3 +1,4 @@
+import { BuildWorkflow } from "../../src/build";
 import { Project } from "../../src/project";
 import { synthSnapshot, TestProject } from "../util";
 
@@ -143,3 +144,22 @@ function synthWorkflows(p: Project): any {
     }, {});
   return filtered;
 }
+
+test("build workflow can set clone options", () => {
+  // GIVEN
+  const p = new TestProject();
+
+  // WHEN
+  const buildWorkflow = new BuildWorkflow(p, {
+    buildTask: p.buildTask,
+    artifactsDirectory: "dist",
+  });
+  buildWorkflow.addCloneOptions("fetch-depth", 0);
+
+  // THEN
+  const workflows = synthWorkflows(p);
+  expect(workflows[".github/workflows/build.yml"]).toBeDefined();
+  expect(workflows[".github/workflows/build.yml"]).toEqual(
+    expect.stringContaining("fetch-depth: 0")
+  );
+});


### PR DESCRIPTION
We need to do a full checkout on build so that our jsii docgen generated golang docs have the correct major version in them