### PR TITLE
feat(cli): interactive project creation (RFC #1365)

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -135,6 +135,10 @@
       "type": "bundled"
     },
     {
+      "name": "@inquirer/prompts",
+      "type": "bundled"
+    },
+    {
       "name": "case",
       "type": "bundled"
     },

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -384,13 +384,13 @@
           "exec": "yarn upgrade npm-check-updates"
         },
         {
-          "exec": "npm-check-updates --upgrade --target=minor --peer --dep=dev,peer,prod,optional --filter=@types/conventional-changelog-config-spec,@types/glob,@types/ini,@types/jest,@types/node,@types/semver,@types/yargs,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,all-contributors-cli,esbuild,eslint-config-prettier,eslint-import-resolver-node,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,eslint,jest,jest-junit,jsii-diff,jsii-docgen,jsii-pacmak,npm-check-updates,prettier,standard-version,ts-jest,@iarna/toml,case,chalk,conventional-changelog-config-spec,fast-json-patch,glob,ini,semver,shx,xmlbuilder2,yaml,yargs"
+          "exec": "npm-check-updates --upgrade --target=minor --peer --dep=dev,peer,prod,optional --filter=@types/conventional-changelog-config-spec,@types/glob,@types/ini,@types/jest,@types/node,@types/semver,@types/yargs,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,all-contributors-cli,esbuild,eslint-config-prettier,eslint-import-resolver-node,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,eslint,jest,jest-junit,jsii-diff,jsii-docgen,jsii-pacmak,npm-check-updates,prettier,standard-version,ts-jest,@iarna/toml,@inquirer/prompts,case,chalk,conventional-changelog-config-spec,fast-json-patch,glob,ini,semver,shx,xmlbuilder2,yaml,yargs"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @types/conventional-changelog-config-spec @types/glob @types/ini @types/jest @types/node @types/semver @types/yargs @typescript-eslint/eslint-plugin @typescript-eslint/parser all-contributors-cli esbuild eslint-config-prettier eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint jest jest-junit jsii-diff jsii-docgen jsii-pacmak npm-check-updates prettier standard-version ts-jest @iarna/toml case chalk conventional-changelog-config-spec fast-json-patch glob ini semver shx xmlbuilder2 yaml yargs"
+          "exec": "yarn upgrade @types/conventional-changelog-config-spec @types/glob @types/ini @types/jest @types/node @types/semver @types/yargs @typescript-eslint/eslint-plugin @typescript-eslint/parser all-contributors-cli esbuild eslint-config-prettier eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint jest jest-junit jsii-diff jsii-docgen jsii-pacmak npm-check-updates prettier standard-version ts-jest @iarna/toml @inquirer/prompts case chalk conventional-changelog-config-spec fast-json-patch glob ini semver shx xmlbuilder2 yaml yargs"
         },
         {
           "exec": "/bin/bash ./projen.bash"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -37,6 +37,7 @@ const project = new cdk.JsiiProject({
     "conventional-changelog-config-spec",
     "yaml@^2.2.2",
     "yargs",
+    "@inquirer/prompts",
     "case",
     "glob@^8",
     "semver",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
   },
   "dependencies": {
     "@iarna/toml": "^2.2.5",
+    "@inquirer/prompts": "^3.1.1",
     "case": "^1.6.3",
     "chalk": "^4.1.2",
     "comment-json": "4.2.2",
@@ -95,6 +96,7 @@
   },
   "bundledDependencies": [
     "@iarna/toml",
+    "@inquirer/prompts",
     "case",
     "chalk",
     "comment-json",

--- a/yarn.lock
+++ b/yarn.lock
@@ -485,6 +485,125 @@
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.5.tgz#b32366c89b43c6f8cefbdefac778b9c828e3ba8c"
   integrity sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==
 
+"@inquirer/checkbox@^1.3.11":
+  version "1.3.11"
+  resolved "https://registry.yarnpkg.com/@inquirer/checkbox/-/checkbox-1.3.11.tgz#3926d8def3142e54bcc621f7f61eace439bf2966"
+  integrity sha512-SaQBDr7niZQzoP5Mqzak5pQY7476mvf4Sj2V8VFrbFHWHsavy3nKGKEOgijNHy151bEgqDog1829g/pKa9Qcrw==
+  dependencies:
+    "@inquirer/core" "^5.0.0"
+    "@inquirer/type" "^1.1.4"
+    ansi-escapes "^4.3.2"
+    chalk "^4.1.2"
+    figures "^3.2.0"
+
+"@inquirer/confirm@^2.0.12":
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/@inquirer/confirm/-/confirm-2.0.12.tgz#d9fe9d5ce82907f956bd1c7d297ef11fc7a94c3f"
+  integrity sha512-Oxz3L0ti+0nWYHPPUIrPkxA2KnQZUGBHnk56yF5RjKqPGFrwvgLZdIXNe/w4I/OtdLeOBqHCrJ+kCvNvHVdk9g==
+  dependencies:
+    "@inquirer/core" "^5.0.0"
+    "@inquirer/type" "^1.1.4"
+    chalk "^4.1.2"
+
+"@inquirer/core@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@inquirer/core/-/core-5.0.0.tgz#0b4b4eb9c076aca7b2cf7d040fbae0eaf98321b5"
+  integrity sha512-q2o4BcANKFyuUI5V6ejmPs1f9SdbJxfnLmhQVb72Fj7hOudoKsJpByJZ0imv9a/rpKDogA+93vtBBMqsnS7/Fg==
+  dependencies:
+    "@inquirer/type" "^1.1.4"
+    "@types/mute-stream" "^0.0.1"
+    "@types/node" "^20.6.0"
+    "@types/wrap-ansi" "^3.0.0"
+    ansi-escapes "^4.3.2"
+    chalk "^4.1.2"
+    cli-spinners "^2.9.0"
+    cli-width "^4.1.0"
+    figures "^3.2.0"
+    mute-stream "^1.0.0"
+    run-async "^3.0.0"
+    signal-exit "^4.1.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^6.2.0"
+
+"@inquirer/editor@^1.2.10":
+  version "1.2.10"
+  resolved "https://registry.yarnpkg.com/@inquirer/editor/-/editor-1.2.10.tgz#7792e241b4f2b0dbc373b8983a89fb2c8f4df7a5"
+  integrity sha512-aluYpazbxIdM54L+xNmVHzOjoXGwkliTCvHxhtPg6itmqDGMVmU1z+T2akHt6Xnx9RyrTpbumFB4xn1iI0UfnA==
+  dependencies:
+    "@inquirer/core" "^5.0.0"
+    "@inquirer/type" "^1.1.4"
+    chalk "^4.1.2"
+    external-editor "^3.1.0"
+
+"@inquirer/expand@^1.1.11":
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/@inquirer/expand/-/expand-1.1.11.tgz#7ae46bb3f7e4d8611af341485e28efed871bcd90"
+  integrity sha512-GSZJbYKPBniyXgWeFLsqiv7TSK9QjpQqCr+i/85Yts3wwixXTrAeoqM3TVVgHO/3j+xeFcuhOm1wy/F2QY5aEg==
+  dependencies:
+    "@inquirer/core" "^5.0.0"
+    "@inquirer/type" "^1.1.4"
+    chalk "^4.1.2"
+    figures "^3.2.0"
+
+"@inquirer/input@^1.2.11":
+  version "1.2.11"
+  resolved "https://registry.yarnpkg.com/@inquirer/input/-/input-1.2.11.tgz#7d2f1f58f69eb7dc33078b35c5ec463344b32a21"
+  integrity sha512-sV1nO6+RxMFTHAznmxMkbMkjGQ8NGMWr0mvXjU35YQ0OFEL+YlD+DPbNd9s3ltnswODZAcnM1yFvdko3S/Kj/w==
+  dependencies:
+    "@inquirer/core" "^5.0.0"
+    "@inquirer/type" "^1.1.4"
+    chalk "^4.1.2"
+
+"@inquirer/password@^1.1.11":
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/@inquirer/password/-/password-1.1.11.tgz#086ab3c9018a34b644922bffb5f84928afa1d41c"
+  integrity sha512-r2eiLMlTuY+k+yJf6XLbnAEz7EDyWdjOrgVAWjSKoEDBc3T9/rq2I+7WiY9FUFArYY/1LxmsNWavs5NuMICx8Q==
+  dependencies:
+    "@inquirer/input" "^1.2.11"
+    "@inquirer/type" "^1.1.4"
+    ansi-escapes "^4.3.2"
+    chalk "^4.1.2"
+
+"@inquirer/prompts@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@inquirer/prompts/-/prompts-3.1.1.tgz#44cf520bd0bfa00a0292b3c54096fd396575e8f9"
+  integrity sha512-7m/7Q4eupJYmn0GxM1H1dcekE4F4YlIB6bSKZs2SVeShARYUVPiAKFZ9c15UzYnBtdjCv4zXI17jbNtCNqmxGQ==
+  dependencies:
+    "@inquirer/checkbox" "^1.3.11"
+    "@inquirer/confirm" "^2.0.12"
+    "@inquirer/core" "^5.0.0"
+    "@inquirer/editor" "^1.2.10"
+    "@inquirer/expand" "^1.1.11"
+    "@inquirer/input" "^1.2.11"
+    "@inquirer/password" "^1.1.11"
+    "@inquirer/rawlist" "^1.2.11"
+    "@inquirer/select" "^1.2.11"
+
+"@inquirer/rawlist@^1.2.11":
+  version "1.2.11"
+  resolved "https://registry.yarnpkg.com/@inquirer/rawlist/-/rawlist-1.2.11.tgz#3a75a7ab231f61be7af7d48872e995d5c65d2dba"
+  integrity sha512-4S2t2pCCR3VgyB3lbPKoiJ9020HHAi9g4M+DIyXHYwGE++7wURAwKkzb6v78fS0yKfCbyFt3BTcL2UffQRQ9Fg==
+  dependencies:
+    "@inquirer/core" "^5.0.0"
+    "@inquirer/type" "^1.1.4"
+    chalk "^4.1.2"
+
+"@inquirer/select@^1.2.11":
+  version "1.2.11"
+  resolved "https://registry.yarnpkg.com/@inquirer/select/-/select-1.2.11.tgz#4a99edadd23f398bf51838b89383d3d0cfd80a05"
+  integrity sha512-LH2wzAsWfu/+wcapeht07zTDefuvGTpv0+9dCAQ68QigF+4gHzpWq5+AbBLbxzuH2Wz4WlHcti85nFUPPM1t3A==
+  dependencies:
+    "@inquirer/core" "^5.0.0"
+    "@inquirer/type" "^1.1.4"
+    ansi-escapes "^4.3.2"
+    chalk "^4.1.2"
+    figures "^3.2.0"
+
+"@inquirer/type@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@inquirer/type/-/type-1.1.4.tgz#8ef3d3d638a59253fbbe4b0297035cddc227eaed"
+  integrity sha512-a6+RCiXBQEbiA73RT1pBfwiH2I+MPcoZoGKuuUYFkws+6ud7nb5kUQGHFGUSBim25IyVMT/mqbWIrkxetcIb/w==
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
@@ -1093,7 +1212,14 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/node@*":
+"@types/mute-stream@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@types/mute-stream/-/mute-stream-0.0.1.tgz#8ec7d16d51e2ceb054d8be0226250169d17af5b2"
+  integrity sha512-0yQLzYhCqGz7CQPE3iDmYjhb7KMBFOP+tBkyw+/Y2YyDI5wpS7itXXxneN1zSsUwWx3Ji6YiVYrhAnpQGS/vkw==
+  dependencies:
+    "@types/node" "*"
+
+"@types/node@*", "@types/node@^20.6.0":
   version "20.6.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.6.0.tgz#9d7daa855d33d4efec8aea88cd66db1c2f0ebe16"
   integrity sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg==
@@ -1117,6 +1243,11 @@
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
+
+"@types/wrap-ansi@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz#18b97a972f94f60a679fd5c796d96421b9abb9fd"
+  integrity sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==
 
 "@types/yargs-parser@*":
   version "21.0.0"
@@ -1322,7 +1453,7 @@ ansi-align@^3.0.1:
   dependencies:
     string-width "^4.1.0"
 
-ansi-escapes@^4.2.1:
+ansi-escapes@^4.2.1, ansi-escapes@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
   integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
@@ -1778,6 +1909,11 @@ cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
+cli-spinners@^2.9.0:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.9.1.tgz#9c0b9dad69a6d47cbb4333c14319b060ed395a35"
+  integrity sha512-jHgecW0pxkonBJdrKsqxgRX9AcG+u/5k0Q7WPDfi8AogLAdwxEkyYYNWwZ5GvVFoFx2uiY1eNcSK00fh+1+FyQ==
+
 cli-table3@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.3.tgz#61ab765aac156b52f222954ffc607a6f01dbeeb2"
@@ -1791,6 +1927,11 @@ cli-width@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
   integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
+
+cli-width@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-4.1.0.tgz#42daac41d3c254ef38ad8ac037672130173691c5"
+  integrity sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==
 
 cliui@^6.0.0:
   version "6.0.0"
@@ -2710,7 +2851,7 @@ exponential-backoff@^3.1.1:
   resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.1.tgz#64ac7526fe341ab18a39016cd22c787d01e00bf6"
   integrity sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==
 
-external-editor@^3.0.3:
+external-editor@^3.0.3, external-editor@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
   integrity sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==
@@ -2774,7 +2915,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-figures@^3.0.0, figures@^3.1.0:
+figures@^3.0.0, figures@^3.1.0, figures@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
   integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
@@ -4763,6 +4904,11 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
+mute-stream@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-1.0.0.tgz#e31bd9fe62f0aed23520aa4324ea6671531e013e"
+  integrity sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -5659,6 +5805,11 @@ run-async@^2.4.0:
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
 
+run-async@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-3.0.0.tgz#42a432f6d76c689522058984384df28be379daad"
+  integrity sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -5799,7 +5950,7 @@ signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
-signal-exit@^4.0.1:
+signal-exit@^4.0.1, signal-exit@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==


### PR DESCRIPTION
Experimenting with implementing the RFC https://github.com/projen/projen/blob/main/rfcs/project-creation-prompt.md

https://github.com/projen/projen/assets/135833592/bbe1d880-6859-4fa8-aa6f-f5f6c9e28f0f

I think it will improve the UX and lower the barrier of entry. I, as a relatively new user or projen, needed to invest time and effort in order to perform basic Projen configuration and turn on/off options i wanted, i had to read the whole super long API page just to find a couple of options I wanted. I think a little bit of guidance when scaffolding a new project might improve the popularity of this awesome tool.

For now I have hardcoded some options and had to integrate the yargs cli class with the prompt library in a hackish way because yargs lacks native support for it.



A few problems that need to be solved and some input from the community would be appreciated:
1.  Library choice: https://github.com/terkelg/prompts recommended in the RFC is poorly maintained. I found that https://github.com/SBoudrias/Inquirer.js is the most active and lightweight lib (although very basic).
2. Option source: It was recommended in the RFC to use the options flagged with @featured flag in the prompts. I think the options marked with this doctag are not very useful for prompts. I would suggest adding a new flag: i.e. @prompt 


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
