### PR TITLE
fix(new): cli fails on windows with RangeError

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,4 +1,3 @@
-import { existsSync } from "fs";
 import { resolve } from "path";
 import * as yargs from "yargs";
 import newCommand from "./cmds/new";
@@ -7,7 +6,7 @@ import { discoverTaskCommands } from "./tasks";
 import { PROJEN_DIR, PROJEN_RC, PROJEN_VERSION } from "../common";
 import * as logging from "../logging";
 import { TaskRuntime } from "../task-runtime";
-import { getNodeMajorVersion } from "../util";
+import { findUp, getNodeMajorVersion } from "../util";
 
 const DEFAULT_RC = resolve(PROJEN_RC);
 
@@ -15,7 +14,7 @@ async function main() {
   const ya = yargs;
   ya.command(newCommand);
 
-  const pathToProjenDir = findProjenDir(process.cwd());
+  const pathToProjenDir = findUp(PROJEN_DIR, process.cwd());
   const runtime = new TaskRuntime(pathToProjenDir ?? ".");
   discoverTaskCommands(runtime, ya);
 
@@ -84,21 +83,3 @@ main().catch((e) => {
   console.error(e.stack);
   process.exit(1);
 });
-
-/**
- * Run up project tree to find .projen directory
- *
- * @param cwd current working directory
- * @returns path to .projen directory or undefined if not found
- */
-function findProjenDir(cwd: string): string | undefined {
-  if (existsSync(resolve(cwd, PROJEN_DIR))) {
-    return cwd;
-  }
-
-  if (cwd === "/") {
-    return undefined;
-  }
-
-  return findProjenDir(resolve(cwd, ".."));
-}

--- a/src/util.ts
+++ b/src/util.ts
@@ -476,10 +476,9 @@ export function findUp(
     return cwd;
   }
 
-  const parent = path.dirname(cwd);
-  if (parent === cwd) {
+  if (isRoot(cwd)) {
     // This is a root
     return undefined;
   }
-  return findUp(lookFor, parent);
+  return findUp(lookFor, path.dirname(cwd));
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -447,3 +447,39 @@ export function anySelected(options: (boolean | undefined)[]): boolean {
 export function multipleSelected(options: (boolean | undefined)[]): boolean {
   return options.filter((opt) => opt).length > 1;
 }
+
+/**
+ * Checks if a path is a FS root
+ *
+ * Optional uses a provided OS specific path implementation,
+ * defaults to use the implementation for the current OS.
+ *
+ * @internal
+ */
+export function isRoot(dir: string, osPathLib: typeof path = path): boolean {
+  const parent = osPathLib.dirname(dir);
+  return parent === dir;
+}
+
+/**
+ * Run up project tree to find a file or directory
+ *
+ * @param lookFor the file or directory to look for
+ * @param cwd current working directory, must be an absolute path
+ * @returns path to the file or directory we are looking for, undefined if not found
+ */
+export function findUp(
+  lookFor: string,
+  cwd: string = process.cwd()
+): string | undefined {
+  if (existsSync(path.join(cwd, lookFor))) {
+    return cwd;
+  }
+
+  const parent = path.dirname(cwd);
+  if (parent === cwd) {
+    // This is a root
+    return undefined;
+  }
+  return findUp(lookFor, parent);
+}

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -1,3 +1,4 @@
+import { posix, win32 } from "path";
 import { TestProject } from "./util";
 import { JsonFile } from "../src/json";
 import {
@@ -8,6 +9,7 @@ import {
   getFilePermissions,
   formatAsPythonModule,
   getGitVersion,
+  isRoot,
 } from "../src/util";
 
 describe("decamelizeRecursively", () => {
@@ -255,4 +257,26 @@ test("getGitVersion", () => {
 test("formatAsPythonModule", () => {
   expect(formatAsPythonModule("foo-bar-baz")).toEqual("foo_bar_baz");
   expect(formatAsPythonModule("foo.bar.baz")).toEqual("foo_bar_baz");
+});
+
+describe("isRoot", () => {
+  describe("unix", () => {
+    test("will detect root", () => {
+      expect(isRoot("/", posix)).toBe(true);
+    });
+
+    test("will return false for path to dir", () => {
+      expect(isRoot("/home/me/code", posix)).toBe(false);
+    });
+  });
+
+  describe("windows", () => {
+    test("will detect root", () => {
+      expect(isRoot("C:\\", win32)).toBe(true);
+    });
+
+    test("will return false for path to dir", () => {
+      expect(isRoot("C:\\Users\\me\\code", win32)).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
The filesystem root check in the custom findUp implementation did not account for windows paths.
This was introduced in #2418 

Manually verified the fix on my windows machine.

This is blocking when a new project is created.
Existing projects were only partially affected, as the cli would have successfully found a projen directory unless run outside a projen dir. But there it would have errored anyway.

Fixes #2574


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.