### PR TITLE
fix(node): Upgrade Workflow is missing id-token permission when GitHub OIDC configured

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -17627,6 +17627,7 @@ Name | Type | Description
 **container**?🔹 | <code>[github.workflows.ContainerOptions](#projen-github-workflows-containeroptions)</code> | Job container options.<br/>__*Default*__: defaults
 **gitIdentity**?🔹 | <code>[github.GitIdentity](#projen-github-gitidentity)</code> | The git identity to use for commits.<br/>__*Default*__: "github-actions
 **labels**?🔹 | <code>Array<string></code> | Labels to apply on the PR.<br/>__*Default*__: no labels.
+**permissions**?🔹 | <code>[github.workflows.JobPermissions](#projen-github-workflows-jobpermissions)</code> | Permissions granted to the upgrade job To limit job permissions for `contents`, the desired permissions have to be explicitly set, e.g.: `{ contents: JobPermission.NONE }`.<br/>__*Default*__: `{ contents: JobPermission.READ }`
 **projenCredentials**?🔹 | <code>[github.GithubCredentials](#projen-github-githubcredentials)</code> | Choose a method for authenticating with GitHub for creating the PR.<br/>__*Default*__: personal access token named PROJEN_GITHUB_TOKEN
 **runsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 **schedule**?🔹 | <code>[javascript.UpgradeDependenciesSchedule](#projen-javascript-upgradedependenciesschedule)</code> | Schedule to run on.<br/>__*Default*__: UpgradeDependenciesSchedule.DAILY

--- a/src/javascript/node-project.ts
+++ b/src/javascript/node-project.ts
@@ -696,6 +696,7 @@ export class NodeProject extends GitHubProject {
             : undefined,
           labels: autoApproveLabel(depsAutoApprove),
           gitIdentity: this.workflowGitIdentity,
+          permissions: workflowPermissions,
         },
       };
       this.upgradeWorkflow = new UpgradeDependencies(

--- a/test/javascript/node-project.test.ts
+++ b/test/javascript/node-project.test.ts
@@ -1162,6 +1162,13 @@ describe("scoped private packages", () => {
         "id-token"
       );
     });
+
+    test("does not add id-token permission to upgrade workflow", () => {
+      const workflow = yaml.parse(output[".github/workflows/upgrade-main.yml"]);
+      expect(Object.keys(workflow.jobs.upgrade.permissions)).not.toContain(
+        "id-token"
+      );
+    });
   });
 
   describe("Auth Provider GITHUB_OIDC", () => {
@@ -1245,6 +1252,16 @@ describe("scoped private packages", () => {
       expect(workflow.jobs.release.permissions).toEqual(
         expect.objectContaining({
           "id-token": "write",
+        })
+      );
+    });
+
+    test("adds id-token permission to upgrade workflow", () => {
+      const workflow = yaml.parse(output[".github/workflows/upgrade-main.yml"]);
+      expect(workflow.jobs.upgrade.permissions).toEqual(
+        expect.objectContaining({
+          "id-token": "write",
+          contents: "read",
         })
       );
     });


### PR DESCRIPTION
Similar fix has been put in place for this `release` and `build` workflows in #2399 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.