### PR TITLE
fix(javascript): correct `TypeScriptCompilerOptions.emitDeclarationOnly` from `true` -> `boolean`

### DIFF
--- a/src/javascript/typescript-config.ts
+++ b/src/javascript/typescript-config.ts
@@ -328,7 +328,7 @@ export interface TypeScriptCompilerOptions {
    *
    * @default false
    */
-  readonly emitDeclarationOnly?: true;
+  readonly emitDeclarationOnly?: boolean;
 
   /**
    * Do not emit compiler output files like JavaScript source code, source-maps or


### PR DESCRIPTION
Small fix to correct the `TypeScriptCompilerOptions.emitDeclarationOnly` type.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
