### PR TITLE
feat: name of github build.yml can be customized

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -5082,6 +5082,7 @@ new build.BuildWorkflow(project: Project, options: BuildWorkflowOptions)
   * **env** (<code>Map<string, string></code>)  Build environment variables. __*Default*__: {}
   * **gitIdentity** (<code>[github.GitIdentity](#projen-github-gitidentity)</code>)  Git identity to use for the workflow. __*Default*__: default identity
   * **mutableBuild** (<code>boolean</code>)  Automatically update files modified during builds to pull-request branches. __*Default*__: true
+  * **name** (<code>string</code>)  Name of the buildfile (e.g. "build" becomes "build.yml"). __*Default*__: "build"
   * **permissions** (<code>[github.workflows.JobPermissions](#projen-github-workflows-jobpermissions)</code>)  Permissions granted to the build job To limit job permissions for `contents`, the desired permissions have to be explicitly set, e.g.: `{ contents: JobPermission.NONE }`. __*Default*__: `{ contents: JobPermission.WRITE }`
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build. __*Default*__: []
   * **preBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute before the build. __*Default*__: []
@@ -14874,6 +14875,7 @@ Name | Type | Description
 **env**?🔹 | <code>Map<string, string></code> | Build environment variables.<br/>__*Default*__: {}
 **gitIdentity**?🔹 | <code>[github.GitIdentity](#projen-github-gitidentity)</code> | Git identity to use for the workflow.<br/>__*Default*__: default identity
 **mutableBuild**?🔹 | <code>boolean</code> | Automatically update files modified during builds to pull-request branches.<br/>__*Default*__: true
+**name**?🔹 | <code>string</code> | Name of the buildfile (e.g. "build" becomes "build.yml").<br/>__*Default*__: "build"
 **permissions**?🔹 | <code>[github.workflows.JobPermissions](#projen-github-workflows-jobpermissions)</code> | Permissions granted to the build job To limit job permissions for `contents`, the desired permissions have to be explicitly set, e.g.: `{ contents: JobPermission.NONE }`.<br/>__*Default*__: `{ contents: JobPermission.WRITE }`
 **postBuildSteps**?🔹 | <code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code> | Steps to execute after build.<br/>__*Default*__: []
 **preBuildSteps**?🔹 | <code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code> | Steps to execute before the build.<br/>__*Default*__: []

--- a/src/build/build-workflow.ts
+++ b/src/build/build-workflow.ts
@@ -41,6 +41,13 @@ export interface BuildWorkflowOptions {
   readonly artifactsDirectory: string;
 
   /**
+   * Name of the buildfile (e.g. "build" becomes "build.yml").
+   *
+   * @default "build"
+   */
+  readonly name?: string;
+
+  /**
    * The container image to use for builds.
    * @default - the default workflow container
    */
@@ -113,6 +120,7 @@ export class BuildWorkflow extends Component {
   private readonly github: GitHub;
   private readonly workflow: GithubWorkflow;
   private readonly artifactsDirectory: string;
+  private readonly name: string;
   private readonly defaultRunners: string[] = ["ubuntu-latest"];
 
   private readonly _postBuildJobs: string[] = [];
@@ -133,9 +141,10 @@ export class BuildWorkflow extends Component {
     this.gitIdentity = options.gitIdentity ?? DEFAULT_GITHUB_ACTIONS_USER;
     this.buildTask = options.buildTask;
     this.artifactsDirectory = options.artifactsDirectory;
+    this.name = options.name ?? "build";
     const mutableBuilds = options.mutableBuild ?? true;
 
-    this.workflow = new GithubWorkflow(github, "build");
+    this.workflow = new GithubWorkflow(github, this.name);
     this.workflow.on(
       options.workflowTriggers ?? {
         pullRequest: {},


### PR DESCRIPTION
I have a use case where I would like two `.github/workflows/build.yml` files side by side in my project (one builds subprojects). I've made changes to the source to accommodate this but cannot find any units tests to add this to. I am also seeing a lot of side effects for snapshot changes locally, so I'm opening this draft PR to run the tests here.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.