### PR TITLE
chore(release): fixup ReleasableCommits API

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -2556,17 +2556,17 @@ Name | Type | Description
 ### Methods
 
 
-#### *static* everyCommit(limitToProjectPath?)🔹 <a id="projen-releasablecommits-everycommit"></a>
+#### *static* everyCommit(path?)🔹 <a id="projen-releasablecommits-everycommit"></a>
 
 Release every commit.
 
 This will only not release if the most recent commit is tagged with the latest matching tag.
 
 ```ts
-static everyCommit(limitToProjectPath?: boolean): ReleasableCommits
+static everyCommit(path?: string): ReleasableCommits
 ```
 
-* **limitToProjectPath** (<code>boolean</code>)  Only consider commits relevant to the path of the (sub-)project.
+* **path** (<code>string</code>)  Consider only commits that are enough to explain how the files that match the specified paths came to be.
 
 __Returns__:
 * <code>[ReleasableCommits](#projen-releasablecommits)</code>
@@ -2588,22 +2588,22 @@ static exec(cmd: string): ReleasableCommits
 __Returns__:
 * <code>[ReleasableCommits](#projen-releasablecommits)</code>
 
-#### *static* featuresAndFixes(limitToProjectPath?)🔹 <a id="projen-releasablecommits-featuresandfixes"></a>
+#### *static* featuresAndFixes(path?)🔹 <a id="projen-releasablecommits-featuresandfixes"></a>
 
 Release only features and fixes.
 
 Shorthand for `ReleasableCommits.onlyOfType(['feat', 'fix'])`.
 
 ```ts
-static featuresAndFixes(limitToProjectPath?: boolean): ReleasableCommits
+static featuresAndFixes(path?: string): ReleasableCommits
 ```
 
-* **limitToProjectPath** (<code>boolean</code>)  Only consider commits relevant to the path of the (sub-)project.
+* **path** (<code>string</code>)  Consider only commits that are enough to explain how the files that match the specified paths came to be.
 
 __Returns__:
 * <code>[ReleasableCommits](#projen-releasablecommits)</code>
 
-#### *static* ofType(types, limitToProjectPath?)🔹 <a id="projen-releasablecommits-oftype"></a>
+#### *static* ofType(types, path?)🔹 <a id="projen-releasablecommits-oftype"></a>
 
 Limit commits by their conventional commit type.
 
@@ -2611,11 +2611,11 @@ This will only release commit that match one of the provided types.
 Commits are required to follow the conventional commit spec and will be ignored otherwise.
 
 ```ts
-static ofType(types: Array<string>, limitToProjectPath?: boolean): ReleasableCommits
+static ofType(types: Array<string>, path?: string): ReleasableCommits
 ```
 
 * **types** (<code>Array<string></code>)  List of conventional commit types that should be released.
-* **limitToProjectPath** (<code>boolean</code>)  Only consider commits relevant to the path of the (sub-)project.
+* **path** (<code>string</code>)  Consider only commits that are enough to explain how the files that match the specified paths came to be.
 
 __Returns__:
 * <code>[ReleasableCommits](#projen-releasablecommits)</code>

--- a/test/release/bump.test.ts
+++ b/test/release/bump.test.ts
@@ -351,9 +351,8 @@ describe("Releasable Commits Configurations", () => {
 
   test("will not bump if no change in a relevant path", async () => {
     const result = await testBump({
-      projectDir: "subproject",
       options: {
-        releasableCommits: ReleasableCommits.featuresAndFixes(true).cmd,
+        releasableCommits: ReleasableCommits.featuresAndFixes("subproject").cmd,
       },
       commits: [
         { message: "first version", tag: "v1.1.0" },
@@ -366,9 +365,8 @@ describe("Releasable Commits Configurations", () => {
 
   test("will bump if change was made to a relevant path", async () => {
     const result = await testBump({
-      projectDir: "subproject",
       options: {
-        releasableCommits: ReleasableCommits.featuresAndFixes(true).cmd,
+        releasableCommits: ReleasableCommits.featuresAndFixes("subproject").cmd,
       },
       commits: [
         { message: "first version", tag: "v1.1.0" },
@@ -422,7 +420,6 @@ async function testBump(
   opts: {
     options?: Partial<BumpOptions>;
     commits?: { message: string; tag?: string; path?: string }[];
-    projectDir?: string;
   } = {}
 ) {
   const workdir = mkdtempSync(join(tmpdir(), "bump-test-"));
@@ -458,8 +455,7 @@ async function testBump(
     }
   }
 
-  const projectDir = opts.projectDir ? join(workdir, opts.projectDir) : workdir;
-  await bump(projectDir, {
+  await bump(workdir, {
     changelog: "changelog.md",
     versionFile: "version.json",
     bumpFile: "bump.txt",
@@ -469,12 +465,11 @@ async function testBump(
 
   return {
     version: JSON.parse(
-      await fs.readFile(join(projectDir, "version.json"), "utf-8")
+      await fs.readFile(join(workdir, "version.json"), "utf-8")
     ).version,
-    changelog: await fs.readFile(join(projectDir, "changelog.md"), "utf8"),
-    bumpfile: await fs.readFile(join(projectDir, "bump.txt"), "utf8"),
-    tag: await fs.readFile(join(projectDir, "releasetag.txt"), "utf8"),
+    changelog: await fs.readFile(join(workdir, "changelog.md"), "utf8"),
+    bumpfile: await fs.readFile(join(workdir, "bump.txt"), "utf8"),
+    tag: await fs.readFile(join(workdir, "releasetag.txt"), "utf8"),
     workdir,
-    projectDir,
   };
 }


### PR DESCRIPTION
Use explicit `path` for `ReleasableCommits`.

Note that the previous PR was merged in error and has not been released since I have cancelled the workflow, so this is not breaking.

#2758