### PR TITLE
fix(github): `RUN_URL` in workflow created PR does not use GitHub enterprise URL

### DIFF
--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -70,7 +70,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            [Workflow Run]: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
             ------
 
@@ -81,7 +81,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            [Workflow Run]: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
             ------
 

--- a/src/github/workflow-actions.ts
+++ b/src/github/workflow-actions.ts
@@ -8,7 +8,8 @@ function context(value: string) {
 
 const REPO = context("github.repository");
 const RUN_ID = context("github.run_id");
-const RUN_URL = `https://github.com/${REPO}/actions/runs/${RUN_ID}`;
+const SERVER_URL = context("github.server_url");
+const RUN_URL = `${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}`;
 const GIT_PATCH_FILE_DEFAULT = ".repo.patch";
 const RUNNER_TEMP = "${{ runner.temp }}";
 

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -712,7 +712,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -722,7 +722,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -1874,7 +1874,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -1884,7 +1884,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -3086,7 +3086,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -3096,7 +3096,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -4158,7 +4158,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -4168,7 +4168,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -567,7 +567,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -577,7 +577,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 

--- a/test/javascript/__snapshots__/node-project.test.ts.snap
+++ b/test/javascript/__snapshots__/node-project.test.ts.snap
@@ -42,7 +42,7 @@ git config user.email "github-actions@github.com"",
         "author": "github-actions <github-actions@github.com>",
         "body": "Upgrades project dependencies. See details in [workflow run].
 
-[Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+[Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
 ------
 
@@ -52,7 +52,7 @@ git config user.email "github-actions@github.com"",
 
 Upgrades project dependencies. See details in [workflow run].
 
-[Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+[Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
 ------
 

--- a/test/javascript/__snapshots__/upgrade-dependencies.test.ts.snap
+++ b/test/javascript/__snapshots__/upgrade-dependencies.test.ts.snap
@@ -69,7 +69,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -79,7 +79,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -159,7 +159,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -169,7 +169,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -249,7 +249,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -259,7 +259,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -339,7 +339,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -349,7 +349,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -429,7 +429,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -439,7 +439,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -519,7 +519,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -529,7 +529,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -609,7 +609,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -619,7 +619,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -699,7 +699,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -709,7 +709,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -789,7 +789,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -799,7 +799,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -879,7 +879,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -889,7 +889,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -967,7 +967,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -977,7 +977,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -1063,7 +1063,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -1073,7 +1073,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -1160,7 +1160,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -1170,7 +1170,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 

--- a/test/jsii/__snapshots__/jsii.test.ts.snap
+++ b/test/jsii/__snapshots__/jsii.test.ts.snap
@@ -567,7 +567,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -577,7 +577,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -2060,7 +2060,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -2070,7 +2070,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -3535,7 +3535,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -3545,7 +3545,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -5028,7 +5028,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -5038,7 +5038,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 

--- a/test/typescript/__snapshots__/typescript.test.ts.snap
+++ b/test/typescript/__snapshots__/typescript.test.ts.snap
@@ -497,7 +497,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -507,7 +507,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 

--- a/test/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-project.test.ts.snap
@@ -276,7 +276,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -286,7 +286,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 

--- a/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -201,7 +201,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -211,7 +211,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 

--- a/test/web/__snapshots__/react-project.test.ts.snap
+++ b/test/web/__snapshots__/react-project.test.ts.snap
@@ -262,7 +262,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -272,7 +272,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 

--- a/test/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/react-ts-project.test.ts.snap
@@ -423,7 +423,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 
@@ -433,7 +433,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+            [Workflow Run]: \${{ github.server_url }}/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
 
             ------
 


### PR DESCRIPTION
When building `RUN_URL` in worklflow-actions, use the `github.server_url` ([source](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context))
context variable. This will allow the URL to be correct on GitHub
Enterprise installations as well as github.com.

This PR was tested locally in a private GitHub Enterprise environment.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
