### PR TITLE
fix(javascript): added bun setup for javascript workflows

### DIFF
--- a/src/cdk/jsii-project.ts
+++ b/src/cdk/jsii-project.ts
@@ -491,6 +491,11 @@ export class JsiiProject extends TypeScriptProject {
         uses: "pnpm/action-setup@v2.2.4",
         with: { version: this.package.pnpmVersion },
       });
+    } else if (this.package.packageManager === NodePackageManager.BUN) {
+      prePublishSteps.push({
+        name: "Setup bun",
+        uses: "oven-sh/setup-bun@v1",
+      });
     }
 
     prePublishSteps.push(

--- a/src/javascript/node-project.ts
+++ b/src/javascript/node-project.ts
@@ -981,6 +981,11 @@ export class NodeProject extends GitHubProject {
         uses: "pnpm/action-setup@v2.2.4",
         with: { version: this.package.pnpmVersion },
       });
+    } else if (this.package.packageManager === NodePackageManager.BUN) {
+      install.push({
+        name: "Setup bun",
+        uses: "oven-sh/setup-bun@v1",
+      });
     }
 
     if (this.nodeVersion || this.workflowPackageCache) {
@@ -998,18 +1003,20 @@ export class NodeProject extends GitHubProject {
           : this.package.packageManager === NodePackageManager.PNPM
           ? "pnpm"
           : "npm";
-      install.push({
-        name: "Setup Node.js",
-        uses: "actions/setup-node@v3",
-        with: {
-          ...(this.nodeVersion && {
-            "node-version": this.nodeVersion,
-          }),
-          ...(this.workflowPackageCache && {
-            cache,
-          }),
-        },
-      });
+      if (this.package.packageManager !== NodePackageManager.BUN) {
+        install.push({
+          name: "Setup Node.js",
+          uses: "actions/setup-node@v3",
+          with: {
+            ...(this.nodeVersion && {
+              "node-version": this.nodeVersion,
+            }),
+            ...(this.workflowPackageCache && {
+              cache,
+            }),
+          },
+        });
+      }
     }
 
     const mutable = options.mutable ?? false;


### PR DESCRIPTION
[Bun](https://bun.sh/) added as a package manager but the workflows are still using NodeJS. This is to fix this.

Fixes #

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
