### PR TITLE
feat: turn task runner into dependencies vs explicit execution

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -108,10 +108,11 @@
           "exec": "jsii --silence-warnings=reserved-word"
         }
       ],
-      "dependsOn": [
+      "runFirst": [
         "pre-compile"
       ],
-      "implies": [
+      "alsoRun": [
+        "pre-compile",
         "post-compile"
       ]
     },
@@ -295,7 +296,7 @@
           "spawn": "default"
         }
       ],
-      "dependsOn": [
+      "runFirst": [
         "compile"
       ]
     },

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -107,6 +107,12 @@
         {
           "exec": "jsii --silence-warnings=reserved-word"
         }
+      ],
+      "dependsOn": [
+        "pre-compile"
+      ],
+      "implies": [
+        "post-compile"
       ]
     },
     "contributors:update": {
@@ -288,6 +294,9 @@
         {
           "spawn": "default"
         }
+      ],
+      "dependsOn": [
+        "compile"
       ]
     },
     "post-upgrade": {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -112,8 +112,7 @@
         "pre-compile"
       ],
       "alsoRun": [
-        "pre-compile",
-        "post-compile"
+        "pre-compile"
       ]
     },
     "contributors:update": {
@@ -295,9 +294,6 @@
         {
           "spawn": "default"
         }
-      ],
-      "runFirst": [
-        "compile"
       ]
     },
     "post-upgrade": {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -108,11 +108,11 @@
           "exec": "jsii --silence-warnings=reserved-word"
         }
       ],
