### PR TITLE
chore(node-package): Use tasks for installing dependencies

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -166,6 +166,24 @@
         }
       ]
     },
+    "install": {
+      "name": "install",
+      "description": "Install project dependencies and update lockfile (non-frozen)",
+      "steps": [
+        {
+          "exec": "yarn install --check-files"
+        }
+      ]
+    },
+    "install:ci": {
+      "name": "install:ci",
+      "description": "Install project dependencies using frozen lockfile",
+      "steps": [
+        {
+          "exec": "yarn install --check-files --frozen-lockfile"
+        }
+      ]
+    },
     "integ": {
       "name": "integ",
       "description": "Run integration tests",

--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -8288,7 +8288,9 @@ Name | Type | Description
 **allowLibraryDependencies**🔹 | <code>boolean</code> | Allow project to take library dependencies.
 **entrypoint**🔹 | <code>string</code> | The module's entrypoint (e.g. `lib/index.js`).
 **installAndUpdateLockfileCommand**🔹 | <code>string</code> | Renders `yarn install` or `npm install` with lockfile update (not frozen).
+**installCiTask**🔹 | <code>[Task](#projen-task)</code> | The task for installing project dependencies (frozen).
 **installCommand**🔹 | <code>string</code> | Returns the command to execute in order to install all dependencies (always frozen).
+**installTask**🔹 | <code>[Task](#projen-task)</code> | The task for installing project dependencies (non-frozen).
 **lockFile**🔹 | <code>string</code> | The name of the lock file.
 **manifest**⚠️ | <code>any</code> | <span></span>
 **npmAccess**🔹 | <code>[javascript.NpmAccess](#projen-javascript-npmaccess)</code> | npm package access level.

--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -605,14 +605,11 @@ export class NodePackage extends Component {
         "Install project dependencies and update lockfile (non-frozen)",
       exec: this.installAndUpdateLockfileCommand,
     });
-    // Necessary to prevent infinite loop
-    this.removeScript(this.installTask.name);
 
     this.installCiTask = project.addTask("install:ci", {
       description: "Install project dependencies using frozen lockfile",
       exec: this.installCommand,
     });
-    this.removeScript(this.installCiTask.name);
   }
 
   /**
@@ -1422,9 +1419,15 @@ export class NodePackage extends Component {
 
   private renderScripts() {
     const result: any = {};
-    for (const task of this.project.tasks.all.sort((x, y) =>
-      x.name.localeCompare(y.name)
-    )) {
+    const tasks = this.project.tasks.all
+      .filter(
+        (t) =>
+          // Must remove to prevent overriding built-in npm command (which would loop)
+          t.name !== this.installTask.name && t.name !== this.installCiTask.name
+      )
+      .sort((x, y) => x.name.localeCompare(y.name));
+
+    for (const task of tasks) {
       result[task.name] = this.npmScriptForTask(task);
     }
 

--- a/src/task-runtime.ts
+++ b/src/task-runtime.ts
@@ -4,7 +4,7 @@ import { platform } from "os";
 import { dirname, join, resolve } from "path";
 import * as path from "path";
 import { format } from "util";
-import * as chalk from "chalk";
+import { gray, underline } from "chalk";
 import { PROJEN_DIR } from "./common";
 import * as logging from "./logging";
 import { TasksManifest, TaskSpec } from "./task-model";
@@ -94,9 +94,7 @@ class RunTask {
     this.parents = parents;
 
     if (!task.steps || task.steps.length === 0) {
-      this.logDebug(
-        chalk.gray("No actions have been specified for this task.")
-      );
+      this.logDebug(gray("No actions have been specified for this task."));
       return;
     }
 
@@ -111,9 +109,7 @@ class RunTask {
     }
 
     if (envlogs.length) {
-      this.logDebug(
-        chalk.gray(`${chalk.underline("env")}: ${envlogs.join(" ")}`)
-      );
+      this.logDebug(gray(`${underline("env")}: ${envlogs.join(" ")}`));
     }
 
     // evaluate condition
@@ -217,7 +213,7 @@ class RunTask {
       return true;
     }
 
-    this.log(chalk.gray(`${chalk.underline("condition")}: ${task.condition}`));
+    this.log(gray(`${underline("condition")}: ${task.condition}`));
     const result = this.shell({
       command: task.condition,
       logprefix: "condition: ",
@@ -291,7 +287,7 @@ class RunTask {
   }
 
   private fmtLog(...args: any[]) {
-    return format(`${chalk.underline(this.fullname)} |`, ...args);
+    return format(`${underline(this.fullname)} |`, ...args);
   }
 
   private shell(options: ShellOptions) {

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -994,6 +994,24 @@ tsconfig.tsbuildinfo
         }
       ]
     },
+    \\"install\\": {
+      \\"name\\": \\"install\\",
+      \\"description\\": \\"Install project dependencies and update lockfile (non-frozen)\\",
+      \\"steps\\": [
+        {
+          \\"exec\\": \\"yarn install --check-files\\"
+        }
+      ]
+    },
+    \\"install:ci\\": {
+      \\"name\\": \\"install:ci\\",
+      \\"description\\": \\"Install project dependencies using frozen lockfile\\",
+      \\"steps\\": [
+        {
+          \\"exec\\": \\"yarn install --check-files --frozen-lockfile\\"
+        }
+      ]
+    },
     \\"package\\": {
       \\"name\\": \\"package\\",
       \\"description\\": \\"Creates the distribution package\\",
@@ -2072,6 +2090,24 @@ tsconfig.tsbuildinfo
       \\"steps\\": [
         {
           \\"exec\\": \\"eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools .projenrc.js\\"
+        }
+      ]
+    },
+    \\"install\\": {
+      \\"name\\": \\"install\\",
+      \\"description\\": \\"Install project dependencies and update lockfile (non-frozen)\\",
+      \\"steps\\": [
+        {
+          \\"exec\\": \\"yarn install --check-files\\"
+        }
+      ]
+    },
+    \\"install:ci\\": {
+      \\"name\\": \\"install:ci\\",
+      \\"description\\": \\"Install project dependencies using frozen lockfile\\",
+      \\"steps\\": [
+        {
+          \\"exec\\": \\"yarn install --check-files --frozen-lockfile\\"
         }
       ]
     },
@@ -3245,6 +3281,24 @@ tsconfig.tsbuildinfo
         }
       ]
     },
+    \\"install\\": {
+      \\"name\\": \\"install\\",
+      \\"description\\": \\"Install project dependencies and update lockfile (non-frozen)\\",
+      \\"steps\\": [
+        {
+          \\"exec\\": \\"yarn install --check-files\\"
+        }
+      ]
+    },
+    \\"install:ci\\": {
+      \\"name\\": \\"install:ci\\",
+      \\"description\\": \\"Install project dependencies using frozen lockfile\\",
+      \\"steps\\": [
+        {
+          \\"exec\\": \\"yarn install --check-files --frozen-lockfile\\"
+        }
+      ]
+    },
     \\"package\\": {
       \\"name\\": \\"package\\",
       \\"description\\": \\"Creates the distribution package\\",
@@ -4311,6 +4365,24 @@ permissions-backup.acl
       \\"steps\\": [
         {
           \\"spawn\\": \\"default\\"
+        }
+      ]
+    },
+    \\"install\\": {
+      \\"name\\": \\"install\\",
+      \\"description\\": \\"Install project dependencies and update lockfile (non-frozen)\\",
+      \\"steps\\": [
+        {
+          \\"exec\\": \\"pnpm i --no-frozen-lockfile\\"
+        }
+      ]
+    },
+    \\"install:ci\\": {
+      \\"name\\": \\"install:ci\\",
+      \\"description\\": \\"Install project dependencies using frozen lockfile\\",
+      \\"steps\\": [
+        {
+          \\"exec\\": \\"pnpm i --frozen-lockfile\\"
         }
       ]
     },

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -945,6 +945,24 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
           },
         ],
       },
+      "install": Object {
+        "description": "Install project dependencies and update lockfile (non-frozen)",
+        "name": "install",
+        "steps": Array [
+          Object {
+            "exec": "yarn install --check-files",
+          },
+        ],
+      },
+      "install:ci": Object {
+        "description": "Install project dependencies using frozen lockfile",
+        "name": "install:ci",
+        "steps": Array [
+          Object {
+            "exec": "yarn install --check-files --frozen-lockfile",
+          },
+        ],
+      },
       "package": Object {
         "description": "Creates the distribution package",
         "name": "package",

--- a/test/typescript/__snapshots__/typescript.test.ts.snap
+++ b/test/typescript/__snapshots__/typescript.test.ts.snap
@@ -823,6 +823,24 @@ tsconfig.tsbuildinfo
           },
         ],
       },
+      "install": Object {
+        "description": "Install project dependencies and update lockfile (non-frozen)",
+        "name": "install",
+        "steps": Array [
+          Object {
+            "exec": "yarn install --check-files",
+          },
+        ],
+      },
+      "install:ci": Object {
+        "description": "Install project dependencies using frozen lockfile",
+        "name": "install:ci",
+        "steps": Array [
+          Object {
+            "exec": "yarn install --check-files --frozen-lockfile",
+          },
+        ],
+      },
       "package": Object {
         "description": "Creates the distribution package",
         "name": "package",

--- a/test/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-project.test.ts.snap
@@ -529,6 +529,24 @@ permissions-backup.acl
           },
         ],
       },
+      "install": Object {
+        "description": "Install project dependencies and update lockfile (non-frozen)",
+        "name": "install",
+        "steps": Array [
+          Object {
+            "exec": "yarn install --check-files",
+          },
+        ],
+      },
+      "install:ci": Object {
+        "description": "Install project dependencies using frozen lockfile",
+        "name": "install:ci",
+        "steps": Array [
+          Object {
+            "exec": "yarn install --check-files --frozen-lockfile",
+          },
+        ],
+      },
       "package": Object {
         "description": "Creates the distribution package",
         "name": "package",

--- a/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -465,6 +465,24 @@ tsconfig.tsbuildinfo
           },
         ],
       },
+      "install": Object {
+        "description": "Install project dependencies and update lockfile (non-frozen)",
+        "name": "install",
+        "steps": Array [
+          Object {
+            "exec": "yarn install --check-files",
+          },
+        ],
+      },
+      "install:ci": Object {
+        "description": "Install project dependencies using frozen lockfile",
+        "name": "install:ci",
+        "steps": Array [
+          Object {
+            "exec": "yarn install --check-files --frozen-lockfile",
+          },
+        ],
+      },
       "package": Object {
         "description": "Creates the distribution package",
         "name": "package",

--- a/test/web/__snapshots__/react-project.test.ts.snap
+++ b/test/web/__snapshots__/react-project.test.ts.snap
@@ -505,6 +505,24 @@ permissions-backup.acl
           },
         ],
       },
+      "install": Object {
+        "description": "Install project dependencies and update lockfile (non-frozen)",
+        "name": "install",
+        "steps": Array [
+          Object {
+            "exec": "yarn install --check-files",
+          },
+        ],
+      },
+      "install:ci": Object {
+        "description": "Install project dependencies using frozen lockfile",
+        "name": "install:ci",
+        "steps": Array [
+          Object {
+            "exec": "yarn install --check-files --frozen-lockfile",
+          },
+        ],
+      },
       "package": Object {
         "description": "Creates the distribution package",
         "name": "package",

--- a/test/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/react-ts-project.test.ts.snap
@@ -729,6 +729,24 @@ tsconfig.tsbuildinfo
           },
         ],
       },
+      "install": Object {
+        "description": "Install project dependencies and update lockfile (non-frozen)",
+        "name": "install",
+        "steps": Array [
+          Object {
+            "exec": "yarn install --check-files",
+          },
+        ],
+      },
+      "install:ci": Object {
+        "description": "Install project dependencies using frozen lockfile",
+        "name": "install:ci",
+        "steps": Array [
+          Object {
+            "exec": "yarn install --check-files --frozen-lockfile",
+          },
+        ],
+      },
       "package": Object {
         "description": "Creates the distribution package",
         "name": "package",


### PR DESCRIPTION
Spawning a task allows end users to hook into the dependency installation process and increases flexibility

This aligns node and python projects on the same dependency installation API. For node projects, had to explicitly exclude the `install` and `install:ci` tasks from being included in `package.json` scripts to prevent infinite loops.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
