### PR TITLE
feat(docker-compose): support entrypoint

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -738,6 +738,7 @@ addService(serviceName: string, description: DockerComposeServiceDescription): D
 * **description** (<code>[DockerComposeServiceDescription](#projen-dockercomposeservicedescription)</code>)  a service description.
   * **command** (<code>Array<string></code>)  Provide a command to the docker container. __*Default*__: use the container's default command
   * **dependsOn** (<code>Array<[IDockerComposeServiceName](#projen-idockercomposeservicename)></code>)  Names of other services this service depends on. __*Default*__: no dependencies
+  * **entrypoint** (<code>string &#124; Array<string></code>)  Entrypoint to run in the container. __*Optional*__
   * **environment** (<code>Map<string, string></code>)  Add environment variables. __*Default*__: no environment variables are provided
   * **image** (<code>string</code>)  Use a docker image. __*Optional*__
   * **imageBuild** (<code>[DockerComposeBuild](#projen-dockercomposebuild)</code>)  Build a docker image. __*Optional*__
@@ -864,6 +865,7 @@ new DockerComposeService(serviceName: string, serviceDescription: DockerComposeS
 * **serviceDescription** (<code>[DockerComposeServiceDescription](#projen-dockercomposeservicedescription)</code>)  *No description*
   * **command** (<code>Array<string></code>)  Provide a command to the docker container. __*Default*__: use the container's default command
   * **dependsOn** (<code>Array<[IDockerComposeServiceName](#projen-idockercomposeservicename)></code>)  Names of other services this service depends on. __*Default*__: no dependencies
+  * **entrypoint** (<code>string &#124; Array<string></code>)  Entrypoint to run in the container. __*Optional*__
   * **environment** (<code>Map<string, string></code>)  Add environment variables. __*Default*__: no environment variables are provided
   * **image** (<code>string</code>)  Use a docker image. __*Optional*__
   * **imageBuild** (<code>[DockerComposeBuild](#projen-dockercomposebuild)</code>)  Build a docker image. __*Optional*__
@@ -886,7 +888,8 @@ Name | Type | Description
 **ports**🔹 | <code>Array<[DockerComposeServicePort](#projen-dockercomposeserviceport)></code> | Published ports.
 **serviceName**🔹 | <code>string</code> | Name of the service.
 **volumes**🔹 | <code>Array<[IDockerComposeVolumeBinding](#projen-idockercomposevolumebinding)></code> | Volumes mounted in the container.
-**command**?🔹 | <code>Array<string></code> | Command to run in the container.<br/>__*Optional*__
+**command**?🔹 | <code>string &#124; Array<string></code> | Command to run in the container.<br/>__*Optional*__
+**entrypoint**?🔹 | <code>string &#124; Array<string></code> | Entrypoint to run in the container.<br/>__*Optional*__
 **image**?🔹 | <code>string</code> | Docker image.<br/>__*Optional*__
 **imageBuild**?🔹 | <code>[DockerComposeBuild](#projen-dockercomposebuild)</code> | Docker image build instructions.<br/>__*Optional*__
 
@@ -12204,6 +12207,7 @@ Name | Type | Description
 -----|------|-------------
 **command**?🔹 | <code>Array<string></code> | Provide a command to the docker container.<br/>__*Default*__: use the container's default command
 **dependsOn**?🔹 | <code>Array<[IDockerComposeServiceName](#projen-idockercomposeservicename)></code> | Names of other services this service depends on.<br/>__*Default*__: no dependencies
+**entrypoint**?🔹 | <code>string &#124; Array<string></code> | Entrypoint to run in the container.<br/>__*Optional*__
 **environment**?🔹 | <code>Map<string, string></code> | Add environment variables.<br/>__*Default*__: no environment variables are provided
 **image**?🔹 | <code>string</code> | Use a docker image.<br/>__*Optional*__
 **imageBuild**?🔹 | <code>[DockerComposeBuild](#projen-dockercomposebuild)</code> | Build a docker image.<br/>__*Optional*__

--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -738,7 +738,7 @@ addService(serviceName: string, description: DockerComposeServiceDescription): D
 * **description** (<code>[DockerComposeServiceDescription](#projen-dockercomposeservicedescription)</code>)  a service description.
   * **command** (<code>Array<string></code>)  Provide a command to the docker container. __*Default*__: use the container's default command
   * **dependsOn** (<code>Array<[IDockerComposeServiceName](#projen-idockercomposeservicename)></code>)  Names of other services this service depends on. __*Default*__: no dependencies
-  * **entrypoint** (<code>string &#124; Array<string></code>)  Entrypoint to run in the container. __*Optional*__
+  * **entrypoint** (<code>Array<string></code>)  Entrypoint to run in the container. __*Optional*__
   * **environment** (<code>Map<string, string></code>)  Add environment variables. __*Default*__: no environment variables are provided
   * **image** (<code>string</code>)  Use a docker image. __*Optional*__
   * **imageBuild** (<code>[DockerComposeBuild](#projen-dockercomposebuild)</code>)  Build a docker image. __*Optional*__
@@ -865,7 +865,7 @@ new DockerComposeService(serviceName: string, serviceDescription: DockerComposeS
 * **serviceDescription** (<code>[DockerComposeServiceDescription](#projen-dockercomposeservicedescription)</code>)  *No description*
   * **command** (<code>Array<string></code>)  Provide a command to the docker container. __*Default*__: use the container's default command
   * **dependsOn** (<code>Array<[IDockerComposeServiceName](#projen-idockercomposeservicename)></code>)  Names of other services this service depends on. __*Default*__: no dependencies
-  * **entrypoint** (<code>string &#124; Array<string></code>)  Entrypoint to run in the container. __*Optional*__
+  * **entrypoint** (<code>Array<string></code>)  Entrypoint to run in the container. __*Optional*__
   * **environment** (<code>Map<string, string></code>)  Add environment variables. __*Default*__: no environment variables are provided
   * **image** (<code>string</code>)  Use a docker image. __*Optional*__
   * **imageBuild** (<code>[DockerComposeBuild](#projen-dockercomposebuild)</code>)  Build a docker image. __*Optional*__
@@ -888,8 +888,8 @@ Name | Type | Description
 **ports**🔹 | <code>Array<[DockerComposeServicePort](#projen-dockercomposeserviceport)></code> | Published ports.
 **serviceName**🔹 | <code>string</code> | Name of the service.
 **volumes**🔹 | <code>Array<[IDockerComposeVolumeBinding](#projen-idockercomposevolumebinding)></code> | Volumes mounted in the container.
-**command**?🔹 | <code>string &#124; Array<string></code> | Command to run in the container.<br/>__*Optional*__
-**entrypoint**?🔹 | <code>string &#124; Array<string></code> | Entrypoint to run in the container.<br/>__*Optional*__
+**command**?🔹 | <code>Array<string></code> | Command to run in the container.<br/>__*Optional*__
+**entrypoint**?🔹 | <code>Array<string></code> | Entrypoint to run in the container.<br/>__*Optional*__
 **image**?🔹 | <code>string</code> | Docker image.<br/>__*Optional*__
 **imageBuild**?🔹 | <code>[DockerComposeBuild](#projen-dockercomposebuild)</code> | Docker image build instructions.<br/>__*Optional*__
 
@@ -12207,7 +12207,7 @@ Name | Type | Description
 -----|------|-------------
 **command**?🔹 | <code>Array<string></code> | Provide a command to the docker container.<br/>__*Default*__: use the container's default command
 **dependsOn**?🔹 | <code>Array<[IDockerComposeServiceName](#projen-idockercomposeservicename)></code> | Names of other services this service depends on.<br/>__*Default*__: no dependencies
-**entrypoint**?🔹 | <code>string &#124; Array<string></code> | Entrypoint to run in the container.<br/>__*Optional*__
+**entrypoint**?🔹 | <code>Array<string></code> | Entrypoint to run in the container.<br/>__*Optional*__
 **environment**?🔹 | <code>Map<string, string></code> | Add environment variables.<br/>__*Default*__: no environment variables are provided
 **image**?🔹 | <code>string</code> | Use a docker image.<br/>__*Optional*__
 **imageBuild**?🔹 | <code>[DockerComposeBuild](#projen-dockercomposebuild)</code> | Build a docker image.<br/>__*Optional*__

--- a/src/docker-compose/docker-compose-render.ts
+++ b/src/docker-compose/docker-compose-render.ts
@@ -20,13 +20,13 @@ interface DockerComposeFileServiceSchema {
   readonly dependsOn?: string[];
   readonly build?: DockerComposeBuild;
   readonly image?: string;
-  readonly command?: string | string[];
+  readonly command?: string[];
   readonly volumes?: DockerComposeVolumeMount[];
   readonly networks?: string[];
   readonly ports?: DockerComposeServicePort[];
   readonly environment?: Record<string, string>;
   readonly labels?: Record<string, string>;
-  readonly entrypoint?: string | string[];
+  readonly entrypoint?: string[];
 }
 
 /**

--- a/src/docker-compose/docker-compose-render.ts
+++ b/src/docker-compose/docker-compose-render.ts
@@ -20,12 +20,13 @@ interface DockerComposeFileServiceSchema {
   readonly dependsOn?: string[];
   readonly build?: DockerComposeBuild;
   readonly image?: string;
-  readonly command?: string[];
+  readonly command?: string | string[];
   readonly volumes?: DockerComposeVolumeMount[];
   readonly networks?: string[];
   readonly ports?: DockerComposeServicePort[];
   readonly environment?: Record<string, string>;
   readonly labels?: Record<string, string>;
+  readonly entrypoint?: string | string[];
 }
 
 /**
@@ -117,6 +118,10 @@ export function renderDockerComposeFile(
       ...getObjectWithKeyAndValueIfValueIsDefined(
         "build",
         serviceDescription.imageBuild
+      ),
+      ...getObjectWithKeyAndValueIfValueIsDefined(
+        "entrypoint",
+        serviceDescription.entrypoint
       ),
       ...getObjectWithKeyAndValueIfValueIsDefined(
         "command",

--- a/src/docker-compose/docker-compose-service.ts
+++ b/src/docker-compose/docker-compose-service.ts
@@ -38,12 +38,12 @@ export class DockerComposeService implements IDockerComposeServiceName {
   /**
    * Command to run in the container.
    */
-  public readonly command?: string | string[];
+  public readonly command?: string[];
 
   /**
    * Entrypoint to run in the container.
    */
-  public readonly entrypoint?: string | string[];
+  public readonly entrypoint?: string[];
 
   /**
    * Other services that this service depends on.
@@ -182,12 +182,12 @@ export interface DockerComposeServiceDescription {
    * Provide a command to the docker container.
    * @default - use the container's default command
    */
-  readonly command?: string | string[];
+  readonly command?: string[];
 
   /**
    * Entrypoint to run in the container.
    */
-  readonly entrypoint?: string | string[];
+  readonly entrypoint?: string[];
 
   /**
    * Names of other services this service depends on.

--- a/src/docker-compose/docker-compose-service.ts
+++ b/src/docker-compose/docker-compose-service.ts
@@ -38,7 +38,12 @@ export class DockerComposeService implements IDockerComposeServiceName {
   /**
    * Command to run in the container.
    */
-  public readonly command?: string[];
+  public readonly command?: string | string[];
+
+  /**
+   * Entrypoint to run in the container.
+   */
+  public readonly entrypoint?: string | string[];
 
   /**
    * Other services that this service depends on.
@@ -93,6 +98,7 @@ export class DockerComposeService implements IDockerComposeServiceName {
     this.ports = serviceDescription.ports ?? [];
     this.environment = serviceDescription.environment ?? {};
     this.labels = serviceDescription.labels ?? {};
+    this.entrypoint = serviceDescription.entrypoint;
   }
 
   /**
@@ -176,7 +182,12 @@ export interface DockerComposeServiceDescription {
    * Provide a command to the docker container.
    * @default - use the container's default command
    */
-  readonly command?: string[];
+  readonly command?: string | string[];
+
+  /**
+   * Entrypoint to run in the container.
+   */
+  readonly entrypoint?: string | string[];
 
   /**
    * Names of other services this service depends on.

--- a/test/docker-compose/docker-compose.test.ts
+++ b/test/docker-compose/docker-compose.test.ts
@@ -207,6 +207,81 @@ describe("docker-compose", () => {
     assertDockerComposeFileValidates(project.outdir);
   });
 
+  test("can add a container command as a string", () => {
+    const project = new TestProject();
+    const dc = new DockerCompose(project, {
+      services: {
+        alpine: {
+          image: "alpine",
+          command: "echo I ran",
+        },
+      },
+    });
+
+    expect(dc._synthesizeDockerCompose()).toEqual({
+      version: "3.3",
+      services: {
+        alpine: {
+          image: "alpine",
+          command: "echo I ran",
+        },
+      },
+    });
+
+    project.synth();
+    assertDockerComposeFileValidates(project.outdir);
+  });
+
+  test("can add a container entrypoint", () => {
+    const project = new TestProject();
+    const dc = new DockerCompose(project, {
+      services: {
+        alpine: {
+          image: "alpine",
+          entrypoint: ["sh"],
+        },
+      },
+    });
+
+    expect(dc._synthesizeDockerCompose()).toEqual({
+      version: "3.3",
+      services: {
+        alpine: {
+          image: "alpine",
+          entrypoint: ["sh"],
+        },
+      },
+    });
+
+    project.synth();
+    assertDockerComposeFileValidates(project.outdir);
+  });
+
+  test("can add a container entrypoint as a string", () => {
+    const project = new TestProject();
+    const dc = new DockerCompose(project, {
+      services: {
+        alpine: {
+          image: "alpine",
+          entrypoint: 'bash -c "$@"',
+        },
+      },
+    });
+
+    expect(dc._synthesizeDockerCompose()).toEqual({
+      version: "3.3",
+      services: {
+        alpine: {
+          image: "alpine",
+          entrypoint: 'bash -c "$@"',
+        },
+      },
+    });
+
+    project.synth();
+    assertDockerComposeFileValidates(project.outdir);
+  });
+
   describe("can add a volume", () => {
     test("bind volume", () => {
       const project = new TestProject();

--- a/test/docker-compose/docker-compose.test.ts
+++ b/test/docker-compose/docker-compose.test.ts
@@ -207,31 +207,6 @@ describe("docker-compose", () => {
     assertDockerComposeFileValidates(project.outdir);
   });
 
-  test("can add a container command as a string", () => {
-    const project = new TestProject();
-    const dc = new DockerCompose(project, {
-      services: {
-        alpine: {
-          image: "alpine",
-          command: "echo I ran",
-        },
-      },
-    });
-
-    expect(dc._synthesizeDockerCompose()).toEqual({
-      version: "3.3",
-      services: {
-        alpine: {
-          image: "alpine",
-          command: "echo I ran",
-        },
-      },
-    });
-
-    project.synth();
-    assertDockerComposeFileValidates(project.outdir);
-  });
-
   test("can add a container entrypoint", () => {
     const project = new TestProject();
     const dc = new DockerCompose(project, {
@@ -249,31 +224,6 @@ describe("docker-compose", () => {
         alpine: {
           image: "alpine",
           entrypoint: ["sh"],
-        },
-      },
-    });
-
-    project.synth();
-    assertDockerComposeFileValidates(project.outdir);
-  });
-
-  test("can add a container entrypoint as a string", () => {
-    const project = new TestProject();
-    const dc = new DockerCompose(project, {
-      services: {
-        alpine: {
-          image: "alpine",
-          entrypoint: 'bash -c "$@"',
-        },
-      },
-    });
-
-    expect(dc._synthesizeDockerCompose()).toEqual({
-      version: "3.3",
-      services: {
-        alpine: {
-          image: "alpine",
-          entrypoint: 'bash -c "$@"',
         },
       },
     });


### PR DESCRIPTION
Allows an entrypoint to be defined in a docker-compose service.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.