### PR TITLE
fix(poetry): add version fallback

### DIFF
--- a/src/python/poetry.ts
+++ b/src/python/poetry.ts
@@ -85,7 +85,7 @@ export class Poetry
         pythonDefined = true;
       }
       if (pkg.type === DependencyType.RUNTIME) {
-        dependencies[pkg.name] = pkg.version;
+        dependencies[pkg.name] = pkg.version ?? "*";
       }
     }
     if (!pythonDefined) {
@@ -99,7 +99,7 @@ export class Poetry
     const dependencies: { [key: string]: any } = {};
     for (const pkg of this.project.deps.all) {
       if ([DependencyType.DEVENV, DependencyType.TEST].includes(pkg.type)) {
-        dependencies[pkg.name] = pkg.version;
+        dependencies[pkg.name] = pkg.version ?? "*";
       }
     }
     return this.permitDependenciesWithMetadata(dependencies);

--- a/test/python/__snapshots__/poetry.test.ts.snap
+++ b/test/python/__snapshots__/poetry.test.ts.snap
@@ -180,6 +180,10 @@ cython_debug/
         "version": "0.0.2",
       },
       {
+        "name": "package3",
+        "type": "runtime",
+      },
+      {
         "name": "pytest",
         "type": "test",
         "version": "6.2.1",
@@ -361,6 +365,7 @@ exclude = [ "my_package/excluded.py" ]
   [tool.poetry.dependencies]
   package1 = "0.0.1"
   package2 = "0.0.2"
+  package3 = "*"
   python = "^3.7"
 
   [tool.poetry.dev-dependencies]

--- a/test/python/poetry.test.ts
+++ b/test/python/poetry.test.ts
@@ -106,7 +106,7 @@ test("poetry enabled with poetry-specific options", () => {
     description: "a short project description",
     license: "Apache-2.0",
     classifiers: ["Development Status :: 4 - Beta"],
-    deps: ["package1@0.0.1", "package2@0.0.2"],
+    deps: ["package1@0.0.1", "package2@0.0.2", "package3"],
     poetryOptions: {
       maintainers: ["First-2 Last-2"],
       repository: "https://github.com/test-python-project",


### PR DESCRIPTION
Python projects with Poetry as a dependency manager are silently ignoring all dependencies without explicit version. This PR fixes that by adding `*` fallback according to [Poetry docs](https://python-poetry.org/docs/managing-dependencies/)


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
