### PR TITLE
fix(upgrade-dependencies): upgrade command doesn't consider requested types

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -9050,14 +9050,15 @@ removeScript(name: string): void
 
 
 
-#### renderUpgradePackagesCommand(exclude, include?)🔹 <a id="projen-javascript-nodepackage-renderupgradepackagescommand"></a>
+#### renderUpgradePackagesCommand(types, exclude, include?)🔹 <a id="projen-javascript-nodepackage-renderupgradepackagescommand"></a>
 
 Render a package manager specific command to upgrade all requested dependencies.
 
 ```ts
-renderUpgradePackagesCommand(exclude: Array<string>, include?: Array<string>): string
+renderUpgradePackagesCommand(types: Array<DependencyType>, exclude: Array<string>, include?: Array<string>): string
 ```
 
+* **types** (<code>Array<[DependencyType](#projen-dependencytype)></code>)  *No description*
 * **exclude** (<code>Array<string></code>)  *No description*
 * **include** (<code>Array<string></code>)  *No description*
 

--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -816,9 +816,8 @@ export class NodePackage extends Component {
     function upgradePackages(command: string) {
       return () => {
         return `${command} ${project.deps.all
-          .filter(
-            (d) => d.type !== DependencyType.OVERRIDE && types.includes(d.type)
-          )
+          .filter((d) => d.type !== DependencyType.OVERRIDE)
+          .filter((d) => types.includes(d.type))
           .map((d) => d.name)
           .filter((d) => (include ? include.includes(d) : true))
           .filter((d) => !exclude.includes(d))

--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -808,21 +808,17 @@ export class NodePackage extends Component {
    * Render a package manager specific command to upgrade all requested dependencies.
    */
   public renderUpgradePackagesCommand(
+    types: DependencyType[],
     exclude: string[],
     include?: string[]
   ): string {
     const project = this.project;
     function upgradePackages(command: string) {
       return () => {
-        if (exclude.length === 0 && !include) {
-          // request to upgrade all packages
-          // separated for asthetic reasons.
-          return command;
-        }
-
-        // filter by exclude and include.
         return `${command} ${project.deps.all
-          .filter((d) => d.type !== DependencyType.OVERRIDE)
+          .filter(
+            (d) => d.type !== DependencyType.OVERRIDE && types.includes(d.type)
+          )
           .map((d) => d.name)
           .filter((d) => (include ? include.includes(d) : true))
           .filter((d) => !exclude.includes(d))

--- a/src/javascript/upgrade-dependencies.ts
+++ b/src/javascript/upgrade-dependencies.ts
@@ -298,14 +298,22 @@ export class UpgradeDependencies extends Component {
       steps.push({ exec: ncuCommand.join(" ") });
     }
 
+    const devDepsTypes = [
+      DependencyType.BUILD,
+      DependencyType.DEVENV,
+      DependencyType.TEST,
+    ];
+
     // peerDependencies are actually installed via devDependencies
-    const devDependenciesToUpgrade = !this.depTypes.includes(
-      DependencyType.PEER
-    )
-      ? []
-      : this.project.deps.all
-          .filter((d) => d.type === DependencyType.PEER)
-          .map((d) => d.name);
+    // so if we weren't requested to upgrade dev dependencies, we need to do it
+    // anyway for peers.
+    const devDependenciesToUpgrade =
+      this.depTypes.includes(DependencyType.PEER) &&
+      !this.depTypes.some((d) => devDepsTypes.includes(d))
+        ? this.project.deps.all
+            .filter((d) => d.type === DependencyType.PEER)
+            .map((d) => d.name)
+        : [];
     if (devDependenciesToUpgrade.length > 0) {
       const ncuCommand = [
         "npm-check-updates",

--- a/src/javascript/upgrade-dependencies.ts
+++ b/src/javascript/upgrade-dependencies.ts
@@ -241,11 +241,14 @@ export class UpgradeDependencies extends Component {
     // update npm-check-updates before everything else, in case there is a bug
     // in it or one of its dependencies. This will make upgrade workflows
     // slightly more stable and resilient to upstream changes.
+    const ncuDep = this.project.deps.all.find(
+      (d) => d.name === "npm-check-updates"
+    )!;
     steps.push({
       exec: this._project.package.renderUpgradePackagesCommand(
-        [DependencyType.BUILD],
+        [ncuDep.type],
         [],
-        ["npm-check-updates"]
+        [ncuDep.name]
       ),
     });
 

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -1174,9 +1174,6 @@ tsconfig.tsbuildinfo
           "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='jsii-rosetta,jsii'"
         },
         {
-          "exec": "npm-check-updates --dep dev --upgrade --target=minor --filter @aws-cdk/aws-apigateway,@aws-cdk/aws-cloudwatch-actions,@aws-cdk/aws-cloudwatch,@aws-cdk/aws-dynamodb,@aws-cdk/aws-ecs-patterns,@aws-cdk/aws-ecs,@aws-cdk/aws-elasticloadbalancingv2,@aws-cdk/aws-events-targets,@aws-cdk/aws-events,@aws-cdk/aws-lambda,@aws-cdk/aws-rds,@aws-cdk/aws-sns-subscriptions,@aws-cdk/aws-sns,@aws-cdk/aws-sqs,@aws-cdk/core,constructs"
-        },
-        {
           "exec": "yarn install --check-files"
         },
         {
@@ -2251,9 +2248,6 @@ tsconfig.tsbuildinfo
         },
         {
           "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='jsii-rosetta,jsii'"
-        },
-        {
-          "exec": "npm-check-updates --dep dev --upgrade --target=minor --filter constructs"
         },
         {
           "exec": "yarn install --check-files"

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -1174,10 +1174,13 @@ tsconfig.tsbuildinfo
           "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='jsii-rosetta,jsii'"
         },
         {
+          "exec": "npm-check-updates --dep dev --upgrade --target=minor --filter @aws-cdk/aws-apigateway,@aws-cdk/aws-cloudwatch-actions,@aws-cdk/aws-cloudwatch,@aws-cdk/aws-dynamodb,@aws-cdk/aws-ecs-patterns,@aws-cdk/aws-ecs,@aws-cdk/aws-elasticloadbalancingv2,@aws-cdk/aws-events-targets,@aws-cdk/aws-events,@aws-cdk/aws-lambda,@aws-cdk/aws-rds,@aws-cdk/aws-sns-subscriptions,@aws-cdk/aws-sns,@aws-cdk/aws-sqs,@aws-cdk/core,constructs"
+        },
+        {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade"
+          "exec": "yarn upgrade @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-sdk eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint jest-junit jest jsii-diff jsii-docgen jsii-pacmak jsii-rosetta jsii npm-check-updates projen standard-version ts-jest typescript @aws-cdk/aws-apigateway @aws-cdk/aws-cloudwatch-actions @aws-cdk/aws-cloudwatch @aws-cdk/aws-dynamodb @aws-cdk/aws-ecs-patterns @aws-cdk/aws-ecs @aws-cdk/aws-elasticloadbalancingv2 @aws-cdk/aws-events-targets @aws-cdk/aws-events @aws-cdk/aws-lambda @aws-cdk/aws-rds @aws-cdk/aws-sns-subscriptions @aws-cdk/aws-sns @aws-cdk/aws-sqs @aws-cdk/core constructs @aws-cdk/aws-apigateway @aws-cdk/aws-cloudwatch-actions @aws-cdk/aws-cloudwatch @aws-cdk/aws-dynamodb @aws-cdk/aws-ecs-patterns @aws-cdk/aws-ecs @aws-cdk/aws-elasticloadbalancingv2 @aws-cdk/aws-events-targets @aws-cdk/aws-events @aws-cdk/aws-lambda @aws-cdk/aws-rds @aws-cdk/aws-sns-subscriptions @aws-cdk/aws-sns @aws-cdk/aws-sqs @aws-cdk/core @aws-cdk/assert"
         },
         {
           "exec": "npx projen"
@@ -2250,10 +2253,13 @@ tsconfig.tsbuildinfo
           "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='jsii-rosetta,jsii'"
         },
         {
+          "exec": "npm-check-updates --dep dev --upgrade --target=minor --filter constructs"
+        },
+        {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade"
+          "exec": "yarn upgrade @types/follow-redirects @types/jest @types/json-stable-stringify @types/node @types/yaml @typescript-eslint/eslint-plugin @typescript-eslint/parser constructs eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint jest-junit jest jsii-diff jsii-docgen jsii-pacmak jsii-rosetta jsii json-schema-to-typescript npm-check-updates projen ts-jest typescript fast-json-patch follow-redirects json-stable-stringify yaml constructs"
         },
         {
           "exec": "npx projen"
@@ -3387,7 +3393,7 @@ tsconfig.tsbuildinfo
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade"
+          "exec": "yarn upgrade @types/fs-extra @types/jest @types/json-schema @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit npm-check-updates projen ts-jest typescript @types/node cdk8s codemaker colors constructs fs-extra jsii-pacmak jsii-srcmak json2jsii sscaff yaml yargs"
         },
         {
           "exec": "npx projen"
@@ -4517,7 +4523,7 @@ resolution-mode=highest
           "exec": "pnpm i --no-frozen-lockfile"
         },
         {
-          "exec": "pnpm update"
+          "exec": "pnpm update aws-sdk jest jest-junit npm-check-updates projen standard-version esbuild"
         },
         {
           "exec": "npx projen"

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -1111,7 +1111,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
             "exec": "yarn install --check-files",
           },
           {
-            "exec": "yarn upgrade",
+            "exec": "yarn upgrade @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint jest-junit jest jsii-diff jsii-docgen jsii-pacmak jsii-rosetta jsii npm-check-updates projen standard-version ts-jest typescript",
           },
           {
             "exec": "npx projen",

--- a/test/javascript/upgrade-dependencies.test.ts
+++ b/test/javascript/upgrade-dependencies.test.ts
@@ -40,13 +40,30 @@ test("allows configuring specific dependency types", () => {
   );
 });
 
+test("upgrade command includes only dependencies of configured types", () => {
+  const project = createProject({
+    deps: ["some-dep"],
+    devDeps: ["some-dev-dep"],
+    depsUpgradeOptions: {
+      // 'devDeps' are added as BUILD
+      types: [DependencyType.BUILD],
+    },
+  });
+  const tasks = synthSnapshot(project)[TaskRuntime.MANIFEST_FILE].tasks;
+  expect(tasks.upgrade.steps[3].exec).toStrictEqual(
+    `yarn upgrade jest jest-junit npm-check-updates projen some-dev-dep standard-version`
+  );
+});
+
 test("upgrades command includes all dependencies", () => {
   const project = createProject({
     deps: ["some-dep"],
   });
 
   const tasks = synthSnapshot(project)[TaskRuntime.MANIFEST_FILE].tasks;
-  expect(tasks.upgrade.steps[7].exec).toStrictEqual(`yarn upgrade`); // implicitly all dependencies
+  expect(tasks.upgrade.steps[7].exec).toStrictEqual(
+    `yarn upgrade jest jest-junit npm-check-updates projen standard-version some-dep`
+  );
 });
 
 test("upgrades command includes dependencies added post instantiation", () => {
@@ -55,7 +72,9 @@ test("upgrades command includes dependencies added post instantiation", () => {
   project.addDeps("some-dep");
 
   const tasks = synthSnapshot(project)[TaskRuntime.MANIFEST_FILE].tasks;
-  expect(tasks.upgrade.steps[7].exec).toStrictEqual(`yarn upgrade`); // implicitly all dependencies
+  expect(tasks.upgrade.steps[7].exec).toStrictEqual(
+    `yarn upgrade jest jest-junit npm-check-updates projen standard-version some-dep`
+  );
 });
 
 test("upgrades command doesn't include ignored packages", () => {

--- a/test/jsii/__snapshots__/jsii.test.ts.snap
+++ b/test/jsii/__snapshots__/jsii.test.ts.snap
@@ -1111,7 +1111,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
             "exec": "yarn install --check-files",
           },
           {
-            "exec": "yarn upgrade",
+            "exec": "yarn upgrade @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint jest-junit jest jsii-diff jsii-docgen jsii-pacmak jsii-rosetta jsii npm-check-updates projen standard-version ts-jest typescript",
           },
           {
             "exec": "npx projen",
@@ -2596,7 +2596,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
             "exec": "yarn install --check-files",
           },
           {
-            "exec": "yarn upgrade",
+            "exec": "yarn upgrade @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit jsii jsii-diff jsii-docgen jsii-pacmak jsii-rosetta npm-check-updates projen standard-version ts-jest typescript",
           },
           {
             "exec": "npx projen",
@@ -4092,7 +4092,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
             "exec": "yarn install --check-files",
           },
           {
-            "exec": "yarn upgrade",
+            "exec": "yarn upgrade @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint jest-junit jest jsii-diff jsii-docgen jsii-pacmak jsii-rosetta jsii npm-check-updates projen standard-version ts-jest typescript",
           },
           {
             "exec": "npx projen",
@@ -5579,7 +5579,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
             "exec": "yarn install --check-files",
           },
           {
-            "exec": "yarn upgrade",
+            "exec": "yarn upgrade @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit jsii-diff jsii-docgen jsii-pacmak jsii-rosetta jsii npm-check-updates projen standard-version ts-jest typescript",
           },
           {
             "exec": "npx projen",

--- a/test/typescript/__snapshots__/typescript.test.ts.snap
+++ b/test/typescript/__snapshots__/typescript.test.ts.snap
@@ -963,7 +963,7 @@ tsconfig.tsbuildinfo
             "exec": "yarn install --check-files",
           },
           {
-            "exec": "yarn upgrade",
+            "exec": "yarn upgrade @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit npm-check-updates projen standard-version ts-jest typescript",
           },
           {
             "exec": "npx projen",

--- a/test/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-project.test.ts.snap
@@ -669,7 +669,7 @@ permissions-backup.acl
             "exec": "yarn install --check-files",
           },
           {
-            "exec": "yarn upgrade",
+            "exec": "yarn upgrade npm-check-updates projen standard-version autoprefixer next postcss react react-dom tailwindcss",
           },
           {
             "exec": "npx projen",

--- a/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -557,7 +557,7 @@ tsconfig.tsbuildinfo
             "exec": "yarn install --check-files",
           },
           {
-            "exec": "yarn upgrade",
+            "exec": "yarn upgrade @types/node @types/react @types/react-dom npm-check-updates projen typescript autoprefixer next postcss react react-dom tailwindcss",
           },
           {
             "exec": "npx projen",

--- a/test/web/__snapshots__/react-project.test.ts.snap
+++ b/test/web/__snapshots__/react-project.test.ts.snap
@@ -632,7 +632,7 @@ permissions-backup.acl
             "exec": "yarn install --check-files",
           },
           {
-            "exec": "yarn upgrade",
+            "exec": "yarn upgrade @testing-library/jest-dom @testing-library/react @testing-library/user-event npm-check-updates projen standard-version react react-dom react-scripts web-vitals",
           },
           {
             "exec": "npx projen",

--- a/test/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/react-ts-project.test.ts.snap
@@ -811,7 +811,7 @@ tsconfig.tsbuildinfo
             "exec": "yarn install --check-files",
           },
           {
-            "exec": "yarn upgrade",
+            "exec": "yarn upgrade @testing-library/jest-dom @testing-library/react @testing-library/user-event @types/jest @types/node @types/react @types/react-dom @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint npm-check-updates projen typescript react react-dom react-scripts web-vitals",
           },
           {
             "exec": "npx projen",


### PR DESCRIPTION
Given 

```ts
depsUpgradeOptions: {
  types: [DependencyType.PEER],
}
```

Would produce:

```console
npm-check-updates --dep peer --upgrade --target=minor
yarn upgrade
```

However, when `yarn upgrade` executes, the peer deps aren't upgraded because peer dependencies aren't installed by default. This causes [failures](https://github.com/cdk8s-team/cdk8s-hasura/actions/runs/5698912124/job/15447288139?pr=177) such as:

```console
build » compile | jsii --silence-warnings=reserved-word
Error: Error: Declared dependency on version ^2.24.0 of cdk[8](https://github.com/cdk8s-team/cdk8s-hasura/actions/runs/5698912124/job/15447288139?pr=177#step:5:9)s, but version 2.23.0 was found
```

Projen actually automatically adds peer dependencies as dev dependencies as well. This means we need to also produce: 

```console
npm-check-updates --dep dev --upgrade --target=minor --filter {peers}
```

Also, `yarn upgrade` is not the right command to run here because it will upgrade ALL transitive dependencies, instead of just for peers. What we need is `yarn upgrade {peers}`.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.