### PR TITLE
fix(new): projen new --from fails with "Unable to resolve package name from spec" error with "save=false" in .npmrc

### DIFF
--- a/src/cli/util.ts
+++ b/src/cli/util.ts
@@ -42,17 +42,17 @@ export function installPackage(baseDir: string, spec: string): string {
 /**
  * Render a command to install an npm package.
  *
- * Engine checks are ignorred at this point so that the module can be installed
+ * Engine checks are ignored at this point so that the module can be installed
  * regardless of the environment. This was needed to unblock the upgrade of the
  * minimum node version of projen, but also okay generally because engine checks
- * will be performed later and for all eternety.
+ * will be performed later and for all eternity.
  *
  * @param dir Base directory
  * @param module The module to install (e.g. foo@^1.2)
  * @returns The string that includes the install command ("npm install ...")
  */
 export function renderInstallCommand(dir: string, module: string): string {
-  return `npm install --save-dev -f --no-package-lock --prefix="${dir}" ${module}`;
+  return `npm install --save --save-dev -f --no-package-lock --prefix="${dir}" ${module}`;
 }
 
 export class CliError extends Error {


### PR DESCRIPTION
Turns out `--save-dev` doesn't overwrite a `save=false` in other npm configs like one might expect.
Passing `--save --save-dev` however does overwrite any config and correctly saves the package as dev dependency.

Fixes #2837

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.