### PR TITLE
feat: add `workflowContainerImage` to `Publisher`

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -10235,6 +10235,7 @@ new release.Publisher(project: Project, options: PublisherOptions)
   * **jsiiReleaseVersion** (<code>string</code>)  *No description* __*Optional*__
   * **publibVersion** (<code>string</code>)  Version requirement for `publib`. __*Default*__: "latest"
   * **publishTasks** (<code>boolean</code>)  Define publishing tasks that can be executed manually as well as workflows. __*Default*__: false
+  * **workflowContainerImage** (<code>string</code>)  Container image to use for GitHub workflows. __*Default*__: default image
   * **workflowNodeVersion** (<code>string</code>)  Node version to setup in GitHub workflows if any node-based CLI utilities are needed. __*Default*__: 16.x
   * **workflowRunsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
 
@@ -18482,6 +18483,7 @@ Name | Type | Description
 **jsiiReleaseVersion**?⚠️ | <code>string</code> | __*Optional*__
 **publibVersion**?🔹 | <code>string</code> | Version requirement for `publib`.<br/>__*Default*__: "latest"
 **publishTasks**?🔹 | <code>boolean</code> | Define publishing tasks that can be executed manually as well as workflows.<br/>__*Default*__: false
+**workflowContainerImage**?🔹 | <code>string</code> | Container image to use for GitHub workflows.<br/>__*Default*__: default image
 **workflowNodeVersion**?🔹 | <code>string</code> | Node version to setup in GitHub workflows if any node-based CLI utilities are needed.<br/>__*Default*__: 16.x
 **workflowRunsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 

--- a/src/cdk/jsii-project.ts
+++ b/src/cdk/jsii-project.ts
@@ -297,9 +297,12 @@ export class JsiiProject extends TypeScriptProject {
       }
     );
 
-    const extraJobOptions: Partial<Job> = options.workflowRunsOn
-      ? { runsOn: options.workflowRunsOn }
-      : {};
+    const extraJobOptions: Partial<Job> = {
+      ...(options.workflowRunsOn ? { runsOn: options.workflowRunsOn } : {}),
+      ...(options.workflowContainerImage
+        ? { container: { image: options.workflowContainerImage } }
+        : {}),
+    };
 
     if (options.releaseToNpm != false) {
       const task = this.addPackagingTask("js");

--- a/src/release/publisher.ts
+++ b/src/release/publisher.ts
@@ -71,6 +71,13 @@ export interface PublisherOptions {
   readonly workflowNodeVersion?: string;
 
   /**
+   * Container image to use for GitHub workflows.
+   *
+   * @default - default image
+   */
+  readonly workflowContainerImage?: string;
+
+  /**
    * Version requirement for `publib`.
    *
    * @default "latest"
@@ -145,6 +152,7 @@ export class Publisher extends Component {
   private readonly dryRun: boolean;
 
   private readonly workflowNodeVersion: string;
+  private readonly workflowContainerImage?: string;
 
   constructor(project: Project, options: PublisherOptions) {
     super(project);
@@ -157,6 +165,7 @@ export class Publisher extends Component {
     this.condition = options.condition;
     this.dryRun = options.dryRun ?? false;
     this.workflowNodeVersion = options.workflowNodeVersion ?? "16.x";
+    this.workflowContainerImage = options.workflowContainerImage;
 
     this.failureIssue = options.failureIssue ?? false;
     this.failureIssueLabel = options.failureIssueLabel ?? "failed-release";
@@ -605,6 +614,11 @@ export class Publisher extends Component {
       ];
 
       const perms = opts.permissions ?? { contents: JobPermission.READ };
+      const container = this.workflowContainerImage
+        ? {
+            image: this.workflowContainerImage,
+          }
+        : undefined;
 
       if (this.failureIssue) {
         steps.push(
@@ -644,6 +658,7 @@ export class Publisher extends Component {
           if: this.condition,
           needs: [this.buildJobId],
           runsOn: this.runsOn,
+          container,
           steps,
         },
       };

--- a/src/release/release.ts
+++ b/src/release/release.ts
@@ -363,6 +363,7 @@ export class Release extends Component {
       publishTasks: options.publishTasks,
       dryRun: options.publishDryRun,
       workflowNodeVersion: options.workflowNodeVersion,
+      workflowContainerImage: options.workflowContainerImage,
     });
 
     const githubRelease = options.githubRelease ?? true;


### PR DESCRIPTION
Currently the `workflowContainerImage` doesn't get propagated to the `package` or `release` jobs

This PR makes sure that in `jsii-project` when creating the `package-[language]` jobs we set `container` in `extraJobOptions` if present.

It also makes sure when instantiating a `Release` object we can pass it to `release_[language]` jobs.

Both of these jobs currently propagate `workflowRunsOn` to them so the precedent is there.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.