### PR TITLE
chore: use node 16.14 version for github workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 16.14.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -93,7 +93,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 16.14.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -122,7 +122,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 16.14.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -147,7 +147,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 16.14.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -175,7 +175,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 16.14.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -93,7 +93,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -122,7 +122,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -147,7 +147,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -175,7 +175,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -103,7 +103,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -154,7 +154,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -204,7 +204,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -253,7 +253,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 16.14.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 16.14.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -103,7 +103,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 16.14.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -154,7 +154,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 16.14.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -204,7 +204,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 16.14.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -253,7 +253,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 16.14.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 16.14.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -64,7 +64,7 @@ const project = new cdk.JsiiProject({
   projenDevDependency: false, // because I am projen
   releaseToNpm: true,
   minNodeVersion: "14.0.0", // Do not change this before a version has been EOL for a while
-  workflowNodeVersion: "16.20.0",
+  workflowNodeVersion: "16.14.0",
 
   codeCov: true,
   prettier: true,

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -64,7 +64,7 @@ const project = new cdk.JsiiProject({
   projenDevDependency: false, // because I am projen
   releaseToNpm: true,
   minNodeVersion: "14.0.0", // Do not change this before a version has been EOL for a while
-  workflowNodeVersion: "16.13.0",
+  workflowNodeVersion: "16.20.0",
 
   codeCov: true,
   prettier: true,


### PR DESCRIPTION
Use Node 16.14 version for github workflows.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.