### PR TITLE
fix(typescript): `jestConfig.testMatch` is ignored

### DIFF
--- a/src/typescript/typescript.ts
+++ b/src/typescript/typescript.ts
@@ -192,7 +192,7 @@ export class TypeScriptProject extends NodeProject {
         ...options.jestOptions,
         jestConfig: {
           ...options.jestOptions?.jestConfig,
-          testMatch: [],
+          testMatch: options.jestOptions?.jestConfig?.testMatch ?? [],
         },
       },
     });


### PR DESCRIPTION
Instead use any provided patterns and then add to it.

Related to #2733 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.