### PR TITLE
feat(cli): allow running `projen` in a subdirectory

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,4 +1,5 @@
 import { resolve } from "path";
+import * as fs from "fs-extra";
 import * as yargs from "yargs";
 import newCommand from "./cmds/new";
 import { synth } from "./synth";
@@ -8,7 +9,7 @@ import * as logging from "../logging";
 import { TaskRuntime } from "../task-runtime";
 import { getNodeMajorVersion } from "../util";
 
-const DEFAULT_RC = resolve(PROJEN_RC);
+const DEFAULT_RC = findProjenRc(process.cwd());
 
 async function main() {
   const ya = yargs;
@@ -81,3 +82,22 @@ main().catch((e) => {
   console.error(e.stack);
   process.exit(1);
 });
+
+/**
+ * Run up project tree to find .projenrc.js
+ *
+ * @param cwd current working directory
+ * @returns path to .projenrc.js or undefined if not found
+ */
+function findProjenRc(cwd: string): string | undefined {
+  if (cwd === "/") {
+    return undefined;
+  }
+
+  const projenrc = resolve(cwd, PROJEN_RC);
+  if (fs.existsSync(projenrc)) {
+    return projenrc;
+  }
+
+  return findProjenRc(resolve(cwd, ".."));
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,13 +9,15 @@ import * as logging from "../logging";
 import { TaskRuntime } from "../task-runtime";
 import { getNodeMajorVersion } from "../util";
 
-const DEFAULT_RC = findProjenRc(process.cwd());
+const DEFAULT_RC = resolve(PROJEN_RC);
 
 async function main() {
   const ya = yargs;
   ya.command(newCommand);
 
-  const runtime = new TaskRuntime(".");
+  let pathToProjenRc = findProjenRc(process.cwd());
+
+  const runtime = new TaskRuntime(pathToProjenRc ?? ".");
   discoverTaskCommands(runtime, ya);
 
   ya.recommendCommands();
@@ -96,7 +98,7 @@ function findProjenRc(cwd: string): string | undefined {
 
   const projenrc = resolve(cwd, PROJEN_RC);
   if (fs.existsSync(projenrc)) {
-    return projenrc;
+    return cwd;
   }
 
   return findProjenRc(resolve(cwd, ".."));

--- a/src/task-runtime.ts
+++ b/src/task-runtime.ts
@@ -35,7 +35,7 @@ export class TaskRuntime {
   public readonly workdir: string;
 
   constructor(workdir: string) {
-    this.workdir = resolve(workdir);
+    this.workdir = workdir;
     const manifestPath = join(this.workdir, TaskRuntime.MANIFEST_FILE);
     this.manifest = existsSync(manifestPath)
       ? JSON.parse(readFileSync(manifestPath, "utf-8"))

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -35,13 +35,18 @@ test('running "projen" for projects with a "default" task will execute it', () =
   expect(directorySnapshot(project.outdir)["bar.txt"]).toStrictEqual("foo\n");
 });
 
-test('running "projen" in a subdirectory will execute .projenrc.js in parent directory', () => {
-  const dir1 = mkdtemp();
-  const dir2 = mkdtemp({ dir: dir1 });
+test('running "projen" in a subdirectory for projects with a "default" task will execute it from parent .projenrc', () => {
+  const project = new Project({ name: "my-project" });
+  const subProject = new Project({
+    name: "my-sub-project",
+    parent: project,
+    outdir: "sub-project",
+  });
+  subProject.defaultTask?.exec('echo "foo" > bar.txt');
+  project.synth();
 
-  const rcfile = join(dir1, ".projenrc.js");
-  writeFileSync(rcfile, MOCK_PROJENRC);
-
-  execProjenCLI(dir2);
-  expect(directorySnapshot(dir2)).toMatchSnapshot();
+  execProjenCLI(subProject.outdir);
+  expect(directorySnapshot(subProject.outdir)["bar.txt"]).toStrictEqual(
+    "foo\n"
+  );
 });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -34,3 +34,14 @@ test('running "projen" for projects with a "default" task will execute it', () =
   execProjenCLI(project.outdir);
   expect(directorySnapshot(project.outdir)["bar.txt"]).toStrictEqual("foo\n");
 });
+
+test('running "projen" in a subdirectory will execute .projenrc.js in parent directory', () => {
+  const dir1 = mkdtemp();
+  const dir2 = mkdtemp({ dir: dir1 });
+
+  const rcfile = join(dir1, ".projenrc.js");
+  writeFileSync(rcfile, MOCK_PROJENRC);
+
+  execProjenCLI(dir2);
+  expect(directorySnapshot(dir2)).toMatchSnapshot();
+});

--- a/test/util.ts
+++ b/test/util.ts
@@ -58,8 +58,10 @@ afterAll((done) => {
   done();
 });
 
-export function mkdtemp(opts: { cleanup?: boolean } = {}) {
-  const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "projen-test-"));
+export function mkdtemp(opts: { cleanup?: boolean; dir?: string } = {}) {
+  const tmpdir = fs.mkdtempSync(
+    path.join(opts.dir ?? os.tmpdir(), "projen-test-")
+  );
   if (opts.cleanup ?? true) {
     autoRemove.add(tmpdir);
   }


### PR DESCRIPTION
This PR adds the feature to run `projen` commands from subdirectories in a projen project.

#### Closes #2418.
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.