### PR TITLE
fix(github): bump version of tibdex/github-app-token action; resolves runtime deprecation warnings

### DIFF
--- a/src/github/github-credentials.ts
+++ b/src/github/github-credentials.ts
@@ -65,7 +65,7 @@ export class GithubCredentials {
         {
           name: "Generate token",
           id: "generate_token",
-          uses: "tibdex/github-app-token@021a2405c7f990db57f5eae5397423dcc554159c",
+          uses: "tibdex/github-app-token@3eb77c7243b85c65e84acfa93fdbac02fb6bd532",
           with: {
             app_id: `\${{ secrets.${appIdSecret} }}`,
             private_key: `\${{ secrets.${privateKeySecret} }}`,

--- a/test/javascript/__snapshots__/upgrade-dependencies.test.ts.snap
+++ b/test/javascript/__snapshots__/upgrade-dependencies.test.ts.snap
@@ -1124,7 +1124,7 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@021a2405c7f990db57f5eae5397423dcc554159c
+        uses: tibdex/github-app-token@3eb77c7243b85c65e84acfa93fdbac02fb6bd532
         with:
           app_id: \${{ secrets.PROJEN_APP_ID }}
           private_key: \${{ secrets.PROJEN_APP_PRIVATE_KEY }}
@@ -1220,7 +1220,7 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@021a2405c7f990db57f5eae5397423dcc554159c
+        uses: tibdex/github-app-token@3eb77c7243b85c65e84acfa93fdbac02fb6bd532
         with:
           app_id: \${{ secrets.PROJEN_APP_ID }}
           private_key: \${{ secrets.PROJEN_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Bump version of action so it uses node20 instead of node16

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
