### PR TITLE
feat(python)!: default python version is now python >=3.8

### DIFF
--- a/src/python/poetry.ts
+++ b/src/python/poetry.ts
@@ -89,8 +89,8 @@ export class Poetry
       }
     }
     if (!pythonDefined) {
-      // Python version must be defined for poetry projects. Default to ^3.7.
-      dependencies.python = "^3.7";
+      // Python version must be defined for poetry projects. Default to ^3.8.
+      dependencies.python = "^3.8";
     }
     return this.permitDependenciesWithMetadata(dependencies);
   }

--- a/src/python/setuppy.ts
+++ b/src/python/setuppy.ts
@@ -81,14 +81,15 @@ export class SetupPy extends FileBase {
     this.setupConfig = {
       name: project.name,
       packages: options.packages,
-      python_requires: ">=3.7",
+      python_requires: ">=3.8",
       classifiers: [
         "Intended Audience :: Developers",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
       ],
       ...(options ? this.renameFields(options) : []),
     };

--- a/test/python/__snapshots__/poetry.test.ts.snap
+++ b/test/python/__snapshots__/poetry.test.ts.snap
@@ -19,7 +19,7 @@ readme = "README.md"
 
   [tool.poetry.dependencies]
   regular-version-package = "1.2.3"
-  python = "^3.7"
+  python = "^3.8"
 
     [tool.poetry.dependencies.package1]
     version = "^3.3.3"
@@ -366,7 +366,7 @@ exclude = [ "my_package/excluded.py" ]
   package1 = "0.0.1"
   package2 = "0.0.2"
   package3 = "*"
-  python = "^3.7"
+  python = "^3.8"
 
   [tool.poetry.dev-dependencies]
   projen = "99.99.99"

--- a/test/python/poetry.test.ts
+++ b/test/python/poetry.test.ts
@@ -19,7 +19,7 @@ test("poetry enabled", () => {
   expect(snapshot["pyproject.toml"]).toContain(
     "Development Status :: 4 - Beta"
   );
-  expect(snapshot["pyproject.toml"]).toContain('python = "^3.7"'); // default python version
+  expect(snapshot["pyproject.toml"]).toContain('python = "^3.8"'); // default python version
 });
 
 test("poetry and venv fails", () => {
@@ -82,7 +82,7 @@ test("poetry enabled", () => {
   expect(snapshot["pyproject.toml"]).toContain(
     "Development Status :: 4 - Beta"
   );
-  expect(snapshot["pyproject.toml"]).toContain('python = "^3.7"'); // default python version
+  expect(snapshot["pyproject.toml"]).toContain('python = "^3.8"'); // default python version
 });
 
 test("poetry enabled with specified python version", () => {
@@ -93,10 +93,10 @@ test("poetry enabled with specified python version", () => {
     license: "Apache-2.0",
     classifiers: ["Development Status :: 4 - Beta"],
   });
-  p.addDependency("python@^3.7,<=3.9");
+  p.addDependency("python@^3.8,<=3.11");
 
   const snapshot = synthSnapshot(p);
-  expect(snapshot["pyproject.toml"]).toContain('python = "^3.7,<=3.9"');
+  expect(snapshot["pyproject.toml"]).toContain('python = "^3.8,<=3.11"');
 });
 
 test("poetry enabled with poetry-specific options", () => {


### PR DESCRIPTION
BREAKING CHANGE: Python >=3.8 is now required for projen and consequently for all projects. Upgrade to a supported Python version.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
