### PR TITLE
fix(object-file): addToArray overrides all previous calls on non-existent array

### DIFF
--- a/src/object-file.ts
+++ b/src/object-file.ts
@@ -177,7 +177,9 @@ export abstract class ObjectFile extends FileBase {
     if (Array.isArray(curr[lastKey])) {
       curr[lastKey].push(...values);
     } else {
-      curr[lastKey] = { __$APPEND: values };
+      curr[lastKey] = {
+        __$APPEND: [...(curr[lastKey]?.__$APPEND ?? []), ...values],
+      };
     }
   }
 

--- a/test/object-file.test.ts
+++ b/test/object-file.test.ts
@@ -306,6 +306,27 @@ describe("addToArray", () => {
       },
     });
   });
+
+  test("addToArray(p, v) respects pre-existing overrides", () => {
+    // GIVEN
+    const prj = new TestProject();
+    const file = new JsonFile(prj, "my/object/file.json", {
+      obj: {},
+      marker: false,
+    });
+
+    // WHEN
+    file.addToArray("first.second.array", "first extra value");
+    file.addToArray("first.second.array", "second extra value");
+    // THEN
+    expect(synthSnapshot(prj)["my/object/file.json"]).toStrictEqual({
+      first: {
+        second: {
+          array: ["first extra value", "second extra value"],
+        },
+      },
+    });
+  });
 });
 
 describe("patch", () => {


### PR DESCRIPTION
`ObjectFile.addToArray` method is overriding all previous calls values when called on a non-existent array (see added regression test). This PR fixes that.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
