### PR TITLE
chore: run projen's daily upgrade (and release) acyclic to the project schedules

### DIFF
--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -4,7 +4,7 @@ name: upgrade-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 12 * * *
 jobs:
   upgrade:
     name: Upgrade

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -1,4 +1,4 @@
-const { cdk, JsonFile, TextFile } = require("./lib");
+const { cdk, javascript, JsonFile, TextFile } = require("./lib");
 const { PROJEN_MARKER } = require("./lib/common");
 
 const project = new cdk.JsiiProject({
@@ -58,6 +58,12 @@ const project = new cdk.JsiiProject({
   depsUpgradeOptions: {
     // markmac depends on projen, we are excluding it here to avoid a circular update loop
     exclude: ["markmac"],
+    workflowOptions: {
+      // Run projen's daily upgrade (and release) acyclic to the schedule that projects are on so they get updates faster
+      schedule: javascript.UpgradeDependenciesSchedule.expressions([
+        "0 12 * * *",
+      ]),
+    },
   },
 
   projenDevDependency: false, // because I am projen


### PR DESCRIPTION
That means projects will get the security updates faster.
At the moment all are run at midnight, usually delaying the projen upgrade to the next day.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.