### PR TITLE
chore: Improve readability of project types on docs Introduction page

### DIFF
--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -35,25 +35,36 @@ Check out [this talk](https://youtu.be/SOWMPzXtTCw) about projen from its creato
 
 Projen ships with a number of different project types. Currently, there are:
 
+### AWS CDK
 * awscdk-app-java - AWS CDK app in Java.
 * awscdk-app-py - AWS CDK app in Python.
 * awscdk-app-ts - AWS CDK app in TypeScript.
 * awscdk-construct - AWS CDK construct library project.
+
+### CDK8s
 * cdk8s-app-py - CDK8s app in Python.
 * cdk8s-app-ts - CDK8s app in TypeScript.
 * cdk8s-construct - CDK8s construct library project.
 * cdktf-construct - CDKTF construct library project.
-* java - Java project.
-* jsii - Multi-language jsii library project.
+
+### React
 * nextjs - Next.js project without TypeScript.
 * nextjs-ts - Next.js project with TypeScript.
-* node - Node.js project.
-* project - Base project.
-* python - Python project.
 * react - React project without TypeScript.
 * react-ts - React project with TypeScript.
+
+### Serverside Frameworks
+* java - Java project.
+* node - Node.js project.
+* python - Python project.
+
+### TypeScript
 * typescript - TypeScript project.
 * typescript-app - TypeScript app.
+
+### Other
+* jsii - Multi-language jsii library project.
+* project - Base project.
 
 Projen's goal is to help your teams manage projects efficiently. In addition to the starter projects listed above,
 it's recommended that you extend these projects to create your own. This allows you to define your own project types

--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -14,7 +14,7 @@ Projen allows you to define and maintain complex project configuration through c
 project configuration files from a well-typed definition. These definitions can be written in any 
 [jsii](https://github.com/aws/jsii)-compatible language. For example, you can define a projen project in TypeScript 
 and synthesize a `package.json` file, a `tsconfig.json` file, a `.gitignore` file, a GitHub workflow file and more. 
-Projen can be used with TypeScript, Python, Java, .NET and Golang.
+Projen can be used with TypeScript, Python, Java and Golang.
 
 Whether you're a single developer or working on large scale teams, projen is designed to let you seamlessly 
 manage project configurations by independent people, teams, and organizations. You do this all through code. As your 


### PR DESCRIPTION
# Objective
In this small PR, I am proposing that we update the doc's [introduction](https://projen.io/docs/introduction/) by breaking up the project types with headers. This will make it easier for developers to scan the list and identify the relevant project types.

## Before:
![image](https://github.com/projen/projen/assets/1624443/6b02f220-d0a2-42b6-9bc2-d231c99f1a32)

## After:
![image](https://github.com/projen/projen/assets/1624443/e2d99869-6072-44a5-8989-7173583a6162)


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
