### PR TITLE
feat(vscode): allow to extend existing setting if exists

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -12088,31 +12088,33 @@ new vscode.VsCodeSettings(vscode: VsCode)
 ### Methods
 
 
-#### addSetting(setting, value, language?)🔹 <a id="projen-vscode-vscodesettings-addsetting"></a>
+#### addSetting(setting, value, language?, extend?)🔹 <a id="projen-vscode-vscodesettings-addsetting"></a>
 
 Adds a workspace setting.
 
 ```ts
-addSetting(setting: string, value: any, language?: string): void
+addSetting(setting: string, value: any, language?: string, extend?: boolean): void
 ```
 
 * **setting** (<code>string</code>)  The setting ID.
 * **value** (<code>any</code>)  The value of the setting.
 * **language** (<code>string</code>)  Scope the setting to a specific language.
+* **extend** (<code>boolean</code>)  Extend an existing setting if exists, override completely if false (default: false).
 
 
 
 
-#### addSettings(settings, languages?)🔹 <a id="projen-vscode-vscodesettings-addsettings"></a>
+#### addSettings(settings, languages?, extend?)🔹 <a id="projen-vscode-vscodesettings-addsettings"></a>
 
 Adds a workspace setting.
 
 ```ts
-addSettings(settings: Map<string, any>, languages?: string &#124; Array<string>): void
+addSettings(settings: Map<string, any>, languages?: string &#124; Array<string>, extend?: boolean): void
 ```
 
 * **settings** (<code>Map<string, any></code>)  Array structure: [setting: string, value: any, languages?: string[]].
 * **languages** (<code>string &#124; Array<string></code>)  *No description*
+* **extend** (<code>boolean</code>)  *No description*
 
 
 

--- a/test/vscode/settings.test.ts
+++ b/test/vscode/settings.test.ts
@@ -105,3 +105,55 @@ test("batch add settings", () => {
     },
   });
 });
+
+test('add array setting with "extend" option', () => {
+  // GIVEN
+  const project = new TestProject();
+
+  // WHEN
+  project.vscode?.settings.addSetting("editor.rulers", [80], undefined, true);
+  project.vscode?.settings.addSetting("editor.rulers", [120], undefined, true);
+  project.vscode?.settings.addSetting("editor.rulers", [80], undefined, true); // duplicate
+
+  // THEN
+  const settings = synthSnapshot(project)[VSCODE_SETTINGS_FILE];
+
+  expect(settings).toStrictEqual({
+    "//": expect.anything(),
+    "editor.rulers": [80, 120],
+  });
+});
+
+test('add object setting with "extend" option', () => {
+  // GIVEN
+  const project = new TestProject();
+
+  // WHEN
+  project.vscode?.settings.addSetting(
+    "search.exclude",
+    {
+      "**/node_modules": true,
+    },
+    undefined,
+    true
+  );
+  project.vscode?.settings.addSetting(
+    "search.exclude",
+    {
+      "**/bower_components": true,
+    },
+    undefined,
+    true
+  );
+
+  // THEN
+  const settings = synthSnapshot(project)[VSCODE_SETTINGS_FILE];
+
+  expect(settings).toStrictEqual({
+    "//": expect.anything(),
+    "search.exclude": {
+      "**/node_modules": true,
+      "**/bower_components": true,
+    },
+  });
+});


### PR DESCRIPTION
VSCode has many settings which values are either array or object, like `files.exclude` or `prettier.documentSelectors`. Particular components normally want just to extend that setting (i.e. adding additional exclude, or some extra file extension to Prettier) rather than completely override it (as it would result in conflicts between components). Unfortunately we can't also reliable use JsonPatch as workaround as we are not always known where that settings already exits. 

This PR adds a flag that allows to extend existing array or object in case if it already exists. To make this a non-breaking change we are adding extra parameter defaulting to current behaviour.

Unit tests are extended to cover added functionality.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
