### PR TITLE
chore: fix CONTRIBUTING.md referring to wrong default branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ $ yarn unlink projen
 ### Version bumping
 
 Currently projen bumps versions automatically thru a GitHub action when a commit
-pushed to main successfully builds. Projen follows [semantic versioning](https://semver.org/)
+pushed to `main` successfully builds. Projen follows [semantic versioning](https://semver.org/)
 through the [standard-version](https://github.com/conventional-changelog/standard-version)
 npm utility.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ $ yarn unlink projen
 ### Version bumping
 
 Currently projen bumps versions automatically thru a GitHub action when a commit
-pushed to master successfully builds. Projen follows [semantic versioning](https://semver.org/)
+pushed to main successfully builds. Projen follows [semantic versioning](https://semver.org/)
 through the [standard-version](https://github.com/conventional-changelog/standard-version)
 npm utility.
 


### PR DESCRIPTION
### Description of changes

In the Release Versioning paragraph the default branch which this works from now is renamed to `main` and we want the document to reflect that. 



#### Fixes

* fix: changed master->main in version bump explainer paragraph

---
Thank you for your open source project. 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
