### PR TITLE
fix(cli): pass through --help flag for tasks that receive args

### DIFF
--- a/src/cli/tasks.ts
+++ b/src/cli/tasks.ts
@@ -23,6 +23,7 @@ export function discoverTaskCommands(runtime: TaskRuntime, ya: yargs.Argv) {
       );
       let taskArgs: Array<string | number> = [];
       if (taskReceivesArgs) {
+        args.help(false);
         args.strict(false);
         args.strictCommands(false);
         taskArgs = hideBin(process.argv).slice(1);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -44,6 +44,15 @@ test('running "projen" with task in root of a project will execute task of the p
   expect(directorySnapshot(project.outdir)["bar.txt"]).toStrictEqual("foo\n");
 });
 
+test('running "projen" with task in root of a project that receives args will pass through --help flag', () => {
+  const project = new Project({ name: "my-project" });
+  project.testTask?.exec('echo "$@" > bar.txt', { receiveArgs: true });
+  project.synth();
+
+  execProjenCLI(project.outdir, ["test", "something", "--help"]);
+  expect(directorySnapshot(project.outdir)["bar.txt"]).toStrictEqual("something --help\n");
+});
+
 test('running "projen" with task in subdirectory of a project will execute task of the project', () => {
   const project = new Project({ name: "my-project" });
   project.testTask?.exec('echo "foo" > bar.txt');

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -50,7 +50,9 @@ test('running "projen" with task in root of a project that receives args will pa
   project.synth();
 
   execProjenCLI(project.outdir, ["test", "something", "--help"]);
-  expect(directorySnapshot(project.outdir)["bar.txt"]).toStrictEqual("something --help\n");
+  expect(directorySnapshot(project.outdir)["bar.txt"]).toStrictEqual(
+    "something --help\n"
+  );
 });
 
 test('running "projen" with task in subdirectory of a project will execute task of the project', () => {


### PR DESCRIPTION
A common use case for tasks is to act as proxies to other CLIs/tools (e.g. pip, poetry, etc). The current behavior of displaying projen's own help document for the `--help` flag for tasks prevents the proper passthrough of `--help` flags that are intended for the downstream tool (when `receiveArgs` is true).

The help document shown for tasks is fairly generic and can't be customized for tasks anyway.

I considered adding an option to the task itself (e.g. `disableHelp: boolean`) to control this behavior, but this current implementation makes more sense to me since `receiveArgs` should really mean all args. I realize that `--inspect` will still be captured by projen, but that one actually does make sense since a) it's not a standard flag on most tools and b) the return value is useful for understanding the task.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.