### PR TITLE
fix(github): extend PullRequestOptions to include PushOptions

### DIFF
--- a/src/github/workflows-model.ts
+++ b/src/github/workflows-model.ts
@@ -1002,7 +1002,7 @@ export interface ProjectColumnOptions {
 /**
  * Pull request options
  */
-export interface PullRequestOptions {
+export interface PullRequestOptions extends PushOptions {
   /**
    * Which activity types to trigger on.
    *
@@ -1082,7 +1082,7 @@ export interface PullRequestTargetOptions extends PushOptions {
  */
 export interface PushOptions {
   /**
-   * When using the push and pull_request events, you can configure a workflow
+   * When using the push, pull_request and pull_request_target events, you can configure a workflow
    * to run on specific branches or tags. For a pull_request event, only
    * branches and tags on the base are evaluated. If you define only tags or
    * only branches, the workflow won't run for events affecting the undefined
@@ -1093,7 +1093,7 @@ export interface PushOptions {
   readonly branches?: string[];
 
   /**
-   * When using the push and pull_request events, you can configure a workflow
+   * When using the push, pull_request and pull_request_target events, you can configure a workflow
    * to run on specific branches or tags. For a pull_request event, only
    * branches and tags on the base are evaluated. If you define only tags or
    * only branches, the workflow won't run for events affecting the undefined
@@ -1104,7 +1104,7 @@ export interface PushOptions {
   readonly tags?: string[];
 
   /**
-   * When using the push and pull_request events, you can configure a workflow
+   * When using the push, pull_request and pull_request_target events, you can configure a workflow
    * to run when at least one file does not match paths-ignore or at least one
    * modified file matches the configured paths. Path filters are not
    * evaluated for pushes to tags.


### PR DESCRIPTION
Hello 👋 firstly, thank you for such an intuitive and easy way to manage projects!

I found this slight issue whilst trying to create a workflow trigger to only occur when a PR is opened and changes occurred in a specific folder, but noticed this wasn't currently possible due to the API available.

The docs for `PushOptions` stated that the `pull_request` event can use these properties (and they are available to use as per the GitHub docs), but `PullRequestOptions` didn't extend `PushOptions`, instead only `PullRequestTargetOptions` did. This PR updates the doc string to include `pull_request_target` and makes `PullRequestOptions` extend `PushOptions`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.