### PR TITLE
feat(vscode): expose configuration files as `.file` property

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -11971,6 +11971,14 @@ new vscode.VsCodeLaunchConfig(vscode: VsCode)
 * **vscode** (<code>[vscode.VsCode](#projen-vscode-vscode)</code>)  *No description*
 
 
+
+### Properties
+
+
+Name | Type | Description 
+-----|------|-------------
+**file**🔹 | <code>[JsonFile](#projen-jsonfile)</code> | <span></span>
+
 ### Methods
 
 
@@ -12032,6 +12040,14 @@ new vscode.VsCodeRecommendedExtensions(vscode: VsCode)
 * **vscode** (<code>[vscode.VsCode](#projen-vscode-vscode)</code>)  *No description*
 
 
+
+### Properties
+
+
+Name | Type | Description 
+-----|------|-------------
+**file**🔹 | <code>[JsonFile](#projen-jsonfile)</code> | <span></span>
+
 ### Methods
 
 
@@ -12084,6 +12100,14 @@ new vscode.VsCodeSettings(vscode: VsCode)
 
 * **vscode** (<code>[vscode.VsCode](#projen-vscode-vscode)</code>)  *No description*
 
+
+
+### Properties
+
+
+Name | Type | Description 
+-----|------|-------------
+**file**🔹 | <code>[JsonFile](#projen-jsonfile)</code> | <span></span>
 
 ### Methods
 

--- a/src/vscode/extensions.ts
+++ b/src/vscode/extensions.ts
@@ -23,10 +23,12 @@ export class VsCodeRecommendedExtensions extends Component {
    */
   private readonly unwantedRecommendations: string[] = [];
 
+  public readonly file: JsonFile;
+
   constructor(vscode: VsCode) {
     super(vscode.project);
 
-    new JsonFile(vscode.project, ".vscode/extensions.json", {
+    this.file = new JsonFile(vscode.project, ".vscode/extensions.json", {
       omitEmpty: true,
       allowComments: true,
       obj: {

--- a/src/vscode/launch-config.ts
+++ b/src/vscode/launch-config.ts
@@ -101,6 +101,8 @@ export class VsCodeLaunchConfig extends Component {
 
   private readonly content: VsCodeLaunchConfiguration;
 
+  public readonly file: JsonFile;
+
   constructor(vscode: VsCode) {
     super(vscode.project);
 
@@ -109,7 +111,7 @@ export class VsCodeLaunchConfig extends Component {
       configurations: [],
     };
 
-    new JsonFile(vscode.project, ".vscode/launch.json", {
+    this.file = new JsonFile(vscode.project, ".vscode/launch.json", {
       obj: () => ({
         ...this.content,
         configurations: this.content.configurations.map(

--- a/src/vscode/settings.ts
+++ b/src/vscode/settings.ts
@@ -8,13 +8,14 @@ import { JsonFile } from "../json";
  */
 export class VsCodeSettings extends Component {
   private readonly content: any;
+  public readonly file: JsonFile;
 
   constructor(vscode: VsCode) {
     super(vscode.project);
 
     this.content = {};
 
-    new JsonFile(vscode.project, ".vscode/settings.json", {
+    this.file = new JsonFile(vscode.project, ".vscode/settings.json", {
       omitEmpty: false,
       obj: this.content,
     });


### PR DESCRIPTION
This PR exposes VSCode related JSON files as `.file` properties on appropriate components.

This will allow to use `.patch` and `.addToArray` method of ObjectFile for advanced customisations (as all those files are created lazily using `project.tryFindObjectFile` may not be a viable alternative currently).

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
