### PR TITLE
feat(typescript): support `importsNotUsedAsValues`

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -17427,6 +17427,7 @@ Name | Type | Description
 **esModuleInterop**?🔹 | <code>boolean</code> | Emit __importStar and __importDefault helpers for runtime babel ecosystem compatibility and enable --allowSyntheticDefaultImports for typesystem compatibility.<br/>__*Default*__: false
 **experimentalDecorators**?🔹 | <code>boolean</code> | Enables experimental support for decorators, which is in stage 2 of the TC39 standardization process.<br/>__*Default*__: true
 **forceConsistentCasingInFileNames**?🔹 | <code>boolean</code> | Disallow inconsistently-cased references to the same file.<br/>__*Default*__: false
+**importsNotUsedAsValues**?🔹 | <code>string</code> | This flag controls how import works.<br/>__*Default*__: "remove"
 **inlineSourceMap**?🔹 | <code>boolean</code> | When set, instead of writing out a .js.map file to provide source maps, TypeScript will embed the source map content in the .js files.<br/>__*Default*__: true
 **inlineSources**?🔹 | <code>boolean</code> | When set, TypeScript will include the original content of the .ts file as an embedded string in the source map. This is often useful in the same cases as inlineSourceMap.<br/>__*Default*__: true
 **isolatedModules**?🔹 | <code>boolean</code> | Perform additional checks to ensure that separate compilation (such as with transpileModule or @babel/plugin-transform-typescript) would be safe.<br/>__*Default*__: false

