### PR TITLE
fix(jest): cannot set `preset` and `globals` config when using in a typescript project

### DIFF
--- a/src/typescript/typescript.ts
+++ b/src/typescript/typescript.ts
@@ -20,6 +20,7 @@ import {
   ProjenrcOptions as ProjenrcTsOptions,
   TypedocDocgen,
 } from "../typescript";
+import { deepMerge } from "../util";
 
 export interface TypeScriptProjectOptions extends NodeProjectOptions {
   /**
@@ -445,12 +446,17 @@ export class TypeScriptProject extends NodeProject {
     );
 
     // add relevant deps
-    jest.config.preset = "ts-jest";
-    jest.config.globals = {
-      "ts-jest": {
-        tsconfig: this.tsconfigDev.fileName,
+    if (!jest.config.preset) {
+      jest.config.preset = "ts-jest";
+    }
+    jest.config.globals = deepMerge([
+      {
+        "ts-jest": {
+          tsconfig: this.tsconfigDev.fileName,
+        },
       },
-    };
+      jest.config.globals,
+    ]);
   }
 }
 

--- a/test/typescript/typescript.test.ts
+++ b/test/typescript/typescript.test.ts
@@ -251,6 +251,52 @@ test("upgrade task ignores pinned versions", () => {
   );
 });
 
+describe("jestConfig", () => {
+  test("uses default values", () => {
+    const prj = new TypeScriptProject({
+      defaultReleaseBranch: "main",
+      name: "test",
+      jestOptions: {
+        jestConfig: {
+          globals: {
+            "ts-jest": {
+              shouldBePreserved: true,
+            },
+          },
+        },
+      },
+    });
+    const snapshot = synthSnapshot(prj);
+    const jest = snapshot["package.json"].jest;
+    expect(jest.preset).toStrictEqual("ts-jest");
+    expect(jest.globals["ts-jest"].tsconfig).toStrictEqual("tsconfig.dev.json");
+    expect(jest.globals["ts-jest"].shouldBePreserved).toStrictEqual(true);
+  });
+
+  test("overrides default values", () => {
+    const prj = new TypeScriptProject({
+      defaultReleaseBranch: "main",
+      name: "test",
+      jestOptions: {
+        jestConfig: {
+          preset: "foo",
+          globals: {
+            "ts-jest": {
+              shouldBePreserved: true,
+              tsconfig: "bar",
+            },
+          },
+        },
+      },
+    });
+    const snapshot = synthSnapshot(prj);
+    const jest = snapshot["package.json"].jest;
+    expect(jest.preset).toStrictEqual("foo");
+    expect(jest.globals["ts-jest"].tsconfig).toStrictEqual("bar");
+    expect(jest.globals["ts-jest"].shouldBePreserved).toStrictEqual(true);
+  });
+});
+
 describe("tsconfigDev", () => {
   test("uses tsconfig.dev.json by default", () => {
     const prj = new TypeScriptProject({


### PR DESCRIPTION
Some of `jestConfig` properties are not able to update through constructor
because of a bug by assigning hard coded default values.

This commit fixes the bug to assign hard coded values only if the same
properties are not set.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
