### PR TITLE
fix: projen cannot be used with node "< 16.0.0"

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "@types/node",
-      "version": "^16",
+      "version": "^14",
       "type": "build"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -60,7 +60,7 @@ const project = new cdk.JsiiProject({
 
   projenDevDependency: false, // because I am projen
   releaseToNpm: true,
-  minNodeVersion: "16.0.0",
+  minNodeVersion: "14.0.0", // Do not change this before a version has been EOL for a while
   workflowNodeVersion: "16.13.0",
 
   codeCov: true,

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@types/glob": "^7.2.0",
     "@types/ini": "^1.3.31",
     "@types/jest": "^27",
-    "@types/node": "^16",
+    "@types/node": "^14",
     "@types/semver": "^7.3.13",
     "@types/yargs": "^16.0.5",
     "@typescript-eslint/eslint-plugin": "^5",
@@ -118,7 +118,7 @@
     "scaffolding"
   ],
   "engines": {
-    "node": ">= 16.0.0"
+    "node": ">= 14.0.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1024,10 +1024,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.15.5.tgz#3af577099a99c61479149b716183e70b5239324a"
   integrity sha512-Ark2WDjjZO7GmvsyFFf81MXuGTA/d6oP38anyxWOL6EREyBKAxKoFHwBhaZxCfLRLpO8JgVXwqOwSwa7jRcjew==
 
-"@types/node@^16":
-  version "16.18.18"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.18.tgz#06cb0eeb5a0175d26d99b7acf4db613ca30cb07f"
-  integrity sha512-fwGw1uvQAzabxL1pyoknPlJIF2t7+K90uTqynleKRx24n3lYcxWa3+KByLhgkF8GEAK2c7hC8Ki0RkNM5H15jQ==
+"@types/node@^14":
+  version "14.18.40"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.40.tgz#773945366f7531d60473087be12b819f300e3e69"
+  integrity sha512-pGteXO/JQX7wPxGR8lyT+doqjMa7XvlVowwrDwLfX92k5SdLkk4cwC7CYSLBxrenw/R5oQwKioVIak7ZgplM3g==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"


### PR DESCRIPTION
Reverts the accidental change of the minimum node version for projen itself. Node 14 is not EOL yet and we will only change the minimum node version a fair time after EOL.

Using projen with a version before Node 16 currently fails with an error like this:
```
error projen@0.69.1: The engine "node" is incompatible with this module. Expected version ">= 16.0.0". Got "14.21.3"
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.