### PR TITLE
fix(release): selective bump ignores commits with 'r' and 'n'

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -156,7 +156,9 @@ export class ReleasableCommits {
     const allowedTypes = types.join("|");
 
     // @see: https://github.com/conventional-commits/parser/blob/eeefb961ebf5b9dfea0fea8b06f8ad34a1e439b9/lib/parser.js
-    const cmd = `git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(${allowedTypes}){1}(\\([^()\\r\\n]+\\))?(!)?:[^\\S\\r\\n]+.+'`;
+    // -E requires this to be POSIX Extended Regular Expression, which comes with certain limitations
+    // see https://en.wikibooks.org/wiki/Regular_Expressions/POSIX-Extended_Regular_Expressions for details
+    const cmd = `git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(${allowedTypes}){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+'`;
 
     return new ReleasableCommits(withPath(cmd, path));
   }

--- a/test/release/bump.test.ts
+++ b/test/release/bump.test.ts
@@ -349,6 +349,24 @@ describe("Releasable Commits Configurations", () => {
     expect(result.version).toEqual("1.2.1");
   });
 
+  test("regressions bump if regex should accept all characters", async () => {
+    const result = await testBump({
+      options: {
+        releasableCommits: ReleasableCommits.featuresAndFixes().cmd,
+      },
+      commits: [
+        { message: "first version", tag: "v1.1.0" },
+        { message: "second version", tag: "v1.2.0" },
+        { message: "docs: update Readme" },
+        {
+          message:
+            "feat(abcdefghijklmnopqrstuvwxyz): abcdefghijklmnopqrstuvwxyz",
+        },
+      ],
+    });
+    expect(result.version).toEqual("1.3.0");
+  });
+
   test("will not bump if no change in a relevant path", async () => {
     const result = await testBump({
       options: {

--- a/test/release/bump.test.ts
+++ b/test/release/bump.test.ts
@@ -349,7 +349,7 @@ describe("Releasable Commits Configurations", () => {
     expect(result.version).toEqual("1.2.1");
   });
 
-  test("regressions bump if regex should accept all characters", async () => {
+  test("regression: bump regex should accept all characters", async () => {
     const result = await testBump({
       options: {
         releasableCommits: ReleasableCommits.featuresAndFixes().cmd,


### PR DESCRIPTION
Using `-E` with `git log` requires the use of [POSIX Extended Regular Expressions](https://en.wikibooks.org/wiki/Regular_Expressions/POSIX-Extended_Regular_Expressions) which comes with certain limitations.

The previous code wrongly assumed that `-P` flag (Perl Regex) is used, but that is not guaranteed to be available on all versions of git.
The use of the POSIX-Extended incompatible values `\r\n` resulted in commit messages containing `r` or `n` being ignored.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.