### PR TITLE
fix(cli): improved error messages for `new` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "shx": "^0.3.4",
     "xmlbuilder2": "^2.4.1",
     "yaml": "^2.2.2",
-    "yargs": "^16.2.0"
+    "yargs": "^17.7.2"
   },
   "bundledDependencies": [
     "@iarna/toml",

--- a/src/cli/cmds/new.ts
+++ b/src/cli/cmds/new.ts
@@ -112,13 +112,11 @@ async function handler(args: any) {
     if (args.projectTypeName) {
       const types = inventory.discover();
       throw new CliError(
-        [
-          `Project type "${args.projectTypeName}" not found. Available types:\n`,
-          ...types.map((t) => `    ${t.pjid}`),
-          "",
-          `Please specify a project type.`,
-          `Example: npx projen new ${types[0].pjid}`,
-        ].join("\n")
+        `Project type "${args.projectTypeName}" not found. Available types:\n`,
+        ...types.map((t) => `    ${t.pjid}`),
+        "",
+        `Please specify a project type.`,
+        `Example: npx projen new ${types[0].pjid}`
       );
     }
 
@@ -315,13 +313,11 @@ async function initProjectFromModule(baseDir: string, spec: string, args: any) {
   // if user did not specify a project type but the module has more than one, we need them to tell us which one...
   if (!requested && projects.length > 1) {
     throw new CliError(
-      [
-        `Multiple project types found after installing "${spec}":\n`,
-        ...types.map((t) => `    ${t}`),
-        "",
-        `Please specify a project type.`,
-        `Example: npx projen new --from ${spec} ${types[0]}`,
-      ].join("\n")
+      `Multiple project types found after installing "${spec}":\n`,
+      ...types.map((t) => `    ${t}`),
+      "",
+      `Please specify a project type.`,
+      `Example: npx projen new --from ${spec} ${types[0]}`
     );
   }
 
@@ -331,13 +327,11 @@ async function initProjectFromModule(baseDir: string, spec: string, args: any) {
     : projects.find((p) => p.pjid === requested);
   if (!type) {
     throw new CliError(
-      [
-        `Project type "${requested}" not found in "${spec}". Found:\n`,
-        ...types.map((t) => `    ${t}`),
-        "",
-        `Please specify a valid project type.`,
-        `Example: npx projen new --from ${spec} ${types[0]}`,
-      ].join("\n")
+      `Project type "${requested}" not found in "${spec}". Found:\n`,
+      ...types.map((t) => `    ${t}`),
+      "",
+      `Please specify a valid project type.`,
+      `Example: npx projen new --from ${spec} ${types[0]}`
     );
   }
 
@@ -374,12 +368,10 @@ async function initProjectFromModule(baseDir: string, spec: string, args: any) {
   // We are missing some required options
   if (missingOptions.length) {
     throw new CliError(
-      [
-        `Cannot create "${type.fqn}". Missing required option${
-          missingOptions.length > 1 ? "s" : ""
-        }:`,
-        ...missingOptions.map((m) => `    ${m}`),
-      ].join("\n")
+      `Cannot create "${type.fqn}". Missing required option${
+        missingOptions.length > 1 ? "s" : ""
+      }:`,
+      ...missingOptions.map((m) => `    ${m}`)
     );
   }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -52,7 +52,7 @@ async function main() {
     global: false,
   });
 
-  const args = ya.argv;
+  const args = await ya.argv;
 
   if (args.debug) {
     process.env.DEBUG = "true";

--- a/src/cli/util.ts
+++ b/src/cli/util.ts
@@ -54,3 +54,10 @@ export function installPackage(baseDir: string, spec: string): string {
 export function renderInstallCommand(dir: string, module: string): string {
   return `npm install --save-dev -f --no-package-lock --prefix="${dir}" ${module}`;
 }
+
+export class CliError extends Error {
+  constructor(...lines: string[]) {
+    super(lines.join("\n"));
+    this.name = "CliError";
+  }
+}

--- a/test/new.test.ts
+++ b/test/new.test.ts
@@ -180,7 +180,7 @@ test("projen new --from can use pjid that is similar to a built-in one", () => {
     } catch (error: any) {
       // expect an error since this project type doesn't exist in the package
       // however it is important that the project type is passed to the package
-      expect(error.message).toContain("Error: Project type jsi not found.");
+      expect(error.message).toContain('Project type "jsi" not found');
     }
   });
 });
@@ -266,6 +266,18 @@ test("projen new with unknown option works", () => {
     const projenrc = directorySnapshot(projectdir)[".projenrc.js"];
     expect(projenrc).toBeDefined();
     expect(projenrc).toMatchSnapshot();
+  });
+});
+
+test("projen new without any arguments displays full help", () => {
+  withProjectDir((projectdir) => {
+    try {
+      execProjenCLI(projectdir, ["new"]);
+    } catch (error: any) {
+      expect(error.message).toMatch("Creates a new projen project");
+      expect(error.message).toMatch("Commands:");
+      expect(error.message).toMatch("Multi-language jsii library project.");
+    }
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6696,7 +6696,7 @@ yargs@^16.0.0, yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.3.1, yargs@^17.7.1:
+yargs@^17.3.1, yargs@^17.7.1, yargs@^17.7.2:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==


### PR DESCRIPTION
After upgrading yargs, it will now display complete help when no commands are provided to `projen new`. (Fixes #2649)
Handle `CliError`s consistently. Style and log through logging instead displaying a stack trace.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.