### PR TITLE
fix(javascript): workflowPackageCache doesn't work with pnpm

### DIFF
--- a/src/javascript/node-project.ts
+++ b/src/javascript/node-project.ts
@@ -963,6 +963,14 @@ export class NodeProject extends GitHubProject {
     // first run the workflow bootstrap steps
     install.push(...this.workflowBootstrapSteps);
 
+    if (this.package.packageManager === NodePackageManager.PNPM) {
+      install.push({
+        name: "Setup pnpm",
+        uses: "pnpm/action-setup@v2.2.4",
+        with: { version: this.package.pnpmVersion },
+      });
+    }
+
     if (this.nodeVersion || this.workflowPackageCache) {
       const cache =
         this.package.packageManager === NodePackageManager.YARN
@@ -983,14 +991,6 @@ export class NodeProject extends GitHubProject {
             cache,
           }),
         },
-      });
-    }
-
-    if (this.package.packageManager === NodePackageManager.PNPM) {
-      install.push({
-        name: "Setup pnpm",
-        uses: "pnpm/action-setup@v2.2.4",
-        with: { version: this.package.pnpmVersion },
       });
     }
 

--- a/test/javascript/node-project.test.ts
+++ b/test/javascript/node-project.test.ts
@@ -980,6 +980,54 @@ test("workflowGitIdentity can be used to customize the git identity used in buil
   });
 });
 
+describe("Setup pnpm", () => {
+  const setupPnpmIndex = (job: any) =>
+    job.steps.findIndex((step: any) => step.name === "Setup pnpm");
+  const setupNodeIndex = (job: any) =>
+    job.steps.findIndex((step: any) => step.name === "Setup Node.js");
+
+  test("Setup pnpm should not run without pnpm option", () => {
+    // WHEN
+    const options = {};
+    const project = new TestNodeProject(options);
+
+    // THEN
+    const output = synthSnapshot(project);
+    const buildWorkflow = yaml.parse(output[".github/workflows/build.yml"]);
+    expect(setupPnpmIndex(buildWorkflow.jobs.build)).toEqual(-1);
+    const releaseWorkflow = yaml.parse(output[".github/workflows/release.yml"]);
+    expect(setupPnpmIndex(releaseWorkflow.jobs.release)).toEqual(-1);
+    const upgradeWorkflow = yaml.parse(
+      output[".github/workflows/upgrade-main.yml"]
+    );
+    expect(setupPnpmIndex(upgradeWorkflow.jobs.upgrade)).toEqual(-1);
+  });
+
+  test("Setup pnpm should run before Setup Node.js", () => {
+    // WHEN
+    const options = {
+      workflowPackageCache: true,
+      packageManager: NodePackageManager.PNPM,
+    };
+    const project = new TestNodeProject(options);
+
+    // THEN
+    const output = synthSnapshot(project);
+    const buildJob = yaml.parse(output[".github/workflows/build.yml"]).jobs
+      .build;
+    expect(setupPnpmIndex(buildJob)).toBeGreaterThanOrEqual(0);
+    expect(setupPnpmIndex(buildJob)).toBeLessThan(setupNodeIndex(buildJob));
+    const releaseJob = yaml.parse(output[".github/workflows/release.yml"]).jobs
+      .release;
+    expect(setupPnpmIndex(releaseJob)).toBeGreaterThanOrEqual(0);
+    expect(setupPnpmIndex(releaseJob)).toBeLessThan(setupNodeIndex(releaseJob));
+    const upgradeJob = yaml.parse(output[".github/workflows/upgrade-main.yml"])
+      .jobs.upgrade;
+    expect(setupPnpmIndex(upgradeJob)).toBeGreaterThanOrEqual(0);
+    expect(setupPnpmIndex(upgradeJob)).toBeLessThan(setupNodeIndex(upgradeJob));
+  });
+});
+
 describe("workflowPackageCache", () => {
   const cache = (job: any) =>
     job.steps.find((step: any) => step.name === "Setup Node.js")?.with?.cache;


### PR DESCRIPTION
To use `workflowPackageCache` option with `pnpm`,
"Setup pnpm" step must run before "Setup Node.js" step.

This order comes from pnpm's integration documentation: https://pnpm.io/continuous-integration#github-actions

Close #2710

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.