### PR TITLE
chore(python-project): correction to projenrcTs option's docstring

### DIFF
--- a/src/python/python-project.ts
+++ b/src/python/python-project.ts
@@ -167,8 +167,8 @@ export interface PythonProjectOptions
   /**
    * Use projenrc in TypeScript.
    *
-   * This will create a `tsconfig.json` file and use `ts-node` in the
-   * default task to parse the project configuration file.
+   * This will create a tsconfig file (default: `tsconfig.projen.json`)
+   * and use `ts-node` in the default task to parse the project source files.
    *
    * @default false
    */


### PR DESCRIPTION
- chore(deps): upgrade dependencies (#2513)
- fix(github): extend PullRequestOptions to include PushOptions (#2511)
- feat(javascript): Jest config support for addSetupfile() addSetupAfterEnv() (#2516)
- chore: fix test that updates snapshot locally (#2518)
- chore(javascript): fix invalid arg name in JSDocs (#2522)
- chore(deps): upgrade dependencies (#2523)
- feat(typescript): support `importsNotUsedAsValues` (#2520)
- chore(deps): upgrade dependencies (#2527)
- chore(deps): upgrade dependencies (#2534)
- fix(file): marker notice is referencing the wrong projenrc file (#2498)
- chore(deps): upgrade dependencies (#2538)
- fix(node): Upgrade Workflow is missing id-token permission when GitHub OIDC configured (#2537)
- chore: remove dependency on fs-extras (#2540)
- feat: generic .projenrc.ts file that can be used in non-TS projects (#2521)
- feat(cli): allow running `projen` from a subdirectory (#2493)
- fix(subprojects): unnecessary use of `cd` when spawning default task of root project (#2542)
- fix(auto-merge): Mergify is not merging pull requests (#2517)
- feat(node)!: default to node16 and remove `jsii/superchain` from workflows (#2510)
- feat(jsii): support for setting new `jsiiVersion` (#2539)
- chore(deps): upgrade dependencies (#2546)
- fix: projen cannot be used with node "< 16.0.0" (#2547)
- chore(python-project): Correct projenrcTs docstring

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.