### PR TITLE
feat(javascript): implement additional manifest resolution strategies for packages with no default or package.json exports.

### DIFF
--- a/src/javascript/util.ts
+++ b/src/javascript/util.ts
@@ -3,10 +3,20 @@ import { basename, dirname, extname, join, sep, resolve } from "path";
 import * as semver from "semver";
 import { findUp } from "../util";
 
+/**
+ * Basic interface for `package.json`.
+ */
 interface PackageManifest {
-  name: string;
-  version: string;
   [key: string]: any;
+
+  /**
+   * Package name.
+   */
+  name: string;
+  /**
+   * Package version.
+   */
+  version: string;
 }
 
 export function renderBundleName(entrypoint: string) {

--- a/src/javascript/util.ts
+++ b/src/javascript/util.ts
@@ -201,21 +201,9 @@ export function tryResolveDependencyVersion(
   dependencyName: string,
   options?: { paths: string[] }
 ): string | undefined {
-  const manifestPath =
-    tryResolveModuleManifestPath(dependencyName, options) ??
-    tryResolveManifestPathFromDefaultExport(dependencyName, options);
-  if (!manifestPath) {
+  const manifest = tryResolveModuleManifest(dependencyName, options);
+  if (!manifest) {
     return undefined;
   }
-  try {
-    const manifest = JSON.parse(
-      readFileSync(manifestPath, "utf-8").toString()
-    ) as { name?: string; version?: string };
-    if (manifest?.name !== dependencyName) {
-      return undefined;
-    }
-    return manifest?.version;
-  } catch {
-    return undefined;
-  }
+  return manifest?.version;
 }

--- a/test/javascript/node-package.test.ts
+++ b/test/javascript/node-package.test.ts
@@ -602,3 +602,39 @@ test("tryResolveDependencyVersion resolves with custom package exports.", () => 
   expect(project.deps.tryGetDependency("rollup")?.version).toEqual("*");
   expect(pkg.tryResolveDependencyVersion("rollup")).toEqual("3.21.1");
 });
+
+test("tryResolveDependencyVersion resolves with no package.json or default export with default conditions.", () => {
+  jest
+    .spyOn(TaskRuntime.prototype, "runTask")
+    .mockImplementation(function (this: TaskRuntime, command) {
+      expect(command).toMatch("install");
+      mockYarnInstall(
+        this.workdir,
+        { "@types/js-yaml": "4.0.5" },
+        {
+          "@types/js-yaml": (manifest) => {
+            return {
+              ...manifest,
+              exports: {
+                ".": {
+                  types: {
+                    import: "./index.d.mts",
+                    default: "./index.d.ts",
+                  },
+                },
+              },
+            };
+          },
+        }
+      );
+    });
+  const outdir = mkdtemp();
+  const project = new TestProject({ outdir });
+
+  const pkg = new NodePackage(project);
+  pkg.addDeps("@types/js-yaml@*");
+  project.synth();
+
+  expect(project.deps.tryGetDependency("@types/js-yaml")?.version).toEqual("*");
+  expect(pkg.tryResolveDependencyVersion("@types/js-yaml")).toEqual("4.0.5");
+});

--- a/test/javascript/util.test.ts
+++ b/test/javascript/util.test.ts
@@ -1,0 +1,128 @@
+import { mkdirSync, writeFileSync } from "fs";
+import * as path from "path";
+import {
+  tryResolveModule,
+  tryResolveModuleManifestPath,
+  tryResolveManifestPathFromDefaultExport,
+  tryResolveManifestPathFromPath,
+  tryResolveManifestPathFromSearch,
+  tryResolveModuleManifest,
+  tryResolveDependencyVersion,
+} from "../../src/javascript/util";
+import { mkdtemp } from "../util";
+
+describe("tryResolveModule", () => {
+  test.each([
+    ["jest", true],
+    ["non-existent-module", false],
+  ])(
+    "should resolve the module path if it exists (%s)",
+    (moduleId, expected) => {
+      const result = tryResolveModule(moduleId);
+      expect(Boolean(result)).toBe(expected);
+    }
+  );
+});
+
+describe("tryResolveModuleManifestPath", () => {
+  test.each([
+    ["jest", true],
+    ["non-existent-module", false],
+  ])(
+    "should resolve the manifest path if the module exists (%s)",
+    (moduleId, expected) => {
+      const result = tryResolveModuleManifestPath(moduleId);
+      expect(Boolean(result)).toBe(expected);
+    }
+  );
+});
+
+describe("tryResolveManifestPathFromDefaultExport", () => {
+  test.each([
+    ["jest", true],
+    ["non-existent-module", false],
+  ])(
+    "should resolve the manifest path if the module exists (%s)",
+    (moduleId, expected) => {
+      const result = tryResolveManifestPathFromDefaultExport(moduleId);
+      expect(Boolean(result)).toBe(expected);
+    }
+  );
+});
+
+describe("tryResolveManifestPathFromPath", () => {
+  test("should resolve the manifest path if the module exists in the specified path", () => {
+    const outdir = mkdtemp();
+    const fakeJestPath = path.join(outdir, "node_modules", "jest");
+    mkdirSync(fakeJestPath, { recursive: true });
+    writeFileSync(
+      path.join(fakeJestPath, "package.json"),
+      JSON.stringify({ name: "jest", version: "0.0.0" })
+    );
+    const result = tryResolveManifestPathFromPath("jest", outdir);
+    expect(result).toBeDefined();
+  });
+
+  test("should return undefined if the module does not exist in the specified path", () => {
+    const result = tryResolveManifestPathFromPath(
+      "non-existent-module",
+      mkdtemp()
+    );
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("tryResolveManifestPathFromSearch", () => {
+  test.each([
+    ["jest", true],
+    ["non-existent-module", false],
+  ])(
+    "should resolve the manifest path if the module exists (%s)",
+    (moduleId, expected) => {
+      const result = tryResolveManifestPathFromSearch(moduleId);
+      expect(Boolean(result)).toBe(expected);
+    }
+  );
+});
+
+describe("tryResolveModuleManifest", () => {
+  test("should resolve the module manifest if the module exists", () => {
+    const result = tryResolveModuleManifest("jest");
+    expect(result).toBeDefined();
+    expect(result!.name).toBe("jest");
+    expect(result!.version).toBeDefined();
+  });
+
+  test("should return undefined if the module does not exist", () => {
+    const result = tryResolveModuleManifest("non-existent-module");
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("tryResolveDependencyVersion", () => {
+  let outdir: string = mkdtemp();
+
+  beforeAll(() => {
+    const fakeModPath = path.join(outdir, "node_modules", "fake-module");
+    mkdirSync(fakeModPath, { recursive: true });
+    writeFileSync(
+      path.join(fakeModPath, "package.json"),
+      JSON.stringify({ name: "fake-module", version: "0.0.0" })
+    );
+  });
+
+  test.each([
+    [["jest"], true],
+    [["fake-module", { paths: [outdir] }], true],
+    [["fake-module", { paths: [mkdtemp()] }], false],
+    [["non-existent-module"], false],
+  ])(
+    "should resolve the dependency version if the module exists (%s)",
+    (params, expected) => {
+      const result = tryResolveDependencyVersion(
+        ...(params as [moduleId: string, options?: { paths: string[] }])
+      );
+      expect(Boolean(result)).toBe(expected);
+    }
+  );
+});


### PR DESCRIPTION
This PR implements an additional strategy for resolving dependency manifest paths by searching for a `package.json` file under an optionally provided list of paths + the current node processes default resolution paths.

Additionally, it extracts a new utility `tryResolveModuleManifest` from `tryResolveDependencyVersion` that handles applying the available strategies in decreasing order of accuracy (resolve package.json from node's module resolution, resolve from default export, search under given paths, search node default resolution paths).

Closes #2674

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
