### PR TITLE
fix(tasks): Handle non-string task env vars

### DIFF
--- a/src/task-runtime.ts
+++ b/src/task-runtime.ts
@@ -255,7 +255,7 @@ class RunTask {
     const output: { [name: string]: string | undefined } = {};
 
     for (const [key, value] of Object.entries(env ?? {})) {
-      if (value.startsWith("$(") && value.endsWith(")")) {
+      if (String(value).startsWith("$(") && String(value).endsWith(")")) {
         const query = value.substring(2, value.length - 1);
         const result = this.shellEval({ command: query });
         if (result.status !== 0) {

--- a/src/task.ts
+++ b/src/task.ts
@@ -1,3 +1,4 @@
+import { warn } from "./logging";
 import {
   TaskCommonOptions,
   TaskSpec,
@@ -57,6 +58,7 @@ export class Task {
     this._locked = false;
 
     this._env = props.env ?? {};
+
     this._steps = props.steps ?? [];
     this.requiredEnv = props.requiredEnv;
 
@@ -207,7 +209,14 @@ export class Task {
    */
   public env(name: string, value: string) {
     this.assertUnlocked();
-    this._env[name] = value;
+    if (typeof value !== "string" && value !== undefined) {
+      warn(
+        `Received non-string value for environment variable ${name}. Value will be stringified.`
+      );
+      this._env[name] = String(value);
+    } else {
+      this._env[name] = value;
+    }
   }
 
   /**

--- a/src/task.ts
+++ b/src/task.ts
@@ -56,8 +56,9 @@ export class Task {
     this.condition = props.condition;
     this.cwd = props.cwd;
     this._locked = false;
+    this._env = {};
 
-    this._env = props.env ?? {};
+    this.addEnv(props.env ?? {});
 
     this._steps = props.steps ?? [];
     this.requiredEnv = props.requiredEnv;
@@ -209,14 +210,7 @@ export class Task {
    */
   public env(name: string, value: string) {
     this.assertUnlocked();
-    if (typeof value !== "string" && value !== undefined) {
-      warn(
-        `Received non-string value for environment variable ${name}. Value will be stringified.`
-      );
-      this._env[name] = String(value);
-    } else {
-      this._env[name] = value;
-    }
+    this.addEnv({ [name]: value });
   }
 
   /**
@@ -252,5 +246,18 @@ export class Task {
     if (this._locked) {
       throw new Error(`Task "${this.name}" is locked for changes`);
     }
+  }
+
+  private addEnv(env: { [name: string]: string }) {
+    Object.entries(env).forEach(([name, value]) => {
+      if (typeof value !== "string" && value !== undefined) {
+        warn(
+          `Received non-string value for environment variable ${name}. Value will be stringified.`
+        );
+        this._env[name] = String(value);
+      } else {
+        this._env[name] = value;
+      }
+    });
   }
 }

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -88,7 +88,14 @@ export class Tasks extends Component {
    * @param value Value
    */
   public addEnvironment(name: string, value: string) {
-    this._env[name] = value;
+    if (typeof value !== "string" && value !== undefined) {
+      this.project.logger.warn(
+        `Received non-string value for environment variable ${name}. Value will be stringified.`
+      );
+      this._env[name] = String(value);
+    } else {
+      this._env[name] = value;
+    }
   }
 
   /**

--- a/test/__snapshots__/projects.test.ts.snap
+++ b/test/__snapshots__/projects.test.ts.snap
@@ -16,7 +16,8 @@ project.synth();"
 `;
 
 exports[`createProject creates a project from an external project type, if it's installed 1`] = `
-"const { AwsCdkTypeScriptApp, javascript } = require(\\"@pepperize/projen-awscdk-app-ts\\");
+"const { javascript } = require(\\"projen\\");
+const { AwsCdkTypeScriptApp } = require(\\"@pepperize/projen-awscdk-app-ts\\");
 const project = new AwsCdkTypeScriptApp({
   cdkVersion: \\"2.50.0\\",
   defaultReleaseBranch: \\"main\\",

--- a/test/__snapshots__/projects.test.ts.snap
+++ b/test/__snapshots__/projects.test.ts.snap
@@ -16,8 +16,7 @@ project.synth();"
 `;
 
 exports[`createProject creates a project from an external project type, if it's installed 1`] = `
-"const { javascript } = require(\\"projen\\");
-const { AwsCdkTypeScriptApp } = require(\\"@pepperize/projen-awscdk-app-ts\\");
+"const { AwsCdkTypeScriptApp, javascript } = require(\\"@pepperize/projen-awscdk-app-ts\\");
 const project = new AwsCdkTypeScriptApp({
   cdkVersion: \\"2.50.0\\",
   defaultReleaseBranch: \\"main\\",

--- a/test/tasks/runtime.test.ts
+++ b/test/tasks/runtime.test.ts
@@ -3,6 +3,7 @@ import { EOL } from "os";
 import { basename, join } from "path";
 import { mkdirpSync } from "fs-extra";
 import { Project } from "../../src";
+import * as logging from "../../src/logging";
 import { TaskRuntime } from "../../src/task-runtime";
 import { TestProject } from "../util";
 
@@ -101,6 +102,7 @@ describe("environment variables", () => {
 
   test("numerics are converted properly (task vars)", () => {
     // GIVEN
+    const warn = jest.spyOn(logging, "warn");
     const p = new TestProject();
 
     // WHEN
@@ -113,6 +115,10 @@ describe("environment variables", () => {
 
     // THEN
     expect(executeTask(p, "test:env")).toEqual(["1!"]);
+    expect(warn).toBeCalledWith(
+      "Received non-string value for environment variable VALUE. Value will be stringified."
+    );
+    warn.mockRestore();
   });
 
   test("numerics are converted properly (global vars)", () => {

--- a/test/tasks/runtime.test.ts
+++ b/test/tasks/runtime.test.ts
@@ -66,6 +66,70 @@ test("execution stops if a step fails", () => {
   );
 });
 
+describe("environment variables", () => {
+  test("are accessible from exec", () => {
+    // GIVEN
+    const p = new TestProject();
+
+    // WHEN
+    p.addTask("test:env", {
+      exec: "echo ${VALUE}!",
+      env: {
+        VALUE: "my_environment_var",
+      },
+    });
+
+    // THEN
+    expect(executeTask(p, "test:env")).toEqual(["my_environment_var!"]);
+  });
+
+  test("are resolved dynamically", () => {
+    // GIVEN
+    const p = new TestProject();
+
+    // WHEN
+    p.addTask("test:env", {
+      exec: "echo ${VALUE}!",
+      env: {
+        VALUE: '$(echo "dynamic_value")',
+      },
+    });
+
+    // THEN
+    expect(executeTask(p, "test:env")).toEqual(["dynamic_value!"]);
+  });
+
+  test("numerics are converted properly (task vars)", () => {
+    // GIVEN
+    const p = new TestProject();
+
+    // WHEN
+    p.addTask("test:env", {
+      exec: "echo ${VALUE}!",
+      env: {
+        VALUE: 1 as unknown as string,
+      },
+    });
+
+    // THEN
+    expect(executeTask(p, "test:env")).toEqual(["1!"]);
+  });
+
+  test("numerics are converted properly (global vars)", () => {
+    // GIVEN
+    const p = new TestProject();
+
+    // WHEN
+    p.addTask("test:env", {
+      exec: "echo ${VALUE}!",
+    });
+    p.tasks.addEnvironment("VALUE", 1 as unknown as string);
+
+    // THEN
+    expect(executeTask(p, "test:env")).toEqual(["1!"]);
+  });
+});
+
 describe("condition", () => {
   test("zero exit code means that steps should be executed", () => {
     // GIVEN


### PR DESCRIPTION
Project types that do not use `.projenrc.ts` cannot guard against end users providing numbers for environment variables. Casting them to strings before storing internally

If someone tries to do either of the following:
```js
// .projenrc.js
project.tasks.addEnvironment('LINT_THRESHOLD', 9);
```
```python
# .projenrc.py
project.tasks.add_environment('LINT_THRESHOLD', 9)
```

They'll get the following error on synthesis:
```
            if (value.startsWith("$(") && value.endsWith(")")) {
                      ^

TypeError: value.startsWith is not a function
    at RunTask.resolveEnvironment (/Users/.../node_modules/projen/lib/task-runtime.js:196:23)
    at new RunTask (/Users/.../node_modules/projen/lib/task-runtime.js:73:25)
    at TaskRuntime.runTask (/Users/.../node_modules/projen/lib/task-runtime.js:52:9)
    at Pip.installDependencies (/Users/.../node_modules/projen/lib/python/pip.js:51:17)
```

This PR makes the internal task components more defensive in terms of what kinds of values it might receive from end users. Added some tests to confirm behavior as well.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
