### PR TITLE
feat(typescript): TypeScript TSConfig 5.0+ parameters, support for TSConfig extends.

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -9630,6 +9630,31 @@ addInclude(pattern: string): void
 
 
 
+#### preSynthesize()🔹 <a id="projen-javascript-typescriptconfig-presynthesize"></a>
+
+Called before synthesis.
+
+```ts
+preSynthesize(): void
+```
+
+
+
+
+
+#### resolveExtendsPath(configPath)🔹 <a id="projen-javascript-typescriptconfig-resolveextendspath"></a>
+
+Resolve valid TypeScript extends paths relative to this config.
+
+```ts
+resolveExtendsPath(configPath: string): string
+```
+
+* **configPath** (<code>string</code>)  Path to resolve against.
+
+__Returns__:
+* <code>string</code>
+
 
 
 ## class TypescriptConfigExtends 🔹 <a id="projen-javascript-typescriptconfigextends"></a>
@@ -18122,7 +18147,7 @@ Name | Type | Description
 **esModuleInterop**?🔹 | <code>boolean</code> | Emit __importStar and __importDefault helpers for runtime babel ecosystem compatibility and enable --allowSyntheticDefaultImports for typesystem compatibility.<br/>__*Default*__: false
 **experimentalDecorators**?🔹 | <code>boolean</code> | Enables experimental support for decorators, which is in stage 2 of the TC39 standardization process.<br/>__*Default*__: true
 **forceConsistentCasingInFileNames**?🔹 | <code>boolean</code> | Disallow inconsistently-cased references to the same file.<br/>__*Default*__: false
