### PR TITLE
fix(typescript-config): add `types` and `declarationsMap` missed fields

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -18562,6 +18562,7 @@ Name | Type | Description
 **customConditions**?🔹 | <code>Array<string></code> | List of additional conditions that should succeed when TypeScript resolves from an `exports` or `imports` field of a `package.json`.<br/>__*Default*__: undefined
 **declaration**?🔹 | <code>boolean</code> | To be specified along with the above.<br/>__*Optional*__
 **declarationDir**?🔹 | <code>string</code> | Offers a way to configure the root directory for where declaration files are emitted.<br/>__*Optional*__
+**declarationMap**?🔹 | <code>boolean</code> | Generates a source map for .d.ts files which map back to the original .ts source file. This will allow editors such as VS Code to go to the original .ts file when using features like Go to Definition.<br/>__*Optional*__
 **emitDeclarationOnly**?🔹 | <code>boolean</code> | Only emit .d.ts files; do not emit .js files.<br/>__*Default*__: false
 **emitDecoratorMetadata**?🔹 | <code>boolean</code> | Enables experimental support for decorators, which is in stage 2 of the TC39 standardization process.<br/>__*Default*__: undefined
 **esModuleInterop**?🔹 | <code>boolean</code> | Emit __importStar and __importDefault helpers for runtime babel ecosystem compatibility and enable --allowSyntheticDefaultImports for typesystem compatibility.<br/>__*Default*__: false
@@ -18602,6 +18603,7 @@ Name | Type | Description
 **strictPropertyInitialization**?🔹 | <code>boolean</code> | When set to true, TypeScript will raise an error when a class property was declared but not set in the constructor.<br/>__*Default*__: true
 **stripInternal**?🔹 | <code>boolean</code> | Do not emit declarations for code that has an `@internal` annotation in it’s JSDoc comment.<br/>__*Default*__: true
 **target**?🔹 | <code>string</code> | Modern browsers support all ES6 features, so ES6 is a good choice.<br/>__*Default*__: "ES2018"
+**types**?🔹 | <code>Array<string></code> | If types is specified, only packages listed will be included in the global scope.<br/>__*Optional*__
 **useUnknownInCatchVariables**?🔹 | <code>boolean</code> | Change the type of the variable in a catch clause from any to unknown Available with TypeScript 4.4 and newer.<br/>__*Default*__: true
 **verbatimModuleSyntax**?🔹 | <code>boolean</code> | Simplifies TypeScript's handling of import/export `type` modifiers.<br/>__*Default*__: undefined
 

--- a/src/javascript/typescript-config.ts
+++ b/src/javascript/typescript-config.ts
@@ -180,6 +180,13 @@ export interface TypeScriptCompilerOptions {
   readonly declaration?: boolean;
 
   /**
+   * Generates a source map for .d.ts files which map back to the original .ts source file.
+   * This will allow editors such as VS Code to go to the original .ts file when using features like Go to Definition.
+   * @see {@link https://www.typescriptlang.org/tsconfig#declarationMap}
+   */
+  readonly declarationMap?: boolean;
+
+  /**
    * List of additional conditions that should succeed when TypeScript resolves from an `exports` or `imports` field of a `package.json`.
    *
    * @see https://www.typescriptlang.org/tsconfig#customConditions
@@ -525,6 +532,12 @@ export interface TypeScriptCompilerOptions {
    * paths lets you declare how TypeScript should resolve an import in your require/imports.
    */
   readonly paths?: { [key: string]: string[] };
+
+  /**
+   * If types is specified, only packages listed will be included in the global scope
+   * @see {@link https://www.typescriptlang.org/tsconfig#types}
+   */
+  readonly types?: string[];
 }
 
 /**


### PR DESCRIPTION
Adding `types` and `declarationMap` missed fields to the `compilerOptions` of TypeScript config. Providing link to the documentation of that fields.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
