### PR TITLE
feat: add generic type parameter to `Component` class

### DIFF
--- a/src/component.ts
+++ b/src/component.ts
@@ -3,8 +3,8 @@ import { Project } from "./project";
 /**
  * Represents a project component.
  */
-export class Component {
-  constructor(public readonly project: Project) {
+export class Component<T extends Project = Project> {
+  constructor(public readonly project: T) {
     project._addComponent(this);
   }
 


### PR DESCRIPTION
If we allow `Component` to take a generic type parameter that extends `Project`, it means we can let a given `Component` access properties and methods that exist on a specific `Project` type.

For example, if we know that a `Component` is specifically for a `NodeProject`, we can pass `Component<NodeProject>` so that we can access `this.project.renderWorkflowSetup`.

Currently, if we want to do this we need to create a new custom `this._project` property with the extended project type manually - when we add this generic type parameter, we can simply access `this.project` instead.

We can make this generic type parameter optional and default to `Project` so that consumers won't be affected.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.