### PR TITLE
feat(awscdk): add experimental integ-runner support

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -3873,6 +3873,7 @@ new awscdk.AwsCdkConstructLibrary(options: AwsCdkConstructLibraryOptions)
   * **cdkVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for CDK. __*Optional*__
   * **constructsVersion** (<code>string</code>)  Minimum version of the `constructs` library to depend on. __*Default*__: for CDK 1.x the default is "3.2.27", for CDK 2.x the default is "10.0.5".
   * **edgeLambdaAutoDiscover** (<code>boolean</code>)  Automatically adds an `cloudfront.experimental.EdgeFunction` for each `.edge-lambda.ts` handler in your source tree. If this is disabled, you can manually add an `awscdk.AutoDiscover` component to your project. __*Default*__: true
+  * **experimentalIntegRunner** (<code>boolean</code>)  Enable experimental support for the AWS CDK integ-runner. __*Default*__: false
   * **integrationTestAutoDiscover** (<code>boolean</code>)  Automatically discovers and creates integration tests for each `.integ.ts` file in under your test directory. __*Default*__: true
   * **lambdaAutoDiscover** (<code>boolean</code>)  Automatically adds an `aws_lambda.Function` for each `.lambda.ts` handler in your source tree. If this is disabled, you either need to explicitly call `aws_lambda.Function.autoDiscover()` or define a `new aws_lambda.Function()` for each handler. __*Default*__: true
   * **lambdaExtensionAutoDiscover** (<code>boolean</code>)  Automatically adds an `awscdk.LambdaExtension` for each `.lambda-extension.ts` entrypoint in your source tree. If this is disabled, you can manually add an `awscdk.AutoDiscover` component to your project. __*Default*__: true
@@ -4565,6 +4566,7 @@ new awscdk.AwsCdkTypeScriptApp(options: AwsCdkTypeScriptAppOptions)
   * **constructsVersion** (<code>string</code>)  Minimum version of the `constructs` library to depend on. __*Default*__: for CDK 1.x the default is "3.2.27", for CDK 2.x the default is "10.0.5".
   * **appEntrypoint** (<code>string</code>)  The CDK app's entrypoint (relative to the source directory, which is "src" by default). __*Default*__: "main.ts"
   * **edgeLambdaAutoDiscover** (<code>boolean</code>)  Automatically adds an `cloudfront.experimental.EdgeFunction` for each `.edge-lambda.ts` handler in your source tree. If this is disabled, you can manually add an `awscdk.AutoDiscover` component to your project. __*Default*__: true
+  * **experimentalIntegRunner** (<code>boolean</code>)  Enable experimental support for the AWS CDK integ-runner. __*Default*__: false
   * **integrationTestAutoDiscover** (<code>boolean</code>)  Automatically discovers and creates integration tests for each `.integ.ts` file in under your test directory. __*Default*__: true
   * **lambdaAutoDiscover** (<code>boolean</code>)  Automatically adds an `awscdk.LambdaFunction` for each `.lambda.ts` handler in your source tree. If this is disabled, you can manually add an `awscdk.AutoDiscover` component to your project. __*Default*__: true
   * **lambdaExtensionAutoDiscover** (<code>boolean</code>)  Automatically adds an `awscdk.LambdaExtension` for each `.lambda-extension.ts` entrypoint in your source tree. If this is disabled, you can manually add an `awscdk.AutoDiscover` component to your project. __*Default*__: true
@@ -4891,6 +4893,7 @@ new awscdk.ConstructLibraryAws(options: AwsCdkConstructLibraryOptions)
   * **cdkVersionPinning** (<code>boolean</code>)  Use pinned version instead of caret version for CDK. __*Optional*__
   * **constructsVersion** (<code>string</code>)  Minimum version of the `constructs` library to depend on. __*Default*__: for CDK 1.x the default is "3.2.27", for CDK 2.x the default is "10.0.5".
   * **edgeLambdaAutoDiscover** (<code>boolean</code>)  Automatically adds an `cloudfront.experimental.EdgeFunction` for each `.edge-lambda.ts` handler in your source tree. If this is disabled, you can manually add an `awscdk.AutoDiscover` component to your project. __*Default*__: true
