### PR TITLE
feat(javascript): generic `tryResolveDependencyVersion` node-package method.

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -8915,6 +8915,19 @@ setScript(name: string, command: string): void
 
 
 
+#### tryResolveDependencyVersion(dependencyName)🔹 <a id="projen-javascript-nodepackage-tryresolvedependencyversion"></a>
+
+Attempt to resolve the currently installed version for a given dependency.
+
+```ts
+tryResolveDependencyVersion(dependencyName: string): string
+```
+
+* **dependencyName** (<code>string</code>)  Dependency to resolve for.
+
+__Returns__:
+* <code>string</code>
+
 
 
 ## class NodeProject 🔹 <a id="projen-javascript-nodeproject"></a>

--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -1301,20 +1301,14 @@ export class NodePackage extends Component {
         let desiredVersion = currentDefinition;
 
         if (currentDefinition === "*") {
-          try {
-            const modulePath = require.resolve(`${name}/package.json`, {
-              paths: [outdir],
-            });
-            const module = JSON.parse(readFileSync(modulePath, "utf-8"));
-            desiredVersion = `^${module.version}`;
-          } catch (e) {}
-
-          if (!desiredVersion) {
+          const resolvedVersion = this.tryResolveDependencyVersion(name);
+          if (!resolvedVersion) {
             this.project.logger.warn(
               `unable to resolve version for ${name} from installed modules`
             );
             continue;
           }
+          desiredVersion = `^${resolvedVersion}`;
         }
 
         if (currentDefinition !== desiredVersion) {

--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -1303,7 +1303,7 @@ export class NodePackage extends Component {
         let desiredVersion = currentDefinition;
 
         if (currentDefinition === "*") {
-          const resolvedVersion = this.tryResolveDependencyVersion(name);
+          const resolvedVersion = tryResolveDependencyVersion(name);
           if (!resolvedVersion) {
             this.project.logger.warn(
               `unable to resolve version for ${name} from installed modules`

--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -865,7 +865,9 @@ export class NodePackage extends Component {
    *
    * @param dependencyName Dependency to resolve for.
    */
-  public tryResolveDependencyVersion(dependencyName: string) {
+  public tryResolveDependencyVersion(
+    dependencyName: string
+  ): string | undefined {
     try {
       const fromDeps = this.project.deps.tryGetDependency(dependencyName);
       const version = semver.coerce(fromDeps?.version, { loose: true });

--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -870,7 +870,7 @@ export class NodePackage extends Component {
       const fromDeps = this.project.deps.tryGetDependency(dependencyName);
       const version = semver.coerce(fromDeps?.version, { loose: true });
       if (version) return version.format();
-    } catch (e) {}
+    } catch {}
     return tryResolveDependencyVersion(dependencyName, {
       paths: [this.project.outdir],
     });

--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -869,7 +869,9 @@ export class NodePackage extends Component {
     try {
       const fromDeps = this.project.deps.tryGetDependency(dependencyName);
       const version = semver.coerce(fromDeps?.version, { loose: true });
-      if (version) return version.format();
+      if (version) {
+        return version.format();
+      }
     } catch {}
     return tryResolveDependencyVersion(dependencyName, {
       paths: [this.project.outdir],

--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -1305,7 +1305,11 @@ export class NodePackage extends Component {
         let desiredVersion = currentDefinition;
 
         if (currentDefinition === "*") {
-          const resolvedVersion = tryResolveDependencyVersion(name);
+          // we already know we don't have the version in project `deps`,
+          // so skip straight to checking manifest.
+          const resolvedVersion = tryResolveDependencyVersion(name, {
+            paths: [this.project.outdir],
+          });
           if (!resolvedVersion) {
             this.project.logger.warn(
               `unable to resolve version for ${name} from installed modules`


### PR DESCRIPTION
Ref: https://github.com/projen/projen/pull/2607#discussion_r1177611408

Defines:

- Generic `tryResolveDependencyVersion` javascript/util utility for locating and reading a package version from a given dependencies package.json manifest.
- A public method `NodePackage.tryResolveDependencyVersion` that checks for a semantically valid (i.e, not '\*') dependency version via `project.deps`. If not found it will fallback on the `tryResolveDependencyVersion` utility from above.

Also refactors `NodePackage.resolveDepsAndWritePackageJson` to utilize `tryResolveDependencyVersion` (should have no change in behavior in theory).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
