### PR TITLE
fix(cli): respect git init.defaultBranch

### DIFF
--- a/src/cli/cmds/new.ts
+++ b/src/cli/cmds/new.ts
@@ -457,6 +457,7 @@ async function initProject(
       execCapture("git --version", { cwd: baseDir }).toString()
     );
     logging.debug("system using git version ", gitversion);
+    // `git config init.defaultBranch` and `git init -b` are only available since git 2.28.0
     if (gitversion && semver.gte(gitversion, "2.28.0")) {
       const defaultGitInitBranch =
         execOrUndefined("git config init.defaultBranch", {

--- a/src/cli/cmds/new.ts
+++ b/src/cli/cmds/new.ts
@@ -6,7 +6,13 @@ import * as inventory from "../../inventory";
 import * as logging from "../../logging";
 import { InitProjectOptionHints } from "../../option-hints";
 import { Projects } from "../../projects";
-import { exec, execCapture, getGitVersion, isTruthy } from "../../util";
+import {
+  exec,
+  execCapture,
+  execOrUndefined,
+  getGitVersion,
+  isTruthy,
+} from "../../util";
 import { tryProcessMacro } from "../macros";
 import { CliError, installPackage, renderInstallCommand } from "../util";
 
@@ -452,10 +458,16 @@ async function initProject(
     );
     logging.debug("system using git version ", gitversion);
     if (gitversion && semver.gte(gitversion, "2.28.0")) {
-      git("init -b main");
+      const defaultGitInitBranch =
+        execOrUndefined("git config init.defaultBranch", {
+          cwd: baseDir,
+        })?.trim() ||
+        args.defaultReleaseBranch ||
+        "main";
+      git(`init -b ${defaultGitInitBranch}`);
       git("add .");
       git('commit --allow-empty -m "chore: project created with projen"');
-      logging.debug("default branch name set to main");
+      logging.debug(`default branch name set to ${defaultGitInitBranch}`);
     } else {
       git("init");
       git("add .");

--- a/src/cli/cmds/new.ts
+++ b/src/cli/cmds/new.ts
@@ -461,9 +461,7 @@ async function initProject(
       const defaultGitInitBranch =
         execOrUndefined("git config init.defaultBranch", {
           cwd: baseDir,
-        })?.trim() ||
-        args.defaultReleaseBranch ||
-        "main";
+        })?.trim() || "main";
       git(`init -b ${defaultGitInitBranch}`);
       git("add .");
       git('commit --allow-empty -m "chore: project created with projen"');


### PR DESCRIPTION
`projen new` by default initialises a git repository using hard coded default branch name `main`. Some organisations / users may have different defaults for git branch (like `mainline`) and so git since version 2.28 provides global option [init.defaultBranch](https://github.blog/2020-07-27-highlights-from-git-2-28/#introducing-init-defaultbranch). This PR makes `projen new` to respect that setting when present.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
