### PR TITLE
fix(gitignore): paths separators are inconsistent for cross platform development

### DIFF
--- a/src/ignore-file.ts
+++ b/src/ignore-file.ts
@@ -1,5 +1,6 @@
 import { FileBase, IResolver } from "./file";
 import { Project } from "./project";
+import { normalizePersistedPath } from "./util";
 
 export interface IgnoreFileOptions {
   /**
@@ -57,7 +58,10 @@ export class IgnoreFile extends FileBase {
       if (!isComment && !isEmptyLine) {
         this.normalizePatterns(pattern);
       }
-      this._patterns.push(pattern);
+
+      const normalizedPattern = normalizePersistedPath(pattern);
+
+      this._patterns.push(normalizedPattern);
     }
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -510,3 +510,18 @@ export function findUp(
   }
   return findUp(lookFor, path.dirname(cwd));
 }
+
+/**
+ * Normalizes a path that is going to be persisted to have a cross platform representation.
+ *
+ * Normalized paths can be persisted and doesn't need to be modified when the platform changes.
+ * `normalizePersistedPath` takes care of platform-specific properties like directory separator.
+ * It uses `path.posix.sep` that is supported both in Windows and Unix platforms.
+ *
+ *
+ * @param p
+ * @returns
+ */
+export function normalizePersistedPath(p: string) {
+  return p.replace(/\\/g, path.posix.sep);
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -519,8 +519,8 @@ export function findUp(
  * It uses `path.posix.sep` that is supported both in Windows and Unix platforms.
  *
  *
- * @param p
- * @returns
+ * @param p the path to be normalized
+ * @returns the normalized path
  */
 export function normalizePersistedPath(p: string) {
   return p.replace(/\\/g, path.posix.sep);

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -355,10 +355,6 @@ describe("assertExecutablePermissions", () => {
   });
 });
 
-test("projen version", () => {
-  expect(PROJEN_VERSION).toBe("99.99.99");
-});
-
 describe("normalizePersistedPath", () => {
   test("changes directory separators to forward slash on Windows", () => {
     // GIVEN

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -12,6 +12,7 @@ import {
   getGitVersion,
   isRoot,
   assertExecutablePermissions,
+  normalizePersistedPath,
 } from "../src/util";
 
 describe("decamelizeRecursively", () => {
@@ -351,5 +352,55 @@ describe("assertExecutablePermissions", () => {
     });
 
     expect(assertExecutablePermissions(filePath, false)).toBe(false);
+  });
+});
+
+test("projen version", () => {
+  expect(PROJEN_VERSION).toBe("99.99.99");
+});
+
+describe("normalizePersistedPath", () => {
+  test("changes directory separators to forward slash on Windows", () => {
+    // GIVEN
+    const input = "C:\\path\\to\\file";
+
+    // WHEN
+    const output = normalizePersistedPath(input);
+
+    // THEN
+    expect(output).toEqual("C:/path/to/file");
+  });
+
+  test("handles mixed directory separators on Windows", () => {
+    // GIVEN
+    const input = "C:\\path/to\\file";
+
+    // WHEN
+    const output = normalizePersistedPath(input);
+
+    // THEN
+    expect(output).toEqual("C:/path/to/file");
+  });
+
+  test("handles path with no separators", () => {
+    // GIVEN
+    const input = "file";
+
+    // WHEN
+    const output = normalizePersistedPath(input);
+
+    // THEN
+    expect(output).toEqual("file");
+  });
+
+  test("keeps directory separators as forward slash on Linux", () => {
+    // GIVEN
+    const input = "/path/to/file";
+
+    // WHEN
+    const output = normalizePersistedPath(input);
+
+    // THEN
+    expect(output).toEqual("/path/to/file");
   });
 });

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -393,6 +393,17 @@ describe("normalizePersistedPath", () => {
     expect(output).toEqual("file");
   });
 
+  test("handles gitignore pattern", () => {
+    // GIVEN
+    const input = "!/path\\to/file";
+
+    // WHEN
+    const output = normalizePersistedPath(input);
+
+    // THEN
+    expect(output).toEqual("!/path/to/file");
+  });
+
   test("keeps directory separators as forward slash on Linux", () => {
     // GIVEN
     const input = "/path/to/file";


### PR DESCRIPTION
Related to #3284

The issue could be related to more components, and this PR doesn't fully resolve it.

Normalize gitignore paths to be consistent across platforms. This avoids the diff shown between Windows (\/) and Linux (/) directory separators.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
