### PR TITLE
fix: construct tree not used internally

### DIFF
--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -2173,7 +2173,7 @@ Name | Type | Description
 **components**🔹 | <code>Array<[Component](#projen-component)></code> | Returns all the components within this project.
 **deps**🔹 | <code>[Dependencies](#projen-dependencies)</code> | Project dependencies.
 **ejected**🔹 | <code>boolean</code> | Whether or not the project is being ejected.
-**files**🔹 | <code>Array<[FileBase](#projen-filebase)></code> | All files in this project and all subprojects.
+**files**🔹 | <code>Array<[FileBase](#projen-filebase)></code> | All files in this project.
 **gitattributes**🔹 | <code>[GitAttributesFile](#projen-gitattributesfile)</code> | The .gitattributes file for this repository.
 **gitignore**🔹 | <code>[IgnoreFile](#projen-ignorefile)</code> | .gitignore.
 **logger**🔹 | <code>[Logger](#projen-logger)</code> | Logging utilities.

--- a/docs/api/API.md
+++ b/docs/api/API.md
@@ -2173,7 +2173,7 @@ Name | Type | Description
 **components**🔹 | <code>Array<[Component](#projen-component)></code> | Returns all the components within this project.
 **deps**🔹 | <code>[Dependencies](#projen-dependencies)</code> | Project dependencies.
 **ejected**🔹 | <code>boolean</code> | Whether or not the project is being ejected.
-**files**🔹 | <code>Array<[FileBase](#projen-filebase)></code> | All files in this project.
+**files**🔹 | <code>Array<[FileBase](#projen-filebase)></code> | All files in this project and all subprojects.
 **gitattributes**🔹 | <code>[GitAttributesFile](#projen-gitattributesfile)</code> | The .gitattributes file for this repository.
 **gitignore**🔹 | <code>[IgnoreFile](#projen-ignorefile)</code> | .gitignore.
 **logger**🔹 | <code>[Logger](#projen-logger)</code> | Logging utilities.

--- a/src/component.ts
+++ b/src/component.ts
@@ -35,7 +35,6 @@ export class Component extends Construct {
     this.node.addMetadata("construct", new.target.name);
 
     this.project = findClosestProject(scope);
-    this.project._addComponent(this);
   }
 
   /**

--- a/src/project.ts
+++ b/src/project.ts
@@ -359,7 +359,7 @@ export class Project extends Construct {
    * The root project.
    */
   public get root(): Project {
-    return this.node.scopes.find(isProject) ?? this;
+    return isProject(this.node.root) ? this.node.root : this;
   }
 
   /**
@@ -378,12 +378,7 @@ export class Project extends Construct {
    * Returns all the subprojects within this project.
    */
   public get subprojects(): Project[] {
-    return this.node
-      .findAll()
-      .filter(
-        (p): p is Project =>
-          isProject(p) && p.parent?.node.path === this.node.path
-      );
+    return this.node.children.filter(isProject);
   }
 
   /**

--- a/test/constructs.test.ts
+++ b/test/constructs.test.ts
@@ -1,8 +1,8 @@
 import { Component, Project } from "../src";
 
-test("project.components() uses the construct tree", () => {
+test("project.components uses the construct tree", () => {
   const project = new Project({
-    name: "test",
+    name: "root",
   });
 
   const a = new Component(project, "A");
@@ -11,12 +11,47 @@ test("project.components() uses the construct tree", () => {
   project.node.tryRemoveChild("A");
 
   // A should not be part of the project's components anymore
-  expect(
-    project.components.find((c) => c.node.path === a.node.path)
-  ).toBeUndefined();
+  expect(project.components.find(match(a))).toBeUndefined();
 
   // B should still be part of the project's components
-  expect(
-    project.components.find((c) => c.node.path === b.node.path)?.node.path
-  ).toBe(b.node.path);
+  expect(project.components.find(match(b))).toBeDefined();
 });
+
+test("project.components includes scoped components", () => {
+  const project = new Project({
+    name: "root",
+  });
+
+  const foo = new Component(project, "Foo");
+  const bar = new Component(foo, "Bar");
+
+  expect(bar.node.scope?.node.path).toBe(foo.node.path);
+  expect(project.components.find(match(foo))).toBeDefined();
+  expect(project.components.find(match(bar))).toBeDefined();
+});
+
+test("project.components does not include subproject components", () => {
+  const root = new Project({
+    name: "root",
+  });
+  const subproject = new Project({
+    name: "subproject",
+    parent: root,
+    outdir: "packages/sub",
+  });
+
+  const foo = new Component(root, "Foo");
+  const bar = new Component(subproject, "Bar");
+
+  expect(root.components.find(match(foo))).toBeDefined();
+  expect(subproject.components.find(match(foo))).toBeUndefined();
+
+  expect(root.components.find(match(bar))).toBeUndefined();
+  expect(subproject.components.find(match(bar))).toBeDefined();
+});
+
+function match(component: Component) {
+  return (other: Component) => {
+    return component.node.path === other.node.path;
+  };
+}

--- a/test/constructs.test.ts
+++ b/test/constructs.test.ts
@@ -1,0 +1,22 @@
+import { Component, Project } from "../src";
+
+test("project.components() uses the construct tree", () => {
+  const project = new Project({
+    name: "test",
+  });
+
+  const a = new Component(project, "A");
+  const b = new Component(project, "B");
+
+  project.node.tryRemoveChild("A");
+
+  // A should not be part of the project's components anymore
+  expect(
+    project.components.find((c) => c.node.path === a.node.path)
+  ).toBeUndefined();
+
+  // B should still be part of the project's components
+  expect(
+    project.components.find((c) => c.node.path === b.node.path)?.node.path
+  ).toBe(b.node.path);
+});


### PR DESCRIPTION
Change the implementations of `project.subprojects`, `project.root`, `project.components` and `projects.files` to operate of the construct tree instead of arrays.

Addresses parts of #3056

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
