### PR TITLE
fix(renovatebot): cannot use file override for renovate.json5

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -2659,21 +2659,6 @@ Name | Type | Description
 -----|------|-------------
 **file**🔹 | <code>[JsonFile](#projen-jsonfile)</code> | The file holding the renovatebot configuration.
 
-### Methods
-
-
-#### preSynthesize()🔹 <a id="projen-renovatebot-presynthesize"></a>
-
-Called before synthesis.
-
-```ts
-preSynthesize(): void
-```
-
-
-
-
-
 
 
 ## class SampleDir 🔹 <a id="projen-sampledir"></a>

--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -2651,6 +2651,14 @@ new Renovatebot(project: Project, options?: RenovatebotOptions)
   * **scheduleInterval** (<code>Array<string></code>)  How often to check for new versions and raise pull requests. __*Default*__: ["at any time"]
 
 
+
+### Properties
+
+
+Name | Type | Description 
+-----|------|-------------
+**file**🔹 | <code>[JsonFile](#projen-jsonfile)</code> | The file holding the renovatebot configuration.
+
 ### Methods
 
 

--- a/src/renovatebot.ts
+++ b/src/renovatebot.ts
@@ -104,6 +104,11 @@ export enum RenovatebotScheduleInterval {
  * Ignores the versions controlled by Projen.
  */
 export class Renovatebot extends Component {
+  /**
+   * The file holding the renovatebot configuration
+   */
+  public readonly file: JsonFile;
+
   private readonly _project: Project;
 
   private readonly explicitIgnores: string[];
@@ -128,6 +133,12 @@ export class Renovatebot extends Component {
     (options.ignoreProjen ?? true) && this.explicitIgnores.push("projen");
     this.overrideConfig = options.overrideConfig ?? {};
     this.marker = options.marker ?? true;
+
+    this.file = new JsonFile(this._project, "renovate.json5", {
+      obj: () => this.createRenovateConfiguration(),
+      committed: true,
+      marker: this.marker,
+    });
   }
 
   // create actual file only here, so we know that all dependencies are added to the project
@@ -145,7 +156,7 @@ export class Renovatebot extends Component {
       ),
     ];
 
-    const config = {
+    return {
       labels: this.labels,
       schedule: this.scheduleInterval,
       extends: [
@@ -165,11 +176,5 @@ export class Renovatebot extends Component {
       ignoreDeps: renovateIgnore,
       ...this.overrideConfig,
     };
-
-    new JsonFile(this._project, "renovate.json5", {
-      obj: config,
-      committed: true,
-      marker: this.marker,
-    });
   }
 }

--- a/src/renovatebot.ts
+++ b/src/renovatebot.ts
@@ -141,11 +141,6 @@ export class Renovatebot extends Component {
     });
   }
 
-  // create actual file only here, so we know that all dependencies are added to the project
-  public preSynthesize() {
-    this.createRenovateConfiguration();
-  }
-
   private createRenovateConfiguration() {
     const renovateIgnore = [
       ...new Set(

--- a/test/renovatebot.test.ts
+++ b/test/renovatebot.test.ts
@@ -1,4 +1,5 @@
 import { synthSnapshot, TestProject } from "./util";
+import { DependencyType } from "../src";
 
 describe("renovatebot", () => {
   test("renovatebot: true creates renovatebot configuration", () => {
@@ -16,6 +17,27 @@ describe("renovatebot", () => {
     // THEN
     expect(snapshot["renovate.json5"]).toMatchSnapshot();
   });
+
+  test("renovatebot: will ignore deps added later", () => {
+    // GIVEN
+    const p = new TestProject({
+      renovatebot: true,
+      renovatebotOptions: {
+        labels: ["renotate", "dependencies"],
+      },
+    });
+    p.deps.addDependency("test@1.0.0", DependencyType.RUNTIME);
+
+    // WHEN
+    const snapshot = synthSnapshot(p);
+
+    // THEN
+    expect(snapshot["renovate.json5"]).toHaveProperty("ignoreDeps", [
+      "test",
+      "projen",
+    ]);
+  });
+
   test("renovatebot: override renovatebot configuration", () => {
     // GIVEN
     const overrideConfig = {
@@ -41,5 +63,18 @@ describe("renovatebot", () => {
     // THEN
     expect(snapshot).toMatchSnapshot();
     expect(snapshot).toStrictEqual(overrideConfig);
+  });
+
+  test("renovatebot: can use file escape hatch", () => {
+    // GIVEN
+    const p = new TestProject({
+      renovatebot: true,
+      renovatebotOptions: {
+        labels: ["renotate", "dependencies"],
+      },
+    });
+
+    // THEN
+    expect(p.tryFindObjectFile("renovate.json5")).toBeDefined();
   });
 });


### PR DESCRIPTION
**Issue**:
> I'm trying to
>```
>const renovateJs = project.tryFindObjectFile('renovate.json5');
>renovateJs?.patch(
>   JsonPatch.add('/', {
>     postUpgradeTasks: {
>       commands: ['npx projen'],
>       executionMode: 'branch',
>     },
>   }),
> );
> ```
> but it looks like the first line isn't finding the renovate.json5 file. I was wondering: is tryFindObjectFile reading the .json5 suffix and tanking? I thought "ok, I'll just rename it to renovate.json which is supported: https://docs.renovatebot.com/configuration-options/, but... it's not obvious where I'd do that.

**Cause**: The configuration file was created in the `preSynthesize` stage to ensure that all dependencies are available in for the renovatebot configuration to consider. This doesn't work with file escape hatches, which access files after the construction phase.

**Solution**: Use the build in feature to delay file content rendering to synth stage.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.