### PR TITLE
fix(subprojects): unnecessary use of cd when calling root default tasks

### DIFF
--- a/src/project.ts
+++ b/src/project.ts
@@ -280,12 +280,9 @@ export class Project {
 
       // Subtasks should call the root task for synth
       if (this.parent) {
-        this.defaultTask.exec(
-          [
-            `cd ${path.relative(this.outdir, this.root.outdir)}`,
-            `${this.projenCommand} ${Project.DEFAULT_TASK}`,
-          ].join(" && ")
-        );
+        this.defaultTask.exec(`${this.projenCommand} ${Project.DEFAULT_TASK}`, {
+          cwd: path.relative(this.outdir, this.root.outdir),
+        });
       }
 
       if (!this.parent) {

--- a/test/__snapshots__/subproject.test.ts.snap
+++ b/test/__snapshots__/subproject.test.ts.snap
@@ -34,7 +34,8 @@ Object {
       "name": "default",
       "steps": Array [
         Object {
-          "exec": "cd .. && npx projen default",
+          "cwd": "..",
+          "exec": "npx projen default",
         },
       ],
     },
@@ -92,7 +93,8 @@ Object {
       "name": "default",
       "steps": Array [
         Object {
-          "exec": "cd ../.. && npx projen default",
+          "cwd": "../..",
+          "exec": "npx projen default",
         },
       ],
     },

--- a/test/subproject.test.ts
+++ b/test/subproject.test.ts
@@ -177,11 +177,17 @@ test("subprojects use root level default task", () => {
   const out = synthSnapshot(root);
   expect(out["one/.projen/tasks.json"]).toMatchSnapshot();
   expect(out["one/.projen/tasks.json"].tasks.default.steps).toEqual([
-    { exec: "cd .. && npx projen default" },
+    {
+      cwd: "..",
+      exec: "npx projen default",
+    },
   ]);
   expect(out["one/two/.projen/tasks.json"]).toMatchSnapshot();
   expect(out["one/two/.projen/tasks.json"].tasks.default.steps).toEqual([
-    { exec: "cd ../.. && npx projen default" },
+    {
+      cwd: "../..",
+      exec: "npx projen default",
+    },
   ]);
 });
 


### PR DESCRIPTION
Instead of doing `cd` which is not as portable, we should use the existing feature to run commands from any directory.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.