### PR TITLE
fix(release): first release ignores minMajorVersion

### DIFF
--- a/src/release/bump-version.ts
+++ b/src/release/bump-version.ts
@@ -187,7 +187,7 @@ export async function bump(cwd: string, options: BumpOptions) {
   );
 
   const cmd = ["npx", "standard-version@^9"];
-  if (isFirstRelease) {
+  if (isFirstRelease && !minMajorVersion) {
     cmd.push("--first-release");
   }
   if (prefix) {

--- a/test/release/bump.test.ts
+++ b/test/release/bump.test.ts
@@ -29,6 +29,16 @@ test("first release, with major", async () => {
   expect(result.tag).toStrictEqual("v2.0.0");
 });
 
+test("first release, with minMajorVersion", async () => {
+  const result = await testBump({
+    options: { minMajorVersion: 1 },
+  });
+  expect(result.version).toStrictEqual("1.0.0");
+  expect(result.changelog).toMatch(/.*## 1\.0\.0 \(\d{4}-\d{2}-\d{2}\).*/); // ## 1.0.0 (2021-01-01)
+  expect(result.bumpfile).toStrictEqual("1.0.0");
+  expect(result.tag).toStrictEqual("v1.0.0");
+});
+
 test("first release, with minor", async () => {
   const result = await testBump({
     options: { majorVersion: 2, minorVersion: 1 },


### PR DESCRIPTION
If minMajorVersion is specified the first release should be taking the minMajorVersion into account instead of defaulting to 0.0.0. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
