### PR TITLE
chore: fix JSII publishing properties in docs

### DIFF
--- a/docs/awscdk-construct.md
+++ b/docs/awscdk-construct.md
@@ -90,18 +90,18 @@ As this is a [jsii project](./jsii.md), it will cross-compile to other languages
 any number of jsii target languages.
 
 ```typescript
-  dotnet: {
+  publishToNuget: {
     dotNetNamespace: 'Acme.HelloNamespace',
     packageId: 'Acme.HelloPackage'
   },
-  java: {
+  publishToMaven: {
     javaPackage: 'com.acme.hello',
     mavenArtifactId: 'hello-jsii',
     mavenGroupId: 'com.acme.hello'
     serverId: 'github',
     repositoryUrl: 'https://maven.pkg.github.com/example/hello-jsii',
   },
-  python: {
+  publishToPypi: {
     distName: 'acme.hello-jsii',
     module: 'acme.hello_jsii'
   },


### PR DESCRIPTION
These old properties are marked as `deprecated` in https://github.com/projen/projen/blob/main/src/cdk/jsii-project.ts

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.