### PR TITLE
chore: adding placeholder text for missing docs

### DIFF
--- a/docs/integrations/circleci/index.md
+++ b/docs/integrations/circleci/index.md
@@ -3,3 +3,5 @@ sidebar_position: 1
 ---
 
 # CircleCI Integration
+
+This is just a placeholder doc. You can contribute to this project! Please see the [Contributing Guide](https://github.com/projen/projen/blob/main/docusaurus/README.md) for more information.

--- a/docs/integrations/github/index.md
+++ b/docs/integrations/github/index.md
@@ -3,3 +3,6 @@ sidebar_position: 1
 ---
 
 # GitHub Integration
+
+
+This is just a placeholder doc. You can contribute to this project! Please see the [Contributing Guide](https://github.com/projen/projen/blob/main/docusaurus/README.md) for more information.

--- a/docs/integrations/gitlab/index.md
+++ b/docs/integrations/gitlab/index.md
@@ -3,3 +3,6 @@ sidebar_position: 1
 ---
 
 # GitLab Integration
+
+
+This is just a placeholder doc. You can contribute to this project! Please see the [Contributing Guide](https://github.com/projen/projen/blob/main/docusaurus/README.md) for more information.

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -3,3 +3,6 @@ sidebar_position: 1
 ---
 
 # CICD Integrations
+
+
+This is just a placeholder doc. You can contribute to this project! Please see the [Contributing Guide](https://github.com/projen/projen/blob/main/docusaurus/README.md) for more information.

--- a/docs/project-types/construct-library.md
+++ b/docs/project-types/construct-library.md
@@ -3,3 +3,6 @@ sidebar_position: 4
 ---
 
 # Construct Library
+
+
+This is just a placeholder doc. You can contribute to this project! Please see the [Contributing Guide](https://github.com/projen/projen/blob/main/docusaurus/README.md) for more information.

--- a/docs/quick-starts/java/spring-boot/index.md
+++ b/docs/quick-starts/java/spring-boot/index.md
@@ -3,3 +3,6 @@ sidebar_position: 2
 ---
 
 # Create a Spring Boot Application
+
+
+This is just a placeholder doc. You can contribute to this project! Please see the [Contributing Guide](https://github.com/projen/projen/blob/main/docusaurus/README.md) for more information.


### PR DESCRIPTION
adding some placeholder text for the docs that are still empty

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
