### PR TITLE
fix(eslint): deprecate `lintProjenRcFile` in favor of explicitly defining rules via `Projenrc`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,11 +38,11 @@
   },
   "ignorePatterns": [
     "*.js",
-    "!.projenrc.js",
     "*.d.ts",
     "node_modules/",
     "*.generated.ts",
-    "coverage"
+    "coverage",
+    "!.projenrc.js"
   ],
   "rules": {
     "prettier/prettier": [

--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -7970,10 +7970,10 @@ new javascript.Eslint(project: NodeProject, options: EslintOptions)
 
 * **project** (<code>[javascript.NodeProject](#projen-javascript-nodeproject)</code>)  *No description*
 * **options** (<code>[javascript.EslintOptions](#projen-javascript-eslintoptions)</code>)  *No description*
-  * **dirs** (<code>Array<string></code>)  Directories with source files to lint (e.g. [ "src" ]). 
+  * **dirs** (<code>Array<string></code>)  Files or glob patterns or directories with source files to lint (e.g. [ "src" ]). 
   * **aliasExtensions** (<code>Array<string></code>)  Enable import alias for module paths. __*Default*__: undefined
   * **aliasMap** (<code>Map<string, string></code>)  Enable import alias for module paths. __*Default*__: undefined
-  * **devdirs** (<code>Array<string></code>)  Directories with source files that include tests and build tools. __*Default*__: []
+  * **devdirs** (<code>Array<string></code>)  Files or glob patterns or directories with source files that include tests and build tools. __*Default*__: []
   * **fileExtensions** (<code>Array<string></code>)  File types that should be linted (e.g. [ ".js", ".ts" ]). __*Default*__: [".ts"]
   * **ignorePatterns** (<code>Array<string></code>)  List of file patterns that should not be linted, using the same syntax as .gitignore patterns. __*Default*__: [ '*.js', '*.d.ts', 'node_modules/', '*.generated.ts', 'coverage' ]
   * **lintProjenRc** (<code>boolean</code>)  Should we lint .projenrc.js. __*Default*__: true
@@ -8018,6 +8018,19 @@ Do not lint these files.
 
 ```ts
 addIgnorePattern(pattern: string): void
+```
+
+* **pattern** (<code>string</code>)  *No description*
+
+
+
+
+#### addLintPattern(pattern)🔹 <a id="projen-javascript-eslint-addlintpattern"></a>
+
+Add a file, glob pattern or directory with source files to lint (e.g. [ "src" ]).
+
+```ts
+addLintPattern(pattern: string): void
 ```
 
 * **pattern** (<code>string</code>)  *No description*
@@ -9082,6 +9095,21 @@ new javascript.Projenrc(project: Project, options?: ProjenrcOptions)
 * **project** (<code>[Project](#projen-project)</code>)  *No description*
 * **options** (<code>[javascript.ProjenrcOptions](#projen-javascript-projenrcoptions)</code>)  *No description*
   * **filename** (<code>string</code>)  The name of the projenrc file. __*Default*__: ".projenrc.js"
+
+
+### Methods
+
+
+#### preSynthesize()🔹 <a id="projen-javascript-projenrc-presynthesize"></a>
+
+Called before synthesis.
+
+```ts
+preSynthesize(): void
+```
+
+
+
 
 
 
@@ -10359,6 +10387,21 @@ new typescript.Projenrc(project: TypeScriptProject, options?: ProjenrcOptions)
 * **options** (<code>[typescript.ProjenrcOptions](#projen-typescript-projenrcoptions)</code>)  *No description*
   * **filename** (<code>string</code>)  The name of the projenrc file. __*Default*__: ".projenrc.ts"
   * **projenCodeDir** (<code>string</code>)  A directory tree that may contain *.ts files that can be referenced from your projenrc typescript file. __*Default*__: "projenrc"
+
+
+### Methods
+
+
+#### preSynthesize()🔹 <a id="projen-typescript-projenrc-presynthesize"></a>
+
+Called before synthesis.
+
+```ts
+preSynthesize(): void
+```
+
+
+
 
 
 
@@ -16783,14 +16826,14 @@ Name | Type | Description
 
 Name | Type | Description 
 -----|------|-------------
-**dirs**🔹 | <code>Array<string></code> | Directories with source files to lint (e.g. [ "src" ]).
+**dirs**🔹 | <code>Array<string></code> | Files or glob patterns or directories with source files to lint (e.g. [ "src" ]).
 **aliasExtensions**?🔹 | <code>Array<string></code> | Enable import alias for module paths.<br/>__*Default*__: undefined
 **aliasMap**?🔹 | <code>Map<string, string></code> | Enable import alias for module paths.<br/>__*Default*__: undefined
-**devdirs**?🔹 | <code>Array<string></code> | Directories with source files that include tests and build tools.<br/>__*Default*__: []
+**devdirs**?🔹 | <code>Array<string></code> | Files or glob patterns or directories with source files that include tests and build tools.<br/>__*Default*__: []
 **fileExtensions**?🔹 | <code>Array<string></code> | File types that should be linted (e.g. [ ".js", ".ts" ]).<br/>__*Default*__: [".ts"]
 **ignorePatterns**?🔹 | <code>Array<string></code> | List of file patterns that should not be linted, using the same syntax as .gitignore patterns.<br/>__*Default*__: [ '*.js', '*.d.ts', 'node_modules/', '*.generated.ts', 'coverage' ]
 **lintProjenRc**?⚠️ | <code>boolean</code> | Should we lint .projenrc.js.<br/>__*Default*__: true
-**lintProjenRcFile**?🔹 | <code>string</code> | Projenrc file to lint.<br/>__*Default*__: PROJEN_RC
+**lintProjenRcFile**?⚠️ | <code>string</code> | Projenrc file to lint.<br/>__*Default*__: PROJEN_RC
 **prettier**?🔹 | <code>boolean</code> | Enable prettier for code formatting.<br/>__*Default*__: false
 **tsAlwaysTryTypes**?🔹 | <code>boolean</code> | Always try to resolve types under `<root>@types` directory even it doesn't contain any source code.<br/>__*Default*__: true
 **tsconfigPath**?🔹 | <code>string</code> | Path to `tsconfig.json` which should be used by eslint.<br/>__*Default*__: "./tsconfig.json"

--- a/src/javascript/projenrc.ts
+++ b/src/javascript/projenrc.ts
@@ -1,5 +1,6 @@
 import { resolve } from "path";
 import { existsSync, outputFileSync } from "fs-extra";
+import { Eslint } from "./eslint";
 import { renderJavaScriptOptions } from "./render-options";
 import { Component } from "../component";
 import { Project } from "../project";
@@ -26,6 +27,19 @@ export class Projenrc extends Component {
     project.defaultTask?.exec(`node ${this.rcfile}`);
 
     this.generateProjenrc();
+  }
+
+  public preSynthesize(): void {
+    const eslint = Eslint.of(this.project);
+    eslint?.addLintPattern(this.rcfile);
+    eslint?.addIgnorePattern(`!${this.rcfile}`);
+    eslint?.addOverride({
+      files: [this.rcfile],
+      rules: {
+        "@typescript-eslint/no-require-imports": "off",
+        "import/no-extraneous-dependencies": "off",
+      },
+    });
   }
 
   private generateProjenrc() {

--- a/src/typescript/typescript.ts
+++ b/src/typescript/typescript.ts
@@ -319,31 +319,20 @@ export class TypeScriptProject extends NodeProject {
       }
     }
 
-    const projenrcTypeScript = options.projenrcTs ?? false;
-
-    const projenRcFilename = projenrcTypeScript
-      ? options.projenrcTsOptions?.filename ?? ".projenrc.ts"
-      : undefined;
-
     if (options.eslint ?? true) {
-      const devdirs = [this.testdir, "build-tools"];
-      if (projenrcTypeScript) {
-        devdirs.push(options.projenrcTsOptions?.projenCodeDir ?? "projenrc");
-      }
-
       this.eslint = new Eslint(this, {
         tsconfigPath: `./${this.tsconfigDev.fileName}`,
         dirs: [this.srcdir],
-        devdirs,
+        devdirs: [this.testdir, "build-tools"],
         fileExtensions: [".ts", ".tsx"],
-        lintProjenRcFile: projenRcFilename,
+        lintProjenRc: false,
         ...options.eslintOptions,
       });
 
       this.tsconfigEslint = this.tsconfigDev;
     }
 
-    if (!this.parent && projenrcTypeScript) {
+    if (!this.parent && options.projenrcTs) {
       new ProjenrcTs(this, options.projenrcTsOptions);
     }
 

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -39,11 +39,11 @@ Object {
   },
   \\"ignorePatterns\\": [
     \\"*.js\\",
-    \\"!.projenrc.js\\",
     \\"*.d.ts\\",
     \\"node_modules/\\",
     \\"*.generated.ts\\",
-    \\"coverage\\"
+    \\"coverage\\",
+    \\"!.projenrc.js\\"
   ],
   \\"rules\\": {
     \\"indent\\": [
@@ -1557,11 +1557,11 @@ Object {
   },
   \\"ignorePatterns\\": [
     \\"*.js\\",
-    \\"!.projenrc.js\\",
     \\"*.d.ts\\",
     \\"node_modules/\\",
     \\"*.generated.ts\\",
-    \\"coverage\\"
+    \\"coverage\\",
+    \\"!.projenrc.js\\"
   ],
   \\"rules\\": {
     \\"indent\\": [
@@ -2767,12 +2767,12 @@ Object {
   },
   \\"ignorePatterns\\": [
     \\"*.js\\",
-    \\"!.projenrc.js\\",
     \\"*.d.ts\\",
     \\"node_modules/\\",
     \\"*.generated.ts\\",
     \\"coverage\\",
-    \\"/templates/\\"
+    \\"/templates/\\",
+    \\"!.projenrc.js\\"
   ],
   \\"rules\\": {
     \\"indent\\": [

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -12,11 +12,11 @@ Object {
     ],
     "ignorePatterns": Array [
       "*.js",
-      "!.projenrc.js",
       "*.d.ts",
       "node_modules/",
       "*.generated.ts",
       "coverage",
+      "!.projenrc.js",
     ],
     "overrides": Array [
       Object {

--- a/test/javascript/__snapshots__/eslint.test.ts.snap
+++ b/test/javascript/__snapshots__/eslint.test.ts.snap
@@ -11,11 +11,11 @@ Object {
   ],
   "ignorePatterns": Array [
     "*.js",
-    "!.projenrc.js",
     "*.d.ts",
     "node_modules/",
     "*.generated.ts",
     "coverage",
+    "!.projenrc.js",
   ],
   "overrides": Array [
     Object {
@@ -247,11 +247,11 @@ Object {
   ],
   "ignorePatterns": Array [
     "*.js",
-    "!.projenrc.js",
     "*.d.ts",
     "node_modules/",
     "*.generated.ts",
     "coverage",
+    "!.projenrc.js",
   ],
   "overrides": Array [
     Object {

--- a/test/javascript/eslint.test.ts
+++ b/test/javascript/eslint.test.ts
@@ -13,6 +13,7 @@ test("devdirs", () => {
   new Eslint(project, {
     devdirs: ["foo", "bar"],
     dirs: ["mysrc"],
+    lintProjenRc: false,
   });
 
   // THEN
@@ -31,6 +32,7 @@ describe("prettier", () => {
     new Eslint(project, {
       dirs: ["mysrc"],
       prettier: true,
+      lintProjenRc: false,
     });
 
     // THEN
@@ -48,6 +50,7 @@ describe("prettier", () => {
     new Eslint(project, {
       dirs: ["mysrc"],
       prettier: true,
+      lintProjenRc: false,
     });
 
     // THEN
@@ -74,6 +77,7 @@ describe("alias", () => {
         "@foo": "./src/foo",
       },
       aliasExtensions: [".ts", ".js"],
+      lintProjenRc: false,
     });
 
     // THEN
@@ -102,6 +106,7 @@ test("tsAlwaysTryTypes", () => {
   const eslint = new Eslint(project, {
     dirs: ["mysrc"],
     tsAlwaysTryTypes: true,
+    lintProjenRc: false,
   });
 
   // THEN
@@ -122,6 +127,7 @@ test("if the prettier is configured, eslint is configured accordingly", () => {
   // WHEN
   new Eslint(project, {
     dirs: ["src"],
+    lintProjenRc: false,
   });
 
   // THEN
@@ -143,6 +149,7 @@ test("can output yml instead of json", () => {
   new Eslint(project, {
     dirs: ["src"],
     yaml: true,
+    lintProjenRc: false,
   });
 
   // THEN
@@ -162,6 +169,7 @@ test("can override the parser", () => {
   // WHEN
   const eslint = new Eslint(project, {
     dirs: ["src"],
+    lintProjenRc: false,
   });
   eslint.addOverride({
     files: ["*.json", "*.json5", "*.jsonc"],
@@ -187,6 +195,7 @@ test("creates a eslint task", () => {
   // WHEN
   const eslint = new Eslint(project, {
     dirs: ["src"],
+    lintProjenRc: false,
   });
 
   // THEN

--- a/test/typescript/__snapshots__/typescript.test.ts.snap
+++ b/test/typescript/__snapshots__/typescript.test.ts.snap
@@ -12,11 +12,11 @@ Object {
     ],
     "ignorePatterns": Array [
       "*.js",
-      "!.projenrc.js",
       "*.d.ts",
       "node_modules/",
       "*.generated.ts",
       "coverage",
+      "!.projenrc.js",
     ],
     "overrides": Array [
       Object {

--- a/test/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/react-ts-project.test.ts.snap
@@ -12,11 +12,11 @@ Object {
     ],
     "ignorePatterns": Array [
       "*.js",
-      "!.projenrc.js",
       "*.d.ts",
       "node_modules/",
       "*.generated.ts",
       "coverage",
+      "!.projenrc.js",
     ],
     "overrides": Array [
       Object {


### PR DESCRIPTION
Currently rules targeting the `Projenrc` file are spread between the `Eslint` and `Projenrc` components.
This is quite awkward to manage and also causes unncessary rules to be added for TypeScript Projenrc files and subprojects.

If you are currently using the `Eslint` component explicitly, we recommend to set `lintProjenRc: false` and add all required rules manually.

Also adds a feature `addLintPattern` to add lint patterns after the component has been created.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.