### PR TITLE
fix(release): allow multiple tags on the same commit for separate branches

### DIFF
--- a/test/release/bump.test.ts
+++ b/test/release/bump.test.ts
@@ -283,6 +283,68 @@ test("second prerelease after the first prerelease", async () => {
   expect(result.version).toEqual("1.0.1-beta.1");
 });
 
+test("same commit same prerelease on beta branch", async () => {
+  const result = await testBump({
+    options: {
+      prerelease: "beta",
+      majorVersion: 1,
+    },
+    commits: [
+      { message: "first version", tag: "v1.0.0" },
+      { message: "fix(test): testing", tag: "v1.0.1-beta.0" },
+      { message: "fix(test): testing2", tag: "v1.0.1-beta.1" },
+    ],
+  });
+
+  expect(result.version).toEqual("1.0.1-beta.1");
+});
+
+test("same commit prerelease on regular branch", async () => {
+  const result = await testBump({
+    options: {
+      majorVersion: 1,
+    },
+    commits: [
+      { message: "first version", tag: "v1.0.0" },
+      { message: "fix(test): testing", tag: "v1.0.1-beta.0" },
+      { message: "fix(test): testing2", tag: "v1.0.1-beta.1" },
+    ],
+  });
+
+  expect(result.version).toEqual("1.0.1");
+});
+
+test("same commit different prereleases", async () => {
+  const result = await testBump({
+    options: {
+      prerelease: "pre",
+      majorVersion: 1,
+    },
+    commits: [
+      { message: "first version", tag: "v1.0.0" },
+      { message: "fix(test): testing", tag: "v1.0.1-beta.0" },
+      { message: "fix(test): testing2", tag: "v1.0.1-beta.1" },
+    ],
+  });
+
+  expect(result.version).toEqual("1.0.1-pre.0");
+});
+
+test("same commit same reqular releases", async () => {
+  const result = await testBump({
+    options: {
+      majorVersion: 1,
+    },
+    commits: [
+      { message: "first version", tag: "v1.0.0" },
+      { message: "fix(test): testing", tag: "v1.0.1-beta.0" },
+      { message: "fix(test): testing2", tag: "v1.0.1" },
+    ],
+  });
+
+  expect(result.version).toEqual("1.0.1");
+});
+
 //----------------------------------------------------------------------------------------------------------------------------------
 
 async function testBump(


### PR DESCRIPTION
Example use case: after testing a pre-release, if all good with the pre-release, it should be promotable to the next stage with the same commit.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.