### PR TITLE
fix(renovate): preset config:base is now called config:recommended

### DIFF
--- a/src/renovatebot.ts
+++ b/src/renovatebot.ts
@@ -156,7 +156,7 @@ export class Renovatebot extends Component {
       schedule: this.scheduleInterval,
       extends: [
         ":preserveSemverRanges",
-        "config:base",
+        "config:recommended",
         "group:allNonMajor",
         "group:recommended",
         "group:monorepos",

--- a/test/__snapshots__/renovatebot.test.ts.snap
+++ b/test/__snapshots__/renovatebot.test.ts.snap
@@ -17,7 +17,7 @@ exports[`renovatebot renovatebot: true creates renovatebot configuration 1`] = `
 {
   "extends": [
     ":preserveSemverRanges",
-    "config:base",
+    "config:recommended",
     "group:allNonMajor",
     "group:recommended",
     "group:monorepos",

--- a/test/javascript/__snapshots__/node-project.test.ts.snap
+++ b/test/javascript/__snapshots__/node-project.test.ts.snap
@@ -114,7 +114,7 @@ exports[`enabling renovatebot does not overturn mergify: false 1`] = `
 {
   "extends": [
     ":preserveSemverRanges",
-    "config:base",
+    "config:recommended",
     "group:allNonMajor",
     "group:recommended",
     "group:monorepos",
@@ -294,7 +294,7 @@ exports[`renovatebot ignored dependency overrides 1`] = `
 {
   "extends": [
     ":preserveSemverRanges",
-    "config:base",
+    "config:recommended",
     "group:allNonMajor",
     "group:recommended",
     "group:monorepos",


### PR DESCRIPTION
Fixes #3153

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
