### PR TITLE
fix(github): bump version of actions/setup-python to v5; resolves runtime deprecation warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,7 +152,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.14.0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - name: Download build artifacts
@@ -206,7 +206,7 @@ jobs:
       contents: read
     if: "! needs.build.outputs.self_mutation_happened"
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - uses: actions/setup-go@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,7 +215,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.14.0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - name: Download build artifacts

--- a/src/github/workflows.ts
+++ b/src/github/workflows.ts
@@ -380,7 +380,7 @@ function setupTools(tools: workflows.Tools) {
 
   if (tools.python) {
     steps.push({
-      uses: "actions/setup-python@v4",
+      uses: "actions/setup-python@v5",
       with: { "python-version": tools.python.version },
     });
   }

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -408,7 +408,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.0.0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - name: Download build artifacts
@@ -627,7 +627,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.0.0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - name: Download build artifacts

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -1844,7 +1844,7 @@ exports[`language bindings release workflow includes release_pypi job 1`] = `
       },
     },
     {
-      "uses": "actions/setup-python@v4",
+      "uses": "actions/setup-python@v5",
       "with": {
         "python-version": "3.x",
       },
@@ -2107,7 +2107,7 @@ exports[`language bindings snapshot python 1`] = `
       },
     },
     {
-      "uses": "actions/setup-python@v4",
+      "uses": "actions/setup-python@v5",
       "with": {
         "python-version": "3.x",
       },

--- a/test/release/__snapshots__/release.test.ts.snap
+++ b/test/release/__snapshots__/release.test.ts.snap
@@ -1956,7 +1956,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - name: Download build artifacts
@@ -2095,7 +2095,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - name: Download build artifacts
@@ -4325,7 +4325,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - name: Download build artifacts


### PR DESCRIPTION
See: https://github.com/actions/setup-python/releases/tag/v5.0.0

Related to #3337

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