+  * **experimentalIntegRunner** (<code>boolean</code>)  Enable experimental support for the AWS CDK integ-runner. __*Default*__: false
   * **integrationTestAutoDiscover** (<code>boolean</code>)  Automatically discovers and creates integration tests for each `.integ.ts` file in under your test directory. __*Default*__: true
   * **lambdaAutoDiscover** (<code>boolean</code>)  Automatically adds an `aws_lambda.Function` for each `.lambda.ts` handler in your source tree. If this is disabled, you either need to explicitly call `aws_lambda.Function.autoDiscover()` or define a `new aws_lambda.Function()` for each handler. __*Default*__: true
   * **lambdaExtensionAutoDiscover** (<code>boolean</code>)  Automatically adds an `awscdk.LambdaExtension` for each `.lambda-extension.ts` entrypoint in your source tree. If this is disabled, you can manually add an `awscdk.AutoDiscover` component to your project. __*Default*__: true
@@ -14160,6 +14163,7 @@ Name | Type | Description
 **eslint**?🔹 | <code>boolean</code> | Setup eslint.<br/>__*Default*__: true
 **eslintOptions**?🔹 | <code>[javascript.EslintOptions](#projen-javascript-eslintoptions)</code> | Eslint options.<br/>__*Default*__: opinionated default options
 **excludeTypescript**?🔹 | <code>Array<string></code> | Accepts a list of glob patterns.<br/>__*Optional*__
+**experimentalIntegRunner**?🔹 | <code>boolean</code> | Enable experimental support for the AWS CDK integ-runner.<br/>__*Default*__: false
 **gitIgnoreOptions**?🔹 | <code>[IgnoreFileOptions](#projen-ignorefileoptions)</code> | Configuration options for .gitignore file.<br/>__*Optional*__
 **gitOptions**?🔹 | <code>[GitOptions](#projen-gitoptions)</code> | Configuration options for git.<br/>__*Optional*__
 **github**?🔹 | <code>boolean</code> | Enable GitHub integration.<br/>__*Default*__: true
@@ -14555,6 +14559,7 @@ Name | Type | Description
 **entrypointTypes**?🔹 | <code>string</code> | The .d.ts file that includes the type declarations for this module.<br/>__*Default*__: .d.ts file derived from the project's entrypoint (usually lib/index.d.ts)
 **eslint**?🔹 | <code>boolean</code> | Setup eslint.<br/>__*Default*__: true
 **eslintOptions**?🔹 | <code>[javascript.EslintOptions](#projen-javascript-eslintoptions)</code> | Eslint options.<br/>__*Default*__: opinionated default options
+**experimentalIntegRunner**?🔹 | <code>boolean</code> | Enable experimental support for the AWS CDK integ-runner.<br/>__*Default*__: false
 **featureFlags**?🔹 | <code>boolean</code> | Include all feature flags in cdk.json.<br/>__*Default*__: true
 **gitIgnoreOptions**?🔹 | <code>[IgnoreFileOptions](#projen-ignorefileoptions)</code> | Configuration options for .gitignore file.<br/>__*Optional*__
 **gitOptions**?🔹 | <code>[GitOptions](#projen-gitoptions)</code> | Configuration options for git.<br/>__*Optional*__
@@ -14773,6 +14778,7 @@ Name | Type | Description
 **eslint**?⚠️ | <code>boolean</code> | Setup eslint.<br/>__*Default*__: true
 **eslintOptions**?⚠️ | <code>[javascript.EslintOptions](#projen-javascript-eslintoptions)</code> | Eslint options.<br/>__*Default*__: opinionated default options
 **excludeTypescript**?⚠️ | <code>Array<string></code> | Accepts a list of glob patterns.<br/>__*Optional*__
+**experimentalIntegRunner**?⚠️ | <code>boolean</code> | Enable experimental support for the AWS CDK integ-runner.<br/>__*Default*__: false
 **gitIgnoreOptions**?⚠️ | <code>[IgnoreFileOptions](#projen-ignorefileoptions)</code> | Configuration options for .gitignore file.<br/>__*Optional*__
 **gitOptions**?⚠️ | <code>[GitOptions](#projen-gitoptions)</code> | Configuration options for git.<br/>__*Optional*__
 **github**?⚠️ | <code>boolean</code> | Enable GitHub integration.<br/>__*Default*__: true

--- a/docs/awscdk.md
+++ b/docs/awscdk.md
@@ -311,7 +311,7 @@ for integration testing. To enable this feature, you specify
 
 
 ```typescript
-const { awscdk } = require('projen');
+import { awscdk } from 'projen';
 
 new awscdk.AwsCdkConstructLibrary({
   // ...
@@ -326,18 +326,18 @@ committed snapshots at build-time, or whenever the test task is run.
 
 Projen also provides two new commands:
 
-`yarn integ [...test names]` - Verifies integration test snapshots. If test
+`projen integ [...test names]` - Verifies integration test snapshots. If test
 names are provided, only the provided integration tests will be checked.
 Otherwise, all integration tests will be checked.
 
-`yarn integ:update [...test names]` - Verifies integration test snapshots or
+`projen integ:update [...test names]` - Verifies integration test snapshots or
 updates the integration test snapshot by re-running the integration test on
-failure. Like `yarn integ`, you may specify zero or more test names.
+failure. Like `projen integ`, you may specify zero or more test names.
 
 > Tests are named based on their file path. For instance, with an integration
 > test contained in `test/r53writer/integ.ddbStreamHandler.ts`, the test name
 > is `r53writer/integ.ddbStreamHandler`, and you could update the test's
-> snapshot by running `yarn integ:update r53writer/integ.ddbStreamHandler`.
+> snapshot by running `projen integ:update r53writer/integ.ddbStreamHandler`.
 
 ## Watch
 

--- a/docs/awscdk.md
+++ b/docs/awscdk.md
@@ -299,6 +299,46 @@ new Trigger(stack, 'RunAssertions', {
 
 [cdk-trigger-docs]:https://docs.aws.amazon.com/cdk/api/v1/docs/triggers-readme.html
 
+## Experimental `integ-runner` integration tests
+
+For TypeScript-based AWS CDK projects, Projen provides experimental support
+for using the [`integ-runner`][integ-runner] tool and [library][integ-library]
+for integration testing. To enable this feature, you specify
+`experimentalIntegRunner: true` in your project options.
+
+[integ-runner]: https://github.com/aws/aws-cdk/tree/main/packages/%40aws-cdk/integ-runner
+[integ-library]: https://docs.aws.amazon.com/cdk/api/v2/docs/integ-tests-alpha-readme.html
+
+
+```typescript
+const { awscdk } = require('projen');
+
+new awscdk.AwsCdkConstructLibrary({
+  // ...
+  experimentalIntegRunner: true
+});
+```
+
+After enabling experimental `integ-runner` support, all `integ.*.ts` files in
+the `test` directory will be automatically discovered and treated as
+integration tests. Projen will check that these integration tests match the
+committed snapshots at build-time, or whenever the test task is run.
+
+Projen also provides two new commands:
+
+`yarn integ [...test names]` - Verifies integration test snapshots. If test
+names are provided, only the provided integration tests will be checked.
+Otherwise, all integration tests will be checked.
+
+`yarn integ:update [...test names]` - Verifies integration test snapshots or
+updates the integration test snapshot by re-running the integration test on
+failure. Like `yarn integ`, you may specify zero or more test names.
+
+> Tests are named based on their file path. For instance, with an integration
+> test contained in `test/r53writer/integ.ddbStreamHandler.ts`, the test name
+> is `r53writer/integ.ddbStreamHandler`, and you could update the test's
+> snapshot by running `yarn integ:update r53writer/integ.ddbStreamHandler`.
+
 ## Watch
 
 > Only relevant for app projects

--- a/src/awscdk/awscdk-app-ts.ts
+++ b/src/awscdk/awscdk-app-ts.ts
@@ -5,6 +5,7 @@ import { AwsCdkDeps, AwsCdkDepsCommonOptions } from "./awscdk-deps";
 import { AwsCdkDepsJs } from "./awscdk-deps-js";
 import { CdkConfig, CdkConfigCommonOptions } from "./cdk-config";
 import { CdkTasks } from "./cdk-tasks";
+import { IntegRunner } from "./integ-runner";
 import { LambdaFunctionCommonOptions } from "./lambda-function";
 import { Component } from "../component";
 import { DependencyType } from "../dependencies";
@@ -56,6 +57,14 @@ export interface AwsCdkTypeScriptAppOptions
    * @default true
    */
   readonly integrationTestAutoDiscover?: boolean;
+
+  /**
+   * Enable experimental support for the AWS CDK integ-runner.
+   *
+   * @default false
+   * @experimental
+   */
+  readonly experimentalIntegRunner?: boolean;
 
   /**
    * Common options for all AWS Lambda functions.
@@ -176,6 +185,10 @@ export class AwsCdkTypeScriptApp extends TypeScriptAppProject {
       lambdaExtensionAutoDiscover: options.lambdaExtensionAutoDiscover ?? true,
       integrationTestAutoDiscover: options.integrationTestAutoDiscover ?? true,
     });
+
+    if (options.experimentalIntegRunner) {
+      new IntegRunner(this);
+    }
   }
 
   /**

--- a/src/awscdk/awscdk-construct.ts
+++ b/src/awscdk/awscdk-construct.ts
@@ -2,6 +2,7 @@ import * as semver from "semver";
 import { AutoDiscover } from "./auto-discover";
 import { AwsCdkDeps, AwsCdkDepsCommonOptions } from "./awscdk-deps";
 import { AwsCdkDepsJs } from "./awscdk-deps-js";
+import { IntegRunner } from "./integ-runner";
 import { LambdaFunctionCommonOptions } from "./lambda-function";
 import { ConstructLibrary, ConstructLibraryOptions } from "../cdk";
 import { DependencyType } from "../dependencies";
@@ -47,6 +48,14 @@ export interface AwsCdkConstructLibraryOptions
    * @default true
    */
   readonly integrationTestAutoDiscover?: boolean;
+
+  /**
+   * Enable experimental support for the AWS CDK integ-runner.
+   *
+   * @default false
+   * @experimental
+   */
+  readonly experimentalIntegRunner?: boolean;
 
   /**
    * Common options for all AWS Lambda functions.
@@ -99,6 +108,10 @@ export class AwsCdkConstructLibrary extends ConstructLibrary {
       lambdaExtensionAutoDiscover: options.lambdaExtensionAutoDiscover ?? true,
       integrationTestAutoDiscover: options.integrationTestAutoDiscover ?? true,
     });
+
+    if (options.experimentalIntegRunner) {
+      new IntegRunner(this);
+    }
   }
 
   /**

--- a/src/awscdk/integ-runner.ts
+++ b/src/awscdk/integ-runner.ts
@@ -22,16 +22,12 @@ export class IntegRunner extends Component {
     const integSnapshotTask = project.addTask("integ", {
       description: "Run integration snapshot tests",
       receiveArgs: true,
-      // Note: We're using -- to stop parsing of options because integ-runner
-      // interprets subsequent arguments as additional languages instead of
-      // test names. Unfortunately, this results in a warning from yarn, but
-      // it does not affect the execution of the command.
-      exec: "yarn integ-runner --language typescript --",
+      exec: "integ-runner $@ --language typescript",
     });
 
     project.addTask("integ:update", {
       description: "Run and update integration snapshot tests",
-      exec: "yarn integ-runner --language typescript --update-on-failed",
+      exec: "integ-runner $@ --language typescript --update-on-failed",
       receiveArgs: true,
     });
 

--- a/src/awscdk/integ-runner.ts
+++ b/src/awscdk/integ-runner.ts
@@ -1,0 +1,40 @@
+import { Component } from "../component";
+import { DependencyType } from "../dependencies";
+import { TypeScriptProject } from "../typescript";
+
+/**
+ * This component adds support for using `integ-runner` and `integ-tests`
+ * in a construct library.
+ */
+export class IntegRunner extends Component {
+  constructor(project: TypeScriptProject) {
+    super(project);
+
+    project.deps.addDependency(
+      "@aws-cdk/integ-runner@latest",
+      DependencyType.DEVENV
+    );
+    project.deps.addDependency(
+      "@aws-cdk/integ-tests-alpha@latest",
+      DependencyType.DEVENV
+    );
+
+    const integSnapshotTask = project.addTask("integ", {
+      description: "Run integration snapshot tests",
+      receiveArgs: true,
+      // Note: We're using -- to stop parsing of options because integ-runner
+      // interprets subsequent arguments as additional languages instead of
+      // test names. Unfortunately, this results in a warning from yarn, but
+      // it does not affect the execution of the command.
+      exec: "yarn integ-runner --language typescript --",
+    });
+
+    project.addTask("integ:update", {
+      description: "Run and update integration snapshot tests",
+      exec: "yarn integ-runner --language typescript --update-on-failed",
+      receiveArgs: true,
+    });
+
+    project.testTask.spawn(integSnapshotTask);
+  }
+}

--- a/test/__snapshots__/inventory.test.ts.snap
+++ b/test/__snapshots__/inventory.test.ts.snap
@@ -3476,6 +3476,23 @@ exports[`inventory 1`] = `
         "switch": "eslint-options",
       },
       {
+        "default": "false",
+        "docs": "Enable experimental support for the AWS CDK integ-runner.",
+        "featured": false,
+        "fullType": {
+          "primitive": "boolean",
+        },
+        "jsonLike": true,
+        "name": "experimentalIntegRunner",
+        "optional": true,
+        "parent": "AwsCdkTypeScriptAppOptions",
+        "path": [
+          "experimentalIntegRunner",
+        ],
+        "simpleType": "boolean",
+        "switch": "experimental-integ-runner",
+      },
+      {
         "default": "true",
         "docs": "Include all feature flags in cdk.json.",
         "featured": false,
@@ -6480,6 +6497,23 @@ exports[`inventory 1`] = `
         ],
         "simpleType": "unknown",
         "switch": "exclude-typescript",
+      },
+      {
+        "default": "false",
+        "docs": "Enable experimental support for the AWS CDK integ-runner.",
+        "featured": false,
+        "fullType": {
+          "primitive": "boolean",
+        },
+        "jsonLike": true,
+        "name": "experimentalIntegRunner",
+        "optional": true,
+        "parent": "AwsCdkConstructLibraryOptions",
+        "path": [
+          "experimentalIntegRunner",
+        ],
+        "simpleType": "boolean",
+        "switch": "experimental-integ-runner",
       },
       {
         "default": "true",

--- a/test/awscdk/awscdk-app.test.ts
+++ b/test/awscdk/awscdk-app.test.ts
@@ -181,11 +181,11 @@ describe("integ-runner", () => {
       snapshot["package.json"]?.devDependencies["@aws-cdk/integ-tests-alpha"]
     ).toStrictEqual("latest");
     expect(project.tasks.tryFind("integ")?.steps).toEqual([
-      { exec: "yarn integ-runner --language typescript --", receiveArgs: true },
+      { exec: "integ-runner $@ --language typescript", receiveArgs: true },
     ]);
     expect(project.tasks.tryFind("integ:update")?.steps).toEqual([
       {
-        exec: "yarn integ-runner --language typescript --update-on-failed",
+        exec: "integ-runner $@ --language typescript --update-on-failed",
         receiveArgs: true,
       },
     ]);

--- a/test/awscdk/awscdk-app.test.ts
+++ b/test/awscdk/awscdk-app.test.ts
@@ -163,6 +163,38 @@ describe("watch", () => {
   });
 });
 
+describe("integ-runner", () => {
+  test('adds "integ-runner" to devDependencies', () => {
+    const project = new AwsCdkTypeScriptApp({
+      name: "hello",
+      cdkVersion: "2.12.0",
+      defaultReleaseBranch: "main",
+      experimentalIntegRunner: true,
+    });
+
+    const snapshot = synthSnapshot(project);
+
+    expect(
+      snapshot["package.json"]?.devDependencies["@aws-cdk/integ-runner"]
+    ).toStrictEqual("latest");
+    expect(
+      snapshot["package.json"]?.devDependencies["@aws-cdk/integ-tests-alpha"]
+    ).toStrictEqual("latest");
+    expect(project.tasks.tryFind("integ")?.steps).toEqual([
+      { exec: "yarn integ-runner --language typescript --", receiveArgs: true },
+    ]);
+    expect(project.tasks.tryFind("integ:update")?.steps).toEqual([
+      {
+        exec: "yarn integ-runner --language typescript --update-on-failed",
+        receiveArgs: true,
+      },
+    ]);
+    expect(project.testTask.steps).toEqual(
+      expect.arrayContaining([{ spawn: "integ" }])
+    );
+  });
+});
+
 test("CDK v1 usage", () => {
   const project = new AwsCdkTypeScriptApp({
     cdkVersion: "1.126.0",

--- a/test/awscdk/awscdk-construct.test.ts
+++ b/test/awscdk/awscdk-construct.test.ts
@@ -304,6 +304,36 @@ describe("workflow container image", () => {
   });
 });
 
+describe("integ-runner", () => {
+  test('adds "integ-runner" to devDependencies', () => {
+    const project = new TestProject({
+      cdkVersion: "2.12.0",
+      experimentalIntegRunner: true,
+    });
+
+    const snapshot = synthSnapshot(project);
+
+    expect(
+      snapshot["package.json"]?.devDependencies["@aws-cdk/integ-runner"]
+    ).toStrictEqual("latest");
+    expect(
+      snapshot["package.json"]?.devDependencies["@aws-cdk/integ-tests-alpha"]
+    ).toStrictEqual("latest");
+    expect(project.tasks.tryFind("integ")?.steps).toEqual([
+      { exec: "yarn integ-runner --language typescript --", receiveArgs: true },
+    ]);
+    expect(project.tasks.tryFind("integ:update")?.steps).toEqual([
+      {
+        exec: "yarn integ-runner --language typescript --update-on-failed",
+        receiveArgs: true,
+      },
+    ]);
+    expect(project.testTask.steps).toEqual(
+      expect.arrayContaining([{ spawn: "integ" }])
+    );
+  });
+});
+
 it("warns the user if they add CDK v1 dependencies to a CDK v2 project", () => {
   // GIVEN
   console.error = jest.fn();

--- a/test/awscdk/awscdk-construct.test.ts
+++ b/test/awscdk/awscdk-construct.test.ts
@@ -320,11 +320,11 @@ describe("integ-runner", () => {
       snapshot["package.json"]?.devDependencies["@aws-cdk/integ-tests-alpha"]
     ).toStrictEqual("latest");
     expect(project.tasks.tryFind("integ")?.steps).toEqual([
-      { exec: "yarn integ-runner --language typescript --", receiveArgs: true },
+      { exec: "integ-runner $@ --language typescript", receiveArgs: true },
     ]);
     expect(project.tasks.tryFind("integ:update")?.steps).toEqual([
       {
-        exec: "yarn integ-runner --language typescript --update-on-failed",
+        exec: "integ-runner $@ --language typescript --update-on-failed",
         receiveArgs: true,
       },
     ]);


### PR DESCRIPTION
This PR introduces preliminary and experimental support for `integ-runner` integration tests in AWS CDK TypeScript projects.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
