### PR TITLE
fix(gitlab): add uppercase support for idTokens

### DIFF
--- a/src/gitlab/configuration.ts
+++ b/src/gitlab/configuration.ts
@@ -374,7 +374,12 @@ function snakeCaseKeys<T = unknown>(obj: T, skipTopLevel: boolean = false): T {
 
   const result: Record<string, unknown> = {};
   for (let [k, v] of Object.entries(obj)) {
-    if (typeof v === "object" && v != null && k !== "variables") {
+    if (
+      typeof v === "object" &&
+      v != null &&
+      k !== "variables" &&
+      k !== "idTokens"
+    ) {
       v = snakeCaseKeys(v);
     }
     result[skipTopLevel ? k : snake(k)] = v;

--- a/test/gitlab/configuration.test.ts
+++ b/test/gitlab/configuration.test.ts
@@ -132,6 +132,24 @@ test("respect the original format when adding global variables", () => {
   });
 });
 
+test("respect the original format when variables are added to jobs", () => {
+  // GIVEN
+  const p = new TestProject({
+    stale: true,
+  });
+  new CiConfiguration(p, "foo", {
+    jobs: {
+      build: {
+        idTokens: { TEST_ID_TOKEN: { aud: "https://test.service.com" } },
+      },
+    },
+  });
+  // THEN
+  expect(
+    YAML.parse(synthSnapshot(p)[".gitlab/ci-templates/foo.yml"]).build.id_tokens
+  ).toStrictEqual({ TEST_ID_TOKEN: { aud: "https://test.service.com" } });
+});
+
 test("adds correct entries for path-based caching", () => {
   // GIVEN
   const p = new TestProject({


### PR DESCRIPTION
Fixing the issue of the job `id_tokens` rendering into a snake case, while not respecting the original format.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
