### PR TITLE
feat(yarn): define Yarn Berry plugins

### DIFF
--- a/src/javascript/yarnrc.ts
+++ b/src/javascript/yarnrc.ts
@@ -133,6 +133,12 @@ export interface YarnSupportedArchitectures {
   readonly libc?: string[];
 }
 
+export interface YarnPlugin {
+  readonly checksum?: string;
+  readonly path: string;
+  readonly spec: string;
+}
+
 /** https://yarnpkg.com/configuration/yarnrc#cacheMigrationMode */
 export enum YarnCacheMigrationMode {
   REQUIRED_ONLY = "requied-only",
@@ -353,6 +359,22 @@ export interface YarnrcOptions {
   readonly virtualFolder?: string;
   /** https://yarnpkg.com/configuration/yarnrc#yarnPath */
   readonly yarnPath?: string;
+
+  /**
+   * To add a plugin, you need to:
+   *
+   * 1. Run `yarn plugin import <plugin-name>` locally. This will download the plugin and place it in the `.yarn/plugins` directory.
+   * 2. Make a note of the `plugins` section of `.yarnrc.yml`. Copy the `spec`, `path`, and (optionally) `checksum` values to this config.
+   * 3. Run `yarn projen` to update your config.
+   *
+   * This process could be improved in the future. This is just an MVP solution to allow using plugins with `projen`
+   * and Yarn Berry.
+   *
+   * Note that Yarn v4+ includes all official plugins (e.g., workspace-tools, interactive-tools) by default: https://yarnpkg.com/blog/release/4.0#breaking-changes
+   *
+   * See https://yarnpkg.com/cli/plugin/import for more details.
+   */
+  readonly plugins?: YarnPlugin[];
 }
 
 export class Yarnrc extends Component {

--- a/test/javascript/node-package.test.ts
+++ b/test/javascript/node-package.test.ts
@@ -747,6 +747,36 @@ describe("yarn berry", () => {
     expect(yarnrcLines).toContain("nodeLinker: node-modules");
   });
 
+  test("allows installing plugins", () => {
+    const project = new TestProject();
+    new NodePackage(project, {
+      packageManager: NodePackageManager.YARN_BERRY,
+      yarnBerryOptions: {
+        yarnRcOptions: {
+          plugins: [
+            {
+              path: ".yarn/plugins/@yarnpkg/plugin-foo.cjs",
+              spec: "https://raw.githubusercontent.com/blimmer/yarn-plugin-foo/main/bundles/%40yarnpkg/plugin-foo.js",
+            },
+            {
+              path: ".yarn/plugins/@yarnpkg/plugin-bar.cjs",
+              spec: "https://raw.githubusercontent.com/blimmer/yarn-plugin-bar/main/bundles/%40yarnpkg/plugin-bar.js",
+            },
+          ],
+        },
+      },
+    });
+
+    const snps = synthSnapshot(project);
+    const yarnrc = snps[".yarnrc.yml"];
+
+    expect(yarnrc).toContain(`plugins:
+  - path: .yarn/plugins/@yarnpkg/plugin-foo.cjs
+    spec: https://raw.githubusercontent.com/blimmer/yarn-plugin-foo/main/bundles/%40yarnpkg/plugin-foo.js
+  - path: .yarn/plugins/@yarnpkg/plugin-bar.cjs
+    spec: https://raw.githubusercontent.com/blimmer/yarn-plugin-bar/main/bundles/%40yarnpkg/plugin-bar.js`);
+  });
+
   describe("gitignore", () => {
     test("produces the expected gitignore for zero-installs", () => {
       const project = new TestProject();


### PR DESCRIPTION
In #3048 we didn't implement support for `plugins` yet. This is a follow-up to introduce a basic interface.

Relates to #2980 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
