### PR TITLE
fix(object-file): allow boxed primitives, Set, Map and RegExp in values

### DIFF
--- a/src/_resolve.ts
+++ b/src/_resolve.ts
@@ -22,7 +22,11 @@ export function resolve(value: any, options: ResolveOptions = {}): any {
   // that by default would be stringified as empty objects ('{}')
   // as they are missing a `toJSON` implementation.
   switch (true) {
-    case types.isRegExp(value) && !value.flags:
+    case types.isRegExp(value):
+      if (value.flags)
+        throw new Error(
+          "RegExp with flags should be explicitly converted to a string"
+        );
       return value.source;
 
     case types.isSet(value):

--- a/src/javascript/eslint.ts
+++ b/src/javascript/eslint.ts
@@ -163,10 +163,10 @@ export class Eslint extends Component {
 
   private _formattingRules: Record<string, any>;
   private readonly _allowDevDeps: Set<string>;
-  private readonly _plugins = new Array<string>();
-  private readonly _extends = new Array<string>();
-  private readonly _fileExtensions: string[];
-  private readonly _lintPatterns: string[];
+  private readonly _plugins = new Set<string>();
+  private readonly _extends = new Set<string>();
+  private readonly _fileExtensions: Set<string>;
+  private readonly _lintPatterns: Set<string>;
   private readonly nodeProject: NodeProject;
 
   constructor(project: NodeProject, options: EslintOptions) {
@@ -192,12 +192,12 @@ export class Eslint extends Component {
 
     const devdirs = options.devdirs ?? [];
 
-    this._lintPatterns = [
+    this._lintPatterns = new Set([
       ...options.dirs,
       ...devdirs,
       ...(lintProjenRc && lintProjenRcFile ? [lintProjenRcFile] : []),
-    ];
-    this._fileExtensions = options.fileExtensions ?? [".ts"];
+    ]);
+    this._fileExtensions = new Set(options.fileExtensions ?? [".ts"]);
 
     this._allowDevDeps = new Set((devdirs ?? []).map((dir) => `**/${dir}/**`));
 
@@ -372,14 +372,14 @@ export class Eslint extends Component {
         node: true,
       },
       root: true,
-      plugins: () => this._plugins,
+      plugins: this._plugins,
       parser: "@typescript-eslint/parser",
       parserOptions: {
         ecmaVersion: 2018,
         sourceType: "module",
         project: tsconfig,
       },
-      extends: () => this._extends,
+      extends: this._extends,
       settings: {
         "import/parsers": {
           "@typescript-eslint/parser": [".ts", ".tsx"],
@@ -428,7 +428,7 @@ export class Eslint extends Component {
    * Add a file, glob pattern or directory with source files to lint (e.g. [ "src" ])
    */
   public addLintPattern(pattern: string) {
-    this._lintPatterns.push(pattern);
+    this._lintPatterns.add(pattern);
     this.updateTask();
   }
 
@@ -446,7 +446,9 @@ export class Eslint extends Component {
    * @param plugins The names of plugins to add
    */
   public addPlugins(...plugins: string[]) {
-    this._plugins.push(...plugins);
+    for (const plugin of plugins) {
+      this._plugins.add(plugin);
+    }
   }
 
   /**
@@ -468,7 +470,9 @@ export class Eslint extends Component {
    * @param extendList The list of "extends" to add.
    */
   public addExtends(...extendList: string[]) {
-    this._extends.push(...extendList);
+    for (const extend of extendList) {
+      this._extends.add(extend);
+    }
   }
 
   /**
@@ -509,7 +513,7 @@ export class Eslint extends Component {
     this.eslintTask.reset(
       [
         "eslint",
-        `--ext ${this._fileExtensions.join(",")}`,
+        `--ext ${[...this._fileExtensions].join(",")}`,
         "--fix",
         "--no-error-on-unmatched-pattern",
         ...this._lintPatterns,

--- a/src/object-file.ts
+++ b/src/object-file.ts
@@ -11,7 +11,13 @@ export interface ObjectFileOptions extends FileBaseOptions {
    * The object that will be serialized. You can modify the object's contents
    * before synthesis.
    *
-   * @default {} an empty object (use `file.obj` to mutate).
+   * Serialization of the object is similar to JSON.stringify with few enhancements:
+   * - values that are functions will be called during synthesis and the result will be serialized - this allow to have lazy values.
+   * - `Set` will be converted to array
+   * - `Map` will be converted to a plain object ({ key: value, ... }})
+   * - `RegExp` without flags will be converted to string representation of the source
+   *
+   *  @default {} an empty object (use `file.obj` to mutate).
    */
   readonly obj?: any;
 

--- a/src/object-file.ts
+++ b/src/object-file.ts
@@ -239,7 +239,6 @@ export abstract class ObjectFile extends FileBase {
     for (const operation of this.patchOperations) {
       patched = JsonPatch.apply(patched, ...operation);
     }
-
     return patched ? JSON.stringify(patched, undefined, 2) : undefined;
   }
 }


### PR DESCRIPTION
With current implementation ObjectFile (and all it subclasses) are throwing on encountering any perfectly valid Javascript boxed primitives in the object values (for example `new Sting('something')` or `new Boolean(something)`) even while those values may be stringified by `JSON.stringify` (the serialisation function that we are using) without any problem. This PR fixes that.

In addition, there are several JavaScript built-in objects that while having some limitations on JSII are very useful either for internal usage or for TS/JS-first usage of projen, however, those classes are missing built-in `.toJSON` method and so also resulting in throw from ObjectFile, particularly RegExp, Set and Map. This PR proposes to fix that by resolving RegExp (without flags) into its string source, Set into an array, and Map into an object. Note, that if we have a subclass of any of those built-in types that implements custom `.toJSON` then it will continue to work as with current version (see added tests).

As a simple demonstration of value of stringifiying `Set` I've included a small commit into this PR that switches implementation of ESLint fields that are expected to have non-repeated values (`plugins` and `extends`) from Array to Set using the fix implemented in this PR.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
