### PR TITLE
feat(node): default to Node.js 18.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.12.0
+          node-version: 18.14.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -95,7 +95,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.12.0
+          node-version: 18.14.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -124,7 +124,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.12.0
+          node-version: 18.14.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -149,7 +149,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.12.0
+          node-version: 18.14.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -177,7 +177,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.12.0
+          node-version: 18.14.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.14.0
+          node-version: 18.12.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -95,7 +95,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.14.0
+          node-version: 18.12.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -124,7 +124,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.14.0
+          node-version: 18.12.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -149,7 +149,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.14.0
+          node-version: 18.12.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -177,7 +177,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.14.0
+          node-version: 18.12.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.14.0
+          node-version: 18.12.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.14.0
+          node-version: 18.12.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -103,7 +103,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.14.0
+          node-version: 18.12.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -154,7 +154,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.14.0
+          node-version: 18.12.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -204,7 +204,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.14.0
+          node-version: 18.12.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -253,7 +253,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.14.0
+          node-version: 18.12.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.12.0
+          node-version: 18.14.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.12.0
+          node-version: 18.14.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -103,7 +103,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.12.0
+          node-version: 18.14.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -154,7 +154,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.12.0
+          node-version: 18.14.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -204,7 +204,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.12.0
+          node-version: 18.14.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -253,7 +253,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.12.0
+          node-version: 18.14.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.12.0
+          node-version: 18.14.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.14.0
+          node-version: 18.12.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "@types/node",
-      "version": "^14",
+      "version": "^16",
       "type": "build"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -73,8 +73,8 @@ const project = new cdk.JsiiProject({
 
   projenDevDependency: false, // because I am projen
   releaseToNpm: true,
-  minNodeVersion: "14.0.0", // Do not change this before a version has been EOL for a while
-  workflowNodeVersion: "16.14.0",
+  minNodeVersion: "16.0.0", // Do not change this before a version has been EOL for a while
+  workflowNodeVersion: "18.12.0",
 
   codeCov: true,
   prettier: true,

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -74,7 +74,7 @@ const project = new cdk.JsiiProject({
   projenDevDependency: false, // because I am projen
   releaseToNpm: true,
   minNodeVersion: "16.0.0", // Do not change this before a version has been EOL for a while
-  workflowNodeVersion: "18.12.0",
+  workflowNodeVersion: "18.14.0",
 
   codeCov: true,
   prettier: true,

--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -5111,7 +5111,7 @@ new awscdk.LambdaFunction(project: Project, options: LambdaFunctionOptions)
   * **awsSdkConnectionReuse** (<code>boolean</code>)  Whether to automatically reuse TCP connections when working with the AWS SDK for JavaScript. __*Default*__: true
   * **bundlingOptions** (<code>[javascript.BundlingOptions](#projen-javascript-bundlingoptions)</code>)  Bundling options for this AWS Lambda function. __*Default*__: defaults
   * **edgeLambda** (<code>boolean</code>)  Whether to create a `cloudfront.experimental.EdgeFunction` instead of a `lambda.Function`. __*Default*__: false
-  * **runtime** (<code>[awscdk.LambdaRuntime](#projen-awscdk-lambdaruntime)</code>)  The node.js version to target. __*Default*__: Runtime.NODEJS_16_X
+  * **runtime** (<code>[awscdk.LambdaRuntime](#projen-awscdk-lambdaruntime)</code>)  The node.js version to target. __*Default*__: Runtime.NODEJS_18_X
   * **cdkDeps** (<code>[awscdk.AwsCdkDeps](#projen-awscdk-awscdkdeps)</code>)  AWS CDK dependency manager. 
   * **entrypoint** (<code>string</code>)  A path from the project root directory to a TypeScript file which contains the AWS Lambda handler entrypoint (exports a `handler` function). 
   * **constructFile** (<code>string</code>)  The name of the generated TypeScript source file. __*Default*__: The name of the entrypoint file, with the `-function.ts` suffix instead of `.lambda.ts`.
@@ -15035,7 +15035,7 @@ Name | Type | Description
 **awsSdkConnectionReuse**?🔹 | <code>boolean</code> | Whether to automatically reuse TCP connections when working with the AWS SDK for JavaScript.<br/>__*Default*__: true
 **bundlingOptions**?🔹 | <code>[javascript.BundlingOptions](#projen-javascript-bundlingoptions)</code> | Bundling options for this AWS Lambda function.<br/>__*Default*__: defaults
 **edgeLambda**?🔹 | <code>boolean</code> | Whether to create a `cloudfront.experimental.EdgeFunction` instead of a `lambda.Function`.<br/>__*Default*__: false
-**runtime**?🔹 | <code>[awscdk.LambdaRuntime](#projen-awscdk-lambdaruntime)</code> | The node.js version to target.<br/>__*Default*__: Runtime.NODEJS_16_X
+**runtime**?🔹 | <code>[awscdk.LambdaRuntime](#projen-awscdk-lambdaruntime)</code> | The node.js version to target.<br/>__*Default*__: Runtime.NODEJS_18_X
 
 
 
@@ -15055,7 +15055,7 @@ Name | Type | Description
 **constructFile**?🔹 | <code>string</code> | The name of the generated TypeScript source file.<br/>__*Default*__: The name of the entrypoint file, with the `-function.ts` suffix instead of `.lambda.ts`.
 **constructName**?🔹 | <code>string</code> | The name of the generated `lambda.Function` subclass.<br/>__*Default*__: A pascal cased version of the name of the entrypoint file, with the extension `Function` (e.g. `ResizeImageFunction`).
 **edgeLambda**?🔹 | <code>boolean</code> | Whether to create a `cloudfront.experimental.EdgeFunction` instead of a `lambda.Function`.<br/>__*Default*__: false
-**runtime**?🔹 | <code>[awscdk.LambdaRuntime](#projen-awscdk-lambdaruntime)</code> | The node.js version to target.<br/>__*Default*__: Runtime.NODEJS_16_X
+**runtime**?🔹 | <code>[awscdk.LambdaRuntime](#projen-awscdk-lambdaruntime)</code> | The node.js version to target.<br/>__*Default*__: Runtime.NODEJS_18_X
 
 
 

--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -5155,7 +5155,7 @@ Name | Type | Description
 *static* **NODEJS_10_X**⚠️ | <code>[awscdk.LambdaRuntime](#projen-awscdk-lambdaruntime)</code> | Node.js 10.x.
 *static* **NODEJS_12_X**⚠️ | <code>[awscdk.LambdaRuntime](#projen-awscdk-lambdaruntime)</code> | Node.js 12.x.
 *static* **NODEJS_14_X**⚠️ | <code>[awscdk.LambdaRuntime](#projen-awscdk-lambdaruntime)</code> | Node.js 14.x.
-*static* **NODEJS_16_X**🔹 | <code>[awscdk.LambdaRuntime](#projen-awscdk-lambdaruntime)</code> | Node.js 16.x.
+*static* **NODEJS_16_X**⚠️ | <code>[awscdk.LambdaRuntime](#projen-awscdk-lambdaruntime)</code> | Node.js 16.x.
 *static* **NODEJS_18_X**🔹 | <code>[awscdk.LambdaRuntime](#projen-awscdk-lambdaruntime)</code> | Node.js 18.x.
 
 
@@ -10749,7 +10749,7 @@ new release.Publisher(project: Project, options: PublisherOptions)
   * **publibVersion** (<code>string</code>)  Version requirement for `publib`. __*Default*__: "latest"
   * **publishTasks** (<code>boolean</code>)  Define publishing tasks that can be executed manually as well as workflows. __*Default*__: false
   * **workflowContainerImage** (<code>string</code>)  Container image to use for GitHub workflows. __*Default*__: default image
-  * **workflowNodeVersion** (<code>string</code>)  Node version to setup in GitHub workflows if any node-based CLI utilities are needed. __*Default*__: 16.x
+  * **workflowNodeVersion** (<code>string</code>)  Node version to setup in GitHub workflows if any node-based CLI utilities are needed. __*Default*__: 18.x
   * **workflowRunsOn** (<code>Array<string></code>)  Github Runner selection labels. __*Default*__: ["ubuntu-latest"]
   * **workflowRunsOnGroup** (<code>[GroupRunnerOptions](#projen-grouprunneroptions)</code>)  Github Runner Group selection options. __*Optional*__
 
@@ -11011,7 +11011,7 @@ new release.Release(project: GitHubProject, options: ReleaseOptions)
   * **task** (<code>[Task](#projen-task)</code>)  The task to execute in order to create the release artifacts. 
   * **versionFile** (<code>string</code>)  A name of a .json file to set the `version` field in after a bump. 
   * **githubRelease** (<code>boolean</code>)  Create a GitHub release for each release. __*Default*__: true
-  * **workflowNodeVersion** (<code>string</code>)  Node version to setup in GitHub workflows if any node-based CLI utilities are needed. __*Default*__: 16.x
+  * **workflowNodeVersion** (<code>string</code>)  Node version to setup in GitHub workflows if any node-based CLI utilities are needed. __*Default*__: 18.x
   * **workflowPermissions** (<code>[github.workflows.JobPermissions](#projen-github-workflows-jobpermissions)</code>)  Permissions granted to the release workflow job. __*Default*__: `{ contents: JobPermission.WRITE }`
 
 
@@ -19347,7 +19347,7 @@ Name | Type | Description
 **publibVersion**?🔹 | <code>string</code> | Version requirement for `publib`.<br/>__*Default*__: "latest"
 **publishTasks**?🔹 | <code>boolean</code> | Define publishing tasks that can be executed manually as well as workflows.<br/>__*Default*__: false
 **workflowContainerImage**?🔹 | <code>string</code> | Container image to use for GitHub workflows.<br/>__*Default*__: default image
-**workflowNodeVersion**?🔹 | <code>string</code> | Node version to setup in GitHub workflows if any node-based CLI utilities are needed.<br/>__*Default*__: 16.x
+**workflowNodeVersion**?🔹 | <code>string</code> | Node version to setup in GitHub workflows if any node-based CLI utilities are needed.<br/>__*Default*__: 18.x
 **workflowRunsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 **workflowRunsOnGroup**?🔹 | <code>[GroupRunnerOptions](#projen-grouprunneroptions)</code> | Github Runner Group selection options.<br/>__*Optional*__
 
@@ -19405,7 +19405,7 @@ Name | Type | Description
 **releaseWorkflowSetupSteps**?🔹 | <code>Array<[github.workflows.JobStep](#projen-github-workflows-jobstep)></code> | A set of workflow steps to execute in order to setup the workflow container.<br/>__*Optional*__
 **versionrcOptions**?🔹 | <code>Map<string, any></code> | Custom configuration used when creating changelog with standard-version package.<br/>__*Default*__: standard configuration applicable for GitHub repositories
 **workflowContainerImage**?🔹 | <code>string</code> | Container image to use for GitHub workflows.<br/>__*Default*__: default image
-**workflowNodeVersion**?🔹 | <code>string</code> | Node version to setup in GitHub workflows if any node-based CLI utilities are needed.<br/>__*Default*__: 16.x
+**workflowNodeVersion**?🔹 | <code>string</code> | Node version to setup in GitHub workflows if any node-based CLI utilities are needed.<br/>__*Default*__: 18.x
 **workflowPermissions**?🔹 | <code>[github.workflows.JobPermissions](#projen-github-workflows-jobpermissions)</code> | Permissions granted to the release workflow job.<br/>__*Default*__: `{ contents: JobPermission.WRITE }`
 **workflowRunsOn**?🔹 | <code>Array<string></code> | Github Runner selection labels.<br/>__*Default*__: ["ubuntu-latest"]
 **workflowRunsOnGroup**?🔹 | <code>[GroupRunnerOptions](#projen-grouprunneroptions)</code> | Github Runner Group selection options.<br/>__*Optional*__

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@types/glob": "^7.2.0",
     "@types/ini": "^1.3.31",
     "@types/jest": "^27",
-    "@types/node": "^14",
+    "@types/node": "^16",
     "@types/semver": "^7.5.3",
     "@types/yargs": "^16.0.6",
     "@typescript-eslint/eslint-plugin": "^6",
@@ -117,7 +117,7 @@
     "scaffolding"
   ],
   "engines": {
-    "node": ">= 14.0.0"
+    "node": ">= 16.0.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/src/awscdk/awscdk-construct.ts
+++ b/src/awscdk/awscdk-construct.ts
@@ -87,7 +87,7 @@ export class AwsCdkConstructLibrary extends ConstructLibrary {
               pinnedDevDependency: false,
             }
           : undefined,
-      workflowNodeVersion: options.minNodeVersion ?? "16.x",
+      workflowNodeVersion: options.minNodeVersion ?? "18.x",
       ...options,
     });
 

--- a/src/awscdk/lambda-function.ts
+++ b/src/awscdk/lambda-function.ts
@@ -331,6 +331,7 @@ export class LambdaRuntime {
 
   /**
    * Node.js 16.x
+   * @deprecated NodeJS16 has been deprecated
    */
   public static readonly NODEJS_16_X = new LambdaRuntime(
     "nodejs16.x",
@@ -343,7 +344,8 @@ export class LambdaRuntime {
    */
   public static readonly NODEJS_18_X = new LambdaRuntime(
     "nodejs18.x",
-    "node18"
+    "node18",
+    { defaultExternals: []}
   );
 
   public readonly esbuildPlatform = "node";

--- a/src/awscdk/lambda-function.ts
+++ b/src/awscdk/lambda-function.ts
@@ -301,7 +301,7 @@ export interface LambdaRuntimeOptions {
 export class LambdaRuntime {
   /**
    * Node.js 10.x
-   * @deprecated NodeJS10 has been deprecated
+   * @deprecated NodeJS10 has been deprecated February 14, 2022
    */
   public static readonly NODEJS_10_X = new LambdaRuntime(
     "nodejs10.x",
@@ -311,7 +311,7 @@ export class LambdaRuntime {
 
   /**
    * Node.js 12.x
-   * @deprecated NodeJS12 has been deprecated
+   * @deprecated NodeJS12 has been deprecated April 30, 2023
    */
   public static readonly NODEJS_12_X = new LambdaRuntime(
     "nodejs12.x",
@@ -321,7 +321,7 @@ export class LambdaRuntime {
 
   /**
    * Node.js 14.x
-   * @deprecated NodeJS14 has been deprecated
+   * @deprecated NodeJS14 has been deprecation November 27, 2023
    */
   public static readonly NODEJS_14_X = new LambdaRuntime(
     "nodejs14.x",
@@ -331,7 +331,7 @@ export class LambdaRuntime {
 
   /**
    * Node.js 16.x
-   * @deprecated NodeJS16 has been deprecated
+   * @deprecated NodeJS16 has been deprecated March 11, 2024
    */
   public static readonly NODEJS_16_X = new LambdaRuntime(
     "nodejs16.x",
@@ -344,8 +344,7 @@ export class LambdaRuntime {
    */
   public static readonly NODEJS_18_X = new LambdaRuntime(
     "nodejs18.x",
-    "node18",
-    { defaultExternals: ["@aws-sdk/*"] }
+    "node18"
   );
 
   public readonly esbuildPlatform = "node";

--- a/src/awscdk/lambda-function.ts
+++ b/src/awscdk/lambda-function.ts
@@ -345,7 +345,7 @@ export class LambdaRuntime {
   public static readonly NODEJS_18_X = new LambdaRuntime(
     "nodejs18.x",
     "node18",
-    { defaultExternals: []}
+    { defaultExternals: ["@aws-sdk/*"]}
   );
 
   public readonly esbuildPlatform = "node";

--- a/src/awscdk/lambda-function.ts
+++ b/src/awscdk/lambda-function.ts
@@ -20,7 +20,7 @@ export interface LambdaFunctionCommonOptions {
   /**
    * The node.js version to target.
    *
-   * @default Runtime.NODEJS_16_X
+   * @default Runtime.NODEJS_18_X
    */
   readonly runtime?: LambdaRuntime;
 
@@ -134,7 +134,7 @@ export class LambdaFunction extends Component {
       );
     }
 
-    const runtime = options.runtime ?? LambdaRuntime.NODEJS_16_X;
+    const runtime = options.runtime ?? LambdaRuntime.NODEJS_18_X;
 
     // allow Lambda handler code to import dev-deps since they are only needed
     // during bundling
@@ -345,7 +345,7 @@ export class LambdaRuntime {
   public static readonly NODEJS_18_X = new LambdaRuntime(
     "nodejs18.x",
     "node18",
-    { defaultExternals: ["@aws-sdk/*"]}
+    { defaultExternals: ["@aws-sdk/*"] }
   );
 
   public readonly esbuildPlatform = "node";

--- a/src/awscdk/lambda-function.ts
+++ b/src/awscdk/lambda-function.ts
@@ -301,7 +301,7 @@ export interface LambdaRuntimeOptions {
 export class LambdaRuntime {
   /**
    * Node.js 10.x
-   * @deprecated NodeJS10 has been deprecated February 14, 2022
+   * @deprecated NodeJS10 has been deprecated on February 14, 2022
    */
   public static readonly NODEJS_10_X = new LambdaRuntime(
     "nodejs10.x",
@@ -311,7 +311,7 @@ export class LambdaRuntime {
 
   /**
    * Node.js 12.x
-   * @deprecated NodeJS12 has been deprecated April 30, 2023
+   * @deprecated NodeJS12 has been deprecated on April 30, 2023
    */
   public static readonly NODEJS_12_X = new LambdaRuntime(
     "nodejs12.x",
@@ -321,7 +321,7 @@ export class LambdaRuntime {
 
   /**
    * Node.js 14.x
-   * @deprecated NodeJS14 has been deprecation November 27, 2023
+   * @deprecated NodeJS14 will be deprecated on November 27, 2023
    */
   public static readonly NODEJS_14_X = new LambdaRuntime(
     "nodejs14.x",
@@ -331,7 +331,7 @@ export class LambdaRuntime {
 
   /**
    * Node.js 16.x
-   * @deprecated NodeJS16 has been deprecated March 11, 2024
+   * @deprecated NodeJS16 will be deprecated on March 11, 2024
    */
   public static readonly NODEJS_16_X = new LambdaRuntime(
     "nodejs16.x",

--- a/src/cdk/jsii-project.ts
+++ b/src/cdk/jsii-project.ts
@@ -450,7 +450,7 @@ export class JsiiProject extends TypeScriptProject {
       ),
       permissions: {},
       tools: {
-        node: { version: this.nodeVersion ?? "16.x" },
+        node: { version: this.nodeVersion ?? "18.x" },
         ...pacmak.publishTools,
       },
       steps: pacmak.prePublishSteps ?? [],

--- a/src/release/publisher.ts
+++ b/src/release/publisher.ts
@@ -67,7 +67,7 @@ export interface PublisherOptions {
    * are needed. For example `publib`, the CLI projen uses to publish releases,
    * is an npm library.
    *
-   * @default 16.x
+   * @default 18.x
    */
   readonly workflowNodeVersion?: string;
 
@@ -176,7 +176,7 @@ export class Publisher extends Component {
     this.jsiiReleaseVersion = this.publibVersion;
     this.condition = options.condition;
     this.dryRun = options.dryRun ?? false;
-    this.workflowNodeVersion = options.workflowNodeVersion ?? "16.x";
+    this.workflowNodeVersion = options.workflowNodeVersion ?? "18.x";
     this.workflowContainerImage = options.workflowContainerImage;
 
     this.failureIssue = options.failureIssue ?? false;

--- a/src/release/release.ts
+++ b/src/release/release.ts
@@ -267,7 +267,7 @@ export interface ReleaseOptions extends ReleaseProjectOptions {
    * are needed. For example `publib`, the CLI projen uses to publish releases,
    * is an npm library.
    *
-   * @default 16.x
+   * @default 18.x
    */
   readonly workflowNodeVersion?: string;
 

--- a/src/web/next.ts
+++ b/src/web/next.ts
@@ -77,7 +77,7 @@ export class NextJsProject extends NodeProject {
     super({
       jest: false,
       minNodeVersion: "12.22.0", // https://nextjs.org/docs#system-requirements
-      workflowNodeVersion: "16.x",
+      workflowNodeVersion: "18.x",
       ...options,
     });
 
@@ -128,7 +128,7 @@ export class NextJsTypeScriptProject extends TypeScriptAppProject {
       eslint: false,
       minNodeVersion: "12.22.0", // https://nextjs.org/docs#system-requirements
       jest: false,
-      workflowNodeVersion: "16.x",
+      workflowNodeVersion: "18.x",
       tsconfig: {
         include: ["**/*.ts", "**/*.tsx"],
         compilerOptions: {

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -4038,7 +4038,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:

--- a/test/awscdk/__snapshots__/awscdk-construct.test.ts.snap
+++ b/test/awscdk/__snapshots__/awscdk-construct.test.ts.snap
@@ -100,7 +100,7 @@ exports[`node version in workflow does setup default version 1`] = `
       "name": "Setup Node.js",
       "uses": "actions/setup-node@v3",
       "with": {
-        "node-version": "16.x",
+        "node-version": "18.x",
       },
     },
     {

--- a/test/awscdk/__snapshots__/lambda-function.test.ts.snap
+++ b/test/awscdk/__snapshots__/lambda-function.test.ts.snap
@@ -49,7 +49,7 @@ export class HelloFunction extends lambda.Function {
     super(scope, id, {
       description: 'src/hello.lambda.ts',
       ...props,
-      runtime: new lambda.Runtime('nodejs12.x', lambda.RuntimeFamily.NODEJS),
+      runtime: new lambda.Runtime('nodejs18.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../assets/hello.lambda')),
     });
@@ -78,7 +78,7 @@ export class WorldFunction extends lambda.Function {
     super(scope, id, {
       description: 'src/subdir/world.lambda.ts',
       ...props,
-      runtime: new lambda.Runtime('nodejs12.x', lambda.RuntimeFamily.NODEJS),
+      runtime: new lambda.Runtime('nodejs18.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../../assets/subdir/world.lambda')),
     });
@@ -107,7 +107,7 @@ export class JangyFunction extends lambda.Function {
     super(scope, id, {
       description: 'src/subdir/jangy.lambda.ts',
       ...props,
-      runtime: new lambda.Runtime('nodejs12.x', lambda.RuntimeFamily.NODEJS),
+      runtime: new lambda.Runtime('nodejs18.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../../assets/subdir/jangy.lambda')),
     });
@@ -140,7 +140,7 @@ exports[`auto-discover 5`] = `
   "name": "bundle:hello.lambda",
   "steps": [
     {
-      "exec": "esbuild --bundle src/hello.lambda.ts --target="node12" --platform="node" --outfile="assets/hello.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:aws-sdk",
+      "exec": "esbuild --bundle src/hello.lambda.ts --target="node18" --platform="node" --outfile="assets/hello.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:@aws-sdk/*",
     },
   ],
 }
@@ -152,7 +152,7 @@ exports[`auto-discover 6`] = `
   "name": "bundle:hello.lambda:watch",
   "steps": [
     {
-      "exec": "esbuild --bundle src/hello.lambda.ts --target="node12" --platform="node" --outfile="assets/hello.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:aws-sdk --watch",
+      "exec": "esbuild --bundle src/hello.lambda.ts --target="node18" --platform="node" --outfile="assets/hello.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:@aws-sdk/* --watch",
     },
   ],
 }
@@ -164,7 +164,7 @@ exports[`auto-discover 7`] = `
   "name": "bundle:subdir/jangy.lambda",
   "steps": [
     {
-      "exec": "esbuild --bundle src/subdir/jangy.lambda.ts --target="node12" --platform="node" --outfile="assets/subdir/jangy.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:aws-sdk",
+      "exec": "esbuild --bundle src/subdir/jangy.lambda.ts --target="node18" --platform="node" --outfile="assets/subdir/jangy.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:@aws-sdk/*",
     },
   ],
 }
@@ -176,7 +176,7 @@ exports[`auto-discover 8`] = `
   "name": "bundle:subdir/jangy.lambda:watch",
   "steps": [
     {
-      "exec": "esbuild --bundle src/subdir/jangy.lambda.ts --target="node12" --platform="node" --outfile="assets/subdir/jangy.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:aws-sdk --watch",
+      "exec": "esbuild --bundle src/subdir/jangy.lambda.ts --target="node18" --platform="node" --outfile="assets/subdir/jangy.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:@aws-sdk/* --watch",
     },
   ],
 }
@@ -188,7 +188,7 @@ exports[`auto-discover 9`] = `
   "name": "bundle:subdir/world.lambda",
   "steps": [
     {
-      "exec": "esbuild --bundle src/subdir/world.lambda.ts --target="node12" --platform="node" --outfile="assets/subdir/world.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:aws-sdk",
+      "exec": "esbuild --bundle src/subdir/world.lambda.ts --target="node18" --platform="node" --outfile="assets/subdir/world.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:@aws-sdk/*",
     },
   ],
 }
@@ -200,7 +200,7 @@ exports[`auto-discover 10`] = `
   "name": "bundle:subdir/world.lambda:watch",
   "steps": [
     {
-      "exec": "esbuild --bundle src/subdir/world.lambda.ts --target="node12" --platform="node" --outfile="assets/subdir/world.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:aws-sdk --watch",
+      "exec": "esbuild --bundle src/subdir/world.lambda.ts --target="node18" --platform="node" --outfile="assets/subdir/world.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:@aws-sdk/* --watch",
     },
   ],
 }

--- a/test/awscdk/__snapshots__/lambda-function.test.ts.snap
+++ b/test/awscdk/__snapshots__/lambda-function.test.ts.snap
@@ -21,7 +21,7 @@ export class HelloFunction extends cloudfront.experimental.EdgeFunction {
     super(scope, id, {
       description: 'src/hello.edge-lambda.ts',
       ...props,
-      runtime: new lambda.Runtime('nodejs16.x', lambda.RuntimeFamily.NODEJS),
+      runtime: new lambda.Runtime('nodejs18.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../assets/hello.edge-lambda')),
     });
@@ -226,7 +226,7 @@ export class HelloFunction extends lambda.Function {
     super(scope, id, {
       description: 'src/hello.lambda.ts',
       ...props,
-      runtime: new lambda.Runtime('nodejs16.x', lambda.RuntimeFamily.NODEJS),
+      runtime: new lambda.Runtime('nodejs18.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../my-assets/hello.lambda')),
     });
@@ -257,7 +257,7 @@ export class HelloFunction extends lambda.Function {
     super(scope, id, {
       description: 'src/hello.lambda.ts',
       ...props,
-      runtime: new lambda.Runtime('nodejs16.x', lambda.RuntimeFamily.NODEJS),
+      runtime: new lambda.Runtime('nodejs18.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../assets/hello.lambda')),
     });
@@ -286,7 +286,7 @@ export class HelloFunction extends lambda.Function {
     super(scope, id, {
       description: 'src/hello.lambda.ts',
       ...props,
-      runtime: new lambda.Runtime('nodejs16.x', lambda.RuntimeFamily.NODEJS),
+      runtime: new lambda.Runtime('nodejs18.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../assets/hello.lambda')),
     });
@@ -315,7 +315,7 @@ export class WorldFunction extends lambda.Function {
     super(scope, id, {
       description: 'src/world.lambda.ts',
       ...props,
-      runtime: new lambda.Runtime('nodejs16.x', lambda.RuntimeFamily.NODEJS),
+      runtime: new lambda.Runtime('nodejs18.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../assets/world.lambda')),
     });

--- a/test/awscdk/awscdk-construct.test.ts
+++ b/test/awscdk/awscdk-construct.test.ts
@@ -227,7 +227,7 @@ describe("node version in workflow", () => {
         expect.objectContaining({
           uses: "actions/setup-node@v3",
           with: {
-            "node-version": "16.x",
+            "node-version": "18.x",
           },
         }),
       ])

--- a/test/awscdk/lambda-function.test.ts
+++ b/test/awscdk/lambda-function.test.ts
@@ -52,7 +52,7 @@ describe("bundled function", () => {
       name: "bundle:hello.lambda",
       steps: [
         {
-          exec: 'esbuild --bundle src/hello.lambda.ts --target="node16" --platform="node" --outfile="my-assets/hello.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:@aws-sdk/*',
+          exec: 'esbuild --bundle src/hello.lambda.ts --target="node18" --platform="node" --outfile="my-assets/hello.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:@aws-sdk/*',
         },
       ],
     });
@@ -102,7 +102,7 @@ test("constructFile and constructName can be used to customize the generated con
   expect(generatedSource).toMatchSnapshot();
 });
 
-test("runtime can be used to customize the lambda runtime and esbuild target", () => {
+test("runtime can be used to customize the lambda runtime Node 14.x and esbuild target", () => {
   const project = new TypeScriptProject({
     name: "hello",
     defaultReleaseBranch: "main",
@@ -131,7 +131,7 @@ test("runtime can be used to customize the lambda runtime and esbuild target", (
   });
 });
 
-test("runtime can be used to customize the lambda runtime and esbuild target", () => {
+test("runtime can be used to customize the lambda runtime Node 16.x and esbuild target", () => {
   const project = new TypeScriptProject({
     name: "hello",
     defaultReleaseBranch: "main",
@@ -155,6 +155,35 @@ test("runtime can be used to customize the lambda runtime and esbuild target", (
     steps: [
       {
         exec: 'esbuild --bundle src/hello.lambda.ts --target="node16" --platform="node" --outfile="assets/hello.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:aws-sdk',
+      },
+    ],
+  });
+});
+
+test("runtime can be used to customize the lambda runtime Node 18.x and esbuild target", () => {
+  const project = new TypeScriptProject({
+    name: "hello",
+    defaultReleaseBranch: "main",
+  });
+
+  new awscdk.LambdaFunction(project, {
+    entrypoint: join("src", "hello.lambda.ts"),
+    runtime: awscdk.LambdaRuntime.NODEJS_18_X,
+    cdkDeps: cdkDepsForProject(project),
+  });
+
+  const snapshot = Testing.synth(project);
+  const generatedSource = snapshot["src/hello-function.ts"];
+  const tasks = snapshot[".projen/tasks.json"].tasks;
+  expect(generatedSource).toContain(
+    "runtime: new lambda.Runtime('nodejs18.x', lambda.RuntimeFamily.NODEJS),"
+  );
+  expect(tasks["bundle:hello.lambda"]).toEqual({
+    description: "Create a JavaScript bundle from src/hello.lambda.ts",
+    name: "bundle:hello.lambda",
+    steps: [
+      {
+        exec: 'esbuild --bundle src/hello.lambda.ts --target="node18" --platform="node" --outfile="assets/hello.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:@aws-sdk/*',
       },
     ],
   });

--- a/test/awscdk/lambda-function.test.ts
+++ b/test/awscdk/lambda-function.test.ts
@@ -52,7 +52,7 @@ describe("bundled function", () => {
       name: "bundle:hello.lambda",
       steps: [
         {
-          exec: 'esbuild --bundle src/hello.lambda.ts --target="node16" --platform="node" --outfile="my-assets/hello.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:aws-sdk',
+          exec: 'esbuild --bundle src/hello.lambda.ts --target="node16" --platform="node" --outfile="my-assets/hello.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:@aws-sdk/*',
         },
       ],
     });
@@ -110,7 +110,7 @@ test("runtime can be used to customize the lambda runtime and esbuild target", (
 
   new awscdk.LambdaFunction(project, {
     entrypoint: join("src", "hello.lambda.ts"),
-    runtime: awscdk.LambdaRuntime.NODEJS_12_X,
+    runtime: awscdk.LambdaRuntime.NODEJS_14_X,
     cdkDeps: cdkDepsForProject(project),
   });
 
@@ -118,14 +118,43 @@ test("runtime can be used to customize the lambda runtime and esbuild target", (
   const generatedSource = snapshot["src/hello-function.ts"];
   const tasks = snapshot[".projen/tasks.json"].tasks;
   expect(generatedSource).toContain(
-    "runtime: new lambda.Runtime('nodejs12.x', lambda.RuntimeFamily.NODEJS),"
+    "runtime: new lambda.Runtime('nodejs14.x', lambda.RuntimeFamily.NODEJS),"
   );
   expect(tasks["bundle:hello.lambda"]).toEqual({
     description: "Create a JavaScript bundle from src/hello.lambda.ts",
     name: "bundle:hello.lambda",
     steps: [
       {
-        exec: 'esbuild --bundle src/hello.lambda.ts --target="node12" --platform="node" --outfile="assets/hello.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:aws-sdk',
+        exec: 'esbuild --bundle src/hello.lambda.ts --target="node14" --platform="node" --outfile="assets/hello.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:aws-sdk',
+      },
+    ],
+  });
+});
+
+test("runtime can be used to customize the lambda runtime and esbuild target", () => {
+  const project = new TypeScriptProject({
+    name: "hello",
+    defaultReleaseBranch: "main",
+  });
+
+  new awscdk.LambdaFunction(project, {
+    entrypoint: join("src", "hello.lambda.ts"),
+    runtime: awscdk.LambdaRuntime.NODEJS_16_X,
+    cdkDeps: cdkDepsForProject(project),
+  });
+
+  const snapshot = Testing.synth(project);
+  const generatedSource = snapshot["src/hello-function.ts"];
+  const tasks = snapshot[".projen/tasks.json"].tasks;
+  expect(generatedSource).toContain(
+    "runtime: new lambda.Runtime('nodejs16.x', lambda.RuntimeFamily.NODEJS),"
+  );
+  expect(tasks["bundle:hello.lambda"]).toEqual({
+    description: "Create a JavaScript bundle from src/hello.lambda.ts",
+    name: "bundle:hello.lambda",
+    steps: [
+      {
+        exec: 'esbuild --bundle src/hello.lambda.ts --target="node16" --platform="node" --outfile="assets/hello.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:aws-sdk',
       },
     ],
   });
@@ -311,7 +340,7 @@ test("auto-discover", () => {
       dependencyType: DependencyType.RUNTIME,
     }),
     lambdaOptions: {
-      runtime: awscdk.LambdaRuntime.NODEJS_12_X,
+      runtime: awscdk.LambdaRuntime.NODEJS_18_X,
     },
   });
 

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -346,7 +346,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -447,7 +447,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -476,7 +476,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -1585,7 +1585,7 @@ exports[`language bindings release workflow includes release_golang job 1`] = `
     {
       "uses": "actions/setup-node@v3",
       "with": {
-        "node-version": "16.x",
+        "node-version": "18.x",
       },
     },
     {
@@ -1656,7 +1656,7 @@ exports[`language bindings release workflow includes release_maven job 1`] = `
     {
       "uses": "actions/setup-node@v3",
       "with": {
-        "node-version": "16.x",
+        "node-version": "18.x",
       },
     },
     {
@@ -1716,7 +1716,7 @@ exports[`language bindings release workflow includes release_npm job 1`] = `
     {
       "uses": "actions/setup-node@v3",
       "with": {
-        "node-version": "16.x",
+        "node-version": "18.x",
       },
     },
     {
@@ -1774,7 +1774,7 @@ exports[`language bindings release workflow includes release_nuget job 1`] = `
     {
       "uses": "actions/setup-node@v3",
       "with": {
-        "node-version": "16.x",
+        "node-version": "18.x",
       },
     },
     {
@@ -1836,7 +1836,7 @@ exports[`language bindings release workflow includes release_pypi job 1`] = `
     {
       "uses": "actions/setup-node@v3",
       "with": {
-        "node-version": "16.x",
+        "node-version": "18.x",
       },
     },
     {
@@ -1896,7 +1896,7 @@ exports[`language bindings snapshot dotnet 1`] = `
     {
       "uses": "actions/setup-node@v3",
       "with": {
-        "node-version": "16.x",
+        "node-version": "18.x",
       },
     },
     {
@@ -1948,7 +1948,7 @@ exports[`language bindings snapshot go 1`] = `
     {
       "uses": "actions/setup-node@v3",
       "with": {
-        "node-version": "16.x",
+        "node-version": "18.x",
       },
     },
     {
@@ -2007,7 +2007,7 @@ exports[`language bindings snapshot java 1`] = `
     {
       "uses": "actions/setup-node@v3",
       "with": {
-        "node-version": "16.x",
+        "node-version": "18.x",
       },
     },
     {
@@ -2053,7 +2053,7 @@ exports[`language bindings snapshot js 1`] = `
     {
       "uses": "actions/setup-node@v3",
       "with": {
-        "node-version": "16.x",
+        "node-version": "18.x",
       },
     },
     {
@@ -2099,7 +2099,7 @@ exports[`language bindings snapshot python 1`] = `
     {
       "uses": "actions/setup-node@v3",
       "with": {
-        "node-version": "16.x",
+        "node-version": "18.x",
       },
     },
     {
@@ -2195,7 +2195,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -2224,7 +2224,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -2257,7 +2257,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -2343,7 +2343,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -2372,7 +2372,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -2405,7 +2405,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -2488,7 +2488,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -2517,7 +2517,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -2550,7 +2550,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -2631,7 +2631,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -2660,7 +2660,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -2693,7 +2693,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x

--- a/test/jsii/__snapshots__/jsii.test.ts.snap
+++ b/test/jsii/__snapshots__/jsii.test.ts.snap
@@ -346,7 +346,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -447,7 +447,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -476,7 +476,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -1834,7 +1834,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -1935,7 +1935,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -1964,7 +1964,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -3303,7 +3303,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -3404,7 +3404,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -3433,7 +3433,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -4791,7 +4791,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -4892,7 +4892,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -4921,7 +4921,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:

--- a/test/release/__snapshots__/release.test.ts.snap
+++ b/test/release/__snapshots__/release.test.ts.snap
@@ -3141,7 +3141,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -3538,7 +3538,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -3772,7 +3772,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -4030,7 +4030,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -4055,7 +4055,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -4087,7 +4087,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -4114,7 +4114,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -4138,7 +4138,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -4164,7 +4164,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -4507,7 +4507,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -4574,7 +4574,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -4898,7 +4898,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -4965,7 +4965,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -5032,7 +5032,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:

--- a/test/release/__snapshots__/release.test.ts.snap
+++ b/test/release/__snapshots__/release.test.ts.snap
@@ -93,7 +93,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -118,7 +118,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -414,7 +414,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -439,7 +439,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -735,7 +735,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -761,7 +761,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -1056,7 +1056,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -1081,7 +1081,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -1381,7 +1381,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -1448,7 +1448,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -1515,7 +1515,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -1850,7 +1850,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -1875,7 +1875,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -1979,7 +1979,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -2004,7 +2004,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -2364,7 +2364,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -2601,7 +2601,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -2641,7 +2641,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -2765,7 +2765,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -2791,7 +2791,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -2820,7 +2820,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -2848,7 +2848,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -5397,7 +5397,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -5673,7 +5673,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:

--- a/test/typescript/__snapshots__/typescript.test.ts.snap
+++ b/test/typescript/__snapshots__/typescript.test.ts.snap
@@ -414,7 +414,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:

--- a/test/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-project.test.ts.snap
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -161,7 +161,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -189,7 +189,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -228,7 +228,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -154,7 +154,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/test/web/__snapshots__/react-project.test.ts.snap
+++ b/test/web/__snapshots__/react-project.test.ts.snap
@@ -179,7 +179,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1107,10 +1107,10 @@
   dependencies:
     undici-types "~5.25.1"
 
-"@types/node@^14":
-  version "14.18.63"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.63.tgz#1788fa8da838dbb5f9ea994b834278205db6ca2b"
-  integrity sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==
+"@types/node@^16":
+  version "16.18.58"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.58.tgz#bf66f63983104ed57c754f4e84ccaf16f8235adb"
+  integrity sha512-YGncyA25/MaVtQkjWW9r0EFBukZ+JulsLcVZBlGUfIb96OBMjkoRWwQo5IEWJ8Fj06Go3GHw+bjYDitv6BaGsA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.2"


### PR DESCRIPTION
Upgrade Node 16.x to 18.x

Using `18.12.0` because it is the first long term support (LTS) version based on the release schedule https://github.com/nodejs/Release/blob/main/schedule.json for v18 on 2022-10-25 from https://nodejs.org/dist/.

Fixes #2979

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
