### PR TITLE
fix(gitlab): `artifacts:reports:coverage_report` replaces deprecated `artifacts:reports:cobertura`

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -304,6 +304,7 @@ Name|Description
 [gitlab.Cache](#projen-gitlab-cache)|Cache Definition.
 [gitlab.CacheKeyFiles](#projen-gitlab-cachekeyfiles)|Use this construct to generate a new key when one or two specific files change.
 [gitlab.CiConfigurationOptions](#projen-gitlab-ciconfigurationoptions)|Options for `CiConfiguration`.
+[gitlab.CoverageReport](#projen-gitlab-coveragereport)|Code coverage report interface.
 [gitlab.Default](#projen-gitlab-default)|Default settings for the CI Configuration.
 [gitlab.Engine](#projen-gitlab-engine)|The engine configuration for a secret.
 [gitlab.Environment](#projen-gitlab-environment)|The environment that a job deploys to.
@@ -16868,6 +16869,20 @@ Name | Type | Description
 
 
 
+## struct CoverageReport 🔹 <a id="projen-gitlab-coveragereport"></a>
+
+
+Code coverage report interface.
+
+
+
+Name | Type | Description 
+-----|------|-------------
+**coverageFormat**🔹 | <code>string</code> | <span></span>
+**path**🔹 | <code>string</code> | <span></span>
+
+
+
 ## struct Default 🔹 <a id="projen-gitlab-default"></a>
 
 
@@ -17148,9 +17163,10 @@ Reports will be uploaded as artifacts, and often displayed in the Gitlab UI, suc
 
 Name | Type | Description 
 -----|------|-------------
-**cobertura**?🔹 | <code>Array<string></code> | Path for file(s) that should be parsed as Cobertura XML coverage report.<br/>__*Optional*__
+**cobertura**?⚠️ | <code>Array<string></code> | Path for file(s) that should be parsed as Cobertura XML coverage report.<br/>__*Optional*__
 **codequality**?🔹 | <code>Array<string></code> | Path to file or list of files with code quality report(s) (such as Code Climate).<br/>__*Optional*__
 **containerScanning**?🔹 | <code>Array<string></code> | Path to file or list of files with Container scanning vulnerabilities report(s).<br/>__*Optional*__
+**coverageReport**?🔹 | <code>[gitlab.CoverageReport](#projen-gitlab-coveragereport)</code> | Code coverage report information.<br/>__*Optional*__
 **dast**?🔹 | <code>Array<string></code> | Path to file or list of files with DAST vulnerabilities report(s).<br/>__*Optional*__
 **dependencyScanning**?🔹 | <code>Array<string></code> | Path to file or list of files with Dependency scanning vulnerabilities report(s).<br/>__*Optional*__
 **dotenv**?🔹 | <code>Array<string></code> | Path to file or list of files containing runtime-created variables for this job.<br/>__*Optional*__

--- a/src/gitlab/configuration-model.ts
+++ b/src/gitlab/configuration-model.ts
@@ -112,17 +112,30 @@ export interface Artifacts {
 }
 
 /**
+ * Code coverage report interface
+ * @link https://docs.gitlab.com/ee/ci/yaml/artifacts_reports.html#artifactsreportscoverage_report
+ */
+export interface CoverageReport {
+  readonly coverageFormat: string;
+  readonly path: string;
+}
+
+/**
  * Reports will be uploaded as artifacts, and often displayed in the Gitlab UI, such as in
  * Merge Requests.
  * @see https://docs.gitlab.com/ee/ci/yaml/#artifactsreports
  */
 export interface Reports {
-  /** Path for file(s) that should be parsed as Cobertura XML coverage report*/
+  /** Path for file(s) that should be parsed as Cobertura XML coverage report
+   * @deprecated per {@link https://docs.gitlab.com/ee/update/deprecations.html#artifactsreportscobertura-keyword} use {@link coverageReport} instead
+   */
   readonly cobertura?: string[];
   /** Path to file or list of files with code quality report(s) (such as Code Climate).*/
   readonly codequality?: string[];
   /** Path to file or list of files with Container scanning vulnerabilities report(s).*/
   readonly containerScanning?: string[];
+  /** Code coverage report information */
+  readonly coverageReport?: CoverageReport;
   /** Path to file or list of files with DAST vulnerabilities report(s).*/
   readonly dast?: string[];
   /** Path to file or list of files with Dependency scanning vulnerabilities report(s).*/

--- a/test/gitlab/configuration.test.ts
+++ b/test/gitlab/configuration.test.ts
@@ -217,3 +217,34 @@ my_job:
 `
   );
 });
+
+test("test code coverage report", () => {
+  // GIVEN
+  const p = new TestProject({
+    stale: true,
+  });
+  new CiConfiguration(p, "foo", {
+    jobs: {
+      build: {
+        artifacts: {
+          reports: {
+            coverageReport: {
+              coverageFormat: "cobertura",
+              path: "coverage/cobertura-coverage.xml",
+            },
+          },
+        },
+      },
+    },
+  });
+  // THEN
+  expect(
+    YAML.parse(synthSnapshot(p)[".gitlab/ci-templates/foo.yml"]).build.artifacts
+      .reports
+  ).toStrictEqual({
+    coverage_report: {
+      coverage_format: "cobertura",
+      path: "coverage/cobertura-coverage.xml",
+    },
+  });
+});


### PR DESCRIPTION
cobertura keyword for code coverage report is depreciated and since GitLab 15.0 is replaced by [artifacts:reports:coverage_report](https://gitlab.com/gitlab-org/gitlab/-/issues/344533) https://docs.gitlab.com/ee/update/deprecations.html#artifactsreportscobertura-keyword

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.