### PR TITLE
chore: updated Configure AWS Credentials action version

### DIFF
--- a/src/javascript/node-project.ts
+++ b/src/javascript/node-project.ts
@@ -840,7 +840,7 @@ export class NodeProject extends GitHubProject {
       return [
         {
           name: "Configure AWS Credentials",
-          uses: "aws-actions/configure-aws-credentials@v1",
+          uses: "aws-actions/configure-aws-credentials@v2",
           with: {
             "aws-region": "us-east-2",
             "role-to-assume": parsedCodeArtifactOptions.roleToAssume,
@@ -858,7 +858,7 @@ export class NodeProject extends GitHubProject {
       return [
         {
           name: "Configure AWS Credentials",
-          uses: "aws-actions/configure-aws-credentials@v1",
+          uses: "aws-actions/configure-aws-credentials@v2",
           with: {
             "aws-access-key-id": secretToString(
               parsedCodeArtifactOptions.accessKeyIdSecret

--- a/src/release/publisher.ts
+++ b/src/release/publisher.ts
@@ -305,7 +305,7 @@ export class Publisher extends Component {
       const region = options.registry?.match(regionCaptureRegex)?.[1];
       prePublishSteps.push({
         name: "Configure AWS Credentials via GitHub OIDC Provider",
-        uses: "aws-actions/configure-aws-credentials@v1",
+        uses: "aws-actions/configure-aws-credentials@v2",
         with: {
           "role-to-assume": options.codeArtifactOptions.roleToAssume,
           "aws-region": region,

--- a/test/javascript/node-project.test.ts
+++ b/test/javascript/node-project.test.ts
@@ -1185,7 +1185,7 @@ describe("scoped private packages", () => {
         expect.arrayContaining([
           {
             name: "Configure AWS Credentials",
-            uses: "aws-actions/configure-aws-credentials@v1",
+            uses: "aws-actions/configure-aws-credentials@v2",
             with: {
               "aws-region": "us-east-2",
               "role-to-assume": roleToAssume,
@@ -1221,7 +1221,7 @@ describe("scoped private packages", () => {
         expect.arrayContaining([
           {
             name: "Configure AWS Credentials",
-            uses: "aws-actions/configure-aws-credentials@v1",
+            uses: "aws-actions/configure-aws-credentials@v2",
             with: {
               "aws-region": "us-east-2",
               "role-to-assume": roleToAssume,
@@ -1342,7 +1342,7 @@ describe("scoped private packages", () => {
       expect.arrayContaining([
         {
           name: "Configure AWS Credentials",
-          uses: "aws-actions/configure-aws-credentials@v1",
+          uses: "aws-actions/configure-aws-credentials@v2",
           with: {
             "aws-access-key-id": secretToString(defaultAccessKeyIdSecret),
             "aws-secret-access-key": secretToString(

--- a/test/release/__snapshots__/release.test.ts.snap
+++ b/test/release/__snapshots__/release.test.ts.snap
@@ -768,7 +768,7 @@ jobs:
         run: cd dist && setfacl --restore=permissions-backup.acl
         continue-on-error: true
       - name: Configure AWS Credentials via GitHub OIDC Provider
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: role-arn
           aws-region: us-west-2


### PR DESCRIPTION
It has been a while that workflows generated by projen would have warning when running about deprecation of `set-output`

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: aws-actions/configure-aws-credentials@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

Last week a new version of `aws-actions/configure-aws-credentials` is [released](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v2.0.0) in which it has solved this issue.

This change will upgrade this action to version 2

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.