### PR TITLE
fix(yarn): fixup snapshot for yarn up (#3088)

### DIFF
--- a/test/__snapshots__/new.test.ts.snap
+++ b/test/__snapshots__/new.test.ts.snap
@@ -68,7 +68,7 @@ exports[`projen new --from external 1`] = `
   "devDependencies": {
     "@pepperize/projen-awscdk-app-ts": "0.0.333",
     "@types/jest": "*",
-    "@types/node": "^16",
+    "@types/node": "^18",
     "@typescript-eslint/eslint-plugin": "^6",
     "@typescript-eslint/parser": "^6",
     "aws-cdk": "^2.1.0",
@@ -192,7 +192,7 @@ exports[`projen new --from external tarball 1`] = `
   "devDependencies": {
     "./pepperize-projen-awscdk-app-ts-0.0.333.tgz": "*",
     "@types/jest": "*",
-    "@types/node": "^16",
+    "@types/node": "^18",
     "@typescript-eslint/eslint-plugin": "^6",
     "@typescript-eslint/parser": "^6",
     "aws-cdk": "^2.1.0",


### PR DESCRIPTION
I'm kinda confused why #3088 didn't fail and the release did: https://github.com/projen/projen/actions/runs/6773601370/job/18408831034

But here's the fix.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
