### PR TITLE
chore: add gitignore rule for asdf's .tool-versions file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,8 +58,9 @@ tsconfig.json
 !/.github/workflows/upgrade-main.yml
 !/projen.bash
 !templates/**
-/.idea
 !test/inventory/**
+/.idea
+**/.tool-versions
 !/.markdownlint.json
 !/.vscode/launch.json
 !/.projen/tree.json

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -188,8 +188,9 @@ project.npmignore.exclude("/projen.bash");
 
 project.addExcludeFromCleanup("test/**"); // because snapshots include the projen marker...
 project.gitignore.include("templates/**");
-project.gitignore.exclude("/.idea");
 project.gitignore.include("test/inventory/**");
+project.gitignore.exclude("/.idea");
+project.gitignore.exclude("**/.tool-versions");
 
 // expand markdown macros in readme
 const macros = project.addTask("readme-macros");


### PR DESCRIPTION
chore: this PR adds a gitignore rule to exclude asdf's .tool-versions local configuration file.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
