### PR TITLE
chore: fix test that updates snapshot locally

### DIFF
--- a/test/__snapshots__/projects.test.ts.snap
+++ b/test/__snapshots__/projects.test.ts.snap
@@ -17,9 +17,8 @@ project.synth();"
 
 exports[`createProject creates a project from an external project type, if it's installed 1`] = `
 "const { javascript } = require(\\"projen\\");
-const { AwsCdkTypeScriptApp } = require(\\"@pepperize/projen-awscdk-app-ts\\");
-const project = new AwsCdkTypeScriptApp({
-  cdkVersion: \\"2.50.0\\",
+const { CdklabsTypeScriptProject } = require(\\"cdklabs-projen-project-types\\");
+const project = new CdklabsTypeScriptProject({
   defaultReleaseBranch: \\"main\\",
   name: \\"test-project\\",
   packageManager: javascript.NodePackageManager.NPM,

--- a/test/projects.test.ts
+++ b/test/projects.test.ts
@@ -68,7 +68,7 @@ describe("createProject", () => {
     withProjectDir(
       (projectdir) => {
         // GIVEN
-        installPackage(projectdir, "@pepperize/projen-awscdk-app-ts@0.0.333");
+        installPackage(projectdir, "cdklabs-projen-project-types@0.1.48");
 
         // WHEN
         Projects.createProject({
@@ -76,7 +76,7 @@ describe("createProject", () => {
           dir: projectdir,
           post: false,
           synth: false,
-          projectFqn: "@pepperize/projen-awscdk-app-ts.AwsCdkTypeScriptApp",
+          projectFqn: "cdklabs-projen-project-types.CdklabsTypeScriptProject",
           projectOptions: {
             name: "test-project",
             defaultReleaseBranch: "main",


### PR DESCRIPTION
Replacing the external module with a different one. The previous external module depends on an older version of projen that does not have a required bug fix. Depending on system configuration, the test would either use the latest projen from the repo (this happens in CI/CD) or the outdated version (this happens locally). Thus creating different snapshots.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.