### PR TITLE
chore: note for windows users regards build script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,8 @@ $ yarn # install dependencies
 $ yarn build # build projen
 ```
 
+Attention Windows users: It has been noted that there are compatibility issues between Git Bash and the Projen build script when running on Windows. Therefore, we recommend directly utilizing the WSL (Windows Subsystem Linux) terminal to build the Projen project.
+
 ## Code Organization
 
 Check out [this recording](https://www.youtube.com/watch?v=8dHwnuSND14) from a walkthrough of the projen codebase.


### PR DESCRIPTION
Updating the Contributing Guide with a note for Windows users to use WSL instead of Git Bash because of incompatibility with the build script. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.