### PR TITLE
fix(typescript): projenrc.ts for TS projects is not excluded from npm package

### DIFF
--- a/src/typescript/projenrc.ts
+++ b/src/typescript/projenrc.ts
@@ -74,6 +74,8 @@ export class Projenrc extends ProjenrcFile {
   public override preSynthesize(): void {
     super.preSynthesize();
 
+    this._tsProject.addPackageIgnore(`/${this.filePath}`);
+
     this._tsProject.tsconfigDev.addInclude(this.filePath);
     this._tsProject.tsconfigDev.addInclude(`${this._projenCodeDir}/**/*.ts`);
 

--- a/test/typescript/projenrc.test.ts
+++ b/test/typescript/projenrc.test.ts
@@ -48,3 +48,17 @@ test("ts-node configured to use SWC", () => {
     steps: [{ exec: "ts-node --swc --project tsconfig.dev.json .projenrc.ts" }],
   });
 });
+
+test("adds .projenrc.ts to .gitignore DO NOT IGNORE and packageIgnore IGNORE", () => {
+  // GIVEN / WHEN
+  const prj = new TypeScriptProject({
+    name: "test",
+    defaultReleaseBranch: "main",
+    projenrcTs: true,
+  });
+
+  // THEN
+  const snapshot = synthSnapshot(prj);
+  expect(snapshot[".gitignore"]).toContain("!/.projenrc.ts"); // Don't ignore here
+  expect(snapshot[".npmignore"]).toContain("/.projenrc.ts"); // Ignore here
+});


### PR DESCRIPTION
Fixes https://github.com/projen/projen/issues/3248

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
