### PR TITLE
fix(javascript): resolving dependency module version fails in projects using workspaces

### DIFF
--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -1308,15 +1308,17 @@ export class NodePackage extends Component {
           // we already know we don't have the version in project `deps`,
           // so skip straight to checking manifest.
           const resolvedVersion = tryResolveDependencyVersion(name, {
-            paths: [this.project.outdir],
+            paths: [outdir],
           });
-          if (!resolvedVersion) {
+          if (resolvedVersion) {
+            desiredVersion = `^${resolvedVersion}`;
+          }
+          if (!desiredVersion) {
             this.project.logger.warn(
               `unable to resolve version for ${name} from installed modules`
             );
             continue;
           }
-          desiredVersion = `^${resolvedVersion}`;
         }
 
         if (currentDefinition !== desiredVersion) {


### PR DESCRIPTION
In #2634 we introduced a generic helper to resolve the version of a dependency from the context.
This refactor also changed the behavior how `*` versions are resolved to an explicit version at synth time.
However this breaks an edge case with projects using subprojects and workspaces.
In that situation dependencies are not installed in the `outdir` of the subproject, but the root.


Fixes #2641

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.