--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -464,7 +464,7 @@ Name|Description
 [javascript.ProseWrap](#projen-javascript-prosewrap)|*No description*
 [javascript.QuoteProps](#projen-javascript-quoteprops)|*No description*
 [javascript.TrailingComma](#projen-javascript-trailingcomma)|*No description*
-[javascript.TypeScriptImportsNotUsedAsValues](#projen-javascript-typescriptimportsnotusedasvalues)|This flag controls how import works, there are 3 different options.
+[javascript.TypeScriptImportsNotUsedAsValues](#projen-javascript-typescriptimportsnotusedasvalues)|This flag controls how `import` works, there are 3 different options.
 [javascript.TypeScriptJsxMode](#projen-javascript-typescriptjsxmode)|Determines how JSX should get transformed into valid JavaScript.
 [javascript.TypeScriptModuleResolution](#projen-javascript-typescriptmoduleresolution)|Determines how modules get resolved.
 [javascript.UpdateSnapshot](#projen-javascript-updatesnapshot)|*No description*
@@ -19832,7 +19832,7 @@ Name | Description
 
 ## enum TypeScriptImportsNotUsedAsValues 🔹 <a id="projen-javascript-typescriptimportsnotusedasvalues"></a>
 
-This flag controls how import works, there are 3 different options.
+This flag controls how `import` works, there are 3 different options.
 
 Name | Description
 -----|-----

--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -464,6 +464,7 @@ Name|Description
 [javascript.ProseWrap](#projen-javascript-prosewrap)|*No description*
 [javascript.QuoteProps](#projen-javascript-quoteprops)|*No description*
 [javascript.TrailingComma](#projen-javascript-trailingcomma)|*No description*
+[javascript.TypeScriptImportsNotUsedAsValues](#projen-javascript-typescriptimportsnotusedasvalues)|This flag controls how import works, there are 3 different options.
 [javascript.TypeScriptJsxMode](#projen-javascript-typescriptjsxmode)|Determines how JSX should get transformed into valid JavaScript.
 [javascript.TypeScriptModuleResolution](#projen-javascript-typescriptmoduleresolution)|Determines how modules get resolved.
 [javascript.UpdateSnapshot](#projen-javascript-updatesnapshot)|*No description*
@@ -17427,7 +17428,7 @@ Name | Type | Description
 **esModuleInterop**?🔹 | <code>boolean</code> | Emit __importStar and __importDefault helpers for runtime babel ecosystem compatibility and enable --allowSyntheticDefaultImports for typesystem compatibility.<br/>__*Default*__: false
 **experimentalDecorators**?🔹 | <code>boolean</code> | Enables experimental support for decorators, which is in stage 2 of the TC39 standardization process.<br/>__*Default*__: true
 **forceConsistentCasingInFileNames**?🔹 | <code>boolean</code> | Disallow inconsistently-cased references to the same file.<br/>__*Default*__: false
-**importsNotUsedAsValues**?🔹 | <code>string</code> | This flag controls how import works.<br/>__*Default*__: "remove"
+**importsNotUsedAsValues**?🔹 | <code>[javascript.TypeScriptImportsNotUsedAsValues](#projen-javascript-typescriptimportsnotusedasvalues)</code> | This flag works because you can use `import type` to explicitly create an `import` statement which should never be emitted into JavaScript.<br/>__*Default*__: "remove"
 **inlineSourceMap**?🔹 | <code>boolean</code> | When set, instead of writing out a .js.map file to provide source maps, TypeScript will embed the source map content in the .js files.<br/>__*Default*__: true
 **inlineSources**?🔹 | <code>boolean</code> | When set, TypeScript will include the original content of the .ts file as an embedded string in the source map. This is often useful in the same cases as inlineSourceMap.<br/>__*Default*__: true
 **isolatedModules**?🔹 | <code>boolean</code> | Perform additional checks to ensure that separate compilation (such as with transpileModule or @babel/plugin-transform-typescript) would be safe.<br/>__*Default*__: false
@@ -19827,6 +19828,17 @@ Name | Description
 **ALL** 🔹|Trailing commas wherever possible (including function arguments).
 **ES5** 🔹|Trailing commas where valid in ES5 (objects, arrays, etc.).
 **NONE** 🔹|No trailing commas.
+
+
+## enum TypeScriptImportsNotUsedAsValues 🔹 <a id="projen-javascript-typescriptimportsnotusedasvalues"></a>
+
+This flag controls how import works, there are 3 different options.
+
+Name | Description
+-----|-----
+**REMOVE** 🔹|The default behavior of dropping `import` statements which only reference types.
+**PRESERVE** 🔹|Preserves all `import` statements whose values or types are never used.
+**ERROR** 🔹|This preserves all imports (the same as the preserve option), but will error when a value import is only used as a type.
 
 
 ## enum TypeScriptJsxMode 🔹 <a id="projen-javascript-typescriptjsxmode"></a>

--- a/src/javascript/typescript-config.ts
+++ b/src/javascript/typescript-config.ts
@@ -63,6 +63,29 @@ export enum TypeScriptModuleResolution {
 }
 
 /**
+ * This flag controls how import works, there are 3 different options.
+ *
+ * @see https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues
+ */
+export enum TypeScriptImportsNotUsedAsValues {
+  /**
+   * The default behavior of dropping `import` statements which only reference types.
+   */
+  REMOVE = "remove",
+
+  /**
+   * Preserves all `import` statements whose values or types are never used. This can cause imports/side-effects to be preserved.
+   */
+  PRESERVE = "preserve",
+
+  /**
+   * This preserves all imports (the same as the preserve option), but will error when a value import is only used as a type.
+   * This might be useful if you want to ensure no values are being accidentally imported, but still make side-effect imports explicit.
+   */
+  ERROR = "error",
+}
+
+/**
  * Determines how JSX should get transformed into valid JavaScript.
  *
  * @see https://www.typescriptlang.org/docs/handbook/jsx.html
@@ -159,12 +182,12 @@ export interface TypeScriptCompilerOptions {
   readonly forceConsistentCasingInFileNames?: boolean;
 
   /**
-   * This flag controls how `import` works, because you can use `import type` to explicitly create an `import` statement which should never be emitted into JavaScript.
+   * This flag works because you can use `import type` to explicitly create an `import` statement which should never be emitted into JavaScript.
    *
    * @see https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues
    * @default "remove"
    */
-  readonly importsNotUsedAsValues?: "remove" | "preserve" | "error";
+  readonly importsNotUsedAsValues?: TypeScriptImportsNotUsedAsValues;
 
   /**
    * When set, instead of writing out a .js.map file to provide source maps,

--- a/src/javascript/typescript-config.ts
+++ b/src/javascript/typescript-config.ts
@@ -63,7 +63,7 @@ export enum TypeScriptModuleResolution {
 }
 
 /**
- * This flag controls how import works, there are 3 different options.
+ * This flag controls how `import` works, there are 3 different options.
  *
  * @see https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues
  */

--- a/src/javascript/typescript-config.ts
+++ b/src/javascript/typescript-config.ts
@@ -159,6 +159,14 @@ export interface TypeScriptCompilerOptions {
   readonly forceConsistentCasingInFileNames?: boolean;
 
   /**
+   * This flag controls how `import` works, because you can use `import type` to explicitly create an `import` statement which should never be emitted into JavaScript.
+   *
+   * @see https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues
+   * @default "remove"
+   */
+  readonly importsNotUsedAsValues?: "remove" | "preserve" | "error";
+
+  /**
    * When set, instead of writing out a .js.map file to provide source maps,
    * TypeScript will embed the source map content in the .js files.
    *


### PR DESCRIPTION
Allows us to set `importsNotUsedAsValues` to `error` instead of the default `remove` option - from the [docs](https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues):

> This might be useful if you want to ensure no values are being accidentally imported, but still make side-effect imports explicit.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.