-      "dependsOn": [
+      "runFirst": [
         "pre-compile"
       ],
-      "implies": [
-        "post-compile"
+      "alsoRun": [
+        "pre-compile"
       ]
     },
     "contributors:update": {
@@ -294,9 +294,6 @@
         {
           "spawn": "default"
         }
-      ],
-      "dependsOn": [
-        "compile"
       ]
     },
     "post-upgrade": {

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -137,8 +137,7 @@ world!
 ```
 
 In the default projen task setup, dependencies are used for the `compile` task:
-`pre-compile` will automatically be run _before_ `compile`, and `post-compile`
-will automatically be run _after_ `compile`.
+`pre-compile` will automatically be run _before_ `compile`.
 
 ### Subtasks (spawn)
 
@@ -174,7 +173,8 @@ the parent task's environment (see below), while dependencies do not.
 
 If in the course of a single `projen` invocation a single task is requested to
 be run multiple times (for example, both by `spawn` as well as by dependencies),
-all invocations after the first will be skipped.
+all invocations after the first will be skipped, so that tasks aren't unnecessarily
+run twice.
 
 ## Environment
 

--- a/src/cli/tasks.ts
+++ b/src/cli/tasks.ts
@@ -75,5 +75,15 @@ export function discoverTaskCommands(runtime: TaskRuntime, ya: yargs.Argv) {
         writeln(`- builtin: ${step.builtin}`);
       }
     }
+
+    if ((task.alsoRun ?? []).length > 0) {
+      writeln(`${chalk.underline("task relationships")}:`);
+      for (const t of task.alsoRun ?? []) {
+        const kind = (task.runFirst ?? []).includes(t)
+          ? "depends on"
+          : "implies";
+        writeln(`- ${chalk.bold(kind)} ${t}`);
+      }
+    }
   }
 }

--- a/src/project-build.ts
+++ b/src/project-build.ts
@@ -51,14 +51,13 @@ export class ProjectBuild extends Component {
       description: "Prepare the project for compilation",
     });
 
-    this.postCompileTask = project.tasks.addTask("post-compile", {
-      description: "Runs after successful compilation",
-    });
-
     this.compileTask = project.tasks.addTask("compile", {
       description: "Only compile",
       dependsOnTasks: [this.preCompileTask],
-      impliesTasks: [this.postCompileTask],
+    });
+
+    this.postCompileTask = project.tasks.addTask("post-compile", {
+      description: "Runs after successful compilation",
     });
 
     this.testTask = project.tasks.addTask("test", {

--- a/src/project-build.ts
+++ b/src/project-build.ts
@@ -51,12 +51,14 @@ export class ProjectBuild extends Component {
       description: "Prepare the project for compilation",
     });
 
-    this.compileTask = project.tasks.addTask("compile", {
-      description: "Only compile",
-    });
-
     this.postCompileTask = project.tasks.addTask("post-compile", {
       description: "Runs after successful compilation",
+    });
+
+    this.compileTask = project.tasks.addTask("compile", {
+      description: "Only compile",
+      dependsOnTasks: [this.preCompileTask],
+      impliesTasks: [this.postCompileTask],
     });
 
     this.testTask = project.tasks.addTask("test", {

--- a/src/task-model.ts
+++ b/src/task-model.ts
@@ -64,18 +64,18 @@ export interface TaskSpec extends TaskCommonOptions {
   readonly steps?: TaskStep[];
 
   /**
-   * The tasks a given task depends on
+   * Tasks that, when selected, should be run before this task
    *
-   * @default - No dependencies
+   * @default - No ordering constraints
    */
-  readonly dependsOn?: string[];
+  readonly runFirst?: string[];
 
   /**
-   * The tasks a given task implies
+   * The tasks that should be selected when this task is selected
    *
-   * @default - No implications
+   * @default - No additional selections
    */
-  readonly implies?: string[];
+  readonly alsoRun?: string[];
 }
 
 /**

--- a/src/task-model.ts
+++ b/src/task-model.ts
@@ -62,6 +62,20 @@ export interface TaskSpec extends TaskCommonOptions {
    * Task steps.
    */
   readonly steps?: TaskStep[];
+
+  /**
+   * The tasks a given task depends on
+   *
+   * @default - No dependencies
+   */
+  readonly dependsOn?: string[];
+
+  /**
+   * The tasks a given task implies
+   *
+   * @default - No implications
+   */
+  readonly implies?: string[];
 }
 
 /**

--- a/src/task-runtime.ts
+++ b/src/task-runtime.ts
@@ -40,12 +40,17 @@ export class TaskRuntime {
    */
   private readonly alreadyRun = new Set<string>();
 
-  constructor(workdir: string) {
+  constructor(workdir: string, manifest?: TasksManifest) {
     this.workdir = resolve(workdir);
-    const manifestPath = join(this.workdir, TaskRuntime.MANIFEST_FILE);
-    this.manifest = existsSync(manifestPath)
-      ? JSON.parse(readFileSync(manifestPath, "utf-8"))
-      : { tasks: {} };
+
+    if (manifest) {
+      this.manifest = manifest;
+    } else {
+      const manifestPath = join(this.workdir, TaskRuntime.MANIFEST_FILE);
+      this.manifest = existsSync(manifestPath)
+        ? JSON.parse(readFileSync(manifestPath, "utf-8"))
+        : { tasks: {} };
+    }
   }
 
   /**

--- a/src/task-runtime.ts
+++ b/src/task-runtime.ts
@@ -105,6 +105,7 @@ export class TaskRuntime {
       logging.debug(gray(`.. skipping ${task.name} (already run)`));
       return;
     }
+    this.alreadyRun.add(key);
 
     new RunTask(this, task, parents, args).run();
   }

--- a/src/task-runtime.ts
+++ b/src/task-runtime.ts
@@ -81,10 +81,9 @@ export class TaskRuntime {
     parents: string[] = [],
     args: Array<string | number> = []
   ) {
-    const tasks = this
-      .findSortedDependenciesOf(name)
+    const tasks = this.findSortedDependenciesOf(name)
       // Retain requested and non-empty tasks
-      .filter(t => t.name === name || (t.steps ?? []).length > 0);
+      .filter((t) => t.name === name || (t.steps ?? []).length > 0);
 
     for (const task of tasks) {
       this.runOne(task, parents, args);
@@ -94,7 +93,7 @@ export class TaskRuntime {
   private runOne(
     task: TaskSpec,
     parents: string[],
-    args: Array<string | number>,
+    args: Array<string | number>
   ) {
     const key = taskKey(task.name, args);
     if (this.alreadyRun.has(key)) {
@@ -116,7 +115,7 @@ export class TaskRuntime {
     return topologicalSort(
       Object.values(ret),
       (t) => t.name,
-      (t) => t.dependsOn ?? [],
+      (t) => t.dependsOn ?? []
     ).flat();
 
     function recurse(name: string) {
@@ -440,5 +439,5 @@ interface ShellOptions {
 }
 
 function taskKey(name: string, args: Array<string | number>) {
-return [name, ...args.map(x => `${x}`)].join('::');
+  return [name, ...args.map((x) => `${x}`)].join("::");
 }

--- a/src/task.ts
+++ b/src/task.ts
@@ -374,7 +374,7 @@ export class Task {
     recurse(target);
 
     function recurse(src: Task) {
-      console.log('comparing', src.name, 'to', target.name);
+      console.log("comparing", src.name, "to", target.name);
       if (src.name == self.name) {
         throw new Error(
           `Cannot add dependency from task ${self.name} to ${target.name}: ${target.name} already depends on ${self.name}`

--- a/src/task.ts
+++ b/src/task.ts
@@ -342,8 +342,8 @@ export class Task {
       steps: steps,
       condition: this.condition,
       cwd: this.cwd,
-      dependsOn: omitEmptyArray(this.dependsOn.map(t => t.name)),
-      implies: omitEmptyArray(this.implies.map(t => t.name)),
+      dependsOn: omitEmptyArray(this.dependsOn.map((t) => t.name)),
+      implies: omitEmptyArray(this.implies.map((t) => t.name)),
     };
   }
 
@@ -375,7 +375,9 @@ export class Task {
 
     function recurse(src: Task) {
       if (src == target) {
-        throw new Error(`Cannot add a dependency from task ${self.name} to ${target.name}: circular dependency`);
+        throw new Error(
+          `Cannot add a dependency from task ${self.name} to ${target.name}: circular dependency`
+        );
       }
       for (const d of src.dependsOn) {
         recurse(d);

--- a/src/task.ts
+++ b/src/task.ts
@@ -371,12 +371,13 @@ export class Task {
   private validateNoCircularDependency(target: Task) {
     const self = this;
 
-    recurse(this);
+    recurse(target);
 
     function recurse(src: Task) {
-      if (src == target) {
+      console.log('comparing', src.name, 'to', target.name);
+      if (src.name == self.name) {
         throw new Error(
-          `Cannot add a dependency from task ${self.name} to ${target.name}: circular dependency`
+          `Cannot add dependency from task ${self.name} to ${target.name}: ${target.name} already depends on ${self.name}`
         );
       }
       for (const d of src.dependsOn) {

--- a/src/util/toposort.ts
+++ b/src/util/toposort.ts
@@ -1,0 +1,47 @@
+export type KeyFunc<T> = (x: T) => string;
+export type DepFunc<T> = (x: T) => string[];
+
+/**
+ * Return a topological sort of all elements of xs, according to the given dependency functions
+ *
+ * Dependencies outside the referenced set are ignored.
+ *
+ * Not a stable sort, but in order to keep the order as stable as possible, we'll sort by key
+ * among elements of equal precedence.
+ *
+ * Returns tranches of elements of equal precedence.
+ */
+export function topologicalSort<T>(xs: Iterable<T>, keyFn: KeyFunc<T>, depFn: DepFunc<T>): T[][] {
+  const remaining = new Map<string, TopoElement<T>>();
+  for (const element of xs) {
+    const key = keyFn(element);
+    remaining.set(key, { key, element, dependencies: depFn(element) });
+  }
+
+  const ret = new Array<T[]>();
+  while (remaining.size > 0) {
+    // All elements with no more deps in the set can be ordered
+    const selectable = Array.from(remaining.values()).filter(e => e.dependencies.every(d => !remaining.has(d)));
+
+    selectable.sort((a, b) => a.key < b.key ? -1 : b.key < a.key ? 1 : 0);
+
+    // If we didn't make any progress, we got stuck
+    if (selectable.length === 0) {
+      throw new Error(`Could not determine ordering between: ${Array.from(remaining.keys()).join(', ')}`);
+    }
+
+    ret.push(selectable.map(s => s.element));
+
+    for (const selected of selectable) {
+      remaining.delete(selected.key);
+    }
+  }
+
+  return ret;
+}
+
+interface TopoElement<T> {
+  key: string;
+  dependencies: string[];
+  element: T;
+}

--- a/src/util/toposort.ts
+++ b/src/util/toposort.ts
@@ -11,7 +11,11 @@ export type DepFunc<T> = (x: T) => string[];
  *
  * Returns tranches of elements of equal precedence.
  */
-export function topologicalSort<T>(xs: Iterable<T>, keyFn: KeyFunc<T>, depFn: DepFunc<T>): T[][] {
+export function topologicalSort<T>(
+  xs: Iterable<T>,
+  keyFn: KeyFunc<T>,
+  depFn: DepFunc<T>
+): T[][] {
   const remaining = new Map<string, TopoElement<T>>();
   for (const element of xs) {
     const key = keyFn(element);
@@ -21,16 +25,22 @@ export function topologicalSort<T>(xs: Iterable<T>, keyFn: KeyFunc<T>, depFn: De
   const ret = new Array<T[]>();
   while (remaining.size > 0) {
     // All elements with no more deps in the set can be ordered
-    const selectable = Array.from(remaining.values()).filter(e => e.dependencies.every(d => !remaining.has(d)));
+    const selectable = Array.from(remaining.values()).filter((e) =>
+      e.dependencies.every((d) => !remaining.has(d))
+    );
 
-    selectable.sort((a, b) => a.key < b.key ? -1 : b.key < a.key ? 1 : 0);
+    selectable.sort((a, b) => (a.key < b.key ? -1 : b.key < a.key ? 1 : 0));
 
     // If we didn't make any progress, we got stuck
     if (selectable.length === 0) {
-      throw new Error(`Could not determine ordering between: ${Array.from(remaining.keys()).join(', ')}`);
+      throw new Error(
+        `Could not determine ordering between: ${Array.from(
+          remaining.keys()
+        ).join(", ")}`
+      );
     }
 
-    ret.push(selectable.map(s => s.element));
+    ret.push(selectable.map((s) => s.element));
 
     for (const selected of selectable) {
       remaining.delete(selected.key);

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -47,7 +47,13 @@ node_modules/
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
       },
       "default": {
@@ -71,6 +77,9 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },
@@ -135,7 +144,13 @@ node_modules/
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
       },
       "default": {
@@ -159,6 +174,9 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -47,14 +47,15 @@ node_modules/
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
       },
       "default": {
         "description": "Synthesize project files",
@@ -77,11 +78,11 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -144,14 +145,15 @@ node_modules/
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
       },
       "default": {
         "description": "Synthesize project files",
@@ -174,11 +176,11 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -49,7 +49,6 @@ node_modules/
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -80,9 +79,6 @@ node_modules/
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -147,7 +143,6 @@ node_modules/
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -178,9 +173,6 @@ node_modules/
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -961,8 +961,7 @@ tsconfig.tsbuildinfo
         "pre-compile"
       ],
       "alsoRun": [
-        "pre-compile",
-        "post-compile"
+        "pre-compile"
       ]
     },
     "default": {
@@ -1080,9 +1079,6 @@ tsconfig.tsbuildinfo
         {
           "spawn": "docgen"
         }
-      ],
-      "runFirst": [
-        "compile"
       ]
     },
     "post-upgrade": {
@@ -2054,8 +2050,7 @@ tsconfig.tsbuildinfo
         "pre-compile"
       ],
       "alsoRun": [
-        "pre-compile",
-        "post-compile"
+        "pre-compile"
       ]
     },
     "default": {
@@ -2185,9 +2180,6 @@ tsconfig.tsbuildinfo
         {
           "spawn": "docgen"
         }
-      ],
-      "runFirst": [
-        "compile"
       ]
     },
     "post-upgrade": {
@@ -3245,8 +3237,7 @@ tsconfig.tsbuildinfo
         "pre-compile"
       ],
       "alsoRun": [
-        "pre-compile",
-        "post-compile"
+        "pre-compile"
       ]
     },
     "default": {
@@ -3311,10 +3302,7 @@ tsconfig.tsbuildinfo
     },
     "post-compile": {
       "name": "post-compile",
-      "description": "Runs after successful compilation",
-      "runFirst": [
-        "compile"
-      ]
+      "description": "Runs after successful compilation"
     },
     "post-upgrade": {
       "name": "post-upgrade",
@@ -4345,8 +4333,7 @@ resolution-mode=highest
         "pre-compile"
       ],
       "alsoRun": [
-        "pre-compile",
-        "post-compile"
+        "pre-compile"
       ]
     },
     "default": {
@@ -4402,10 +4389,7 @@ resolution-mode=highest
     },
     "post-compile": {
       "name": "post-compile",
-      "description": "Runs after successful compilation",
-      "runFirst": [
-        "compile"
-      ]
+      "description": "Runs after successful compilation"
     },
     "post-upgrade": {
       "name": "post-upgrade",

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -956,6 +956,12 @@ tsconfig.tsbuildinfo
         {
           "exec": "jsii --silence-warnings=reserved-word"
         }
+      ],
+      "dependsOn": [
+        "pre-compile"
+      ],
+      "implies": [
+        "post-compile"
       ]
     },
     "default": {
@@ -1073,6 +1079,9 @@ tsconfig.tsbuildinfo
         {
           "spawn": "docgen"
         }
+      ],
+      "dependsOn": [
+        "compile"
       ]
     },
     "post-upgrade": {
@@ -2039,6 +2048,12 @@ tsconfig.tsbuildinfo
         {
           "exec": "cp src/_loadurl.js lib/"
         }
+      ],
+      "dependsOn": [
+        "pre-compile"
+      ],
+      "implies": [
+        "post-compile"
       ]
     },
     "default": {
@@ -2168,6 +2183,9 @@ tsconfig.tsbuildinfo
         {
           "spawn": "docgen"
         }
+      ],
+      "dependsOn": [
+        "compile"
       ]
     },
     "post-upgrade": {
@@ -3220,6 +3238,12 @@ tsconfig.tsbuildinfo
         {
           "exec": "tsc --build"
         }
+      ],
+      "dependsOn": [
+        "pre-compile"
+      ],
+      "implies": [
+        "post-compile"
       ]
     },
     "default": {
@@ -3284,7 +3308,10 @@ tsconfig.tsbuildinfo
     },
     "post-compile": {
       "name": "post-compile",
-      "description": "Runs after successful compilation"
+      "description": "Runs after successful compilation",
+      "dependsOn": [
+        "compile"
+      ]
     },
     "post-upgrade": {
       "name": "post-upgrade",
@@ -4310,7 +4337,13 @@ resolution-mode=highest
     },
     "compile": {
       "name": "compile",
-      "description": "Only compile"
+      "description": "Only compile",
+      "dependsOn": [
+        "pre-compile"
+      ],
+      "implies": [
+        "post-compile"
+      ]
     },
     "default": {
       "name": "default",
@@ -4365,7 +4398,10 @@ resolution-mode=highest
     },
     "post-compile": {
       "name": "post-compile",
-      "description": "Runs after successful compilation"
+      "description": "Runs after successful compilation",
+      "dependsOn": [
+        "compile"
+      ]
     },
     "post-upgrade": {
       "name": "post-upgrade",

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -957,10 +957,11 @@ tsconfig.tsbuildinfo
           "exec": "jsii --silence-warnings=reserved-word"
         }
       ],
-      "dependsOn": [
+      "runFirst": [
         "pre-compile"
       ],
-      "implies": [
+      "alsoRun": [
+        "pre-compile",
         "post-compile"
       ]
     },
@@ -1080,7 +1081,7 @@ tsconfig.tsbuildinfo
           "spawn": "docgen"
         }
       ],
-      "dependsOn": [
+      "runFirst": [
         "compile"
       ]
     },
@@ -2049,10 +2050,11 @@ tsconfig.tsbuildinfo
           "exec": "cp src/_loadurl.js lib/"
         }
       ],
-      "dependsOn": [
+      "runFirst": [
         "pre-compile"
       ],
-      "implies": [
+      "alsoRun": [
+        "pre-compile",
         "post-compile"
       ]
     },
@@ -2184,7 +2186,7 @@ tsconfig.tsbuildinfo
           "spawn": "docgen"
         }
       ],
-      "dependsOn": [
+      "runFirst": [
         "compile"
       ]
     },
@@ -3239,10 +3241,11 @@ tsconfig.tsbuildinfo
           "exec": "tsc --build"
         }
       ],
-      "dependsOn": [
+      "runFirst": [
         "pre-compile"
       ],
-      "implies": [
+      "alsoRun": [
+        "pre-compile",
         "post-compile"
       ]
     },
@@ -3309,7 +3312,7 @@ tsconfig.tsbuildinfo
     "post-compile": {
       "name": "post-compile",
       "description": "Runs after successful compilation",
-      "dependsOn": [
+      "runFirst": [
         "compile"
       ]
     },
@@ -4338,10 +4341,11 @@ resolution-mode=highest
     "compile": {
       "name": "compile",
       "description": "Only compile",
-      "dependsOn": [
+      "runFirst": [
         "pre-compile"
       ],
-      "implies": [
+      "alsoRun": [
+        "pre-compile",
         "post-compile"
       ]
     },
@@ -4399,7 +4403,7 @@ resolution-mode=highest
     "post-compile": {
       "name": "post-compile",
       "description": "Runs after successful compilation",
-      "dependsOn": [
+      "runFirst": [
         "compile"
       ]
     },

--- a/test/__snapshots__/subproject.test.ts.snap
+++ b/test/__snapshots__/subproject.test.ts.snap
@@ -28,7 +28,6 @@ exports[`subprojects use root level default task 1`] = `
     "compile": {
       "alsoRun": [
         "pre-compile",
-        "post-compile",
       ],
       "description": "Only compile",
       "name": "compile",
@@ -53,9 +52,6 @@ exports[`subprojects use root level default task 1`] = `
     "post-compile": {
       "description": "Runs after successful compilation",
       "name": "post-compile",
-      "runFirst": [
-        "compile",
-      ],
     },
     "pre-compile": {
       "description": "Prepare the project for compilation",
@@ -97,7 +93,6 @@ exports[`subprojects use root level default task 2`] = `
     "compile": {
       "alsoRun": [
         "pre-compile",
-        "post-compile",
       ],
       "description": "Only compile",
       "name": "compile",
@@ -122,9 +117,6 @@ exports[`subprojects use root level default task 2`] = `
     "post-compile": {
       "description": "Runs after successful compilation",
       "name": "post-compile",
-      "runFirst": [
-        "compile",
-      ],
     },
     "pre-compile": {
       "description": "Prepare the project for compilation",

--- a/test/__snapshots__/subproject.test.ts.snap
+++ b/test/__snapshots__/subproject.test.ts.snap
@@ -26,7 +26,13 @@ exports[`subprojects use root level default task 1`] = `
       ],
     },
     "compile": {
+      "dependsOn": [
+        "pre-compile",
+      ],
       "description": "Only compile",
+      "implies": [
+        "post-compile",
+      ],
       "name": "compile",
     },
     "default": {
@@ -44,6 +50,9 @@ exports[`subprojects use root level default task 1`] = `
       "name": "package",
     },
     "post-compile": {
+      "dependsOn": [
+        "compile",
+      ],
       "description": "Runs after successful compilation",
       "name": "post-compile",
     },
@@ -85,7 +94,13 @@ exports[`subprojects use root level default task 2`] = `
       ],
     },
     "compile": {
+      "dependsOn": [
+        "pre-compile",
+      ],
       "description": "Only compile",
+      "implies": [
+        "post-compile",
+      ],
       "name": "compile",
     },
     "default": {
@@ -103,6 +118,9 @@ exports[`subprojects use root level default task 2`] = `
       "name": "package",
     },
     "post-compile": {
+      "dependsOn": [
+        "compile",
+      ],
       "description": "Runs after successful compilation",
       "name": "post-compile",
     },

--- a/test/__snapshots__/subproject.test.ts.snap
+++ b/test/__snapshots__/subproject.test.ts.snap
@@ -26,14 +26,15 @@ exports[`subprojects use root level default task 1`] = `
       ],
     },
     "compile": {
-      "dependsOn": [
+      "alsoRun": [
         "pre-compile",
-      ],
-      "description": "Only compile",
-      "implies": [
         "post-compile",
       ],
+      "description": "Only compile",
       "name": "compile",
+      "runFirst": [
+        "pre-compile",
+      ],
     },
     "default": {
       "description": "Synthesize project files",
@@ -50,11 +51,11 @@ exports[`subprojects use root level default task 1`] = `
       "name": "package",
     },
     "post-compile": {
-      "dependsOn": [
-        "compile",
-      ],
       "description": "Runs after successful compilation",
       "name": "post-compile",
+      "runFirst": [
+        "compile",
+      ],
     },
     "pre-compile": {
       "description": "Prepare the project for compilation",
@@ -94,14 +95,15 @@ exports[`subprojects use root level default task 2`] = `
       ],
     },
     "compile": {
-      "dependsOn": [
+      "alsoRun": [
         "pre-compile",
-      ],
-      "description": "Only compile",
-      "implies": [
         "post-compile",
       ],
+      "description": "Only compile",
       "name": "compile",
+      "runFirst": [
+        "pre-compile",
+      ],
     },
     "default": {
       "description": "Synthesize project files",
@@ -118,11 +120,11 @@ exports[`subprojects use root level default task 2`] = `
       "name": "package",
     },
     "post-compile": {
-      "dependsOn": [
-        "compile",
-      ],
       "description": "Runs after successful compilation",
       "name": "post-compile",
+      "runFirst": [
+        "compile",
+      ],
     },
     "pre-compile": {
       "description": "Prepare the project for compilation",

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -904,14 +904,15 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
         "steps": [
           {
             "exec": "jsii --silence-warnings=reserved-word",
@@ -1003,11 +1004,11 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         ],
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
         "steps": [
           {
             "spawn": "docgen",

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -906,7 +906,6 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -1006,9 +1005,6 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
         "steps": [
           {
             "spawn": "docgen",

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -904,7 +904,13 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
         "steps": [
           {
@@ -997,6 +1003,9 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         ],
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
         "steps": [

--- a/test/java/__snapshots__/java-project.test.ts.snap
+++ b/test/java/__snapshots__/java-project.test.ts.snap
@@ -247,7 +247,13 @@ dist/java
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
         "steps": [
           {
@@ -295,6 +301,9 @@ dist/java
         ],
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },
@@ -979,7 +988,13 @@ dist/java
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
         "steps": [
           {
@@ -1027,6 +1042,9 @@ dist/java
         ],
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },

--- a/test/java/__snapshots__/java-project.test.ts.snap
+++ b/test/java/__snapshots__/java-project.test.ts.snap
@@ -247,14 +247,15 @@ dist/java
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
         "steps": [
           {
             "exec": "mvn compiler:compile",
@@ -301,11 +302,11 @@ dist/java
         ],
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -988,14 +989,15 @@ dist/java
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
         "steps": [
           {
             "exec": "mvn compiler:compile",
@@ -1042,11 +1044,11 @@ dist/java
         ],
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",

--- a/test/java/__snapshots__/java-project.test.ts.snap
+++ b/test/java/__snapshots__/java-project.test.ts.snap
@@ -249,7 +249,6 @@ dist/java
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -304,9 +303,6 @@ dist/java
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -991,7 +987,6 @@ dist/java
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -1046,9 +1041,6 @@ dist/java
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",

--- a/test/java/__snapshots__/projenrc.test.ts.snap
+++ b/test/java/__snapshots__/projenrc.test.ts.snap
@@ -120,7 +120,6 @@ node_modules/
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -159,9 +158,6 @@ node_modules/
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -312,7 +308,6 @@ node_modules/
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -351,9 +346,6 @@ node_modules/
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -504,7 +496,6 @@ node_modules/
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -543,9 +534,6 @@ node_modules/
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",

--- a/test/java/__snapshots__/projenrc.test.ts.snap
+++ b/test/java/__snapshots__/projenrc.test.ts.snap
@@ -118,14 +118,15 @@ node_modules/
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
       },
       "default": {
         "description": "Synthesize project files",
@@ -156,11 +157,11 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -309,14 +310,15 @@ node_modules/
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
       },
       "default": {
         "description": "Synthesize project files",
@@ -347,11 +349,11 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -500,14 +502,15 @@ node_modules/
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
       },
       "default": {
         "description": "Synthesize project files",
@@ -538,11 +541,11 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",

--- a/test/java/__snapshots__/projenrc.test.ts.snap
+++ b/test/java/__snapshots__/projenrc.test.ts.snap
@@ -118,7 +118,13 @@ node_modules/
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
       },
       "default": {
@@ -150,6 +156,9 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },
@@ -300,7 +309,13 @@ node_modules/
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
       },
       "default": {
@@ -332,6 +347,9 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },
@@ -482,7 +500,13 @@ node_modules/
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
       },
       "default": {
@@ -514,6 +538,9 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },

--- a/test/jsii/__snapshots__/jsii.test.ts.snap
+++ b/test/jsii/__snapshots__/jsii.test.ts.snap
@@ -904,7 +904,13 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
         "steps": [
           {
@@ -997,6 +1003,9 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         ],
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
         "steps": [
@@ -2366,7 +2375,13 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
         "steps": [
           {
@@ -2459,6 +2474,9 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         ],
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
         "steps": [
@@ -3839,7 +3857,13 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
         "steps": [
           {
@@ -3932,6 +3956,9 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         ],
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
         "steps": [
@@ -5303,7 +5330,13 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
         "steps": [
           {
@@ -5396,6 +5429,9 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         ],
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
         "steps": [

--- a/test/jsii/__snapshots__/jsii.test.ts.snap
+++ b/test/jsii/__snapshots__/jsii.test.ts.snap
@@ -906,7 +906,6 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -1006,9 +1005,6 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
         "steps": [
           {
             "spawn": "docgen",
@@ -2378,7 +2374,6 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -2478,9 +2473,6 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
         "steps": [
           {
             "spawn": "docgen",
@@ -3861,7 +3853,6 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -3961,9 +3952,6 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
         "steps": [
           {
             "spawn": "docgen",
@@ -5335,7 +5323,6 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -5435,9 +5422,6 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
         "steps": [
           {
             "spawn": "docgen",

--- a/test/jsii/__snapshots__/jsii.test.ts.snap
+++ b/test/jsii/__snapshots__/jsii.test.ts.snap
@@ -904,14 +904,15 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
         "steps": [
           {
             "exec": "jsii --silence-warnings=reserved-word",
@@ -1003,11 +1004,11 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         ],
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
         "steps": [
           {
             "spawn": "docgen",
@@ -2375,14 +2376,15 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
         "steps": [
           {
             "exec": "jsii --silence-warnings=reserved-word",
@@ -2474,11 +2476,11 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         ],
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
         "steps": [
           {
             "spawn": "docgen",
@@ -3857,14 +3859,15 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
         "steps": [
           {
             "exec": "jsii --silence-warnings=reserved-word",
@@ -3956,11 +3959,11 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         ],
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
         "steps": [
           {
             "spawn": "docgen",
@@ -5330,14 +5333,15 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
         "steps": [
           {
             "exec": "jsii --silence-warnings=reserved-word",
@@ -5429,11 +5433,11 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         ],
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
         "steps": [
           {
             "spawn": "docgen",

--- a/test/json/__snapshots__/projenrc.test.ts.snap
+++ b/test/json/__snapshots__/projenrc.test.ts.snap
@@ -90,7 +90,6 @@ node_modules/
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -129,9 +128,6 @@ node_modules/
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -237,7 +233,6 @@ node_modules/
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -276,9 +271,6 @@ node_modules/
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",

--- a/test/json/__snapshots__/projenrc.test.ts.snap
+++ b/test/json/__snapshots__/projenrc.test.ts.snap
@@ -88,14 +88,15 @@ node_modules/
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
       },
       "default": {
         "description": "Synthesize project files",
@@ -126,11 +127,11 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -234,14 +235,15 @@ node_modules/
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
       },
       "default": {
         "description": "Synthesize project files",
@@ -272,11 +274,11 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",

--- a/test/json/__snapshots__/projenrc.test.ts.snap
+++ b/test/json/__snapshots__/projenrc.test.ts.snap
@@ -88,7 +88,13 @@ node_modules/
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
       },
       "default": {
@@ -120,6 +126,9 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },
@@ -225,7 +234,13 @@ node_modules/
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
       },
       "default": {
@@ -257,6 +272,9 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },

--- a/test/python/__snapshots__/poetry.test.ts.snap
+++ b/test/python/__snapshots__/poetry.test.ts.snap
@@ -237,7 +237,6 @@ cython_debug/
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -287,9 +286,6 @@ cython_debug/
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",

--- a/test/python/__snapshots__/poetry.test.ts.snap
+++ b/test/python/__snapshots__/poetry.test.ts.snap
@@ -235,14 +235,15 @@ cython_debug/
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
       },
       "default": {
         "description": "Synthesize project files",
@@ -284,11 +285,11 @@ cython_debug/
         ],
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",

--- a/test/python/__snapshots__/poetry.test.ts.snap
+++ b/test/python/__snapshots__/poetry.test.ts.snap
@@ -235,7 +235,13 @@ cython_debug/
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
       },
       "default": {
@@ -278,6 +284,9 @@ cython_debug/
         ],
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },

--- a/test/python/__snapshots__/projenrc.test.ts.snap
+++ b/test/python/__snapshots__/projenrc.test.ts.snap
@@ -124,14 +124,15 @@ node_modules/
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
       },
       "default": {
         "description": "Synthesize project files",
@@ -159,11 +160,11 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",

--- a/test/python/__snapshots__/projenrc.test.ts.snap
+++ b/test/python/__snapshots__/projenrc.test.ts.snap
@@ -124,7 +124,13 @@ node_modules/
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
       },
       "default": {
@@ -153,6 +159,9 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },

--- a/test/python/__snapshots__/projenrc.test.ts.snap
+++ b/test/python/__snapshots__/projenrc.test.ts.snap
@@ -126,7 +126,6 @@ node_modules/
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -162,9 +161,6 @@ node_modules/
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",

--- a/test/python/__snapshots__/python-project.test.ts.snap
+++ b/test/python/__snapshots__/python-project.test.ts.snap
@@ -189,14 +189,15 @@ cython_debug/
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
       },
       "default": {
         "description": "Synthesize project files",
@@ -239,11 +240,11 @@ cython_debug/
         "name": "package",
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -508,14 +509,15 @@ cython_debug/
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
       },
       "default": {
         "description": "Synthesize project files",
@@ -558,11 +560,11 @@ cython_debug/
         "name": "package",
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -829,14 +831,15 @@ cython_debug/
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
       },
       "default": {
         "description": "Synthesize project files",
@@ -879,11 +882,11 @@ cython_debug/
         "name": "package",
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -1131,14 +1134,15 @@ cython_debug/
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
       },
       "default": {
         "description": "Synthesize project files",
@@ -1181,11 +1185,11 @@ cython_debug/
         "name": "package",
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",

--- a/test/python/__snapshots__/python-project.test.ts.snap
+++ b/test/python/__snapshots__/python-project.test.ts.snap
@@ -189,7 +189,13 @@ cython_debug/
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
       },
       "default": {
@@ -233,6 +239,9 @@ cython_debug/
         "name": "package",
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },
@@ -499,7 +508,13 @@ cython_debug/
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
       },
       "default": {
@@ -543,6 +558,9 @@ cython_debug/
         "name": "package",
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },
@@ -811,7 +829,13 @@ cython_debug/
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
       },
       "default": {
@@ -855,6 +879,9 @@ cython_debug/
         "name": "package",
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },
@@ -1104,7 +1131,13 @@ cython_debug/
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
       },
       "default": {
@@ -1148,6 +1181,9 @@ cython_debug/
         "name": "package",
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },

--- a/test/python/__snapshots__/python-project.test.ts.snap
+++ b/test/python/__snapshots__/python-project.test.ts.snap
@@ -191,7 +191,6 @@ cython_debug/
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -242,9 +241,6 @@ cython_debug/
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -511,7 +507,6 @@ cython_debug/
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -562,9 +557,6 @@ cython_debug/
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -833,7 +825,6 @@ cython_debug/
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -884,9 +875,6 @@ cython_debug/
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -1136,7 +1124,6 @@ cython_debug/
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -1187,9 +1174,6 @@ cython_debug/
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",

--- a/test/release/__snapshots__/release.test.ts.snap
+++ b/test/release/__snapshots__/release.test.ts.snap
@@ -203,7 +203,13 @@ node_modules/
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
       },
       "default": {
@@ -227,6 +233,9 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },
@@ -524,7 +533,13 @@ node_modules/
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
       },
       "default": {
@@ -548,6 +563,9 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },
@@ -849,7 +867,13 @@ node_modules/
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
       },
       "default": {
@@ -873,6 +897,9 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },
@@ -1167,7 +1194,13 @@ node_modules/
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
       },
       "default": {
@@ -1191,6 +1224,9 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },
@@ -1603,7 +1639,13 @@ node_modules/
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
       },
       "default": {
@@ -1627,6 +1669,9 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },
@@ -2097,7 +2142,13 @@ node_modules/
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
       },
       "default": {
@@ -2121,6 +2172,9 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },
@@ -2450,7 +2504,13 @@ node_modules/
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
       },
       "default": {
@@ -2474,6 +2534,9 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },
@@ -2934,7 +2997,13 @@ node_modules/
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
       },
       "default": {
@@ -2958,6 +3027,9 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },
@@ -3205,7 +3277,13 @@ exports[`majorVersion can be 0 2`] = `
       ],
     },
     "compile": {
+      "dependsOn": [
+        "pre-compile",
+      ],
       "description": "Only compile",
+      "implies": [
+        "post-compile",
+      ],
       "name": "compile",
     },
     "default": {
@@ -3229,6 +3307,9 @@ exports[`majorVersion can be 0 2`] = `
       "name": "package",
     },
     "post-compile": {
+      "dependsOn": [
+        "compile",
+      ],
       "description": "Runs after successful compilation",
       "name": "post-compile",
     },
@@ -3348,7 +3429,13 @@ exports[`minMajorVersion can be 1 1`] = `
       ],
     },
     "compile": {
+      "dependsOn": [
+        "pre-compile",
+      ],
       "description": "Only compile",
+      "implies": [
+        "post-compile",
+      ],
       "name": "compile",
     },
     "default": {
@@ -3372,6 +3459,9 @@ exports[`minMajorVersion can be 1 1`] = `
       "name": "package",
     },
     "post-compile": {
+      "dependsOn": [
+        "compile",
+      ],
       "description": "Runs after successful compilation",
       "name": "post-compile",
     },
@@ -3622,7 +3712,13 @@ node_modules/
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
       },
       "default": {
@@ -3646,6 +3742,9 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },
@@ -3838,7 +3937,13 @@ exports[`prerelease can be specified per branch 3`] = `
       ],
     },
     "compile": {
+      "dependsOn": [
+        "pre-compile",
+      ],
       "description": "Only compile",
+      "implies": [
+        "post-compile",
+      ],
       "name": "compile",
     },
     "default": {
@@ -3862,6 +3967,9 @@ exports[`prerelease can be specified per branch 3`] = `
       "name": "package",
     },
     "post-compile": {
+      "dependsOn": [
+        "compile",
+      ],
       "description": "Runs after successful compilation",
       "name": "post-compile",
     },
@@ -4230,7 +4338,13 @@ exports[`publisher (defaults) 2`] = `
       ],
     },
     "compile": {
+      "dependsOn": [
+        "pre-compile",
+      ],
       "description": "Only compile",
+      "implies": [
+        "post-compile",
+      ],
       "name": "compile",
     },
     "default": {
@@ -4254,6 +4368,9 @@ exports[`publisher (defaults) 2`] = `
       "name": "package",
     },
     "post-compile": {
+      "dependsOn": [
+        "compile",
+      ],
       "description": "Runs after successful compilation",
       "name": "post-compile",
     },
@@ -4660,7 +4777,13 @@ node_modules/
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
       },
       "default": {
@@ -4684,6 +4807,9 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },
@@ -5120,7 +5246,13 @@ node_modules/
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
       },
       "default": {
@@ -5144,6 +5276,9 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },
@@ -5481,7 +5616,13 @@ node_modules/
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
       },
       "default": {
@@ -5505,6 +5646,9 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },
@@ -5757,7 +5901,13 @@ node_modules/
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
       },
       "default": {
@@ -5781,6 +5931,9 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },

--- a/test/release/__snapshots__/release.test.ts.snap
+++ b/test/release/__snapshots__/release.test.ts.snap
@@ -205,7 +205,6 @@ node_modules/
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -236,9 +235,6 @@ node_modules/
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -536,7 +532,6 @@ node_modules/
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -567,9 +562,6 @@ node_modules/
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -871,7 +863,6 @@ node_modules/
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -902,9 +893,6 @@ node_modules/
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -1199,7 +1187,6 @@ node_modules/
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -1230,9 +1217,6 @@ node_modules/
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -1645,7 +1629,6 @@ node_modules/
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -1676,9 +1659,6 @@ node_modules/
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -2149,7 +2129,6 @@ node_modules/
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -2180,9 +2159,6 @@ node_modules/
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -2512,7 +2488,6 @@ node_modules/
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -2543,9 +2518,6 @@ node_modules/
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -3006,7 +2978,6 @@ node_modules/
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -3037,9 +3008,6 @@ node_modules/
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -3287,7 +3255,6 @@ exports[`majorVersion can be 0 2`] = `
     "compile": {
       "alsoRun": [
         "pre-compile",
-        "post-compile",
       ],
       "description": "Only compile",
       "name": "compile",
@@ -3318,9 +3285,6 @@ exports[`majorVersion can be 0 2`] = `
     "post-compile": {
       "description": "Runs after successful compilation",
       "name": "post-compile",
-      "runFirst": [
-        "compile",
-      ],
     },
     "pre-compile": {
       "description": "Prepare the project for compilation",
@@ -3440,7 +3404,6 @@ exports[`minMajorVersion can be 1 1`] = `
     "compile": {
       "alsoRun": [
         "pre-compile",
-        "post-compile",
       ],
       "description": "Only compile",
       "name": "compile",
@@ -3471,9 +3434,6 @@ exports[`minMajorVersion can be 1 1`] = `
     "post-compile": {
       "description": "Runs after successful compilation",
       "name": "post-compile",
-      "runFirst": [
-        "compile",
-      ],
     },
     "pre-compile": {
       "description": "Prepare the project for compilation",
@@ -3724,7 +3684,6 @@ node_modules/
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -3755,9 +3714,6 @@ node_modules/
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -3950,7 +3906,6 @@ exports[`prerelease can be specified per branch 3`] = `
     "compile": {
       "alsoRun": [
         "pre-compile",
-        "post-compile",
       ],
       "description": "Only compile",
       "name": "compile",
@@ -3981,9 +3936,6 @@ exports[`prerelease can be specified per branch 3`] = `
     "post-compile": {
       "description": "Runs after successful compilation",
       "name": "post-compile",
-      "runFirst": [
-        "compile",
-      ],
     },
     "pre-compile": {
       "description": "Prepare the project for compilation",
@@ -4352,7 +4304,6 @@ exports[`publisher (defaults) 2`] = `
     "compile": {
       "alsoRun": [
         "pre-compile",
-        "post-compile",
       ],
       "description": "Only compile",
       "name": "compile",
@@ -4383,9 +4334,6 @@ exports[`publisher (defaults) 2`] = `
     "post-compile": {
       "description": "Runs after successful compilation",
       "name": "post-compile",
-      "runFirst": [
-        "compile",
-      ],
     },
     "pre-compile": {
       "description": "Prepare the project for compilation",
@@ -4792,7 +4740,6 @@ node_modules/
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -4823,9 +4770,6 @@ node_modules/
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -5262,7 +5206,6 @@ node_modules/
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -5293,9 +5236,6 @@ node_modules/
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -5633,7 +5573,6 @@ node_modules/
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -5664,9 +5603,6 @@ node_modules/
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -5919,7 +5855,6 @@ node_modules/
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -5950,9 +5885,6 @@ node_modules/
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",

--- a/test/release/__snapshots__/release.test.ts.snap
+++ b/test/release/__snapshots__/release.test.ts.snap
@@ -203,14 +203,15 @@ node_modules/
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
       },
       "default": {
         "description": "Synthesize project files",
@@ -233,11 +234,11 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -533,14 +534,15 @@ node_modules/
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
       },
       "default": {
         "description": "Synthesize project files",
@@ -563,11 +565,11 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -867,14 +869,15 @@ node_modules/
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
       },
       "default": {
         "description": "Synthesize project files",
@@ -897,11 +900,11 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -1194,14 +1197,15 @@ node_modules/
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
       },
       "default": {
         "description": "Synthesize project files",
@@ -1224,11 +1228,11 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -1639,14 +1643,15 @@ node_modules/
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
       },
       "default": {
         "description": "Synthesize project files",
@@ -1669,11 +1674,11 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -2142,14 +2147,15 @@ node_modules/
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
       },
       "default": {
         "description": "Synthesize project files",
@@ -2172,11 +2178,11 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -2504,14 +2510,15 @@ node_modules/
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
       },
       "default": {
         "description": "Synthesize project files",
@@ -2534,11 +2541,11 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -2997,14 +3004,15 @@ node_modules/
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
       },
       "default": {
         "description": "Synthesize project files",
@@ -3027,11 +3035,11 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -3277,14 +3285,15 @@ exports[`majorVersion can be 0 2`] = `
       ],
     },
     "compile": {
-      "dependsOn": [
+      "alsoRun": [
         "pre-compile",
-      ],
-      "description": "Only compile",
-      "implies": [
         "post-compile",
       ],
+      "description": "Only compile",
       "name": "compile",
+      "runFirst": [
+        "pre-compile",
+      ],
     },
     "default": {
       "description": "Synthesize project files",
@@ -3307,11 +3316,11 @@ exports[`majorVersion can be 0 2`] = `
       "name": "package",
     },
     "post-compile": {
-      "dependsOn": [
-        "compile",
-      ],
       "description": "Runs after successful compilation",
       "name": "post-compile",
+      "runFirst": [
+        "compile",
+      ],
     },
     "pre-compile": {
       "description": "Prepare the project for compilation",
@@ -3429,14 +3438,15 @@ exports[`minMajorVersion can be 1 1`] = `
       ],
     },
     "compile": {
-      "dependsOn": [
+      "alsoRun": [
         "pre-compile",
-      ],
-      "description": "Only compile",
-      "implies": [
         "post-compile",
       ],
+      "description": "Only compile",
       "name": "compile",
+      "runFirst": [
+        "pre-compile",
+      ],
     },
     "default": {
       "description": "Synthesize project files",
@@ -3459,11 +3469,11 @@ exports[`minMajorVersion can be 1 1`] = `
       "name": "package",
     },
     "post-compile": {
-      "dependsOn": [
-        "compile",
-      ],
       "description": "Runs after successful compilation",
       "name": "post-compile",
+      "runFirst": [
+        "compile",
+      ],
     },
     "pre-compile": {
       "description": "Prepare the project for compilation",
@@ -3712,14 +3722,15 @@ node_modules/
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
       },
       "default": {
         "description": "Synthesize project files",
@@ -3742,11 +3753,11 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -3937,14 +3948,15 @@ exports[`prerelease can be specified per branch 3`] = `
       ],
     },
     "compile": {
-      "dependsOn": [
+      "alsoRun": [
         "pre-compile",
-      ],
-      "description": "Only compile",
-      "implies": [
         "post-compile",
       ],
+      "description": "Only compile",
       "name": "compile",
+      "runFirst": [
+        "pre-compile",
+      ],
     },
     "default": {
       "description": "Synthesize project files",
@@ -3967,11 +3979,11 @@ exports[`prerelease can be specified per branch 3`] = `
       "name": "package",
     },
     "post-compile": {
-      "dependsOn": [
-        "compile",
-      ],
       "description": "Runs after successful compilation",
       "name": "post-compile",
+      "runFirst": [
+        "compile",
+      ],
     },
     "pre-compile": {
       "description": "Prepare the project for compilation",
@@ -4338,14 +4350,15 @@ exports[`publisher (defaults) 2`] = `
       ],
     },
     "compile": {
-      "dependsOn": [
+      "alsoRun": [
         "pre-compile",
-      ],
-      "description": "Only compile",
-      "implies": [
         "post-compile",
       ],
+      "description": "Only compile",
       "name": "compile",
+      "runFirst": [
+        "pre-compile",
+      ],
     },
     "default": {
       "description": "Synthesize project files",
@@ -4368,11 +4381,11 @@ exports[`publisher (defaults) 2`] = `
       "name": "package",
     },
     "post-compile": {
-      "dependsOn": [
-        "compile",
-      ],
       "description": "Runs after successful compilation",
       "name": "post-compile",
+      "runFirst": [
+        "compile",
+      ],
     },
     "pre-compile": {
       "description": "Prepare the project for compilation",
@@ -4777,14 +4790,15 @@ node_modules/
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
       },
       "default": {
         "description": "Synthesize project files",
@@ -4807,11 +4821,11 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -5246,14 +5260,15 @@ node_modules/
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
       },
       "default": {
         "description": "Synthesize project files",
@@ -5276,11 +5291,11 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -5616,14 +5631,15 @@ node_modules/
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
       },
       "default": {
         "description": "Synthesize project files",
@@ -5646,11 +5662,11 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",
@@ -5901,14 +5917,15 @@ node_modules/
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
       },
       "default": {
         "description": "Synthesize project files",
@@ -5931,11 +5948,11 @@ node_modules/
         "name": "package",
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "pre-compile": {
         "description": "Prepare the project for compilation",

--- a/test/tasks/__snapshots__/tasks.test.ts.snap
+++ b/test/tasks/__snapshots__/tasks.test.ts.snap
@@ -31,7 +31,6 @@ exports[`default tasks 1`] = `
     "compile": {
       "alsoRun": [
         "pre-compile",
-        "post-compile",
       ],
       "description": "Only compile",
       "name": "compile",
@@ -62,9 +61,6 @@ exports[`default tasks 1`] = `
     "post-compile": {
       "description": "Runs after successful compilation",
       "name": "post-compile",
-      "runFirst": [
-        "compile",
-      ],
     },
     "pre-compile": {
       "description": "Prepare the project for compilation",

--- a/test/tasks/__snapshots__/tasks.test.ts.snap
+++ b/test/tasks/__snapshots__/tasks.test.ts.snap
@@ -29,7 +29,13 @@ exports[`default tasks 1`] = `
       ],
     },
     "compile": {
+      "dependsOn": [
+        "pre-compile",
+      ],
       "description": "Only compile",
+      "implies": [
+        "post-compile",
+      ],
       "name": "compile",
     },
     "default": {
@@ -53,6 +59,9 @@ exports[`default tasks 1`] = `
       "name": "package",
     },
     "post-compile": {
+      "dependsOn": [
+        "compile",
+      ],
       "description": "Runs after successful compilation",
       "name": "post-compile",
     },

--- a/test/tasks/__snapshots__/tasks.test.ts.snap
+++ b/test/tasks/__snapshots__/tasks.test.ts.snap
@@ -29,14 +29,15 @@ exports[`default tasks 1`] = `
       ],
     },
     "compile": {
-      "dependsOn": [
+      "alsoRun": [
         "pre-compile",
-      ],
-      "description": "Only compile",
-      "implies": [
         "post-compile",
       ],
+      "description": "Only compile",
       "name": "compile",
+      "runFirst": [
+        "pre-compile",
+      ],
     },
     "default": {
       "description": "Synthesize project files",
@@ -59,11 +60,11 @@ exports[`default tasks 1`] = `
       "name": "package",
     },
     "post-compile": {
-      "dependsOn": [
-        "compile",
-      ],
       "description": "Runs after successful compilation",
       "name": "post-compile",
+      "runFirst": [
+        "compile",
+      ],
     },
     "pre-compile": {
       "description": "Prepare the project for compilation",

--- a/test/tasks/tasks.test.ts
+++ b/test/tasks/tasks.test.ts
@@ -1,7 +1,7 @@
 import { Project, TaskRuntime } from "../../src";
+import * as logging from "../../src/logging";
 import { TasksManifest, TaskStep } from "../../src/task-model";
 import { TestProject, synthSnapshot } from "../util";
-import * as logging from "../../src/logging";
 
 test("default tasks", () => {
   const p = new TestProject();
@@ -451,71 +451,71 @@ test("steps can receive args", () => {
   });
 });
 
-test('dependencies are respected', () => {
+test("dependencies are respected", () => {
   const p = new TestProject();
   const logSpy = jest.spyOn(logging, "info");
 
   // WHEN
   const hello1 = p.addTask("hello1", {
-    steps: [{ say: 'hello1' }],
+    steps: [{ say: "hello1" }],
   });
   p.addTask("hello2", {
-    steps: [{ say: 'hello2' }],
+    steps: [{ say: "hello2" }],
     dependsOnTasks: [hello1],
   });
 
   // THEN
-  const runtime = new TaskRuntime('.', synthTasksManifest(p));
-  runtime.runTask('hello2');
-  expect(logSpy).nthCalledWith(1, expect.stringContaining('hello1'));
-  expect(logSpy).nthCalledWith(2, expect.stringContaining('hello2'));
+  const runtime = new TaskRuntime(".", synthTasksManifest(p));
+  runtime.runTask("hello2");
+  expect(logSpy).nthCalledWith(1, expect.stringContaining("hello1"));
+  expect(logSpy).nthCalledWith(2, expect.stringContaining("hello2"));
 
   logSpy.mockRestore();
 });
 
-test('implications are respected', () => {
+test("implications are respected", () => {
   const p = new TestProject();
   const logSpy = jest.spyOn(logging, "info");
 
   // WHEN
   const hello2 = p.addTask("hello2", {
-    steps: [{ say: 'hello2' }],
+    steps: [{ say: "hello2" }],
   });
   p.addTask("hello1", {
-    steps: [{ say: 'hello1' }],
+    steps: [{ say: "hello1" }],
     impliesTasks: [hello2],
   });
 
   // THEN
-  const runtime = new TaskRuntime('.', synthTasksManifest(p));
-  runtime.runTask('hello1');
-  expect(logSpy).nthCalledWith(1, expect.stringContaining('hello1'));
-  expect(logSpy).nthCalledWith(2, expect.stringContaining('hello2'));
+  const runtime = new TaskRuntime(".", synthTasksManifest(p));
+  runtime.runTask("hello1");
+  expect(logSpy).nthCalledWith(1, expect.stringContaining("hello1"));
+  expect(logSpy).nthCalledWith(2, expect.stringContaining("hello2"));
 
   logSpy.mockRestore();
 });
 
-test('tasks are not executed twice', () => {
+test("tasks are not executed twice", () => {
   const p = new TestProject();
   const logSpy = jest.spyOn(logging, "info");
 
   // WHEN
   const hello1 = p.addTask("hello1", {
-    steps: [{ say: 'hello1' }],
+    steps: [{ say: "hello1" }],
   });
   const hello2 = p.addTask("hello2", {
-    steps: [{ say: 'hello2' }],
+    steps: [{ say: "hello2" }],
     dependsOnTasks: [hello1],
   });
-  const compound = p.addTask('compound');
+  const compound = p.addTask("compound");
   compound.spawn(hello1);
   compound.spawn(hello2);
 
   // THEN
-  const runtime = new TaskRuntime('.', synthTasksManifest(p));
-  runtime.runTask('compound');
-  expect(logSpy).nthCalledWith(1, expect.stringContaining('hello1'));
-  expect(logSpy).nthCalledWith(2, expect.stringContaining('hello2'));
+  const runtime = new TaskRuntime(".", synthTasksManifest(p));
+  runtime.runTask("compound");
+  expect(logSpy).nthCalledWith(1, expect.stringContaining("hello1"));
+  expect(logSpy).nthCalledWith(2, expect.stringContaining("hello2"));
 
   logSpy.mockRestore();
 });

--- a/test/tasks/tasks.test.ts
+++ b/test/tasks/tasks.test.ts
@@ -520,17 +520,19 @@ test("tasks are not executed twice", () => {
   logSpy.mockRestore();
 });
 
-test('cannot add circular dependency between tasks', () => {
+test("cannot add circular dependency between tasks", () => {
   const p = new TestProject();
   const hello1 = p.addTask("hello1", {
-    steps: [{ say: 'hello1' }],
+    steps: [{ say: "hello1" }],
   });
   const hello2 = p.addTask("hello2", {
-    steps: [{ say: 'hello2' }],
+    steps: [{ say: "hello2" }],
     dependsOnTasks: [hello1],
   });
 
-  expect(() => hello1.addTaskDependency(hello2)).toThrow(/Cannot add dependency/);
+  expect(() => hello1.addTaskDependency(hello2)).toThrow(
+    /Cannot add dependency/
+  );
 });
 
 function expectManifest(p: Project, toStrictEqual: TasksManifest) {

--- a/test/tasks/tasks.test.ts
+++ b/test/tasks/tasks.test.ts
@@ -520,6 +520,19 @@ test('tasks are not executed twice', () => {
   logSpy.mockRestore();
 });
 
+test('cannot add circular dependency between tasks', () => {
+  const p = new TestProject();
+  const hello1 = p.addTask("hello1", {
+    steps: [{ say: 'hello1' }],
+  });
+  const hello2 = p.addTask("hello2", {
+    steps: [{ say: 'hello2' }],
+    dependsOnTasks: [hello1],
+  });
+
+  expect(() => hello1.addTaskDependency(hello2)).toThrow(/Cannot add dependency/);
+});
+
 function expectManifest(p: Project, toStrictEqual: TasksManifest) {
   const manifest = synthTasksManifest(p);
   delete manifest["//"];

--- a/test/typescript/__snapshots__/typescript.test.ts.snap
+++ b/test/typescript/__snapshots__/typescript.test.ts.snap
@@ -785,14 +785,15 @@ tsconfig.tsbuildinfo
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
         "steps": [
           {
             "exec": "tsc --build",
@@ -860,11 +861,11 @@ tsconfig.tsbuildinfo
         ],
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "post-upgrade": {
         "description": "Runs after upgrading dependencies",

--- a/test/typescript/__snapshots__/typescript.test.ts.snap
+++ b/test/typescript/__snapshots__/typescript.test.ts.snap
@@ -785,7 +785,13 @@ tsconfig.tsbuildinfo
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
         "steps": [
           {
@@ -854,6 +860,9 @@ tsconfig.tsbuildinfo
         ],
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },

--- a/test/typescript/__snapshots__/typescript.test.ts.snap
+++ b/test/typescript/__snapshots__/typescript.test.ts.snap
@@ -787,7 +787,6 @@ tsconfig.tsbuildinfo
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -863,9 +862,6 @@ tsconfig.tsbuildinfo
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "post-upgrade": {
         "description": "Runs after upgrading dependencies",

--- a/test/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-project.test.ts.snap
@@ -486,14 +486,15 @@ permissions-backup.acl
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
         "steps": [
           {
             "exec": "next build",
@@ -570,11 +571,11 @@ permissions-backup.acl
         ],
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "post-upgrade": {
         "description": "Runs after upgrading dependencies",

--- a/test/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-project.test.ts.snap
@@ -486,7 +486,13 @@ permissions-backup.acl
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
         "steps": [
           {
@@ -564,6 +570,9 @@ permissions-backup.acl
         ],
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },

--- a/test/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-project.test.ts.snap
@@ -488,7 +488,6 @@ permissions-backup.acl
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -573,9 +572,6 @@ permissions-backup.acl
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "post-upgrade": {
         "description": "Runs after upgrading dependencies",

--- a/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -419,14 +419,15 @@ tsconfig.tsbuildinfo
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
         "steps": [
           {
             "exec": "tsc --build",
@@ -498,11 +499,11 @@ tsconfig.tsbuildinfo
         "name": "package",
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "post-upgrade": {
         "description": "Runs after upgrading dependencies",

--- a/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -421,7 +421,6 @@ tsconfig.tsbuildinfo
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -501,9 +500,6 @@ tsconfig.tsbuildinfo
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "post-upgrade": {
         "description": "Runs after upgrading dependencies",

--- a/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -419,7 +419,13 @@ tsconfig.tsbuildinfo
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
         "steps": [
           {
@@ -492,6 +498,9 @@ tsconfig.tsbuildinfo
         "name": "package",
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },

--- a/test/web/__snapshots__/react-project.test.ts.snap
+++ b/test/web/__snapshots__/react-project.test.ts.snap
@@ -473,7 +473,6 @@ permissions-backup.acl
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -549,9 +548,6 @@ permissions-backup.acl
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "post-upgrade": {
         "description": "Runs after upgrading dependencies",

--- a/test/web/__snapshots__/react-project.test.ts.snap
+++ b/test/web/__snapshots__/react-project.test.ts.snap
@@ -471,7 +471,13 @@ permissions-backup.acl
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
         "steps": [
           {
@@ -540,6 +546,9 @@ permissions-backup.acl
         ],
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },

--- a/test/web/__snapshots__/react-project.test.ts.snap
+++ b/test/web/__snapshots__/react-project.test.ts.snap
@@ -471,14 +471,15 @@ permissions-backup.acl
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
         "steps": [
           {
             "exec": "react-scripts build",
@@ -546,11 +547,11 @@ permissions-backup.acl
         ],
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "post-upgrade": {
         "description": "Runs after upgrading dependencies",

--- a/test/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/react-ts-project.test.ts.snap
@@ -682,7 +682,13 @@ tsconfig.tsbuildinfo
         ],
       },
       "compile": {
+        "dependsOn": [
+          "pre-compile",
+        ],
         "description": "Only compile",
+        "implies": [
+          "post-compile",
+        ],
         "name": "compile",
         "steps": [
           {
@@ -752,6 +758,9 @@ tsconfig.tsbuildinfo
         "name": "package",
       },
       "post-compile": {
+        "dependsOn": [
+          "compile",
+        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
       },

--- a/test/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/react-ts-project.test.ts.snap
@@ -682,14 +682,15 @@ tsconfig.tsbuildinfo
         ],
       },
       "compile": {
-        "dependsOn": [
+        "alsoRun": [
           "pre-compile",
-        ],
-        "description": "Only compile",
-        "implies": [
           "post-compile",
         ],
+        "description": "Only compile",
         "name": "compile",
+        "runFirst": [
+          "pre-compile",
+        ],
         "steps": [
           {
             "exec": "react-scripts build",
@@ -758,11 +759,11 @@ tsconfig.tsbuildinfo
         "name": "package",
       },
       "post-compile": {
-        "dependsOn": [
-          "compile",
-        ],
         "description": "Runs after successful compilation",
         "name": "post-compile",
+        "runFirst": [
+          "compile",
+        ],
       },
       "post-upgrade": {
         "description": "Runs after upgrading dependencies",

--- a/test/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/react-ts-project.test.ts.snap
@@ -684,7 +684,6 @@ tsconfig.tsbuildinfo
       "compile": {
         "alsoRun": [
           "pre-compile",
-          "post-compile",
         ],
         "description": "Only compile",
         "name": "compile",
@@ -761,9 +760,6 @@ tsconfig.tsbuildinfo
       "post-compile": {
         "description": "Runs after successful compilation",
         "name": "post-compile",
-        "runFirst": [
-          "compile",
-        ],
       },
       "post-upgrade": {
         "description": "Runs after upgrading dependencies",


### PR DESCRIPTION
This PR adds a dependency system to tasks; it also adds a reverse dependency system (an "implies" system). This means that tasks can now require other tasks to run before and after themselves.

The motivation for this was that when you have a `pre-compile` task, you *always* want this task to run when you run `npx projen compile`; but in the old system, the only way to run `pre-compile` was to run the `npx projen build` task instead, which does a lot more work which is not always desired.

When the same task is being requested in a single run of `projen` (for example, if `pre-compile` is requested to be run both as a dependency of `compile`, as well as implied by the `build` task) duplicate invocations will be skipped.

This also has a task implication system -- it used to be that when `compile` was requested, `post-compile` would automatically be run. Then I tried it in practice on the `projen` repo and I was annoyed at having to wait for the `jsii-docgen` tasks in `post-compile` (when all I wanted was some compiled code!) so I took the implication out again. The feature is still in but not really contributing to any UX improvements at the moment. I'm loath to take it out because of the sunken cost fallacy (😅) so if you want it gone, give me a couple of days to shore up my resolve to destroy my own work 🙈

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
