### PR TITLE
feat!: bump `minNodeVersion` to `18.12.0`

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "@types/node",
-      "version": "^16",
+      "version": "^18",
       "type": "build"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -76,7 +76,7 @@ const project = new cdk.JsiiProject({
 
   projenDevDependency: false, // because I am projen
   releaseToNpm: true,
-  minNodeVersion: "16.0.0", // Do not change this before a version has been EOL for a while
+  minNodeVersion: "18.14.0",
   workflowNodeVersion: "18.14.0",
 
   codeCov: true,

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -76,7 +76,7 @@ const project = new cdk.JsiiProject({
 
   projenDevDependency: false, // because I am projen
   releaseToNpm: true,
-  minNodeVersion: "18.14.0",
+  minNodeVersion: "18.12.0",
   workflowNodeVersion: "18.14.0",
 
   codeCov: true,

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@types/glob": "^7.2.0",
     "@types/ini": "^1.3.33",
     "@types/jest": "^27",
-    "@types/node": "^16",
+    "@types/node": "^18",
     "@types/semver": "^7.5.6",
     "@types/yargs": "^16.0.9",
     "@typescript-eslint/eslint-plugin": "^6",
@@ -120,7 +120,7 @@
     "scaffolding"
   ],
   "engines": {
-    "node": ">= 16.0.0"
+    "node": ">= 18.14.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "scaffolding"
   ],
   "engines": {
-    "node": ">= 18.14.0"
+    "node": ">= 18.12.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -956,10 +956,12 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@^16":
-  version "16.18.66"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.66.tgz#f59cc2ff96cc47f972a11a458a9b29bf0a209c34"
-  integrity sha512-sePmD/imfKvC4re/Wwos1NEcXYm6O96CAG5gQVY53nmDb8ePQ4qPku6uruN7n6TJ0t5FhcoUc2+yvE2/UZVDZw==
+"@types/node@^18":
+  version "18.19.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.0.tgz#e86ce256c46661016fa83360bf8738eb4efdc88c"
+  integrity sha512-667KNhaD7U29mT5wf+TZUnrzPrlL2GNQ5N0BMjO2oNULhBxX0/FKCkm6JMu0Jh7Z+1LwUlR21ekd7KhIboNFNw==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.4"


### PR DESCRIPTION
BREAKING CHANGE: Node16 has been EOL for a while. Projen now requires Node18. Please upgrade your Node version.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
