### PR TITLE
fix(node-package)!: components cannot change deps at preSynthesize stage

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -9085,18 +9085,6 @@ postSynthesize(): void
 
 
 
-#### preSynthesize()🔹 <a id="projen-javascript-nodepackage-presynthesize"></a>
-
-Called before synthesis.
-
-```ts
-preSynthesize(): void
-```
-
-
-
-
-
 #### removeScript(name)🔹 <a id="projen-javascript-nodepackage-removescript"></a>
 
 Removes an npm script (always successful).
@@ -9120,6 +9108,18 @@ setScript(name: string, command: string): void
 
 * **name** (<code>string</code>)  The script name.
 * **command** (<code>string</code>)  The command to execute.
+
+
+
+
+#### synthesize()🔹 <a id="projen-javascript-nodepackage-synthesize"></a>
+
+Synthesizes files to the project output directory.
+
+```ts
+synthesize(): void
+```
+
 
 
 


### PR DESCRIPTION
NodePackage are synthesising all dependencies during `preSynthesize` phase rather than during `synthesize` (as projen philosophy dictates). This results that any components added after NodePackage (that means almost all of them in normal situation of using NodeProject) cannot make any changes to dependencies during their `preSynthesize` (that changes will be silently ignored).

However, ability for components to make dependencies changes during `preSynthesize` are crucial to not require specific components order. For example a component (i.e. implementing [BrowsersList](https://github.com/browserslist/browserslist) config) wants to add a dev dependency (i.e. [stylelint-no-unsupported-browser-features](https://github.com/ismay/stylelint-no-unsupported-browser-features)) only if another component (in this example - implementing [Stylelint](https://stylelint.io/user-guide/configure/) config) are present in the project. The logical place to do it without forcing components adding order is at `preSynthesize` that will be called when all components are added to the project.

This PR fixes the above mentioned fact by noticing that we are actually reading pre-existing `package.json` twice - once in the constructor and once again in the `renderDependencies`. So we assigning first read to a class private field and just re-use that at `renderDependencies`.

One existing unit test that were based on assumption at which moment pre-existing package.json will be read slightly adjusted to be free of that assumption.

Another unit test added to demonstrate that modifying dependencies from components during `preSynthesize` is now working as expected.

BREAKING CHANGE: This may potentially affect some edge cases that were relying on the internal implementation of the dependencies handling. If new dependencies appear/disappear after applying this fix, previous code `preSynthesize` handler should be inspected for any `.addDependency`-like calls - those were incorrectly ignored previously and should be removed if actually are not needed.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
