### PR TITLE
[WIP] feat(Python): python executable support python3

### DIFF
--- a/src/python/projenrc.ts
+++ b/src/python/projenrc.ts
@@ -22,6 +22,12 @@ export interface ProjenrcOptions {
    * @default - current version
    */
   readonly projenVersion?: string;
+
+  /**
+   * Python executable to use. default python3 alternative:  python.
+   * @default  "python3"
+   */
+  readonly pythonexec?: string;
 }
 
 /**
@@ -35,20 +41,21 @@ export class Projenrc extends ProjenrcFile {
    * The name of the projenrc file.
    */
   public readonly filePath: string;
+  public readonly pythonexec: string;
 
   constructor(project: Project, options: ProjenrcOptions = {}) {
     super(project);
 
     const projenVersion = options.projenVersion ?? PROJEN_VERSION;
     this.filePath = options.filename ?? ".projenrc.py";
-
+    this.pythonexec = options.pythonexec ?? "python3";
     project.deps.addDependency(
       `projen@${projenVersion}`,
       DependencyType.DEVENV
     );
 
     // set up the "default" task which is the task executed when `projen` is executed for this project.
-    project.defaultTask?.exec("python .projenrc.py");
+    project.defaultTask?.exec(`${this.pythonexec} .projenrc.py`);
 
     // if this is a new project, generate a skeleton for projenrc.py
     this.generateProjenrc();

--- a/src/python/venv.ts
+++ b/src/python/venv.ts
@@ -15,6 +15,12 @@ export interface VenvOptions {
    * @default ".env"
    */
   readonly envdir?: string;
+
+  /**
+   * Python executable to use. default python3 alternative:  python.
+   * @default  "python3"
+   */
+  readonly pythonexec?: string;
 }
 
 /**
@@ -25,11 +31,13 @@ export class Venv extends Component implements IPythonEnv {
    * Name of directory to store the environment in
    */
   private readonly envdir: string;
+  private readonly pythonexec: string;
 
   constructor(project: Project, options: VenvOptions = {}) {
     super(project);
 
     this.envdir = options.envdir ?? ".env";
+    this.pythonexec = options.pythonexec ?? "python3";
 
     this.project.addGitIgnore(`/${this.envdir}`);
     this.project.tasks.addEnvironment(
@@ -49,7 +57,9 @@ export class Venv extends Component implements IPythonEnv {
     const absoluteEnvdir = path.join(this.project.outdir, this.envdir);
     if (!fs.existsSync(absoluteEnvdir)) {
       this.project.logger.info("Setting up a virtual environment...");
-      exec(`python -m venv ${this.envdir}`, { cwd: this.project.outdir });
+      exec(`${this.pythonexec} -m venv ${this.envdir}`, {
+        cwd: this.project.outdir,
+      });
       this.project.logger.info(
         `Environment successfully created (located in ./${this.envdir}).`
       );


### PR DESCRIPTION
When executing a python project, on new mac systems it fails because of lack of python 2.x. 
as a result of that the fix was to make the executable of python a variable with a default of python3. 

i'm not sure if it's all in the correct location (first issue), so please provide feedback. 

open issue : #2300 
