### PR TITLE
chore(javascript): fix invalid arg name in JSDocs

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -8229,7 +8229,7 @@ Adds a a setup file to Jest's setupFiles configuration.
 addSetupFile(file: string): void
 ```
 
-* **file** (<code>string</code>)  *No description*
+* **file** (<code>string</code>)  File path to setup file.
 
 
 
@@ -8242,7 +8242,7 @@ Adds a a setup file to Jest's setupFilesAfterEnv configuration.
 addSetupFileAfterEnv(file: string): void
 ```
 
-* **file** (<code>string</code>)  *No description*
+* **file** (<code>string</code>)  File path to setup file.
 
 
 

--- a/src/javascript/jest.ts
+++ b/src/javascript/jest.ts
@@ -760,7 +760,7 @@ export class Jest extends Component {
 
   /**
    * Adds a a setup file to Jest's setupFiles configuration.
-   * @param string File path to setup file
+   * @param file File path to setup file
    */
   public addSetupFile(file: string) {
     if (!this.config.setupFiles) {
@@ -771,7 +771,7 @@ export class Jest extends Component {
 
   /**
    * Adds a a setup file to Jest's setupFilesAfterEnv configuration.
-   * @param string File path to setup file
+   * @param file File path to setup file
    */
   public addSetupFileAfterEnv(file: string) {
     if (!this.config.setupFilesAfterEnv) {


### PR DESCRIPTION
Looks like I used an argument type instead of argument name in one spot of my recent PR #2515 in the JSDocs. I may look at building a test to catch this in the future but since it's Friday, here's a quick fix for the issue I created instead.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.