### PR TITLE
feat(java): expose readonly maven packaging dist dir

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -7997,6 +7997,14 @@ new java.MavenPackaging(project: Project, pom: Pom, options?: MavenPackagingOpti
 
 
 
+### Properties
+
+
+Name | Type | Description 
+-----|------|-------------
+**distdir**🔹 | <code>string</code> | The directory containing the package output, relative to the project outdir.
+
+
 
 ## class MavenSample 🔹 <a id="projen-java-mavensample"></a>
 

--- a/src/java/maven-packaging.ts
+++ b/src/java/maven-packaging.ts
@@ -35,6 +35,11 @@ export interface MavenPackagingOptions {
  * Configures a maven project to produce a .jar archive with sources and javadocs.
  */
 export class MavenPackaging extends Component {
+  /**
+   * The directory containing the package output, relative to the project outdir
+   */
+  public readonly distdir: string;
+
   constructor(project: Project, pom: Pom, options: MavenPackagingOptions = {}) {
     super(project);
 
@@ -78,16 +83,16 @@ export class MavenPackaging extends Component {
       MAVEN_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1",
     };
 
-    const distdir = options.distdir ?? "dist/java";
+    this.distdir = options.distdir ?? "dist/java";
 
     for (const [k, v] of Object.entries(env)) {
       this.project.packageTask.env(k, v);
     }
-    this.project.packageTask.exec(`mkdir -p ${distdir}`);
+    this.project.packageTask.exec(`mkdir -p ${this.distdir}`);
     this.project.packageTask.exec(
-      `mvn deploy -D=altDeploymentRepository=local::default::file:///$PWD/${distdir}`
+      `mvn deploy -D=altDeploymentRepository=local::default::file:///$PWD/${this.distdir}`
     );
 
-    project.gitignore.exclude(distdir);
+    project.gitignore.exclude(this.distdir);
   }
 }


### PR DESCRIPTION
It can be useful to know the location of the dist dir, eg. for setting up local dependencies in a monorepo (ref: https://github.com/aws/aws-prototyping-sdk/pull/358 )

This change exposes it as a readonly property.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.