-**importsNotUsedAsValues**?⚠️ | <code>[javascript.TypeScriptImportsNotUsedAsValues](#projen-javascript-typescriptimportsnotusedasvalues)</code> | This flag works because you can use `import type` to explicitly create an `import` statement which should never be emitted into JavaScript.<br/>__*Default*__: "remove"
+**importsNotUsedAsValues**?🔹 | <code>[javascript.TypeScriptImportsNotUsedAsValues](#projen-javascript-typescriptimportsnotusedasvalues)</code> | This flag works because you can use `import type` to explicitly create an `import` statement which should never be emitted into JavaScript.<br/>__*Default*__: "remove"
 **inlineSourceMap**?🔹 | <code>boolean</code> | When set, instead of writing out a .js.map file to provide source maps, TypeScript will embed the source map content in the .js files.<br/>__*Default*__: true
 **inlineSources**?🔹 | <code>boolean</code> | When set, TypeScript will include the original content of the .ts file as an embedded string in the source map. This is often useful in the same cases as inlineSourceMap.<br/>__*Default*__: true
 **isolatedModules**?🔹 | <code>boolean</code> | Perform additional checks to ensure that separate compilation (such as with transpileModule or @babel/plugin-transform-typescript) would be safe.<br/>__*Default*__: false

--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -114,6 +114,7 @@ Name|Description
 [javascript.Projenrc](#projen-javascript-projenrc)|Sets up a javascript project to use TypeScript for projenrc.
 [javascript.Transform](#projen-javascript-transform)|*No description*
 [javascript.TypescriptConfig](#projen-javascript-typescriptconfig)|*No description*
+[javascript.TypescriptConfigExtends](#projen-javascript-typescriptconfigextends)|Container for `TypescriptConfig` `tsconfig.json` base configuration(s). Extending from more than one base config file requires TypeScript 5.0+.
 [javascript.UpgradeDependencies](#projen-javascript-upgradedependencies)|Upgrade node project dependencies.
 [javascript.UpgradeDependenciesSchedule](#projen-javascript-upgradedependenciesschedule)|How often to check for new versions and raise pull requests for version upgrades.
 [javascript.WatchPlugin](#projen-javascript-watchplugin)|*No description*
@@ -9569,7 +9570,7 @@ new javascript.TypescriptConfig(project: Project, options: TypescriptConfigOptio
 * **options** (<code>[javascript.TypescriptConfigOptions](#projen-javascript-typescriptconfigoptions)</code>)  *No description*
   * **compilerOptions** (<code>[javascript.TypeScriptCompilerOptions](#projen-javascript-typescriptcompileroptions)</code>)  Compiler options to use. 
   * **exclude** (<code>Array<string></code>)  Filters results from the "include" option. __*Default*__: node_modules is excluded by default
-  * **extends** (<code>string &#124; Array<string> &#124; [javascript.TypescriptConfig](#projen-javascript-typescriptconfig) &#124; Array<[javascript.TypescriptConfig](#projen-javascript-typescriptconfig)></code>)  Path or list of paths (TypeScript 5.0+) to base configuration(s) to inherit from. __*Optional*__
+  * **extends** (<code>[javascript.TypescriptConfigExtends](#projen-javascript-typescriptconfigextends)</code>)  Base `tsconfig.json` configuration(s) to inherit from. __*Optional*__
   * **fileName** (<code>string</code>)  *No description* __*Default*__: "tsconfig.json"
   * **include** (<code>Array<string></code>)  Specifies a list of glob patterns that match TypeScript files to be included in compilation. __*Default*__: all .ts files recursively
 
@@ -9582,7 +9583,7 @@ Name | Type | Description
 -----|------|-------------
 **compilerOptions**🔹 | <code>[javascript.TypeScriptCompilerOptions](#projen-javascript-typescriptcompileroptions)</code> | <span></span>
 **exclude**🔹 | <code>Array<string></code> | <span></span>
-**extends**🔹 | <code>Array<string></code> | <span></span>
+**extends**🔹 | <code>Array<string></code> | Array of base `tsconfig.json` paths. Any absolute paths are resolved relative to this instance, while any relative paths are used as is.
 **file**🔹 | <code>[JsonFile](#projen-jsonfile)</code> | <span></span>
 **fileName**🔹 | <code>string</code> | <span></span>
 **include**🔹 | <code>Array<string></code> | <span></span>
@@ -9605,13 +9606,13 @@ addExclude(pattern: string): void
 
 #### addExtends(value)🔹 <a id="projen-javascript-typescriptconfig-addextends"></a>
 
-
+Extend from base `TypescriptConfig` instance.
 
 ```ts
-addExtends(value: string &#124; TypescriptConfig): void
+addExtends(value: TypescriptConfig): void
 ```
 
-* **value** (<code>string &#124; [javascript.TypescriptConfig](#projen-javascript-typescriptconfig)</code>)  *No description*
+* **value** (<code>[javascript.TypescriptConfig](#projen-javascript-typescriptconfig)</code>)  Base `TypescriptConfig` instance.
 
 
 
@@ -9628,6 +9629,56 @@ addInclude(pattern: string): void
 
 
 
+
+
+
+## class TypescriptConfigExtends 🔹 <a id="projen-javascript-typescriptconfigextends"></a>
+
+Container for `TypescriptConfig` `tsconfig.json` base configuration(s). Extending from more than one base config file requires TypeScript 5.0+.
+
+__Submodule__: javascript
+
+
+### Methods
+
+
+#### toJSON()🔹 <a id="projen-javascript-typescriptconfigextends-tojson"></a>
+
+
+
+```ts
+toJSON(): Array<string>
+```
+
+
+__Returns__:
+* <code>Array<string></code>
+
+#### *static* fromPaths(paths)🔹 <a id="projen-javascript-typescriptconfigextends-frompaths"></a>
+
+Factory for creation from array of file paths.
+
+```ts
+static fromPaths(paths: Array<string>): TypescriptConfigExtends
+```
+
+* **paths** (<code>Array<string></code>)  Absolute or relative paths to base `tsconfig.json` files.
+
+__Returns__:
+* <code>[javascript.TypescriptConfigExtends](#projen-javascript-typescriptconfigextends)</code>
+
+#### *static* fromTypeScriptConfigs(configs)🔹 <a id="projen-javascript-typescriptconfigextends-fromtypescriptconfigs"></a>
+
+Factory for creation from array of other `TypescriptConfig` instances.
+
+```ts
+static fromTypeScriptConfigs(configs: Array<TypescriptConfig>): TypescriptConfigExtends
+```
+
+* **configs** (<code>Array<[javascript.TypescriptConfig](#projen-javascript-typescriptconfig)></code>)  Base `TypescriptConfig` instances.
+
+__Returns__:
+* <code>[javascript.TypescriptConfigExtends](#projen-javascript-typescriptconfigextends)</code>
 
 
 
@@ -18120,7 +18171,7 @@ Name | Type | Description
 -----|------|-------------
 **compilerOptions**🔹 | <code>[javascript.TypeScriptCompilerOptions](#projen-javascript-typescriptcompileroptions)</code> | Compiler options to use.
 **exclude**?🔹 | <code>Array<string></code> | Filters results from the "include" option.<br/>__*Default*__: node_modules is excluded by default
-**extends**?🔹 | <code>string &#124; Array<string> &#124; [javascript.TypescriptConfig](#projen-javascript-typescriptconfig) &#124; Array<[javascript.TypescriptConfig](#projen-javascript-typescriptconfig)></code> | Path or list of paths (TypeScript 5.0+) to base configuration(s) to inherit from.<br/>__*Optional*__
+**extends**?🔹 | <code>[javascript.TypescriptConfigExtends](#projen-javascript-typescriptconfigextends)</code> | Base `tsconfig.json` configuration(s) to inherit from.<br/>__*Optional*__
 **fileName**?🔹 | <code>string</code> | __*Default*__: "tsconfig.json"
 **include**?🔹 | <code>Array<string></code> | Specifies a list of glob patterns that match TypeScript files to be included in compilation.<br/>__*Default*__: all .ts files recursively
 

--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -9667,12 +9667,12 @@ static fromPaths(paths: Array<string>): TypescriptConfigExtends
 __Returns__:
 * <code>[javascript.TypescriptConfigExtends](#projen-javascript-typescriptconfigextends)</code>
 
-#### *static* fromTypeScriptConfigs(configs)🔹 <a id="projen-javascript-typescriptconfigextends-fromtypescriptconfigs"></a>
+#### *static* fromTypescriptConfigs(configs)🔹 <a id="projen-javascript-typescriptconfigextends-fromtypescriptconfigs"></a>
 
 Factory for creation from array of other `TypescriptConfig` instances.
 
 ```ts
-static fromTypeScriptConfigs(configs: Array<TypescriptConfig>): TypescriptConfigExtends
+static fromTypescriptConfigs(configs: Array<TypescriptConfig>): TypescriptConfigExtends
 ```
 
 * **configs** (<code>Array<[javascript.TypescriptConfig](#projen-javascript-typescriptconfig)></code>)  Base `TypescriptConfig` instances.

--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -18105,7 +18105,7 @@ Name | Type | Description
 **strictPropertyInitialization**?🔹 | <code>boolean</code> | When set to true, TypeScript will raise an error when a class property was declared but not set in the constructor.<br/>__*Default*__: true
 **stripInternal**?🔹 | <code>boolean</code> | Do not emit declarations for code that has an @internal annotation in it’s JSDoc comment.<br/>__*Default*__: true
 **target**?🔹 | <code>string</code> | Modern browsers support all ES6 features, so ES6 is a good choice.<br/>__*Default*__: "ES2018"
-**verbatimModuleSyntax**?🔹 | <code>string</code> | Simplifies TypeScript's handling of import/export `type` modifiers.<br/>__*Default*__: undefined
+**verbatimModuleSyntax**?🔹 | <code>boolean</code> | Simplifies TypeScript's handling of import/export `type` modifiers.<br/>__*Default*__: undefined
 
 
 

--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -9569,6 +9569,7 @@ new javascript.TypescriptConfig(project: Project, options: TypescriptConfigOptio
 * **options** (<code>[javascript.TypescriptConfigOptions](#projen-javascript-typescriptconfigoptions)</code>)  *No description*
   * **compilerOptions** (<code>[javascript.TypeScriptCompilerOptions](#projen-javascript-typescriptcompileroptions)</code>)  Compiler options to use. 
   * **exclude** (<code>Array<string></code>)  Filters results from the "include" option. __*Default*__: node_modules is excluded by default
+  * **extends** (<code>string &#124; Array<string> &#124; [javascript.TypescriptConfig](#projen-javascript-typescriptconfig) &#124; Array<[javascript.TypescriptConfig](#projen-javascript-typescriptconfig)></code>)  Path or list of paths (TypeScript 5.0+) to base configuration(s) to inherit from. __*Optional*__
   * **fileName** (<code>string</code>)  *No description* __*Default*__: "tsconfig.json"
   * **include** (<code>Array<string></code>)  Specifies a list of glob patterns that match TypeScript files to be included in compilation. __*Default*__: all .ts files recursively
 
@@ -9581,6 +9582,7 @@ Name | Type | Description
 -----|------|-------------
 **compilerOptions**🔹 | <code>[javascript.TypeScriptCompilerOptions](#projen-javascript-typescriptcompileroptions)</code> | <span></span>
 **exclude**🔹 | <code>Array<string></code> | <span></span>
+**extends**🔹 | <code>Array<string></code> | <span></span>
 **file**🔹 | <code>[JsonFile](#projen-jsonfile)</code> | <span></span>
 **fileName**🔹 | <code>string</code> | <span></span>
 **include**🔹 | <code>Array<string></code> | <span></span>
@@ -9597,6 +9599,19 @@ addExclude(pattern: string): void
 ```
 
 * **pattern** (<code>string</code>)  *No description*
+
+
+
+
+#### addExtends(value)🔹 <a id="projen-javascript-typescriptconfig-addextends"></a>
+
+
+
+```ts
+addExtends(value: string &#124; TypescriptConfig): void
+```
+
+* **value** (<code>string &#124; [javascript.TypescriptConfig](#projen-javascript-typescriptconfig)</code>)  *No description*
 
 
 
@@ -18042,10 +18057,13 @@ Name | Type | Description
 
 Name | Type | Description 
 -----|------|-------------
+**allowArbitraryExtensions**?🔹 | <code>boolean</code> | Suppress arbitrary extension import errors with the assumption that a bundler will be handling it.<br/>__*Default*__: undefined
+**allowImportingTsExtensions**?🔹 | <code>boolean</code> | Allows TypeScript files to import each other with TypeScript-specific extensions (`.ts`, `.mts`, `.tsx`). Requires `noEmit` or `emitDeclarationOnly`.<br/>__*Default*__: undefined
 **allowJs**?🔹 | <code>boolean</code> | Allow JavaScript files to be compiled.<br/>__*Default*__: false
 **allowSyntheticDefaultImports**?🔹 | <code>boolean</code> | Allow default imports from modules with no default export.<br/>__*Optional*__
 **alwaysStrict**?🔹 | <code>boolean</code> | Ensures that your files are parsed in the ECMAScript strict mode, and emit “use strict” for each source file.<br/>__*Default*__: true
 **baseUrl**?🔹 | <code>string</code> | Lets you set a base directory to resolve non-absolute module names.<br/>__*Optional*__
+**customConditions**?🔹 | <code>Array<string></code> | List of additional conditions that should succeed when TypeScript resolves from an `exports` or `imports` field of a `package.json`.<br/>__*Default*__: undefined
 **declaration**?🔹 | <code>boolean</code> | To be specified along with the above.<br/>__*Optional*__
 **declarationDir**?🔹 | <code>string</code> | Offers a way to configure the root directory for where declaration files are emitted.<br/>__*Optional*__
 **emitDeclarationOnly**?🔹 | <code>boolean</code> | Only emit .d.ts files; do not emit .js files.<br/>__*Default*__: false
@@ -18053,7 +18071,7 @@ Name | Type | Description
 **esModuleInterop**?🔹 | <code>boolean</code> | Emit __importStar and __importDefault helpers for runtime babel ecosystem compatibility and enable --allowSyntheticDefaultImports for typesystem compatibility.<br/>__*Default*__: false
 **experimentalDecorators**?🔹 | <code>boolean</code> | Enables experimental support for decorators, which is in stage 2 of the TC39 standardization process.<br/>__*Default*__: true
 **forceConsistentCasingInFileNames**?🔹 | <code>boolean</code> | Disallow inconsistently-cased references to the same file.<br/>__*Default*__: false
-**importsNotUsedAsValues**?🔹 | <code>[javascript.TypeScriptImportsNotUsedAsValues](#projen-javascript-typescriptimportsnotusedasvalues)</code> | This flag works because you can use `import type` to explicitly create an `import` statement which should never be emitted into JavaScript.<br/>__*Default*__: "remove"
+**importsNotUsedAsValues**?⚠️ | <code>[javascript.TypeScriptImportsNotUsedAsValues](#projen-javascript-typescriptimportsnotusedasvalues)</code> | This flag works because you can use `import type` to explicitly create an `import` statement which should never be emitted into JavaScript.<br/>__*Default*__: "remove"
 **inlineSourceMap**?🔹 | <code>boolean</code> | When set, instead of writing out a .js.map file to provide source maps, TypeScript will embed the source map content in the .js files.<br/>__*Default*__: true
 **inlineSources**?🔹 | <code>boolean</code> | When set, TypeScript will include the original content of the .ts file as an embedded string in the source map. This is often useful in the same cases as inlineSourceMap.<br/>__*Default*__: true
 **isolatedModules**?🔹 | <code>boolean</code> | Perform additional checks to ensure that separate compilation (such as with transpileModule or @babel/plugin-transform-typescript) would be safe.<br/>__*Default*__: false
@@ -18076,6 +18094,8 @@ Name | Type | Description
 **outDir**?🔹 | <code>string</code> | Output directory for the compiled files.<br/>__*Optional*__
 **paths**?🔹 | <code>Map<string, Array<string>></code> | A series of entries which re-map imports to lookup locations relative to the baseUrl, there is a larger coverage of paths in the handbook.<br/>__*Optional*__
 **resolveJsonModule**?🔹 | <code>boolean</code> | Allows importing modules with a ‘.json’ extension, which is a common practice in node projects. This includes generating a type for the import based on the static JSON shape.<br/>__*Default*__: true
+**resolvePackageJsonExports**?🔹 | <code>boolean</code> | Forces TypeScript to consult the `exports` field of `package.json` files if it ever reads from a package in `node_modules`.<br/>__*Default*__: true
+**resolvePackageJsonImports**?🔹 | <code>boolean</code> | Forces TypeScript to consult the `imports` field of `package.json` when performing a lookup that begins with `#` from a file that has a `package.json` as an ancestor.<br/>__*Default*__: undefined
 **rootDir**?🔹 | <code>string</code> | Specifies the root directory of input files.<br/>__*Optional*__
 **skipLibCheck**?🔹 | <code>boolean</code> | Skip type checking of all declaration files (*.d.ts).<br/>__*Default*__: false
 **sourceMap**?🔹 | <code>boolean</code> | Enables the generation of sourcemap files.<br/>__*Default*__: undefined
@@ -18085,6 +18105,7 @@ Name | Type | Description
 **strictPropertyInitialization**?🔹 | <code>boolean</code> | When set to true, TypeScript will raise an error when a class property was declared but not set in the constructor.<br/>__*Default*__: true
 **stripInternal**?🔹 | <code>boolean</code> | Do not emit declarations for code that has an @internal annotation in it’s JSDoc comment.<br/>__*Default*__: true
 **target**?🔹 | <code>string</code> | Modern browsers support all ES6 features, so ES6 is a good choice.<br/>__*Default*__: "ES2018"
+**verbatimModuleSyntax**?🔹 | <code>string</code> | Simplifies TypeScript's handling of import/export `type` modifiers.<br/>__*Default*__: undefined
 
 
 
@@ -18099,6 +18120,7 @@ Name | Type | Description
 -----|------|-------------
 **compilerOptions**🔹 | <code>[javascript.TypeScriptCompilerOptions](#projen-javascript-typescriptcompileroptions)</code> | Compiler options to use.
 **exclude**?🔹 | <code>Array<string></code> | Filters results from the "include" option.<br/>__*Default*__: node_modules is excluded by default
+**extends**?🔹 | <code>string &#124; Array<string> &#124; [javascript.TypescriptConfig](#projen-javascript-typescriptconfig) &#124; Array<[javascript.TypescriptConfig](#projen-javascript-typescriptconfig)></code> | Path or list of paths (TypeScript 5.0+) to base configuration(s) to inherit from.<br/>__*Optional*__
 **fileName**?🔹 | <code>string</code> | __*Default*__: "tsconfig.json"
 **include**?🔹 | <code>Array<string></code> | Specifies a list of glob patterns that match TypeScript files to be included in compilation.<br/>__*Default*__: all .ts files recursively
 
@@ -20606,6 +20628,7 @@ Name | Description
 **NODE** 🔹|Resolution strategy which attempts to mimic the Node.js module resolution strategy at runtime.
 **NODE16** 🔹|Node.js’ ECMAScript Module Support from TypeScript 4.7 onwards.
 **NODE_NEXT** 🔹|Node.js’ ECMAScript Module Support from TypeScript 4.7 onwards.
+**BUNDLER** 🔹|Resolution strategy which attempts to mimic resolution patterns of modern bundlers;
 
 
 ## enum UpdateSnapshot 🔹 <a id="projen-javascript-updatesnapshot"></a>

--- a/src/javascript/typescript-config.ts
+++ b/src/javascript/typescript-config.ts
@@ -655,7 +655,7 @@ export class TypescriptConfig extends Component {
     if (!tsVersion) return;
     if (tsVersion.major < 5) {
       this.project.logger.warn(
-        "TypeScript < 5.0.0 is can only extend from a single base config.",
+        "TypeScript < 5.0.0 can only extend from a single base config.",
         `TypeScript Version: ${tsVersion.format()}`,
         `File: ${this.file.absolutePath}`,
         `Extends: ${this.extends}`

--- a/src/javascript/typescript-config.ts
+++ b/src/javascript/typescript-config.ts
@@ -136,6 +136,22 @@ export interface TypeScriptCompilerOptions {
   readonly allowJs?: boolean;
 
   /**
+   * Allows TypeScript files to import each other with TypeScript-specific extensions (`.ts`, `.mts`, `.tsx`).
+   * Requires `noEmit` or `emitDeclarationOnly`.
+   *
+   * @default undefined
+   */
+  readonly allowImportingTsExtensions?: boolean;
+
+  /**
+   * Suppress arbitrary extension import errors with the assumption that a bundler will be handling it.
+   *
+   * @see https://www.typescriptlang.org/tsconfig#allowArbitraryExtensions
+   * @default undefined
+   */
+  readonly allowArbitraryExtensions?: boolean;
+
+  /**
    * Ensures that your files are parsed in the ECMAScript strict mode, and emit “use strict”
    * for each source file.
    *
@@ -154,6 +170,14 @@ export interface TypeScriptCompilerOptions {
    *
    */
   readonly declaration?: boolean;
+
+  /**
+   * List of additional conditions that should succeed when TypeScript resolves from an `exports` or `imports` field of a `package.json`.
+   *
+   * @see https://www.typescriptlang.org/tsconfig#customConditions
+   * @default undefined
+   */
+  readonly customConditions?: string[];
 
   /**
    * Emit __importStar and __importDefault helpers for runtime babel
@@ -190,8 +214,17 @@ export interface TypeScriptCompilerOptions {
   readonly forceConsistentCasingInFileNames?: boolean;
 
   /**
+   * Simplifies TypeScript's handling of import/export `type` modifiers.
+   *
+   * @see https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax
+   * @default undefined
+   */
+  readonly verbatimModuleSyntax?: string;
+
+  /**
    * This flag works because you can use `import type` to explicitly create an `import` statement which should never be emitted into JavaScript.
    *
+   * @deprecated For TypeScript 5.0+ use `verbatimModuleSyntax` instead.
    * @see https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues
    * @default "remove"
    */
@@ -413,6 +446,20 @@ export interface TypeScriptCompilerOptions {
    * @default true
    */
   readonly stripInternal?: boolean;
+
+  /**
+   * Forces TypeScript to consult the `exports` field of `package.json` files if it ever reads from a package in `node_modules`.
+   *
+   * @default true
+   */
+  readonly resolvePackageJsonExports?: boolean;
+
+  /**
+   * Forces TypeScript to consult the `imports` field of `package.json` when performing a lookup that begins with `#` from a file that has a `package.json` as an ancestor.
+   *
+   * @default undefined
+   */
+  readonly resolvePackageJsonImports?: boolean;
 
   /**
    * Modern browsers support all ES6 features, so ES6 is a good choice. You might choose to set

--- a/src/javascript/typescript-config.ts
+++ b/src/javascript/typescript-config.ts
@@ -576,14 +576,7 @@ export class TypescriptConfig extends Component {
     this.file = new JsonFile(project, fileName, {
       allowComments: true,
       obj: {
-        extends: () =>
-          // use string value for singular extension for TS<5.0 support;
-          // omit if no extensions.
-          this.extends.length === 1
-            ? this.extends[0]
-            : this.extends.length
-            ? this.extends
-            : undefined,
+        extends: () => this.renderExtends(),
         compilerOptions: this.compilerOptions,
         include: () => this.include,
         exclude: () => this.exclude,
@@ -593,6 +586,20 @@ export class TypescriptConfig extends Component {
     if (project instanceof NodeProject) {
       project.npmignore?.exclude(`/${fileName}`);
     }
+  }
+
+  /**
+   * Render appropriate value for `extends` field.
+   * @private
+   */
+  private renderExtends(): string | string[] | undefined {
+    if (this.extends.length <= 1) {
+      // render string value when only one extension (TS<5.0);
+      // omit if no extensions.
+      return this.extends[0];
+    }
+    // render many extensions as array (TS>=5.0)
+    return this.extends;
   }
 
   /**

--- a/src/javascript/typescript-config.ts
+++ b/src/javascript/typescript-config.ts
@@ -232,7 +232,10 @@ export interface TypeScriptCompilerOptions {
   /**
    * This flag works because you can use `import type` to explicitly create an `import` statement which should never be emitted into JavaScript.
    *
-   * @deprecated For TypeScript 5.0+ use `verbatimModuleSyntax` instead.
+   * @remarks
+   * For TypeScript 5.0+ use `verbatimModuleSyntax` instead.
+   * Posed for deprecation upon TypeScript 5.5.
+   *
    * @see https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues
    * @default "remove"
    */

--- a/src/javascript/typescript-config.ts
+++ b/src/javascript/typescript-config.ts
@@ -520,6 +520,10 @@ export interface TypeScriptCompilerOptions {
 export class TypescriptConfigExtends {
   /**
    * Factory for creation from array of file paths.
+   *
+   * @remarks
+   * TypeScript 5.0+ is required to specify more than one value in `paths`.
+   *
    * @param paths Absolute or relative paths to base `tsconfig.json` files.
    */
   public static fromPaths(paths: string[]) {
@@ -528,6 +532,10 @@ export class TypescriptConfigExtends {
 
   /**
    * Factory for creation from array of other `TypescriptConfig` instances.
+   *
+   * @remarks
+   * TypeScript 5.0+ is required to specify more than on value in `configs`.
+   *
    * @param configs Base `TypescriptConfig` instances.
    */
   public static fromTypescriptConfigs(configs: TypescriptConfig[]) {
@@ -647,6 +655,10 @@ export class TypescriptConfig extends Component {
 
   /**
    * Extend from base `TypescriptConfig` instance.
+   *
+   * @remarks
+   * TypeScript 5.0+ is required to extend from more than one base `TypescriptConfig`.
+   *
    * @param value Base `TypescriptConfig` instance.
    */
   public addExtends(value: TypescriptConfig) {

--- a/src/javascript/typescript-config.ts
+++ b/src/javascript/typescript-config.ts
@@ -634,7 +634,7 @@ export class TypescriptConfig extends Component {
     if (!ts || !tsVersion) return;
     if (tsVersion.major < 5) {
       this.project.logger.warn(
-        "TypeScript >= 5.0.0 is required to extends from more than one base config.",
+        "TypeScript < 5.0.0 is can only extend from a single base config.",
         `TypeScript Version: ${ts.version}`,
         `File: ${this.file.absolutePath}`,
         `Extends: ${this.extends}`

--- a/src/javascript/typescript-config.ts
+++ b/src/javascript/typescript-config.ts
@@ -11,7 +11,7 @@ export interface TypescriptConfigOptions {
   readonly fileName?: string;
 
   /**
-   * Path or list of paths (TypeScript 5.0+) to base configuration(s) to inherit from.
+   * Base `tsconfig.json` configuration(s) to inherit from.
    */
   readonly extends?: TypescriptConfigExtends;
 
@@ -510,12 +510,13 @@ export interface TypeScriptCompilerOptions {
 }
 
 /**
- * Container for `TypescriptConfig` `.tsconfig.json` extensions.
+ * Container for `TypescriptConfig` `tsconfig.json` base configuration(s).
+ * Extending from more than one base config file requires TypeScript 5.0+.
  */
 export class TypescriptConfigExtends {
   /**
    * Factory for creation from array of file paths.
-   * @param paths Absolute or relative paths to base `.tsconfig.json` files.
+   * @param paths Absolute or relative paths to base `tsconfig.json` files.
    */
   public static fromPaths(paths: string[]) {
     return new TypescriptConfigExtends(paths);
@@ -583,7 +584,7 @@ export class TypescriptConfig extends Component {
   }
 
   /**
-   * Array of base `.tsconfig.json` paths.
+   * Array of base `tsconfig.json` paths.
    * Any absolute paths are resolved relative to this instance,
    * while any relative paths are used as is.
    */

--- a/src/javascript/typescript-config.ts
+++ b/src/javascript/typescript-config.ts
@@ -61,6 +61,13 @@ export enum TypeScriptModuleResolution {
    * @see https://www.typescriptlang.org/tsconfig#moduleResolution
    */
   NODE_NEXT = "nodenext",
+
+  /**
+   * Resolution strategy which attempts to mimic resolution patterns of modern bundlers; from TypeScript 5.0 onwards.
+   *
+   * @see https://www.typescriptlang.org/tsconfig#moduleResolution
+   */
+  BUNDLER = "bundler",
 }
 
 /**

--- a/src/javascript/typescript-config.ts
+++ b/src/javascript/typescript-config.ts
@@ -526,7 +526,7 @@ export class TypescriptConfigExtends {
    * Factory for creation from array of other `TypescriptConfig` instances.
    * @param configs Base `TypescriptConfig` instances.
    */
-  public static fromTypeScriptConfigs(configs: TypescriptConfig[]) {
+  public static fromTypescriptConfigs(configs: TypescriptConfig[]) {
     const paths = configs.map((config) => config.file.absolutePath);
     return TypescriptConfigExtends.fromPaths(paths);
   }

--- a/src/javascript/typescript-config.ts
+++ b/src/javascript/typescript-config.ts
@@ -226,7 +226,7 @@ export interface TypeScriptCompilerOptions {
    * @see https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax
    * @default undefined
    */
-  readonly verbatimModuleSyntax?: string;
+  readonly verbatimModuleSyntax?: boolean;
 
   /**
    * This flag works because you can use `import type` to explicitly create an `import` statement which should never be emitted into JavaScript.

--- a/test/javascript/typescript-config.test.ts
+++ b/test/javascript/typescript-config.test.ts
@@ -53,7 +53,7 @@ describe("TypescriptConfig", () => {
       });
       const tsConfig = new TypescriptConfig(project, {
         fileName: "tsconfig.inherit.json",
-        extends: TypescriptConfigExtends.fromTypeScriptConfigs([baseConfig]),
+        extends: TypescriptConfigExtends.fromTypescriptConfigs([baseConfig]),
         compilerOptions: { allowJs: true },
       });
       project.synth();
@@ -88,7 +88,7 @@ describe("TypescriptConfig", () => {
       const commonBase = new TypescriptConfig(project, {
         fileName: "tsconfig.json",
         compilerOptions: { outDir: "testOurDir" },
-        extends: TypescriptConfigExtends.fromTypeScriptConfigs([buildBase]),
+        extends: TypescriptConfigExtends.fromTypescriptConfigs([buildBase]),
       });
 
       const bundlerConfig = new TypescriptConfig(project, {

--- a/test/javascript/typescript-config.test.ts
+++ b/test/javascript/typescript-config.test.ts
@@ -2,6 +2,7 @@ import * as ts from "typescript";
 import {
   NodeProject,
   TypescriptConfig,
+  TypescriptConfigExtends,
   TypeScriptModuleResolution,
 } from "../../src/javascript";
 import { withProjectDir } from "../util";
@@ -52,7 +53,7 @@ describe("TypescriptConfig", () => {
       });
       const tsConfig = new TypescriptConfig(project, {
         fileName: "tsconfig.inherit.json",
-        extends: [baseConfig],
+        extends: TypescriptConfigExtends.fromTypeScriptConfigs([baseConfig]),
         compilerOptions: { allowJs: true },
       });
       project.synth();
@@ -91,9 +92,11 @@ describe("TypescriptConfig", () => {
       });
       const tsConfig = new TypescriptConfig(project, {
         fileName: "sub/tsconfig.inherit.json",
+        extends: TypescriptConfigExtends.fromPaths([
+          "../a/tsconfig.outdir.json",
+        ]),
         compilerOptions: { allowJs: true },
       });
-      tsConfig.addExtends("../a/tsconfig.outdir.json");
       tsConfig.addExtends(bundlerConfig);
       project.synth();
 

--- a/test/javascript/typescript-config.test.ts
+++ b/test/javascript/typescript-config.test.ts
@@ -226,7 +226,7 @@ describe("TypescriptConfig", () => {
         project.synth();
         const doExpect = expectWarn ? expect(logSpy) : expect(logSpy).not;
         doExpect.toHaveBeenCalledWith(
-          "TypeScript >= 5.0.0 is required to extends from more than one base config.",
+          "TypeScript < 5.0.0 is can only extend from a single base config.",
           `TypeScript Version: ${
             project.deps.tryGetDependency("typescript")?.version
           }`,

--- a/test/javascript/typescript-config.test.ts
+++ b/test/javascript/typescript-config.test.ts
@@ -1,5 +1,9 @@
 import * as ts from "typescript";
-import { NodeProject, TypescriptConfig } from "../../src/javascript";
+import {
+  NodeProject,
+  TypescriptConfig,
+  TypeScriptModuleResolution,
+} from "../../src/javascript";
 import { withProjectDir } from "../util";
 
 describe("TypescriptConfig", () => {
@@ -33,6 +37,76 @@ describe("TypescriptConfig", () => {
         "compilerOptions.outDir",
         "testOurDir"
       );
+    });
+  });
+
+  test("TypeScript should parse generated config with extensions without warnings", () => {
+    withProjectDir((outdir) => {
+      const project = new NodeProject({
+        name: "project",
+        defaultReleaseBranch: "main",
+        outdir,
+      });
+      const baseConfig = new TypescriptConfig(project, {
+        compilerOptions: { outDir: "testOurDir" },
+      });
+      const tsConfig = new TypescriptConfig(project, {
+        fileName: "tsconfig.inherit.json",
+        extends: [baseConfig],
+        compilerOptions: { allowJs: true },
+      });
+      project.synth();
+
+      const loadedBase = ts.readConfigFile(
+        baseConfig.file.absolutePath,
+        ts.sys.readFile
+      );
+      const loadedConfig = ts.readConfigFile(
+        tsConfig.file.absolutePath,
+        ts.sys.readFile
+      );
+
+      expect(loadedConfig.error).toBeUndefined();
+      expect(loadedConfig.config).toHaveProperty("extends", "tsconfig.json");
+      expect(loadedBase.config).not.toHaveProperty("extends");
+    });
+  });
+
+  test("TypeScript should parse generated config with multiple extensions", () => {
+    withProjectDir((outdir) => {
+      const project = new NodeProject({
+        name: "project",
+        defaultReleaseBranch: "main",
+        outdir,
+      });
+      new TypescriptConfig(project, {
+        fileName: "a/tsconfig.outdir.json",
+        compilerOptions: { outDir: "testOurDir" },
+      });
+      const bundlerConfig = new TypescriptConfig(project, {
+        fileName: "sub/b/d/c/tsconfig.bundler.json",
+        compilerOptions: {
+          moduleResolution: TypeScriptModuleResolution.BUNDLER,
+        },
+      });
+      const tsConfig = new TypescriptConfig(project, {
+        fileName: "sub/tsconfig.inherit.json",
+        compilerOptions: { allowJs: true },
+      });
+      tsConfig.addExtends("../a/tsconfig.outdir.json");
+      tsConfig.addExtends(bundlerConfig);
+      project.synth();
+
+      const loadedConfig = ts.readConfigFile(
+        tsConfig.file.absolutePath,
+        ts.sys.readFile
+      );
+
+      expect(loadedConfig.error).toBeUndefined();
+      expect(loadedConfig.config).toHaveProperty("extends", [
+        "../a/tsconfig.outdir.json",
+        "b/d/c/tsconfig.bundler.json",
+      ]);
     });
   });
 });

--- a/test/javascript/typescript-config.test.ts
+++ b/test/javascript/typescript-config.test.ts
@@ -68,8 +68,35 @@ describe("TypescriptConfig", () => {
       );
 
       expect(loadedConfig.error).toBeUndefined();
-      expect(loadedConfig.config).toHaveProperty("extends", "tsconfig.json");
+      expect(loadedConfig.config).toHaveProperty("extends", "./tsconfig.json");
       expect(loadedBase.config).not.toHaveProperty("extends");
+    });
+  });
+
+  test("TypeScript should allow parse package for extends.", () => {
+    withProjectDir((outdir) => {
+      const project = new NodeProject({
+        name: "project",
+        defaultReleaseBranch: "main",
+        outdir,
+      });
+      const baseConfig = new TypescriptConfig(project, {
+        compilerOptions: { outDir: "testOurDir" },
+        extends: TypescriptConfigExtends.fromPaths([
+          "@tsconfig/recommended/tsconfig.json",
+        ]),
+      });
+      project.synth();
+
+      const loadedConfig = ts.readConfigFile(
+        baseConfig.file.absolutePath,
+        ts.sys.readFile
+      );
+      expect(loadedConfig.error).toBeUndefined();
+      expect(loadedConfig.config).toHaveProperty(
+        "extends",
+        "@tsconfig/recommended/tsconfig.json"
+      );
     });
   });
 
@@ -136,13 +163,13 @@ describe("TypescriptConfig", () => {
       expect(baseConfig.error).toBeUndefined();
       expect(baseConfig.config).toHaveProperty(
         "extends",
-        "tsconfig.build.json"
+        "./tsconfig.build.json"
       );
       // expect array extends field when multiple extensions.
       expect(loadedConfig.error).toBeUndefined();
       expect(loadedConfig.config).toHaveProperty("extends", [
         "../tsconfig.json",
-        "b/d/c/tsconfig.bundler.json",
+        "./b/d/c/tsconfig.bundler.json",
         "../other/bases/tsconfig.esm.json",
       ]);
     });


### PR DESCRIPTION
This PR brings in the new parameters offered in [TypeScript 5.0](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html) and implements support for the `extends` field.

The logic for the `extends` maintains backwards compatibility for:

- Existing projects by not writing it if undefined / empty.
- Typescript <5.0 by writing a single relative path if/when only a singular extension is added.

While also allowing for the newly introduced support for multiple bases via an array.


##### Overview

1.  Support for the `bundler` module resolution strategy, which mimics the resolution patterns of modern bundlers.
2.  Addition of new TypeScript 5.0 configuration options and handling of deprecated options:
    - `allowImportingTsExtensions`: Allows TypeScript files to import each other with TypeScript-specific extensions (`.ts`, `.mts`, `.tsx`).
    - `allowArbitraryExtensions`: Suppresses arbitrary extension import errors with the assumption that a bundler will handle them.
    - `customConditions`: Specifies a list of additional conditions that should succeed when TypeScript resolves from an `exports` or `imports` field of a `package.json`.
    - `verbatimModuleSyntax`: Simplifies TypeScript's handling of import/export `type` modifiers.
    - `resolvePackageJsonExports`: Forces TypeScript to consult the `exports` field of `package.json` files if it ever reads from a package in `node_modules`.
    - `resolvePackageJsonImports`: Forces TypeScript to consult the `imports` field of `package.json` when performing a lookup that begins with `#` from a file that has a `package.json` as an ancestor.
3.  Implementation of the `extends` field in TypeScript configurations, allowing configurations to inherit settings from other configurations using a string, a list of strings, or `TypescriptConfig` instances.
4.  Unit tests to verify the extends functionality.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
