### PR TITLE
fix(github): invalid commit for tibdex/github-app-token action

### DIFF
--- a/src/github/github-credentials.ts
+++ b/src/github/github-credentials.ts
@@ -65,7 +65,7 @@ export class GithubCredentials {
         {
           name: "Generate token",
           id: "generate_token",
-          uses: "tibdex/github-app-token@3eb77c7243b85c65e84acfa93fdbac02fb6bd532",
+          uses: "tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a",
           with: {
             app_id: `\${{ secrets.${appIdSecret} }}`,
             private_key: `\${{ secrets.${privateKeySecret} }}`,

--- a/test/javascript/__snapshots__/upgrade-dependencies.test.ts.snap
+++ b/test/javascript/__snapshots__/upgrade-dependencies.test.ts.snap
@@ -1137,7 +1137,7 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@3eb77c7243b85c65e84acfa93fdbac02fb6bd532
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
         with:
           app_id: \${{ secrets.PROJEN_APP_ID }}
           private_key: \${{ secrets.PROJEN_APP_PRIVATE_KEY }}
@@ -1234,7 +1234,7 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@3eb77c7243b85c65e84acfa93fdbac02fb6bd532
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
         with:
           app_id: \${{ secrets.PROJEN_APP_ID }}
           private_key: \${{ secrets.PROJEN_APP_PRIVATE_KEY }}


### PR DESCRIPTION
In PR #3338 we attempted to update the version of the `tibdex/github-app-token` GitHub Action to a later version.
We incorrectly picked the latest commit from the main branch of this action. However that's not how most GitHub Actions work. Instead they a tag a dangling commit that has been specially created with the required build artifacts.

This PR we are updates the hash to the correct working version as referenced from the release page: https://github.com/tibdex/github-app-token/tree/v2.1.0

Fixes: https://github.com/projen/projen/issues/3340

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
