### PR TITLE
fix(node-project): updated code artifact login script to work for node version above 16

### DIFF
--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -535,8 +535,6 @@ export class NodePackage extends Component {
 
     this.processDeps(options);
 
-    this.addCodeArtifactLoginScript();
-
     const prev = this.readPackageJson() ?? {};
 
     // empty objects are here to preserve order for backwards compatibility
@@ -604,6 +602,8 @@ export class NodePackage extends Component {
     this.maxNodeVersion = options.maxNodeVersion;
     this.pnpmVersion = options.pnpmVersion ?? "7";
     this.addNodeEngine();
+
+    this.addCodeArtifactLoginScript();
 
     // license
     if (options.licensed ?? true) {
@@ -1079,7 +1079,7 @@ export class NodePackage extends Component {
             `npm config set //${registry}:_authToken=$CODEARTIFACT_AUTH_TOKEN`,
           ];
           if (!this.minNodeVersion || semver.major(this.minNodeVersion) <= 16)
-            commands.push("`npm config set //${registry}:always-auth=true`");
+            commands.push(`npm config set //${registry}:always-auth=true`);
           return {
             exec: commands.join("; "),
           };

--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -1077,8 +1077,9 @@ export class NodePackage extends Component {
             `npm config set ${scope}:registry ${registryUrl}`,
             `CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${domain} --region ${region} --domain-owner ${accountId} --query authorizationToken --output text)`,
             `npm config set //${registry}:_authToken=$CODEARTIFACT_AUTH_TOKEN`,
-            `npm config set //${registry}:always-auth=true`,
           ];
+          if (!this.minNodeVersion || semver.major(this.minNodeVersion) <= 16)
+            commands.push("`npm config set //${registry}:always-auth=true`");
           return {
             exec: commands.join("; "),
           };

--- a/test/javascript/node-project.test.ts
+++ b/test/javascript/node-project.test.ts
@@ -1556,6 +1556,7 @@ describe("scoped private packages", () => {
         },
       ],
     });
+  });
 
   test("adds ca:login script without always-auth when min node version is greater than 16", () => {
     const project = new TestNodeProject({
@@ -1565,7 +1566,7 @@ describe("scoped private packages", () => {
           scope,
         },
       ],
-      minNodeVersion: '18.11.0'
+      minNodeVersion: "18.11.0",
     });
     const output = synthSnapshot(project);
 


### PR DESCRIPTION
npm has removed the support for this flag in npm version 7 (https://docs.npmjs.com/cli/v7/using-npm/changelog#v7111-2021-04-23). The npm version for node 18 and above errors on setting this flag.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.