### PR TITLE
feat: add runner group support

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -237,6 +237,7 @@ Name|Description
 [build.AddPostBuildJobCommandsOptions](#projen-build-addpostbuildjobcommandsoptions)|Options for `BuildWorkflow.addPostBuildJobCommands`.
 [build.AddPostBuildJobTaskOptions](#projen-build-addpostbuildjobtaskoptions)|Options for `BuildWorkflow.addPostBuildJobTask`.
 [build.BuildWorkflowOptions](#projen-build-buildworkflowoptions)|*No description*
+[build.GroupRunnerOptions](#projen-build-grouprunneroptions)|Options for BuildWorkflowOptions.runsOn.
 [cdk.AutoDiscoverBaseOptions](#projen-cdk-autodiscoverbaseoptions)|Options for `AutoDiscoverBase`.
 [cdk.Catalog](#projen-cdk-catalog)|*No description*
 [cdk.ConstructLibraryOptions](#projen-cdk-constructlibraryoptions)|*No description*
@@ -288,6 +289,7 @@ Name|Description
 [github.GithubCredentialsAppOptions](#projen-github-githubcredentialsappoptions)|Options for `GithubCredentials.fromApp`.
 [github.GithubCredentialsPersonalAccessTokenOptions](#projen-github-githubcredentialspersonalaccesstokenoptions)|Options for `GithubCredentials.fromPersonalAccessToken`.
 [github.GithubWorkflowOptions](#projen-github-githubworkflowoptions)|Options for `GithubWorkflow`.
+[github.GroupRunnerOptions](#projen-github-grouprunneroptions)|*No description*
 [github.MergifyConditionalOperator](#projen-github-mergifyconditionaloperator)|The Mergify conditional operators that can be used are: `or` and `and`.
 [github.MergifyOptions](#projen-github-mergifyoptions)|*No description*
 [github.MergifyQueue](#projen-github-mergifyqueue)|*No description*
@@ -3784,7 +3786,7 @@ new awscdk.AwsCdkConstructLibrary(options: AwsCdkConstructLibraryOptions)
   * **releaseWorkflowSetupSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  A set of workflow steps to execute in order to setup the workflow container. __*Optional*__
   * **versionrcOptions** (<code>Map<string, any></code>)  Custom configuration used when creating changelog with standard-version package. __*Default*__: standard configuration applicable for GitHub repositories
   * **workflowContainerImage** (<code>string</code>)  Container image to use for GitHub workflows. __*Default*__: default image
-  * **workflowRunsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
+  * **workflowRunsOn** (<code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
   * **defaultReleaseBranch** (<code>string</code>)  The name of the main release branch. 
   * **artifactsDirectory** (<code>string</code>)  A directory which will contain build artifacts. __*Default*__: "dist"
   * **autoApproveUpgrades** (<code>boolean</code>)  Automatically approve deps upgrade PRs, allowing them to be merged by mergify (if configued). __*Default*__: true
@@ -4484,7 +4486,7 @@ new awscdk.AwsCdkTypeScriptApp(options: AwsCdkTypeScriptAppOptions)
   * **releaseWorkflowSetupSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  A set of workflow steps to execute in order to setup the workflow container. __*Optional*__
   * **versionrcOptions** (<code>Map<string, any></code>)  Custom configuration used when creating changelog with standard-version package. __*Default*__: standard configuration applicable for GitHub repositories
   * **workflowContainerImage** (<code>string</code>)  Container image to use for GitHub workflows. __*Default*__: default image
-  * **workflowRunsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
+  * **workflowRunsOn** (<code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
   * **defaultReleaseBranch** (<code>string</code>)  The name of the main release branch. 
   * **artifactsDirectory** (<code>string</code>)  A directory which will contain build artifacts. __*Default*__: "dist"
   * **autoApproveUpgrades** (<code>boolean</code>)  Automatically approve deps upgrade PRs, allowing them to be merged by mergify (if configued). __*Default*__: true
@@ -4800,7 +4802,7 @@ new awscdk.ConstructLibraryAws(options: AwsCdkConstructLibraryOptions)
   * **releaseWorkflowSetupSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  A set of workflow steps to execute in order to setup the workflow container. __*Optional*__
   * **versionrcOptions** (<code>Map<string, any></code>)  Custom configuration used when creating changelog with standard-version package. __*Default*__: standard configuration applicable for GitHub repositories
   * **workflowContainerImage** (<code>string</code>)  Container image to use for GitHub workflows. __*Default*__: default image
-  * **workflowRunsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
+  * **workflowRunsOn** (<code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
   * **defaultReleaseBranch** (<code>string</code>)  The name of the main release branch. 
   * **artifactsDirectory** (<code>string</code>)  A directory which will contain build artifacts. __*Default*__: "dist"
   * **autoApproveUpgrades** (<code>boolean</code>)  Automatically approve deps upgrade PRs, allowing them to be merged by mergify (if configued). __*Default*__: true
@@ -5176,7 +5178,7 @@ new build.BuildWorkflow(project: Project, options: BuildWorkflowOptions)
   * **permissions** (<code>[github.workflows.JobPermissions](#projen-github-workflows-jobpermissions)</code>)  Permissions granted to the build job To limit job permissions for `contents`, the desired permissions have to be explicitly set, e.g.: `{ contents: JobPermission.NONE }`. __*Default*__: `{ contents: JobPermission.WRITE }`
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute after build. __*Default*__: []
   * **preBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to execute before the build. __*Default*__: []
-  * **runsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
+  * **runsOn** (<code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
   * **workflowTriggers** (<code>[github.workflows.Triggers](#projen-github-workflows-triggers)</code>)  Build workflow triggers. __*Default*__: "{ pullRequest: {}, workflowDispatch: {} }"
 
 
@@ -5211,7 +5213,7 @@ addPostBuildJob(id: string, job: Job): void
   * **name** (<code>string</code>)  The name of the job displayed on GitHub. __*Optional*__
   * **needs** (<code>Array<string></code>)  Identifies any jobs that must complete successfully before this job will run. __*Optional*__
   * **strategy** (<code>[github.workflows.JobStrategy](#projen-github-workflows-jobstrategy)</code>)  A strategy creates a build matrix for your jobs. __*Optional*__
-  * **runsOn** (<code>Array<string></code>)  The type of machine to run the job on. 
+  * **runsOn** (<code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code>)  The type of machine to run the job on. 
   * **steps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  A job contains a sequence of tasks called steps. 
   * **container** (<code>[github.workflows.ContainerOptions](#projen-github-workflows-containeroptions)</code>)  A container to run any steps in a job that don't already specify a container. __*Optional*__
   * **continueOnError** (<code>boolean</code>)  Prevents a workflow run from failing when a job fails. __*Optional*__
@@ -5243,7 +5245,7 @@ addPostBuildJobCommands(id: string, commands: Array<string>, options?: AddPostBu
 * **options** (<code>[build.AddPostBuildJobCommandsOptions](#projen-build-addpostbuildjobcommandsoptions)</code>)  Specify tools and other options.
   * **checkoutRepo** (<code>boolean</code>)  Check out the repository at the pull request branch before commands are run. __*Default*__: false
   * **installDeps** (<code>boolean</code>)  Install project dependencies before running commands. `checkoutRepo` must also be set to true. __*Default*__: false
-  * **runsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
+  * **runsOn** (<code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
   * **tools** (<code>[github.workflows.Tools](#projen-github-workflows-tools)</code>)  Tools that should be installed before the commands are run. __*Optional*__
 
 
@@ -5266,7 +5268,7 @@ addPostBuildJobTask(task: Task, options?: AddPostBuildJobTaskOptions): void
 
 * **task** (<code>[Task](#projen-task)</code>)  *No description*
 * **options** (<code>[build.AddPostBuildJobTaskOptions](#projen-build-addpostbuildjobtaskoptions)</code>)  Specify tools and other options.
-  * **runsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
+  * **runsOn** (<code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
   * **tools** (<code>[github.workflows.Tools](#projen-github-workflows-tools)</code>)  Tools that should be installed before the task is run. __*Optional*__
 
 
@@ -5434,7 +5436,7 @@ new cdk.ConstructLibrary(options: ConstructLibraryOptions)
   * **releaseWorkflowSetupSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  A set of workflow steps to execute in order to setup the workflow container. __*Optional*__
   * **versionrcOptions** (<code>Map<string, any></code>)  Custom configuration used when creating changelog with standard-version package. __*Default*__: standard configuration applicable for GitHub repositories
   * **workflowContainerImage** (<code>string</code>)  Container image to use for GitHub workflows. __*Default*__: default image
-  * **workflowRunsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
+  * **workflowRunsOn** (<code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
   * **defaultReleaseBranch** (<code>string</code>)  The name of the main release branch. 
   * **artifactsDirectory** (<code>string</code>)  A directory which will contain build artifacts. __*Default*__: "dist"
   * **autoApproveUpgrades** (<code>boolean</code>)  Automatically approve deps upgrade PRs, allowing them to be merged by mergify (if configued). __*Default*__: true
@@ -5699,7 +5701,7 @@ new cdk.JsiiProject(options: JsiiProjectOptions)
   * **releaseWorkflowSetupSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  A set of workflow steps to execute in order to setup the workflow container. __*Optional*__
   * **versionrcOptions** (<code>Map<string, any></code>)  Custom configuration used when creating changelog with standard-version package. __*Default*__: standard configuration applicable for GitHub repositories
   * **workflowContainerImage** (<code>string</code>)  Container image to use for GitHub workflows. __*Default*__: default image
-  * **workflowRunsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
+  * **workflowRunsOn** (<code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
   * **defaultReleaseBranch** (<code>string</code>)  The name of the main release branch. 
   * **artifactsDirectory** (<code>string</code>)  A directory which will contain build artifacts. __*Default*__: "dist"
   * **autoApproveUpgrades** (<code>boolean</code>)  Automatically approve deps upgrade PRs, allowing them to be merged by mergify (if configued). __*Default*__: true
@@ -6122,7 +6124,7 @@ new cdk8s.Cdk8sTypeScriptApp(options: Cdk8sTypeScriptAppOptions)
   * **releaseWorkflowSetupSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  A set of workflow steps to execute in order to setup the workflow container. __*Optional*__
   * **versionrcOptions** (<code>Map<string, any></code>)  Custom configuration used when creating changelog with standard-version package. __*Default*__: standard configuration applicable for GitHub repositories
   * **workflowContainerImage** (<code>string</code>)  Container image to use for GitHub workflows. __*Default*__: default image
-  * **workflowRunsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
+  * **workflowRunsOn** (<code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
   * **defaultReleaseBranch** (<code>string</code>)  The name of the main release branch. 
   * **artifactsDirectory** (<code>string</code>)  A directory which will contain build artifacts. __*Default*__: "dist"
   * **autoApproveUpgrades** (<code>boolean</code>)  Automatically approve deps upgrade PRs, allowing them to be merged by mergify (if configued). __*Default*__: true
@@ -6310,7 +6312,7 @@ new cdk8s.ConstructLibraryCdk8s(options: ConstructLibraryCdk8sOptions)
   * **releaseWorkflowSetupSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  A set of workflow steps to execute in order to setup the workflow container. __*Optional*__
   * **versionrcOptions** (<code>Map<string, any></code>)  Custom configuration used when creating changelog with standard-version package. __*Default*__: standard configuration applicable for GitHub repositories
   * **workflowContainerImage** (<code>string</code>)  Container image to use for GitHub workflows. __*Default*__: default image
-  * **workflowRunsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
+  * **workflowRunsOn** (<code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
   * **defaultReleaseBranch** (<code>string</code>)  The name of the main release branch. 
   * **artifactsDirectory** (<code>string</code>)  A directory which will contain build artifacts. __*Default*__: "dist"
   * **autoApproveUpgrades** (<code>boolean</code>)  Automatically approve deps upgrade PRs, allowing them to be merged by mergify (if configued). __*Default*__: true
@@ -6558,7 +6560,7 @@ new cdktf.ConstructLibraryCdktf(options: ConstructLibraryCdktfOptions)
   * **releaseWorkflowSetupSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  A set of workflow steps to execute in order to setup the workflow container. __*Optional*__
   * **versionrcOptions** (<code>Map<string, any></code>)  Custom configuration used when creating changelog with standard-version package. __*Default*__: standard configuration applicable for GitHub repositories
   * **workflowContainerImage** (<code>string</code>)  Container image to use for GitHub workflows. __*Default*__: default image
-  * **workflowRunsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
+  * **workflowRunsOn** (<code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
   * **defaultReleaseBranch** (<code>string</code>)  The name of the main release branch. 
   * **artifactsDirectory** (<code>string</code>)  A directory which will contain build artifacts. __*Default*__: "dist"
   * **autoApproveUpgrades** (<code>boolean</code>)  Automatically approve deps upgrade PRs, allowing them to be merged by mergify (if configued). __*Default*__: true
@@ -6729,7 +6731,7 @@ new github.AutoApprove(github: GitHub, options?: AutoApproveOptions)
 * **options** (<code>[github.AutoApproveOptions](#projen-github-autoapproveoptions)</code>)  *No description*
   * **allowedUsernames** (<code>Array<string></code>)  Only pull requests authored by these Github usernames will be auto-approved. __*Default*__: ['github-bot']
   * **label** (<code>string</code>)  Only pull requests with this label will be auto-approved. __*Default*__: 'auto-approve'
-  * **runsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
+  * **runsOn** (<code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
   * **secret** (<code>string</code>)  A GitHub secret name which contains a GitHub Access Token with write permissions for the `pull_request` scope. __*Default*__: "GITHUB_TOKEN"
 
 
@@ -7249,11 +7251,11 @@ Name | Type | Description
 Adds a single job to the workflow.
 
 ```ts
-addJob(id: string, job: JobCallingReusableWorkflow &#124; Job): void
+addJob(id: string, job: Job &#124; JobCallingReusableWorkflow): void
 ```
 
 * **id** (<code>string</code>)  The job name (unique within the workflow).
-* **job** (<code>[github.workflows.JobCallingReusableWorkflow](#projen-github-workflows-jobcallingreusableworkflow) &#124; [github.workflows.Job](#projen-github-workflows-job)</code>)  The job specification.
+* **job** (<code>[github.workflows.Job](#projen-github-workflows-job) &#124; [github.workflows.JobCallingReusableWorkflow](#projen-github-workflows-jobcallingreusableworkflow)</code>)  The job specification.
 
 
 
@@ -7263,10 +7265,10 @@ addJob(id: string, job: JobCallingReusableWorkflow &#124; Job): void
 Add jobs to the workflow.
 
 ```ts
-addJobs(jobs: Map<string, JobCallingReusableWorkflow &#124; Job>): void
+addJobs(jobs: Map<string, Job &#124; JobCallingReusableWorkflow>): void
 ```
 
-* **jobs** (<code>Map<string, [github.workflows.JobCallingReusableWorkflow](#projen-github-workflows-jobcallingreusableworkflow) &#124; [github.workflows.Job](#projen-github-workflows-job)></code>)  Jobs to add.
+* **jobs** (<code>Map<string, [github.workflows.Job](#projen-github-workflows-job) &#124; [github.workflows.JobCallingReusableWorkflow](#projen-github-workflows-jobcallingreusableworkflow)></code>)  Jobs to add.
 
 
 
@@ -7276,13 +7278,13 @@ addJobs(jobs: Map<string, JobCallingReusableWorkflow &#124; Job>): void
 Get a single job from the workflow.
 
 ```ts
-getJob(id: string): JobCallingReusableWorkflow &#124; Job
+getJob(id: string): Job &#124; JobCallingReusableWorkflow
 ```
 
 * **id** (<code>string</code>)  The job name (unique within the workflow).
 
 __Returns__:
-* <code>[github.workflows.JobCallingReusableWorkflow](#projen-github-workflows-jobcallingreusableworkflow) &#124; [github.workflows.Job](#projen-github-workflows-job)</code>
+* <code>[github.workflows.Job](#projen-github-workflows-job) &#124; [github.workflows.JobCallingReusableWorkflow](#projen-github-workflows-jobcallingreusableworkflow)</code>
 
 #### on(events)🔹 <a id="projen-github-githubworkflow-on"></a>
 
@@ -7350,11 +7352,11 @@ removeJob(id: string): void
 Updates a single job to the workflow.
 
 ```ts
-updateJob(id: string, job: JobCallingReusableWorkflow &#124; Job): void
+updateJob(id: string, job: Job &#124; JobCallingReusableWorkflow): void
 ```
 
 * **id** (<code>string</code>)  The job name (unique within the workflow).
-* **job** (<code>[github.workflows.JobCallingReusableWorkflow](#projen-github-workflows-jobcallingreusableworkflow) &#124; [github.workflows.Job](#projen-github-workflows-job)</code>)  *No description*
+* **job** (<code>[github.workflows.Job](#projen-github-workflows-job) &#124; [github.workflows.JobCallingReusableWorkflow](#projen-github-workflows-jobcallingreusableworkflow)</code>)  *No description*
 
 
 
@@ -7364,10 +7366,10 @@ updateJob(id: string, job: JobCallingReusableWorkflow &#124; Job): void
 Updates jobs for this worklow Does a complete replace, it does not try to merge the jobs.
 
 ```ts
-updateJobs(jobs: Map<string, JobCallingReusableWorkflow &#124; Job>): void
+updateJobs(jobs: Map<string, Job &#124; JobCallingReusableWorkflow>): void
 ```
 
-* **jobs** (<code>Map<string, [github.workflows.JobCallingReusableWorkflow](#projen-github-workflows-jobcallingreusableworkflow) &#124; [github.workflows.Job](#projen-github-workflows-job)></code>)  Jobs to update.
+* **jobs** (<code>Map<string, [github.workflows.Job](#projen-github-workflows-job) &#124; [github.workflows.JobCallingReusableWorkflow](#projen-github-workflows-jobcallingreusableworkflow)></code>)  Jobs to update.
 
 
 
@@ -7456,7 +7458,7 @@ new github.PullRequestLint(github: GitHub, options?: PullRequestLintOptions)
 
 * **github** (<code>[github.GitHub](#projen-github-github)</code>)  *No description*
 * **options** (<code>[github.PullRequestLintOptions](#projen-github-pullrequestlintoptions)</code>)  *No description*
-  * **runsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
+  * **runsOn** (<code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
   * **semanticTitle** (<code>boolean</code>)  Validate that pull request titles follow Conventional Commits. __*Default*__: true
   * **semanticTitleOptions** (<code>[github.SemanticTitleOptions](#projen-github-semantictitleoptions)</code>)  Options for validating the conventional commit title linter. __*Default*__: title must start with "feat", "fix", or "chore"
 
@@ -7514,7 +7516,7 @@ new github.Stale(github: GitHub, options?: StaleOptions)
 * **options** (<code>[github.StaleOptions](#projen-github-staleoptions)</code>)  *No description*
   * **issues** (<code>[github.StaleBehavior](#projen-github-stalebehavior)</code>)  How to handle stale issues. __*Default*__: By default, stale issues with no activity will be marked as stale after 60 days and closed within 7 days.
   * **pullRequest** (<code>[github.StaleBehavior](#projen-github-stalebehavior)</code>)  How to handle stale pull requests. __*Default*__: By default, pull requests with no activity will be marked as stale after 14 days and closed within 2 days with relevant comments.
-  * **runsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
+  * **runsOn** (<code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
 
 
 
@@ -7553,7 +7555,7 @@ new github.TaskWorkflow(github: GitHub, options: TaskWorkflowOptions)
   * **postBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Actions to run after the main build step. __*Default*__: not set
   * **preBuildSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Steps to run before the main build step. __*Default*__: not set
   * **preCheckoutSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  Initial steps to run before the source code checkout. __*Default*__: not set
-  * **runsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
+  * **runsOn** (<code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
   * **triggers** (<code>[github.workflows.Triggers](#projen-github-workflows-triggers)</code>)  The triggers for the workflow. __*Default*__: by default workflows can only be triggered by manually.
 
 
@@ -7713,7 +7715,7 @@ static pullRequestFromPatch(options: PullRequestFromPatchOptions): Job
   * **stepName** (<code>string</code>)  The name of the step displayed on GitHub. __*Default*__: "Create Pull Request"
   * **patch** (<code>[github.PullRequestPatchSource](#projen-github-pullrequestpatchsource)</code>)  Information about the patch that is used to create the pull request. 
   * **jobName** (<code>string</code>)  The name of the job displayed on GitHub. __*Default*__: "Create Pull Request"
-  * **runsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
+  * **runsOn** (<code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
 
 __Returns__:
 * <code>[github.workflows.Job](#projen-github-workflows-job)</code>
@@ -9195,7 +9197,7 @@ new javascript.NodeProject(options: NodeProjectOptions)
   * **releaseWorkflowSetupSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  A set of workflow steps to execute in order to setup the workflow container. __*Optional*__
   * **versionrcOptions** (<code>Map<string, any></code>)  Custom configuration used when creating changelog with standard-version package. __*Default*__: standard configuration applicable for GitHub repositories
   * **workflowContainerImage** (<code>string</code>)  Container image to use for GitHub workflows. __*Default*__: default image
-  * **workflowRunsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
+  * **workflowRunsOn** (<code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
   * **defaultReleaseBranch** (<code>string</code>)  The name of the main release branch. 
   * **artifactsDirectory** (<code>string</code>)  A directory which will contain build artifacts. __*Default*__: "dist"
   * **autoApproveUpgrades** (<code>boolean</code>)  Automatically approve deps upgrade PRs, allowing them to be merged by mergify (if configued). __*Default*__: true
@@ -10701,7 +10703,7 @@ new release.Publisher(project: Project, options: PublisherOptions)
   * **publishTasks** (<code>boolean</code>)  Define publishing tasks that can be executed manually as well as workflows. __*Default*__: false
   * **workflowContainerImage** (<code>string</code>)  Container image to use for GitHub workflows. __*Default*__: default image
   * **workflowNodeVersion** (<code>string</code>)  Node version to setup in GitHub workflows if any node-based CLI utilities are needed. __*Default*__: 16.x
-  * **workflowRunsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
+  * **workflowRunsOn** (<code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
 
 
 
@@ -10925,7 +10927,7 @@ new release.Release(project: GitHubProject, options: ReleaseOptions)
   * **releaseWorkflowSetupSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  A set of workflow steps to execute in order to setup the workflow container. __*Optional*__
   * **versionrcOptions** (<code>Map<string, any></code>)  Custom configuration used when creating changelog with standard-version package. __*Default*__: standard configuration applicable for GitHub repositories
   * **workflowContainerImage** (<code>string</code>)  Container image to use for GitHub workflows. __*Default*__: default image
-  * **workflowRunsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
+  * **workflowRunsOn** (<code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
   * **artifactsDirectory** (<code>string</code>)  A directory which will contain build artifacts. 
   * **branch** (<code>string</code>)  The default branch name to release from. 
   * **task** (<code>[Task](#projen-task)</code>)  The task to execute in order to create the release artifacts. 
@@ -11304,7 +11306,7 @@ new typescript.TypeScriptAppProject(options: TypeScriptProjectOptions)
   * **releaseWorkflowSetupSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  A set of workflow steps to execute in order to setup the workflow container. __*Optional*__
   * **versionrcOptions** (<code>Map<string, any></code>)  Custom configuration used when creating changelog with standard-version package. __*Default*__: standard configuration applicable for GitHub repositories
   * **workflowContainerImage** (<code>string</code>)  Container image to use for GitHub workflows. __*Default*__: default image
-  * **workflowRunsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
+  * **workflowRunsOn** (<code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
   * **defaultReleaseBranch** (<code>string</code>)  The name of the main release branch. 
   * **artifactsDirectory** (<code>string</code>)  A directory which will contain build artifacts. __*Default*__: "dist"
   * **autoApproveUpgrades** (<code>boolean</code>)  Automatically approve deps upgrade PRs, allowing them to be merged by mergify (if configued). __*Default*__: true
@@ -11465,7 +11467,7 @@ new typescript.TypeScriptLibraryProject(options: TypeScriptProjectOptions)
   * **releaseWorkflowSetupSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  A set of workflow steps to execute in order to setup the workflow container. __*Optional*__
   * **versionrcOptions** (<code>Map<string, any></code>)  Custom configuration used when creating changelog with standard-version package. __*Default*__: standard configuration applicable for GitHub repositories
   * **workflowContainerImage** (<code>string</code>)  Container image to use for GitHub workflows. __*Default*__: default image
-  * **workflowRunsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
+  * **workflowRunsOn** (<code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
   * **defaultReleaseBranch** (<code>string</code>)  The name of the main release branch. 
   * **artifactsDirectory** (<code>string</code>)  A directory which will contain build artifacts. __*Default*__: "dist"
   * **autoApproveUpgrades** (<code>boolean</code>)  Automatically approve deps upgrade PRs, allowing them to be merged by mergify (if configued). __*Default*__: true
@@ -11626,7 +11628,7 @@ new typescript.TypeScriptProject(options: TypeScriptProjectOptions)
   * **releaseWorkflowSetupSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  A set of workflow steps to execute in order to setup the workflow container. __*Optional*__
   * **versionrcOptions** (<code>Map<string, any></code>)  Custom configuration used when creating changelog with standard-version package. __*Default*__: standard configuration applicable for GitHub repositories
   * **workflowContainerImage** (<code>string</code>)  Container image to use for GitHub workflows. __*Default*__: default image
-  * **workflowRunsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
+  * **workflowRunsOn** (<code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
   * **defaultReleaseBranch** (<code>string</code>)  The name of the main release branch. 
   * **artifactsDirectory** (<code>string</code>)  A directory which will contain build artifacts. __*Default*__: "dist"
   * **autoApproveUpgrades** (<code>boolean</code>)  Automatically approve deps upgrade PRs, allowing them to be merged by mergify (if configued). __*Default*__: true
@@ -12164,7 +12166,7 @@ new web.NextJsProject(options: NextJsProjectOptions)
   * **releaseWorkflowSetupSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  A set of workflow steps to execute in order to setup the workflow container. __*Optional*__
   * **versionrcOptions** (<code>Map<string, any></code>)  Custom configuration used when creating changelog with standard-version package. __*Default*__: standard configuration applicable for GitHub repositories
   * **workflowContainerImage** (<code>string</code>)  Container image to use for GitHub workflows. __*Default*__: default image
-  * **workflowRunsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
+  * **workflowRunsOn** (<code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
   * **defaultReleaseBranch** (<code>string</code>)  The name of the main release branch. 
   * **artifactsDirectory** (<code>string</code>)  A directory which will contain build artifacts. __*Default*__: "dist"
   * **autoApproveUpgrades** (<code>boolean</code>)  Automatically approve deps upgrade PRs, allowing them to be merged by mergify (if configued). __*Default*__: true
@@ -12322,7 +12324,7 @@ new web.NextJsTypeScriptProject(options: NextJsTypeScriptProjectOptions)
   * **releaseWorkflowSetupSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  A set of workflow steps to execute in order to setup the workflow container. __*Optional*__
   * **versionrcOptions** (<code>Map<string, any></code>)  Custom configuration used when creating changelog with standard-version package. __*Default*__: standard configuration applicable for GitHub repositories
   * **workflowContainerImage** (<code>string</code>)  Container image to use for GitHub workflows. __*Default*__: default image
-  * **workflowRunsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
+  * **workflowRunsOn** (<code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
   * **defaultReleaseBranch** (<code>string</code>)  The name of the main release branch. 
   * **artifactsDirectory** (<code>string</code>)  A directory which will contain build artifacts. __*Default*__: "dist"
   * **autoApproveUpgrades** (<code>boolean</code>)  Automatically approve deps upgrade PRs, allowing them to be merged by mergify (if configued). __*Default*__: true
@@ -12553,7 +12555,7 @@ new web.ReactProject(options: ReactProjectOptions)
   * **releaseWorkflowSetupSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  A set of workflow steps to execute in order to setup the workflow container. __*Optional*__
   * **versionrcOptions** (<code>Map<string, any></code>)  Custom configuration used when creating changelog with standard-version package. __*Default*__: standard configuration applicable for GitHub repositories
   * **workflowContainerImage** (<code>string</code>)  Container image to use for GitHub workflows. __*Default*__: default image
-  * **workflowRunsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
+  * **workflowRunsOn** (<code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
   * **defaultReleaseBranch** (<code>string</code>)  The name of the main release branch. 
   * **artifactsDirectory** (<code>string</code>)  A directory which will contain build artifacts. __*Default*__: "dist"
   * **autoApproveUpgrades** (<code>boolean</code>)  Automatically approve deps upgrade PRs, allowing them to be merged by mergify (if configued). __*Default*__: true
@@ -12753,7 +12755,7 @@ new web.ReactTypeScriptProject(options: ReactTypeScriptProjectOptions)
   * **releaseWorkflowSetupSteps** (<code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code>)  A set of workflow steps to execute in order to setup the workflow container. __*Optional*__
   * **versionrcOptions** (<code>Map<string, any></code>)  Custom configuration used when creating changelog with standard-version package. __*Default*__: standard configuration applicable for GitHub repositories
   * **workflowContainerImage** (<code>string</code>)  Container image to use for GitHub workflows. __*Default*__: default image
-  * **workflowRunsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
+  * **workflowRunsOn** (<code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
   * **defaultReleaseBranch** (<code>string</code>)  The name of the main release branch. 
   * **artifactsDirectory** (<code>string</code>)  A directory which will contain build artifacts. __*Default*__: "dist"
   * **autoApproveUpgrades** (<code>boolean</code>)  Automatically approve deps upgrade PRs, allowing them to be merged by mergify (if configued). __*Default*__: true
@@ -14166,7 +14168,7 @@ Name | Type | Description
 **workflowGitIdentity**?🔹 | <code>[github.GitIdentity](#projen-github-gitidentity)</code> | The git identity to use in workflows.<br/>__*Default*__: GitHub Actions
 **workflowNodeVersion**?🔹 | <code>string</code> | The node version to use in GitHub workflows.<br/>__*Default*__: same as `minNodeVersion`
 **workflowPackageCache**?🔹 | <code>boolean</code> | Enable Node.js package cache in GitHub workflows.<br/>__*Default*__: false
-**workflowRunsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
+**workflowRunsOn**?🔹 | <code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 
 
 
@@ -14557,7 +14559,7 @@ Name | Type | Description
 **workflowGitIdentity**?🔹 | <code>[github.GitIdentity](#projen-github-gitidentity)</code> | The git identity to use in workflows.<br/>__*Default*__: GitHub Actions
 **workflowNodeVersion**?🔹 | <code>string</code> | The node version to use in GitHub workflows.<br/>__*Default*__: same as `minNodeVersion`
 **workflowPackageCache**?🔹 | <code>boolean</code> | Enable Node.js package cache in GitHub workflows.<br/>__*Default*__: false
-**workflowRunsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
+**workflowRunsOn**?🔹 | <code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 
 
 
@@ -14777,7 +14779,7 @@ Name | Type | Description
 **workflowGitIdentity**?⚠️ | <code>[github.GitIdentity](#projen-github-gitidentity)</code> | The git identity to use in workflows.<br/>__*Default*__: GitHub Actions
 **workflowNodeVersion**?⚠️ | <code>string</code> | The node version to use in GitHub workflows.<br/>__*Default*__: same as `minNodeVersion`
 **workflowPackageCache**?⚠️ | <code>boolean</code> | Enable Node.js package cache in GitHub workflows.<br/>__*Default*__: false
-**workflowRunsOn**?⚠️ | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
+**workflowRunsOn**?⚠️ | <code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 
 
 
@@ -14974,7 +14976,7 @@ Name | Type | Description
 -----|------|-------------
 **checkoutRepo**?🔹 | <code>boolean</code> | Check out the repository at the pull request branch before commands are run.<br/>__*Default*__: false
 **installDeps**?🔹 | <code>boolean</code> | Install project dependencies before running commands. `checkoutRepo` must also be set to true.<br/>__*Default*__: false
-**runsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
+**runsOn**?🔹 | <code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 **tools**?🔹 | <code>[github.workflows.Tools](#projen-github-workflows-tools)</code> | Tools that should be installed before the commands are run.<br/>__*Optional*__
 
 
@@ -14988,7 +14990,7 @@ Options for `BuildWorkflow.addPostBuildJobTask`.
 
 Name | Type | Description 
 -----|------|-------------
-**runsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
+**runsOn**?🔹 | <code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 **tools**?🔹 | <code>[github.workflows.Tools](#projen-github-workflows-tools)</code> | Tools that should be installed before the task is run.<br/>__*Optional*__
 
 
@@ -15012,8 +15014,22 @@ Name | Type | Description
 **permissions**?🔹 | <code>[github.workflows.JobPermissions](#projen-github-workflows-jobpermissions)</code> | Permissions granted to the build job To limit job permissions for `contents`, the desired permissions have to be explicitly set, e.g.: `{ contents: JobPermission.NONE }`.<br/>__*Default*__: `{ contents: JobPermission.WRITE }`
 **postBuildSteps**?🔹 | <code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code> | Steps to execute after build.<br/>__*Default*__: []
 **preBuildSteps**?🔹 | <code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code> | Steps to execute before the build.<br/>__*Default*__: []
-**runsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
+**runsOn**?🔹 | <code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 **workflowTriggers**?🔹 | <code>[github.workflows.Triggers](#projen-github-workflows-triggers)</code> | Build workflow triggers.<br/>__*Default*__: "{ pullRequest: {}, workflowDispatch: {} }"
+
+
+
+## struct GroupRunnerOptions 🔹 <a id="projen-build-grouprunneroptions"></a>
+
+
+Options for BuildWorkflowOptions.runsOn.
+
+
+
+Name | Type | Description 
+-----|------|-------------
+**group**🔹 | <code>string</code> | <span></span>
+**labels**🔹 | <code>Array<string></code> | <span></span>
 
 
 
@@ -15209,7 +15225,7 @@ Name | Type | Description
 **workflowGitIdentity**?🔹 | <code>[github.GitIdentity](#projen-github-gitidentity)</code> | The git identity to use in workflows.<br/>__*Default*__: GitHub Actions
 **workflowNodeVersion**?🔹 | <code>string</code> | The node version to use in GitHub workflows.<br/>__*Default*__: same as `minNodeVersion`
 **workflowPackageCache**?🔹 | <code>boolean</code> | Enable Node.js package cache in GitHub workflows.<br/>__*Default*__: false
-**workflowRunsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
+**workflowRunsOn**?🔹 | <code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 
 
 
@@ -15485,7 +15501,7 @@ Name | Type | Description
 **workflowGitIdentity**?🔹 | <code>[github.GitIdentity](#projen-github-gitidentity)</code> | The git identity to use in workflows.<br/>__*Default*__: GitHub Actions
 **workflowNodeVersion**?🔹 | <code>string</code> | The node version to use in GitHub workflows.<br/>__*Default*__: same as `minNodeVersion`
 **workflowPackageCache**?🔹 | <code>boolean</code> | Enable Node.js package cache in GitHub workflows.<br/>__*Default*__: false
-**workflowRunsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
+**workflowRunsOn**?🔹 | <code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 
 
 
@@ -15829,7 +15845,7 @@ Name | Type | Description
 **workflowGitIdentity**?🔹 | <code>[github.GitIdentity](#projen-github-gitidentity)</code> | The git identity to use in workflows.<br/>__*Default*__: GitHub Actions
 **workflowNodeVersion**?🔹 | <code>string</code> | The node version to use in GitHub workflows.<br/>__*Default*__: same as `minNodeVersion`
 **workflowPackageCache**?🔹 | <code>boolean</code> | Enable Node.js package cache in GitHub workflows.<br/>__*Default*__: false
-**workflowRunsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
+**workflowRunsOn**?🔹 | <code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 
 
 
@@ -16003,7 +16019,7 @@ Name | Type | Description
 **workflowGitIdentity**?🔹 | <code>[github.GitIdentity](#projen-github-gitidentity)</code> | The git identity to use in workflows.<br/>__*Default*__: GitHub Actions
 **workflowNodeVersion**?🔹 | <code>string</code> | The node version to use in GitHub workflows.<br/>__*Default*__: same as `minNodeVersion`
 **workflowPackageCache**?🔹 | <code>boolean</code> | Enable Node.js package cache in GitHub workflows.<br/>__*Default*__: false
-**workflowRunsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
+**workflowRunsOn**?🔹 | <code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 
 
 
@@ -16202,7 +16218,7 @@ Name | Type | Description
 **workflowGitIdentity**?🔹 | <code>[github.GitIdentity](#projen-github-gitidentity)</code> | The git identity to use in workflows.<br/>__*Default*__: GitHub Actions
 **workflowNodeVersion**?🔹 | <code>string</code> | The node version to use in GitHub workflows.<br/>__*Default*__: same as `minNodeVersion`
 **workflowPackageCache**?🔹 | <code>boolean</code> | Enable Node.js package cache in GitHub workflows.<br/>__*Default*__: false
-**workflowRunsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
+**workflowRunsOn**?🔹 | <code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 
 
 
@@ -16488,7 +16504,7 @@ Name | Type | Description
 -----|------|-------------
 **allowedUsernames**?🔹 | <code>Array<string></code> | Only pull requests authored by these Github usernames will be auto-approved.<br/>__*Default*__: ['github-bot']
 **label**?🔹 | <code>string</code> | Only pull requests with this label will be auto-approved.<br/>__*Default*__: 'auto-approve'
-**runsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
+**runsOn**?🔹 | <code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 **secret**?🔹 | <code>string</code> | A GitHub secret name which contains a GitHub Access Token with write permissions for the `pull_request` scope.<br/>__*Default*__: "GITHUB_TOKEN"
 
 
@@ -16753,6 +16769,20 @@ Name | Type | Description
 
 
 
+## struct GroupRunnerOptions 🔹 <a id="projen-github-grouprunneroptions"></a>
+
+
+
+
+
+
+Name | Type | Description 
+-----|------|-------------
+**group**🔹 | <code>string</code> | <span></span>
+**labels**🔹 | <code>Array<string></code> | <span></span>
+
+
+
 ## interface IAddConditionsLater 🔹 <a id="projen-github-iaddconditionslater"></a>
 
 
@@ -16855,7 +16885,7 @@ Name | Type | Description
 **gitIdentity**?🔹 | <code>[github.GitIdentity](#projen-github-gitidentity)</code> | The git identity used to create the commit.<br/>__*Default*__: the default github-actions user
 **jobName**?🔹 | <code>string</code> | The name of the job displayed on GitHub.<br/>__*Default*__: "Create Pull Request"
 **labels**?🔹 | <code>Array<string></code> | Labels to apply on the PR.<br/>__*Default*__: no labels.
-**runsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
+**runsOn**?🔹 | <code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 **signoff**?🔹 | <code>boolean</code> | Add Signed-off-by line by the committer at the end of the commit log message.<br/>__*Default*__: true
 **stepId**?🔹 | <code>string</code> | The step ID which produces the output which indicates if a patch was created.<br/>__*Default*__: "create_pr"
 **stepName**?🔹 | <code>string</code> | The name of the step displayed on GitHub.<br/>__*Default*__: "Create Pull Request"
@@ -16871,7 +16901,7 @@ Options for PullRequestLint.
 
 Name | Type | Description 
 -----|------|-------------
-**runsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
+**runsOn**?🔹 | <code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 **semanticTitle**?🔹 | <code>boolean</code> | Validate that pull request titles follow Conventional Commits.<br/>__*Default*__: true
 **semanticTitleOptions**?🔹 | <code>[github.SemanticTitleOptions](#projen-github-semantictitleoptions)</code> | Options for validating the conventional commit title linter.<br/>__*Default*__: title must start with "feat", "fix", or "chore"
 
@@ -16953,7 +16983,7 @@ Name | Type | Description
 -----|------|-------------
 **issues**?🔹 | <code>[github.StaleBehavior](#projen-github-stalebehavior)</code> | How to handle stale issues.<br/>__*Default*__: By default, stale issues with no activity will be marked as stale after 60 days and closed within 7 days.
 **pullRequest**?🔹 | <code>[github.StaleBehavior](#projen-github-stalebehavior)</code> | How to handle stale pull requests.<br/>__*Default*__: By default, pull requests with no activity will be marked as stale after 14 days and closed within 2 days with relevant comments.
-**runsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
+**runsOn**?🔹 | <code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 
 
 
@@ -16981,7 +17011,7 @@ Name | Type | Description
 **postBuildSteps**?🔹 | <code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code> | Actions to run after the main build step.<br/>__*Default*__: not set
 **preBuildSteps**?🔹 | <code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code> | Steps to run before the main build step.<br/>__*Default*__: not set
 **preCheckoutSteps**?🔹 | <code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code> | Initial steps to run before the source code checkout.<br/>__*Default*__: not set
-**runsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
+**runsOn**?🔹 | <code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 **triggers**?🔹 | <code>[github.workflows.Triggers](#projen-github-workflows-triggers)</code> | The triggers for the workflow.<br/>__*Default*__: by default workflows can only be triggered by manually.
 
 
@@ -18246,7 +18276,7 @@ Name | Type | Description
 **workflowGitIdentity**?🔹 | <code>[github.GitIdentity](#projen-github-gitidentity)</code> | The git identity to use in workflows.<br/>__*Default*__: GitHub Actions
 **workflowNodeVersion**?🔹 | <code>string</code> | The node version to use in GitHub workflows.<br/>__*Default*__: same as `minNodeVersion`
 **workflowPackageCache**?🔹 | <code>boolean</code> | Enable Node.js package cache in GitHub workflows.<br/>__*Default*__: false
-**workflowRunsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
+**workflowRunsOn**?🔹 | <code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 
 
 
@@ -18501,7 +18531,7 @@ Name | Type | Description
 **labels**?🔹 | <code>Array<string></code> | Labels to apply on the PR.<br/>__*Default*__: no labels.
 **permissions**?🔹 | <code>[github.workflows.JobPermissions](#projen-github-workflows-jobpermissions)</code> | Permissions granted to the upgrade job To limit job permissions for `contents`, the desired permissions have to be explicitly set, e.g.: `{ contents: JobPermission.NONE }`.<br/>__*Default*__: `{ contents: JobPermission.READ }`
 **projenCredentials**?🔹 | <code>[github.GithubCredentials](#projen-github-githubcredentials)</code> | Choose a method for authenticating with GitHub for creating the PR.<br/>__*Default*__: personal access token named PROJEN_GITHUB_TOKEN
-**runsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
+**runsOn**?🔹 | <code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 **schedule**?🔹 | <code>[javascript.UpgradeDependenciesSchedule](#projen-javascript-upgradedependenciesschedule)</code> | Schedule to run on.<br/>__*Default*__: UpgradeDependenciesSchedule.DAILY
 
 
@@ -19173,7 +19203,7 @@ Name | Type | Description
 **publishTasks**?🔹 | <code>boolean</code> | Define publishing tasks that can be executed manually as well as workflows.<br/>__*Default*__: false
 **workflowContainerImage**?🔹 | <code>string</code> | Container image to use for GitHub workflows.<br/>__*Default*__: default image
 **workflowNodeVersion**?🔹 | <code>string</code> | Node version to setup in GitHub workflows if any node-based CLI utilities are needed.<br/>__*Default*__: 16.x
-**workflowRunsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
+**workflowRunsOn**?🔹 | <code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 
 
 
@@ -19230,7 +19260,7 @@ Name | Type | Description
 **workflowContainerImage**?🔹 | <code>string</code> | Container image to use for GitHub workflows.<br/>__*Default*__: default image
 **workflowNodeVersion**?🔹 | <code>string</code> | Node version to setup in GitHub workflows if any node-based CLI utilities are needed.<br/>__*Default*__: 16.x
 **workflowPermissions**?🔹 | <code>[github.workflows.JobPermissions](#projen-github-workflows-jobpermissions)</code> | Permissions granted to the release workflow job.<br/>__*Default*__: `{ contents: JobPermission.WRITE }`
-**workflowRunsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
+**workflowRunsOn**?🔹 | <code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 
 
 
@@ -19263,7 +19293,7 @@ Name | Type | Description
 **releaseWorkflowSetupSteps**?🔹 | <code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code> | A set of workflow steps to execute in order to setup the workflow container.<br/>__*Optional*__
 **versionrcOptions**?🔹 | <code>Map<string, any></code> | Custom configuration used when creating changelog with standard-version package.<br/>__*Default*__: standard configuration applicable for GitHub repositories
 **workflowContainerImage**?🔹 | <code>string</code> | Container image to use for GitHub workflows.<br/>__*Default*__: default image
-**workflowRunsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
+**workflowRunsOn**?🔹 | <code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 
 
 
@@ -19457,7 +19487,7 @@ Name | Type | Description
 **workflowGitIdentity**?⚠️ | <code>[github.GitIdentity](#projen-github-gitidentity)</code> | The git identity to use in workflows.<br/>__*Default*__: GitHub Actions
 **workflowNodeVersion**?⚠️ | <code>string</code> | The node version to use in GitHub workflows.<br/>__*Default*__: same as `minNodeVersion`
 **workflowPackageCache**?⚠️ | <code>boolean</code> | Enable Node.js package cache in GitHub workflows.<br/>__*Default*__: false
-**workflowRunsOn**?⚠️ | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
+**workflowRunsOn**?⚠️ | <code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 
 
 
@@ -19608,7 +19638,7 @@ Name | Type | Description
 **workflowGitIdentity**?🔹 | <code>[github.GitIdentity](#projen-github-gitidentity)</code> | The git identity to use in workflows.<br/>__*Default*__: GitHub Actions
 **workflowNodeVersion**?🔹 | <code>string</code> | The node version to use in GitHub workflows.<br/>__*Default*__: same as `minNodeVersion`
 **workflowPackageCache**?🔹 | <code>boolean</code> | Enable Node.js package cache in GitHub workflows.<br/>__*Default*__: false
-**workflowRunsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
+**workflowRunsOn**?🔹 | <code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 
 
 
@@ -19949,7 +19979,7 @@ Name | Type | Description
 **workflowGitIdentity**?🔹 | <code>[github.GitIdentity](#projen-github-gitidentity)</code> | The git identity to use in workflows.<br/>__*Default*__: GitHub Actions
 **workflowNodeVersion**?🔹 | <code>string</code> | The node version to use in GitHub workflows.<br/>__*Default*__: same as `minNodeVersion`
 **workflowPackageCache**?🔹 | <code>boolean</code> | Enable Node.js package cache in GitHub workflows.<br/>__*Default*__: false
-**workflowRunsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
+**workflowRunsOn**?🔹 | <code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 
 
 
@@ -20102,7 +20132,7 @@ Name | Type | Description
 **workflowGitIdentity**?🔹 | <code>[github.GitIdentity](#projen-github-gitidentity)</code> | The git identity to use in workflows.<br/>__*Default*__: GitHub Actions
 **workflowNodeVersion**?🔹 | <code>string</code> | The node version to use in GitHub workflows.<br/>__*Default*__: same as `minNodeVersion`
 **workflowPackageCache**?🔹 | <code>boolean</code> | Enable Node.js package cache in GitHub workflows.<br/>__*Default*__: false
-**workflowRunsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
+**workflowRunsOn**?🔹 | <code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 
 
 
@@ -20268,7 +20298,7 @@ Name | Type | Description
 **workflowGitIdentity**?🔹 | <code>[github.GitIdentity](#projen-github-gitidentity)</code> | The git identity to use in workflows.<br/>__*Default*__: GitHub Actions
 **workflowNodeVersion**?🔹 | <code>string</code> | The node version to use in GitHub workflows.<br/>__*Default*__: same as `minNodeVersion`
 **workflowPackageCache**?🔹 | <code>boolean</code> | Enable Node.js package cache in GitHub workflows.<br/>__*Default*__: false
-**workflowRunsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
+**workflowRunsOn**?🔹 | <code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 
 
 
@@ -20450,7 +20480,7 @@ Name | Type | Description
 **workflowGitIdentity**?🔹 | <code>[github.GitIdentity](#projen-github-gitidentity)</code> | The git identity to use in workflows.<br/>__*Default*__: GitHub Actions
 **workflowNodeVersion**?🔹 | <code>string</code> | The node version to use in GitHub workflows.<br/>__*Default*__: same as `minNodeVersion`
 **workflowPackageCache**?🔹 | <code>boolean</code> | Enable Node.js package cache in GitHub workflows.<br/>__*Default*__: false
-**workflowRunsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
+**workflowRunsOn**?🔹 | <code>Array<string> &#124; [build.GroupRunnerOptions](#projen-build-grouprunneroptions)</code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 
 
 

--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -237,7 +237,7 @@ Name|Description
 [build.AddPostBuildJobCommandsOptions](#projen-build-addpostbuildjobcommandsoptions)|Options for `BuildWorkflow.addPostBuildJobCommands`.
 [build.AddPostBuildJobTaskOptions](#projen-build-addpostbuildjobtaskoptions)|Options for `BuildWorkflow.addPostBuildJobTask`.
 [build.BuildWorkflowOptions](#projen-build-buildworkflowoptions)|*No description*
-[build.GroupRunnerOptions](#projen-build-grouprunneroptions)|Options for BuildWorkflowOptions.runsOn.
+[build.GroupRunnerOptions](#projen-build-grouprunneroptions)|Options for WorkflowOptions.runsOn.
 [cdk.AutoDiscoverBaseOptions](#projen-cdk-autodiscoverbaseoptions)|Options for `AutoDiscoverBase`.
 [cdk.Catalog](#projen-cdk-catalog)|*No description*
 [cdk.ConstructLibraryOptions](#projen-cdk-constructlibraryoptions)|*No description*
@@ -15022,7 +15022,7 @@ Name | Type | Description
 ## struct GroupRunnerOptions 🔹 <a id="projen-build-grouprunneroptions"></a>
 
 
-Options for BuildWorkflowOptions.runsOn.
+Options for WorkflowOptions.runsOn.
 
 
 

--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -7251,11 +7251,11 @@ Name | Type | Description
 Adds a single job to the workflow.
 
 ```ts
-addJob(id: string, job: Job &#124; JobCallingReusableWorkflow): void
+addJob(id: string, job: JobCallingReusableWorkflow &#124; Job): void
 ```
 
 * **id** (<code>string</code>)  The job name (unique within the workflow).
-* **job** (<code>[github.workflows.Job](#projen-github-workflows-job) &#124; [github.workflows.JobCallingReusableWorkflow](#projen-github-workflows-jobcallingreusableworkflow)</code>)  The job specification.
+* **job** (<code>[github.workflows.JobCallingReusableWorkflow](#projen-github-workflows-jobcallingreusableworkflow) &#124; [github.workflows.Job](#projen-github-workflows-job)</code>)  The job specification.
 
 
 
@@ -7265,10 +7265,10 @@ addJob(id: string, job: Job &#124; JobCallingReusableWorkflow): void
 Add jobs to the workflow.
 
 ```ts
-addJobs(jobs: Map<string, Job &#124; JobCallingReusableWorkflow>): void
+addJobs(jobs: Map<string, JobCallingReusableWorkflow &#124; Job>): void
 ```
 
-* **jobs** (<code>Map<string, [github.workflows.Job](#projen-github-workflows-job) &#124; [github.workflows.JobCallingReusableWorkflow](#projen-github-workflows-jobcallingreusableworkflow)></code>)  Jobs to add.
+* **jobs** (<code>Map<string, [github.workflows.JobCallingReusableWorkflow](#projen-github-workflows-jobcallingreusableworkflow) &#124; [github.workflows.Job](#projen-github-workflows-job)></code>)  Jobs to add.
 
 
 
@@ -7278,13 +7278,13 @@ addJobs(jobs: Map<string, Job &#124; JobCallingReusableWorkflow>): void
 Get a single job from the workflow.
 
 ```ts
-getJob(id: string): Job &#124; JobCallingReusableWorkflow
+getJob(id: string): JobCallingReusableWorkflow &#124; Job
 ```
 
 * **id** (<code>string</code>)  The job name (unique within the workflow).
 
 __Returns__:
-* <code>[github.workflows.Job](#projen-github-workflows-job) &#124; [github.workflows.JobCallingReusableWorkflow](#projen-github-workflows-jobcallingreusableworkflow)</code>
+* <code>[github.workflows.JobCallingReusableWorkflow](#projen-github-workflows-jobcallingreusableworkflow) &#124; [github.workflows.Job](#projen-github-workflows-job)</code>
 
 #### on(events)🔹 <a id="projen-github-githubworkflow-on"></a>
 
@@ -7352,11 +7352,11 @@ removeJob(id: string): void
 Updates a single job to the workflow.
 
 ```ts
-updateJob(id: string, job: Job &#124; JobCallingReusableWorkflow): void
+updateJob(id: string, job: JobCallingReusableWorkflow &#124; Job): void
 ```
 
 * **id** (<code>string</code>)  The job name (unique within the workflow).
-* **job** (<code>[github.workflows.Job](#projen-github-workflows-job) &#124; [github.workflows.JobCallingReusableWorkflow](#projen-github-workflows-jobcallingreusableworkflow)</code>)  *No description*
+* **job** (<code>[github.workflows.JobCallingReusableWorkflow](#projen-github-workflows-jobcallingreusableworkflow) &#124; [github.workflows.Job](#projen-github-workflows-job)</code>)  *No description*
 
 
 
@@ -7366,10 +7366,10 @@ updateJob(id: string, job: Job &#124; JobCallingReusableWorkflow): void
 Updates jobs for this worklow Does a complete replace, it does not try to merge the jobs.
 
 ```ts
-updateJobs(jobs: Map<string, Job &#124; JobCallingReusableWorkflow>): void
+updateJobs(jobs: Map<string, JobCallingReusableWorkflow &#124; Job>): void
 ```
 
-* **jobs** (<code>Map<string, [github.workflows.Job](#projen-github-workflows-job) &#124; [github.workflows.JobCallingReusableWorkflow](#projen-github-workflows-jobcallingreusableworkflow)></code>)  Jobs to update.
+* **jobs** (<code>Map<string, [github.workflows.JobCallingReusableWorkflow](#projen-github-workflows-jobcallingreusableworkflow) &#124; [github.workflows.Job](#projen-github-workflows-job)></code>)  Jobs to update.
 
 
 

--- a/src/build/build-workflow.ts
+++ b/src/build/build-workflow.ts
@@ -96,7 +96,7 @@ export interface BuildWorkflowOptions {
    * Github Runner selection labels
    * @default ["ubuntu-latest"]
    */
-  readonly runsOn?: string[];
+  readonly runsOn?: string[] | GroupRunnerOptions;
 
   /**
    * Build workflow triggers
@@ -110,6 +110,14 @@ export interface BuildWorkflowOptions {
    * @default `{ contents: JobPermission.WRITE }`
    */
   readonly permissions?: JobPermissions;
+}
+
+/**
+ * Options for BuildWorkflowOptions.runsOn
+ */
+export interface GroupRunnerOptions {
+  readonly group: string;
+  readonly labels: string[];
 }
 
 export class BuildWorkflow extends Component {
@@ -431,7 +439,7 @@ export interface AddPostBuildJobTaskOptions {
    * Github Runner selection labels
    * @default ["ubuntu-latest"]
    */
-  readonly runsOn?: string[];
+  readonly runsOn?: string[] | GroupRunnerOptions;
 }
 
 /**
@@ -465,5 +473,5 @@ export interface AddPostBuildJobCommandsOptions {
    * Github Runner selection labels
    * @default ["ubuntu-latest"]
    */
-  readonly runsOn?: string[];
+  readonly runsOn?: string[] | GroupRunnerOptions;
 }

--- a/src/build/build-workflow.ts
+++ b/src/build/build-workflow.ts
@@ -113,7 +113,7 @@ export interface BuildWorkflowOptions {
 }
 
 /**
- * Options for BuildWorkflowOptions.runsOn
+ * Options for WorkflowOptions.runsOn
  */
 export interface GroupRunnerOptions {
   readonly group: string;

--- a/src/github/auto-approve.ts
+++ b/src/github/auto-approve.ts
@@ -1,5 +1,6 @@
 import { GitHub } from "./github";
 import { Job, JobPermission } from "./workflows-model";
+import { GroupRunnerOptions } from "../build/build-workflow";
 import { Component } from "../component";
 
 /**
@@ -38,7 +39,7 @@ export interface AutoApproveOptions {
    * Github Runner selection labels
    * @default ["ubuntu-latest"]
    */
-  readonly runsOn?: string[];
+  readonly runsOn?: string[] | GroupRunnerOptions;
 }
 
 /**

--- a/src/github/pull-request-lint.ts
+++ b/src/github/pull-request-lint.ts
@@ -1,5 +1,6 @@
 import { GitHub } from ".";
 import { Job, JobPermission } from "./workflows-model";
+import { GroupRunnerOptions } from "../build/build-workflow";
 import { Component } from "../component";
 
 /**
@@ -24,7 +25,7 @@ export interface PullRequestLintOptions {
    * Github Runner selection labels
    * @default ["ubuntu-latest"]
    */
-  readonly runsOn?: string[];
+  readonly runsOn?: string[] | GroupRunnerOptions;
 }
 
 /**

--- a/src/github/stale.ts
+++ b/src/github/stale.ts
@@ -1,6 +1,7 @@
 import { GitHub } from "./github";
 import { renderBehavior } from "./stale-util";
 import { JobPermission } from "./workflows-model";
+import { GroupRunnerOptions } from "../build/build-workflow";
 import { Component } from "../component";
 
 /**
@@ -27,7 +28,7 @@ export interface StaleOptions {
    * Github Runner selection labels
    * @default ["ubuntu-latest"]
    */
-  readonly runsOn?: string[];
+  readonly runsOn?: string[] | GroupRunnerOptions;
 }
 
 /**

--- a/src/github/task-workflow.ts
+++ b/src/github/task-workflow.ts
@@ -10,6 +10,7 @@ import {
   JobStepOutput,
   Triggers,
 } from "./workflows-model";
+import { GroupRunnerOptions } from "../build/build-workflow";
 import { Task } from "../task";
 
 const DEFAULT_JOB_ID = "build";
@@ -112,7 +113,7 @@ export interface TaskWorkflowOptions {
    * Github Runner selection labels
    * @default ["ubuntu-latest"]
    */
-  readonly runsOn?: string[];
+  readonly runsOn?: string[] | GroupRunnerOptions;
 
   /**
    * Whether to download files from Git LFS for this workflow

--- a/src/github/workflow-jobs.ts
+++ b/src/github/workflow-jobs.ts
@@ -6,6 +6,7 @@ import {
 } from ".";
 import { DEFAULT_GITHUB_ACTIONS_USER } from "./constants";
 import { Job, JobStep } from "./workflows-model";
+import { GroupRunnerOptions } from "../build/build-workflow";
 
 /**
  * A set of utility functions for creating jobs in GitHub Workflows.
@@ -74,5 +75,5 @@ export interface PullRequestFromPatchOptions extends CreatePullRequestOptions {
    * Github Runner selection labels
    * @default ["ubuntu-latest"]
    */
-  readonly runsOn?: string[];
+  readonly runsOn?: string[] | GroupRunnerOptions;
 }

--- a/src/github/workflows-model.ts
+++ b/src/github/workflows-model.ts
@@ -1,5 +1,7 @@
 // @see https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
 
+import { GroupRunnerOptions } from "../build";
+
 export interface CommonJobDefinition {
   /**
    * The name of the job displayed on GitHub.
@@ -90,7 +92,7 @@ export interface Job extends CommonJobDefinition {
    *
    * @example ["ubuntu-latest"]
    */
-  readonly runsOn: string[];
+  readonly runsOn: string[] | GroupRunnerOptions;
 
   /**
    * A job contains a sequence of tasks called steps. Steps can run commands,

--- a/src/github/workflows.ts
+++ b/src/github/workflows.ts
@@ -429,17 +429,6 @@ function verifyJobConstraints(
     }
   }
 
-  // TODO Rami-Husein
-  // verify that job has a "runsOn" statement to ensure a worker can be selected appropriately
-  // for (const [id, job] of Object.entries(jobs)) {
-  //   if (!("uses" in job)) {
-  //     if ("runsOn" in job && job.runsOn.length === 0) {
-  //       throw new Error(
-  //         `${id}: at least one runner selector labels must be provided in "runsOn" to ensure a runner instance can be selected`
-  //       );
-  //     }
-  //   }
-  // }
   // verify that job has a "runsOn" statement to ensure a worker can be selected appropriately
   for (const [id, job] of Object.entries(jobs)) {
     if (!("uses" in job)) {

--- a/src/javascript/upgrade-dependencies.ts
+++ b/src/javascript/upgrade-dependencies.ts
@@ -1,3 +1,4 @@
+import { GroupRunnerOptions } from "../build/build-workflow";
 import { Component } from "../component";
 import { DependencyType } from "../dependencies";
 import {
@@ -495,7 +496,7 @@ export interface UpgradeDependenciesWorkflowOptions {
    * Github Runner selection labels
    * @default ["ubuntu-latest"]
    */
-  readonly runsOn?: string[];
+  readonly runsOn?: string[] | GroupRunnerOptions;
 
   /**
    * Permissions granted to the upgrade job

--- a/src/release/publisher.ts
+++ b/src/release/publisher.ts
@@ -1,4 +1,5 @@
 import { BranchOptions } from "./release";
+import { GroupRunnerOptions } from "../build/build-workflow";
 import { Component } from "../component";
 import {
   BUILD_ARTIFACT_NAME,
@@ -103,7 +104,7 @@ export interface PublisherOptions {
    * Github Runner selection labels
    * @default ["ubuntu-latest"]
    */
-  readonly workflowRunsOn?: string[];
+  readonly workflowRunsOn?: string[] | GroupRunnerOptions;
 
   /**
    * Define publishing tasks that can be executed manually as well as workflows.
@@ -141,7 +142,7 @@ export class Publisher extends Component {
 
   private readonly failureIssue: boolean;
   private readonly failureIssueLabel: string;
-  private readonly runsOn: string[];
+  private readonly runsOn: string[] | GroupRunnerOptions;
   private readonly publishTasks: boolean;
 
   // functions that create jobs associated with a specific branch

--- a/src/release/release.ts
+++ b/src/release/release.ts
@@ -1,6 +1,7 @@
 import * as path from "path";
 import { Publisher } from "./publisher";
 import { ReleaseTrigger } from "./release-trigger";
+import { GroupRunnerOptions } from "../build/build-workflow";
 import { Component } from "../component";
 import { GitHub, GitHubProject, GithubWorkflow, TaskWorkflow } from "../github";
 import {
@@ -178,7 +179,7 @@ export interface ReleaseProjectOptions {
    * Github Runner selection labels
    * @default ["ubuntu-latest"]
    */
-  readonly workflowRunsOn?: string[];
+  readonly workflowRunsOn?: string[] | GroupRunnerOptions;
 
   /**
    * Define publishing tasks that can be executed manually as well as workflows.
@@ -297,7 +298,7 @@ export class Release extends Component {
   private readonly jobs: Record<string, Job> = {};
   private readonly defaultBranch: ReleaseBranch;
   private readonly github?: GitHub;
-  private readonly workflowRunsOn?: string[];
+  private readonly workflowRunsOn?: string[] | GroupRunnerOptions;
   private readonly workflowPermissions: JobPermissions;
 
   private readonly _branchHooks: BranchHook[];

--- a/test/__snapshots__/inventory.test.ts.snap
+++ b/test/__snapshots__/inventory.test.ts.snap
@@ -5371,14 +5371,23 @@ exports[`inventory 1`] = `
         "docs": "Github Runner selection labels.",
         "featured": false,
         "fullType": {
-          "collection": {
-            "elementtype": {
-              "primitive": "string",
-            },
-            "kind": "array",
+          "union": {
+            "types": [
+              {
+                "collection": {
+                  "elementtype": {
+                    "primitive": "string",
+                  },
+                  "kind": "array",
+                },
+              },
+              {
+                "fqn": "projen.build.GroupRunnerOptions",
+              },
+            ],
           },
         },
-        "jsonLike": true,
+        "jsonLike": false,
         "name": "workflowRunsOn",
         "optional": true,
         "parent": "ReleaseProjectOptions",
@@ -8424,14 +8433,23 @@ exports[`inventory 1`] = `
         "docs": "Github Runner selection labels.",
         "featured": false,
         "fullType": {
-          "collection": {
-            "elementtype": {
-              "primitive": "string",
-            },
-            "kind": "array",
+          "union": {
+            "types": [
+              {
+                "collection": {
+                  "elementtype": {
+                    "primitive": "string",
+                  },
+                  "kind": "array",
+                },
+              },
+              {
+                "fqn": "projen.build.GroupRunnerOptions",
+              },
+            ],
           },
         },
-        "jsonLike": true,
+        "jsonLike": false,
         "name": "workflowRunsOn",
         "optional": true,
         "parent": "ReleaseProjectOptions",
@@ -12439,14 +12457,23 @@ exports[`inventory 1`] = `
         "docs": "Github Runner selection labels.",
         "featured": false,
         "fullType": {
-          "collection": {
-            "elementtype": {
-              "primitive": "string",
-            },
-            "kind": "array",
+          "union": {
+            "types": [
+              {
+                "collection": {
+                  "elementtype": {
+                    "primitive": "string",
+                  },
+                  "kind": "array",
+                },
+              },
+              {
+                "fqn": "projen.build.GroupRunnerOptions",
+              },
+            ],
           },
         },
-        "jsonLike": true,
+        "jsonLike": false,
         "name": "workflowRunsOn",
         "optional": true,
         "parent": "ReleaseProjectOptions",
@@ -15359,14 +15386,23 @@ exports[`inventory 1`] = `
         "docs": "Github Runner selection labels.",
         "featured": false,
         "fullType": {
-          "collection": {
-            "elementtype": {
-              "primitive": "string",
-            },
-            "kind": "array",
+          "union": {
+            "types": [
+              {
+                "collection": {
+                  "elementtype": {
+                    "primitive": "string",
+                  },
+                  "kind": "array",
+                },
+              },
+              {
+                "fqn": "projen.build.GroupRunnerOptions",
+              },
+            ],
           },
         },
-        "jsonLike": true,
+        "jsonLike": false,
         "name": "workflowRunsOn",
         "optional": true,
         "parent": "ReleaseProjectOptions",
@@ -18211,14 +18247,23 @@ exports[`inventory 1`] = `
         "docs": "Github Runner selection labels.",
         "featured": false,
         "fullType": {
-          "collection": {
-            "elementtype": {
-              "primitive": "string",
-            },
-            "kind": "array",
+          "union": {
+            "types": [
+              {
+                "collection": {
+                  "elementtype": {
+                    "primitive": "string",
+                  },
+                  "kind": "array",
+                },
+              },
+              {
+                "fqn": "projen.build.GroupRunnerOptions",
+              },
+            ],
           },
         },
-        "jsonLike": true,
+        "jsonLike": false,
         "name": "workflowRunsOn",
         "optional": true,
         "parent": "ReleaseProjectOptions",
@@ -21847,14 +21892,23 @@ exports[`inventory 1`] = `
         "docs": "Github Runner selection labels.",
         "featured": false,
         "fullType": {
-          "collection": {
-            "elementtype": {
-              "primitive": "string",
-            },
-            "kind": "array",
+          "union": {
+            "types": [
+              {
+                "collection": {
+                  "elementtype": {
+                    "primitive": "string",
+                  },
+                  "kind": "array",
+                },
+              },
+              {
+                "fqn": "projen.build.GroupRunnerOptions",
+              },
+            ],
           },
         },
-        "jsonLike": true,
+        "jsonLike": false,
         "name": "workflowRunsOn",
         "optional": true,
         "parent": "ReleaseProjectOptions",
@@ -24131,14 +24185,23 @@ exports[`inventory 1`] = `
         "docs": "Github Runner selection labels.",
         "featured": false,
         "fullType": {
-          "collection": {
-            "elementtype": {
-              "primitive": "string",
-            },
-            "kind": "array",
+          "union": {
+            "types": [
+              {
+                "collection": {
+                  "elementtype": {
+                    "primitive": "string",
+                  },
+                  "kind": "array",
+                },
+              },
+              {
+                "fqn": "projen.build.GroupRunnerOptions",
+              },
+            ],
           },
         },
-        "jsonLike": true,
+        "jsonLike": false,
         "name": "workflowRunsOn",
         "optional": true,
         "parent": "ReleaseProjectOptions",
@@ -26678,14 +26741,23 @@ exports[`inventory 1`] = `
         "docs": "Github Runner selection labels.",
         "featured": false,
         "fullType": {
-          "collection": {
-            "elementtype": {
-              "primitive": "string",
-            },
-            "kind": "array",
+          "union": {
+            "types": [
+              {
+                "collection": {
+                  "elementtype": {
+                    "primitive": "string",
+                  },
+                  "kind": "array",
+                },
+              },
+              {
+                "fqn": "projen.build.GroupRunnerOptions",
+              },
+            ],
           },
         },
-        "jsonLike": true,
+        "jsonLike": false,
         "name": "workflowRunsOn",
         "optional": true,
         "parent": "ReleaseProjectOptions",
@@ -28894,14 +28966,23 @@ exports[`inventory 1`] = `
         "docs": "Github Runner selection labels.",
         "featured": false,
         "fullType": {
-          "collection": {
-            "elementtype": {
-              "primitive": "string",
-            },
-            "kind": "array",
+          "union": {
+            "types": [
+              {
+                "collection": {
+                  "elementtype": {
+                    "primitive": "string",
+                  },
+                  "kind": "array",
+                },
+              },
+              {
+                "fqn": "projen.build.GroupRunnerOptions",
+              },
+            ],
           },
         },
-        "jsonLike": true,
+        "jsonLike": false,
         "name": "workflowRunsOn",
         "optional": true,
         "parent": "ReleaseProjectOptions",
@@ -32422,14 +32503,23 @@ exports[`inventory 1`] = `
         "docs": "Github Runner selection labels.",
         "featured": false,
         "fullType": {
-          "collection": {
-            "elementtype": {
-              "primitive": "string",
-            },
-            "kind": "array",
+          "union": {
+            "types": [
+              {
+                "collection": {
+                  "elementtype": {
+                    "primitive": "string",
+                  },
+                  "kind": "array",
+                },
+              },
+              {
+                "fqn": "projen.build.GroupRunnerOptions",
+              },
+            ],
           },
         },
-        "jsonLike": true,
+        "jsonLike": false,
         "name": "workflowRunsOn",
         "optional": true,
         "parent": "ReleaseProjectOptions",
@@ -34957,14 +35047,23 @@ exports[`inventory 1`] = `
         "docs": "Github Runner selection labels.",
         "featured": false,
         "fullType": {
-          "collection": {
-            "elementtype": {
-              "primitive": "string",
-            },
-            "kind": "array",
+          "union": {
+            "types": [
+              {
+                "collection": {
+                  "elementtype": {
+                    "primitive": "string",
+                  },
+                  "kind": "array",
+                },
+              },
+              {
+                "fqn": "projen.build.GroupRunnerOptions",
+              },
+            ],
           },
         },
-        "jsonLike": true,
+        "jsonLike": false,
         "name": "workflowRunsOn",
         "optional": true,
         "parent": "ReleaseProjectOptions",
@@ -37470,14 +37569,23 @@ exports[`inventory 1`] = `
         "docs": "Github Runner selection labels.",
         "featured": false,
         "fullType": {
-          "collection": {
-            "elementtype": {
-              "primitive": "string",
-            },
-            "kind": "array",
+          "union": {
+            "types": [
+              {
+                "collection": {
+                  "elementtype": {
+                    "primitive": "string",
+                  },
+                  "kind": "array",
+                },
+              },
+              {
+                "fqn": "projen.build.GroupRunnerOptions",
+              },
+            ],
           },
         },
-        "jsonLike": true,
+        "jsonLike": false,
         "name": "workflowRunsOn",
         "optional": true,
         "parent": "ReleaseProjectOptions",
@@ -39983,14 +40091,23 @@ exports[`inventory 1`] = `
         "docs": "Github Runner selection labels.",
         "featured": false,
         "fullType": {
-          "collection": {
-            "elementtype": {
-              "primitive": "string",
-            },
-            "kind": "array",
+          "union": {
+            "types": [
+              {
+                "collection": {
+                  "elementtype": {
+                    "primitive": "string",
+                  },
+                  "kind": "array",
+                },
+              },
+              {
+                "fqn": "projen.build.GroupRunnerOptions",
+              },
+            ],
           },
         },
-        "jsonLike": true,
+        "jsonLike": false,
         "name": "workflowRunsOn",
         "optional": true,
         "parent": "ReleaseProjectOptions",

--- a/test/cdk/jsii.test.ts
+++ b/test/cdk/jsii.test.ts
@@ -574,7 +574,7 @@ describe("workflows use global workflowRunsOn option", () => {
 
   const EXPECTED_RUNS_ON = ["self-hosted", "linux", "x64"];
 
-  expect(build).toHaveProperty("jobs.build.runs-on", EXPECTED_RUNS_ON);
+  // expect(build).toHaveProperty("jobs.build.runs-on", EXPECTED_RUNS_ON);
   expect(build).toHaveProperty("jobs.self-mutation.runs-on", EXPECTED_RUNS_ON);
 
   test.each(["js", "java", "python", "dotnet", "go"])(

--- a/test/cdk/jsii.test.ts
+++ b/test/cdk/jsii.test.ts
@@ -574,8 +574,112 @@ describe("workflows use global workflowRunsOn option", () => {
 
   const EXPECTED_RUNS_ON = ["self-hosted", "linux", "x64"];
 
-  // expect(build).toHaveProperty("jobs.build.runs-on", EXPECTED_RUNS_ON);
+  expect(build).toHaveProperty("jobs.build.runs-on", EXPECTED_RUNS_ON);
   expect(build).toHaveProperty("jobs.self-mutation.runs-on", EXPECTED_RUNS_ON);
+
+  test.each(["js", "java", "python", "dotnet", "go"])(
+    "snapshot %s",
+    (language) => {
+      expect(build).toHaveProperty(
+        `jobs.package-${language}.runs-on`,
+        EXPECTED_RUNS_ON
+      );
+    }
+  );
+
+  test.each(["pypi", "nuget", "npm", "maven", "golang"])(
+    "release workflow includes release_%s job",
+    (language) => {
+      expect(release).toHaveProperty(
+        `jobs.release_${language}.runs-on`,
+        EXPECTED_RUNS_ON
+      );
+    }
+  );
+});
+
+describe("workflows use global workflowRunsOn option - runner group extended", () => {
+  const project = new JsiiProject({
+    author: "My name",
+    name: "testproject",
+    authorAddress: "https://foo.bar",
+    defaultReleaseBranch: "main",
+    repositoryUrl: "https://github.com/foo/bar.git",
+    publishToGo: { moduleName: "github.com/foo/bar" },
+    publishToMaven: {
+      javaPackage: "io.github.cdklabs.watchful",
+      mavenGroupId: "io.github.cdklabs",
+      mavenArtifactId: "cdk-watchful",
+    },
+    publishToNuget: {
+      dotNetNamespace: "DotNet.Namespace",
+      packageId: "PackageId",
+    },
+    publishToPypi: { distName: "dist-name", module: "module-name" },
+    workflowRunsOn: {
+      group: "Default",
+      labels: ["self-hosted", "linux", "x64"],
+    },
+    depsUpgradeOptions: {
+      workflowOptions: {
+        runsOn: {
+          group: "Default",
+          labels: ["self-hosted", "linux", "x64"],
+        },
+      },
+    },
+    githubOptions: {
+      pullRequestLintOptions: {
+        runsOn: {
+          group: "Default",
+          labels: ["self-hosted", "linux", "x64"],
+        },
+      },
+    },
+  });
+
+  const output = synthSnapshot(project);
+  const build = yaml.parse(output[".github/workflows/build.yml"]);
+  const release = yaml.parse(output[".github/workflows/release.yml"]);
+  const upgrade = yaml.parse(output[".github/workflows/upgrade-main.yml"]);
+  const prLint = yaml.parse(output[".github/workflows/pull-request-lint.yml"]);
+
+  const EXPECTED_RUNS_ON = JSON.parse(
+    '{"group":"Default","labels":["self-hosted", "linux", "x64"]}'
+  );
+
+  expect(build).toHaveProperty("jobs.build.runs-on.group", "Default");
+  expect(build).toHaveProperty("jobs.build.runs-on.labels", [
+    "self-hosted",
+    "linux",
+    "x64",
+  ]);
+  expect(build).toHaveProperty("jobs.self-mutation.runs-on.group", "Default");
+  expect(build).toHaveProperty("jobs.self-mutation.runs-on.labels", [
+    "self-hosted",
+    "linux",
+    "x64",
+  ]);
+
+  expect(upgrade).toHaveProperty("jobs.upgrade.runs-on.group", "Default");
+  expect(upgrade).toHaveProperty("jobs.upgrade.runs-on.labels", [
+    "self-hosted",
+    "linux",
+    "x64",
+  ]);
+  expect(upgrade).toHaveProperty("jobs.pr.runs-on.group", "Default");
+  expect(upgrade).toHaveProperty("jobs.pr.runs-on.labels", [
+    "self-hosted",
+    "linux",
+    "x64",
+  ]);
+
+  expect(prLint).toHaveProperty("jobs.validate.runs-on.group", "Default");
+  expect(prLint).toHaveProperty("jobs.validate.runs-on.labels", [
+    "self-hosted",
+    "linux",
+    "x64",
+  ]);
 
   test.each(["js", "java", "python", "dotnet", "go"])(
     "snapshot %s",

--- a/test/github/auto-approve.test.ts
+++ b/test/github/auto-approve.test.ts
@@ -64,7 +64,7 @@ describe("auto-approve", () => {
       secret: "MY_SECRET",
       runsOn: {
         group: "Default",
-        labels: ["self-hosted", "x86", "linux"],
+        labels: ["self-hosted", "x64", "linux"],
       },
     });
 
@@ -72,7 +72,7 @@ describe("auto-approve", () => {
 
     expect(
       JSON.stringify(YAML.parse(snapshot[".github/workflows/auto-approve.yml"]))
-    ).toContain('{"group":"Default","labels":["self-hosted","x86","linux"]}');
+    ).toContain('{"group":"Default","labels":["self-hosted","x64","linux"]}');
   });
 });
 

--- a/test/github/auto-approve.test.ts
+++ b/test/github/auto-approve.test.ts
@@ -69,10 +69,14 @@ describe("auto-approve", () => {
     });
 
     const snapshot = synthSnapshot(project);
+    const build = YAML.parse(snapshot[".github/workflows/auto-approve.yml"]);
 
-    expect(
-      JSON.stringify(YAML.parse(snapshot[".github/workflows/auto-approve.yml"]))
-    ).toContain('{"group":"Default","labels":["self-hosted","x64","linux"]}');
+    expect(build).toHaveProperty("jobs.approve.runs-on.group", "Default");
+    expect(build).toHaveProperty("jobs.approve.runs-on.labels", [
+      "self-hosted",
+      "x64",
+      "linux",
+    ]);
   });
 });
 

--- a/test/github/auto-approve.test.ts
+++ b/test/github/auto-approve.test.ts
@@ -1,3 +1,4 @@
+import * as YAML from "yaml";
 import { AutoApprove } from "../../src/github/auto-approve";
 import { NodeProject, NodeProjectOptions } from "../../src/javascript";
 import { synthSnapshot } from "../util";
@@ -54,6 +55,24 @@ describe("auto-approve", () => {
     expect(snapshot[".github/workflows/auto-approve.yml"]).toContain(
       "runs-on: self-hosted"
     );
+  });
+
+  test("with custom runner group", () => {
+    const project = createProject();
+
+    new AutoApprove(project.github!, {
+      secret: "MY_SECRET",
+      runsOn: {
+        group: "Default",
+        labels: ["self-hosted", "x86", "linux"],
+      },
+    });
+
+    const snapshot = synthSnapshot(project);
+
+    expect(
+      JSON.stringify(YAML.parse(snapshot[".github/workflows/auto-approve.yml"]))
+    ).toContain('{"group":"Default","labels":["self-hosted","x86","linux"]}');
   });
 });
 

--- a/test/github/pull-request-lint.test.ts
+++ b/test/github/pull-request-lint.test.ts
@@ -71,6 +71,41 @@ test("with custom runner", () => {
   );
 });
 
+test("with runner group", () => {
+  // GIVEN
+  const project = createProject();
+
+  // WHEN
+  new PullRequestLint(project.github!, {
+    runsOn: {
+      group: "Default",
+      labels: ["self-hosted", "x86", "linux"],
+    },
+  });
+
+  // THEN
+  const snapshot = synthSnapshot(project);
+  expect(snapshot[".github/workflows/pull-request-lint.yml"]).toContain(
+    "group: Default"
+  );
+});
+
+test("with runner group and labels", () => {
+  // GIVEN
+  const project = createProject();
+
+  // WHEN
+  new PullRequestLint(project.github!, {
+    runsOn: { group: "Default", labels: ["x86", "linux"] },
+  });
+
+  // THEN
+  const snapshot = synthSnapshot(project);
+  expect(snapshot[".github/workflows/pull-request-lint.yml"]).toContain(
+    "group: Default"
+  );
+});
+
 test("with github base url", () => {
   // GIVEN
   const project = createProject();

--- a/test/github/pull-request-lint.test.ts
+++ b/test/github/pull-request-lint.test.ts
@@ -86,12 +86,14 @@ test("with custom runner group", () => {
 
   // THEN
   const snapshot = synthSnapshot(project);
+  const build = yaml.parse(snapshot[".github/workflows/pull-request-lint.yml"]);
 
-  expect(
-    JSON.stringify(
-      yaml.parse(snapshot[".github/workflows/pull-request-lint.yml"])
-    )
-  ).toContain('{"group":"Default","labels":["self-hosted","x64","linux"]}');
+  expect(build).toHaveProperty("jobs.validate.runs-on.group", "Default");
+  expect(build).toHaveProperty("jobs.validate.runs-on.labels", [
+    "self-hosted",
+    "x64",
+    "linux",
+  ]);
 });
 
 test("with github base url", () => {

--- a/test/github/pull-request-lint.test.ts
+++ b/test/github/pull-request-lint.test.ts
@@ -80,7 +80,7 @@ test("with custom runner group", () => {
   new PullRequestLint(project.github!, {
     runsOn: {
       group: "Default",
-      labels: ["self-hosted", "x86", "linux"],
+      labels: ["self-hosted", "x64", "linux"],
     },
   });
 
@@ -91,7 +91,7 @@ test("with custom runner group", () => {
     JSON.stringify(
       yaml.parse(snapshot[".github/workflows/pull-request-lint.yml"])
     )
-  ).toContain('{"group":"Default","labels":["self-hosted","x86","linux"]}');
+  ).toContain('{"group":"Default","labels":["self-hosted","x64","linux"]}');
 });
 
 test("with github base url", () => {

--- a/test/github/pull-request-lint.test.ts
+++ b/test/github/pull-request-lint.test.ts
@@ -1,3 +1,4 @@
+import * as yaml from "yaml";
 import { PullRequestLint } from "../../src/github/pull-request-lint";
 import { NodeProject, NodeProjectOptions } from "../../src/javascript";
 import { synthSnapshot } from "../util";
@@ -71,7 +72,7 @@ test("with custom runner", () => {
   );
 });
 
-test("with runner group", () => {
+test("with custom runner group", () => {
   // GIVEN
   const project = createProject();
 
@@ -85,25 +86,12 @@ test("with runner group", () => {
 
   // THEN
   const snapshot = synthSnapshot(project);
-  expect(snapshot[".github/workflows/pull-request-lint.yml"]).toContain(
-    "group: Default"
-  );
-});
 
-test("with runner group and labels", () => {
-  // GIVEN
-  const project = createProject();
-
-  // WHEN
-  new PullRequestLint(project.github!, {
-    runsOn: { group: "Default", labels: ["x86", "linux"] },
-  });
-
-  // THEN
-  const snapshot = synthSnapshot(project);
-  expect(snapshot[".github/workflows/pull-request-lint.yml"]).toContain(
-    "group: Default"
-  );
+  expect(
+    JSON.stringify(
+      yaml.parse(snapshot[".github/workflows/pull-request-lint.yml"])
+    )
+  ).toContain('{"group":"Default","labels":["self-hosted","x86","linux"]}');
 });
 
 test("with github base url", () => {

--- a/test/github/stale.test.ts
+++ b/test/github/stale.test.ts
@@ -51,6 +51,24 @@ test("with custom runner", () => {
   );
 });
 
+test("with custom runner group", () => {
+  const project = new TestProject({
+    stale: true,
+    staleOptions: {
+      runsOn: {
+        group: "Default",
+        labels: ["self-hosted", "x86", "linux"],
+      },
+    },
+  });
+
+  const snapshot = synthSnapshot(project);
+
+  expect(
+    JSON.stringify(YAML.parse(snapshot[".github/workflows/stale.yml"]))
+  ).toContain('{"group":"Default","labels":["self-hosted","x86","linux"]}');
+});
+
 describe("renderBehavior()", () => {
   test("defaults", () => {
     expect(

--- a/test/github/stale.test.ts
+++ b/test/github/stale.test.ts
@@ -57,7 +57,7 @@ test("with custom runner group", () => {
     staleOptions: {
       runsOn: {
         group: "Default",
-        labels: ["self-hosted", "x86", "linux"],
+        labels: ["self-hosted", "x64", "linux"],
       },
     },
   });
@@ -66,7 +66,7 @@ test("with custom runner group", () => {
 
   expect(
     JSON.stringify(YAML.parse(snapshot[".github/workflows/stale.yml"]))
-  ).toContain('{"group":"Default","labels":["self-hosted","x86","linux"]}');
+  ).toContain('{"group":"Default","labels":["self-hosted","x64","linux"]}');
 });
 
 describe("renderBehavior()", () => {

--- a/test/github/stale.test.ts
+++ b/test/github/stale.test.ts
@@ -63,10 +63,14 @@ test("with custom runner group", () => {
   });
 
   const snapshot = synthSnapshot(project);
+  const build = YAML.parse(snapshot[".github/workflows/stale.yml"]);
 
-  expect(
-    JSON.stringify(YAML.parse(snapshot[".github/workflows/stale.yml"]))
-  ).toContain('{"group":"Default","labels":["self-hosted","x64","linux"]}');
+  expect(build).toHaveProperty("jobs.stale.runs-on.group", "Default");
+  expect(build).toHaveProperty("jobs.stale.runs-on.labels", [
+    "self-hosted",
+    "x64",
+    "linux",
+  ]);
 });
 
 describe("renderBehavior()", () => {

--- a/test/github/task-workflow.test.ts
+++ b/test/github/task-workflow.test.ts
@@ -1,3 +1,4 @@
+import * as yaml from "yaml";
 import { TaskWorkflow } from "../../src/github/task-workflow";
 import { Task } from "../../src/task";
 import { synthSnapshot, TestProject } from "../util";
@@ -66,6 +67,28 @@ describe("task-workflow", () => {
     expect(snapshot[".github/workflows/task-workflow.yml"]).toContain(
       "runs-on: self-hosted"
     );
+  });
+
+  test("with custom runner group", () => {
+    const project = new TestProject();
+
+    new TaskWorkflow(project.github!, {
+      name: "task-workflow",
+      task,
+      permissions: {},
+      runsOn: {
+        group: "Default",
+        labels: ["self-hosted", "x86", "linux"],
+      },
+    });
+
+    const snapshot = synthSnapshot(project);
+
+    expect(
+      JSON.stringify(
+        yaml.parse(snapshot[".github/workflows/task-workflow.yml"])
+      )
+    ).toContain('{"group":"Default","labels":["self-hosted","x86","linux"]}');
   });
 
   test("enabling LFS on a GitHub repo adds the lfs property to workflows", () => {

--- a/test/github/task-workflow.test.ts
+++ b/test/github/task-workflow.test.ts
@@ -78,7 +78,7 @@ describe("task-workflow", () => {
       permissions: {},
       runsOn: {
         group: "Default",
-        labels: ["self-hosted", "x86", "linux"],
+        labels: ["self-hosted", "x64", "linux"],
       },
     });
 
@@ -88,7 +88,7 @@ describe("task-workflow", () => {
       JSON.stringify(
         yaml.parse(snapshot[".github/workflows/task-workflow.yml"])
       )
-    ).toContain('{"group":"Default","labels":["self-hosted","x86","linux"]}');
+    ).toContain('{"group":"Default","labels":["self-hosted","x64","linux"]}');
   });
 
   test("enabling LFS on a GitHub repo adds the lfs property to workflows", () => {

--- a/test/github/task-workflow.test.ts
+++ b/test/github/task-workflow.test.ts
@@ -83,12 +83,14 @@ describe("task-workflow", () => {
     });
 
     const snapshot = synthSnapshot(project);
+    const build = yaml.parse(snapshot[".github/workflows/task-workflow.yml"]);
 
-    expect(
-      JSON.stringify(
-        yaml.parse(snapshot[".github/workflows/task-workflow.yml"])
-      )
-    ).toContain('{"group":"Default","labels":["self-hosted","x64","linux"]}');
+    expect(build).toHaveProperty("jobs.build.runs-on.group", "Default");
+    expect(build).toHaveProperty("jobs.build.runs-on.labels", [
+      "self-hosted",
+      "x64",
+      "linux",
+    ]);
   });
 
   test("enabling LFS on a GitHub repo adds the lfs property to workflows", () => {

--- a/test/javascript/node-project.test.ts
+++ b/test/javascript/node-project.test.ts
@@ -1096,7 +1096,14 @@ describe("workflowRunsOn", () => {
     // THEN
     const output = synthSnapshot(project);
     const buildWorkflow = yaml.parse(output[".github/workflows/build.yml"]);
-    expect(buildWorkflow.jobs.build["runs-on"]).toEqual("ubuntu-latest");
+    const runsOn = buildWorkflow.jobs.build["runs-on"];
+
+    if (typeof runsOn === "string") {
+      expect(runsOn).toEqual("ubuntu-latest");
+    } else {
+      expect(runsOn).toMatchObject({ group: "Default" });
+    }
+
     expect(buildWorkflow.jobs["self-mutation"]["runs-on"]).toEqual(
       "ubuntu-latest"
     );
@@ -1111,7 +1118,14 @@ describe("workflowRunsOn", () => {
     // THEN
     const output = synthSnapshot(project);
     const buildWorkflow = yaml.parse(output[".github/workflows/build.yml"]);
-    expect(buildWorkflow.jobs.build["runs-on"]).toEqual("self-hosted");
+    const runsOn = buildWorkflow.jobs.build["runs-on"];
+
+    if (typeof runsOn === "string") {
+      expect(runsOn).toEqual("self-hosted");
+    } else {
+      expect(runsOn).toMatchObject({ group: "Default" });
+    }
+
     expect(buildWorkflow.jobs["self-mutation"]["runs-on"]).toEqual(
       "self-hosted"
     );

--- a/test/javascript/node-project.test.ts
+++ b/test/javascript/node-project.test.ts
@@ -1129,38 +1129,26 @@ describe("workflowRunsOn", () => {
     const project = new TestNodeProject({
       workflowRunsOn: {
         group: "Default",
-        labels: ["self-hosted", "x86", "linux"],
+        labels: ["self-hosted", "linux", "x64"],
       },
     });
 
     // THEN
     const output = synthSnapshot(project);
-    const buildWorkflow = yaml.parse(output[".github/workflows/build.yml"]);
-    expect(JSON.stringify(buildWorkflow.jobs.build["runs-on"])).toContain(
-      "group"
-    );
-    expect(JSON.stringify(buildWorkflow.jobs.build["runs-on"])).toContain(
-      "labels"
-    );
-    expect(JSON.stringify(buildWorkflow.jobs.build["runs-on"].group)).toContain(
-      "Default"
-    );
-    expect(
-      JSON.stringify(buildWorkflow.jobs.build["runs-on"].labels)
-    ).toContain("self-hosted");
+    const build = yaml.parse(output[".github/workflows/build.yml"]);
 
-    expect(
-      JSON.stringify(buildWorkflow.jobs["self-mutation"]["runs-on"])
-    ).toContain("group");
-    expect(
-      JSON.stringify(buildWorkflow.jobs["self-mutation"]["runs-on"])
-    ).toContain("labels");
-    expect(
-      JSON.stringify(buildWorkflow.jobs["self-mutation"]["runs-on"].group)
-    ).toContain("Default");
-    expect(
-      JSON.stringify(buildWorkflow.jobs["self-mutation"]["runs-on"].labels)
-    ).toContain("self-hosted");
+    expect(build).toHaveProperty("jobs.build.runs-on.group", "Default");
+    expect(build).toHaveProperty("jobs.build.runs-on.labels", [
+      "self-hosted",
+      "linux",
+      "x64",
+    ]);
+    expect(build).toHaveProperty("jobs.self-mutation.runs-on.group", "Default");
+    expect(build).toHaveProperty("jobs.self-mutation.runs-on.labels", [
+      "self-hosted",
+      "linux",
+      "x64",
+    ]);
   });
 });
 

--- a/test/javascript/node-project.test.ts
+++ b/test/javascript/node-project.test.ts
@@ -1096,14 +1096,7 @@ describe("workflowRunsOn", () => {
     // THEN
     const output = synthSnapshot(project);
     const buildWorkflow = yaml.parse(output[".github/workflows/build.yml"]);
-    const runsOn = buildWorkflow.jobs.build["runs-on"];
-
-    if (typeof runsOn === "string") {
-      expect(runsOn).toEqual("ubuntu-latest");
-    } else {
-      expect(runsOn).toMatchObject({ group: "Default" });
-    }
-
+    expect(buildWorkflow.jobs.build["runs-on"]).toEqual("ubuntu-latest");
     expect(buildWorkflow.jobs["self-mutation"]["runs-on"]).toEqual(
       "ubuntu-latest"
     );

--- a/test/javascript/node-project.test.ts
+++ b/test/javascript/node-project.test.ts
@@ -1118,17 +1118,49 @@ describe("workflowRunsOn", () => {
     // THEN
     const output = synthSnapshot(project);
     const buildWorkflow = yaml.parse(output[".github/workflows/build.yml"]);
-    const runsOn = buildWorkflow.jobs.build["runs-on"];
-
-    if (typeof runsOn === "string") {
-      expect(runsOn).toEqual("self-hosted");
-    } else {
-      expect(runsOn).toMatchObject({ group: "Default" });
-    }
-
+    expect(buildWorkflow.jobs.build["runs-on"]).toEqual("self-hosted");
     expect(buildWorkflow.jobs["self-mutation"]["runs-on"]).toEqual(
       "self-hosted"
     );
+  });
+
+  test("use github runner group specified in workflowRunsOn", () => {
+    // WHEN
+    const project = new TestNodeProject({
+      workflowRunsOn: {
+        group: "Default",
+        labels: ["self-hosted", "x86", "linux"],
+      },
+    });
+
+    // THEN
+    const output = synthSnapshot(project);
+    const buildWorkflow = yaml.parse(output[".github/workflows/build.yml"]);
+    expect(JSON.stringify(buildWorkflow.jobs.build["runs-on"])).toContain(
+      "group"
+    );
+    expect(JSON.stringify(buildWorkflow.jobs.build["runs-on"])).toContain(
+      "labels"
+    );
+    expect(JSON.stringify(buildWorkflow.jobs.build["runs-on"].group)).toContain(
+      "Default"
+    );
+    expect(
+      JSON.stringify(buildWorkflow.jobs.build["runs-on"].labels)
+    ).toContain("self-hosted");
+
+    expect(
+      JSON.stringify(buildWorkflow.jobs["self-mutation"]["runs-on"])
+    ).toContain("group");
+    expect(
+      JSON.stringify(buildWorkflow.jobs["self-mutation"]["runs-on"])
+    ).toContain("labels");
+    expect(
+      JSON.stringify(buildWorkflow.jobs["self-mutation"]["runs-on"].group)
+    ).toContain("Default");
+    expect(
+      JSON.stringify(buildWorkflow.jobs["self-mutation"]["runs-on"].labels)
+    ).toContain("self-hosted");
   });
 });
 

--- a/test/javascript/upgrade-dependencies.test.ts
+++ b/test/javascript/upgrade-dependencies.test.ts
@@ -1,4 +1,4 @@
-import * as yaml from "yaml";
+import * as YAML from "yaml";
 import { DependencyType } from "../../src";
 import { GithubCredentials, workflows } from "../../src/github";
 import {
@@ -111,7 +111,7 @@ test("upgrade workflow can be overwritten", () => {
     ?.addOverride("hello", "world");
 
   const snapshot = synthSnapshot(project);
-  const upgrade = yaml.parse(snapshot[".github/workflows/upgrade-main.yml"]);
+  const upgrade = YAML.parse(snapshot[".github/workflows/upgrade-main.yml"]);
   expect(upgrade.hello).toStrictEqual("world");
 });
 
@@ -256,7 +256,7 @@ test("git identity can be customized", () => {
   });
 
   const snapshot = synthSnapshot(project);
-  const upgrade = yaml.parse(snapshot[".github/workflows/upgrade-main.yml"]);
+  const upgrade = YAML.parse(snapshot[".github/workflows/upgrade-main.yml"]);
   expect(upgrade.jobs.pr.steps[3]).toEqual({
     name: "Set git identity",
     run: [
@@ -276,7 +276,7 @@ test("github runner can be customized", () => {
   });
 
   const snapshot = synthSnapshot(project);
-  const upgrade = yaml.parse(snapshot[".github/workflows/upgrade-main.yml"]);
+  const upgrade = YAML.parse(snapshot[".github/workflows/upgrade-main.yml"]);
   expect(upgrade.jobs.upgrade["runs-on"]).toEqual("self-hosted");
   expect(upgrade.jobs.pr["runs-on"]).toEqual("self-hosted");
 });
@@ -292,7 +292,7 @@ test("labels and assignees can be customized", () => {
   });
 
   const snapshot = synthSnapshot(project);
-  const upgrade = yaml.parse(snapshot[".github/workflows/upgrade-main.yml"]);
+  const upgrade = YAML.parse(snapshot[".github/workflows/upgrade-main.yml"]);
   expect(upgrade.jobs.pr.steps[4].with.labels).toEqual("deps-upgrade-label");
   expect(upgrade.jobs.pr.steps[4].with.assignees).toEqual("repo-maintainer");
 });

--- a/test/javascript/upgrade-dependencies.test.ts
+++ b/test/javascript/upgrade-dependencies.test.ts
@@ -1,4 +1,4 @@
-import * as YAML from "yaml";
+import * as yaml from "yaml";
 import { DependencyType } from "../../src";
 import { GithubCredentials, workflows } from "../../src/github";
 import {
@@ -111,7 +111,7 @@ test("upgrade workflow can be overwritten", () => {
     ?.addOverride("hello", "world");
 
   const snapshot = synthSnapshot(project);
-  const upgrade = YAML.parse(snapshot[".github/workflows/upgrade-main.yml"]);
+  const upgrade = yaml.parse(snapshot[".github/workflows/upgrade-main.yml"]);
   expect(upgrade.hello).toStrictEqual("world");
 });
 
@@ -256,7 +256,7 @@ test("git identity can be customized", () => {
   });
 
   const snapshot = synthSnapshot(project);
-  const upgrade = YAML.parse(snapshot[".github/workflows/upgrade-main.yml"]);
+  const upgrade = yaml.parse(snapshot[".github/workflows/upgrade-main.yml"]);
   expect(upgrade.jobs.pr.steps[3]).toEqual({
     name: "Set git identity",
     run: [
@@ -276,7 +276,7 @@ test("github runner can be customized", () => {
   });
 
   const snapshot = synthSnapshot(project);
-  const upgrade = YAML.parse(snapshot[".github/workflows/upgrade-main.yml"]);
+  const upgrade = yaml.parse(snapshot[".github/workflows/upgrade-main.yml"]);
   expect(upgrade.jobs.upgrade["runs-on"]).toEqual("self-hosted");
   expect(upgrade.jobs.pr["runs-on"]).toEqual("self-hosted");
 });
@@ -292,7 +292,7 @@ test("labels and assignees can be customized", () => {
   });
 
   const snapshot = synthSnapshot(project);
-  const upgrade = YAML.parse(snapshot[".github/workflows/upgrade-main.yml"]);
+  const upgrade = yaml.parse(snapshot[".github/workflows/upgrade-main.yml"]);
   expect(upgrade.jobs.pr.steps[4].with.labels).toEqual("deps-upgrade-label");
   expect(upgrade.jobs.pr.steps[4].with.assignees).toEqual("repo-maintainer");
 });


### PR DESCRIPTION
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes #2814  

**[GitHub Actions: Restrict workflows to specific runners using runner group names](https://github.blog/changelog/2022-11-01-github-actions-restrict-workflows-to-specific-runners-using-runner-group-names/)**

`.projenrc.ts` properties:
- `workflowRunsOn`, 
- `githubOptions.pullRequestLintOptions.runsOn`
- `depsUpgradeOptions.workflowOptions.runsOn`
- `autoApproveOptions.runsOn`
- `staleOptions.runsOns`

...now all support specifying Runner Groups, by name.    

```
  workflowRunsOn: {
    group: "Default",
    labels: ["self-hosted", "Linux", "x64"],
  }
  ```
  
  The original support for specifying Labels in an array is still supported:
```
workflowRunsOn: ['ubuntu-latest', 'x86']
```