### PR TITLE
fix(jest): directory separators are inconsistent for cross platform development

### DIFF
--- a/src/javascript/jest.ts
+++ b/src/javascript/jest.ts
@@ -4,6 +4,7 @@ import { Component } from "../component";
 import { NodeProject } from "../javascript";
 import { JsonFile } from "../json";
 import { Project } from "../project";
+import { normalizePersistedPath } from "../util";
 
 const DEFAULT_TEST_REPORTS_DIR = "test-reports";
 
@@ -851,7 +852,9 @@ export class Jest extends Component {
   }
 
   public addSnapshotResolver(file: string) {
-    this._snapshotResolver = file;
+    const normalized = normalizePersistedPath(file);
+
+    this._snapshotResolver = normalized;
   }
 
   /**

--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -21,7 +21,7 @@ import { Project } from "../project";
 import { isAwsCodeArtifactRegistry } from "../release";
 import { Task } from "../task";
 import { TaskRuntime } from "../task-runtime";
-import { isTruthy, sorted, writeFile } from "../util";
+import { isTruthy, normalizePersistedPath, sorted, writeFile } from "../util";
 
 const UNLICENSED = "UNLICENSED";
 const DEFAULT_NPM_REGISTRY_URL = "https://registry.npmjs.org/";
@@ -1434,7 +1434,11 @@ export class NodePackage extends Component {
       for (const file of readdirSync(bindir)) {
         try {
           accessSync(join(bindir, file), constants.X_OK);
-          this.bin[file] = join(binrel, file).replace(/\\/g, "/");
+
+          const binPath = join(binrel, file);
+          const normalizedPath = normalizePersistedPath(binPath);
+
+          this.bin[file] = normalizedPath;
         } catch (e) {
           // not executable, skip
         }

--- a/src/project.ts
+++ b/src/project.ts
@@ -21,7 +21,7 @@ import { ProjenrcJson, ProjenrcJsonOptions } from "./projenrc-json";
 import { Renovatebot, RenovatebotOptions } from "./renovatebot";
 import { Task, TaskOptions } from "./task";
 import { Tasks } from "./tasks";
-import { isTruthy } from "./util";
+import { isTruthy, normalizePersistedPath } from "./util";
 import {
   isProject,
   findClosestProject,
@@ -353,7 +353,7 @@ export class Project extends Construct {
           // replace `\` with `/` to ensure paths match across platforms
           files: this.files
             .filter((f) => f.readonly)
-            .map((f) => f.path.replace(/\\/g, "/")),
+            .map((f) => normalizePersistedPath(f.path)),
         }),
         // This file is used by projen to track the generated files, so must be committed.
         committed: true,
@@ -607,7 +607,7 @@ export class Project extends Construct {
     // delete orphaned files before we start synthesizing new ones
     cleanup(
       outdir,
-      this.files.map((f) => f.path.replace(/\\/g, "/")),
+      this.files.map((f) => normalizePersistedPath(f.path)),
       this.excludeFromCleanup
     );
 

--- a/src/typescript/typescript.ts
+++ b/src/typescript/typescript.ts
@@ -23,7 +23,7 @@ import {
   ProjenrcOptions as ProjenrcTsOptions,
   TypedocDocgen,
 } from "../typescript";
-import { deepMerge } from "../util";
+import { deepMerge, normalizePersistedPath } from "../util";
 
 /**
  * @see https://kulshekhar.github.io/ts-jest/docs/getting-started/options/babelConfig/
@@ -443,14 +443,13 @@ export class TypeScriptProject extends NodeProject {
     const compiledTests = this.testdir.startsWith(this.srcdir + path.posix.sep);
 
     if (options.entrypointTypes || this.entrypoint !== "") {
+      const entrypointPath = path.join(
+        path.dirname(this.entrypoint),
+        path.basename(this.entrypoint, ".js")
+      );
+      const normalizedPath = normalizePersistedPath(entrypointPath);
       const entrypointTypes =
-        options.entrypointTypes ??
-        `${path
-          .join(
-            path.dirname(this.entrypoint),
-            path.basename(this.entrypoint, ".js")
-          )
-          .replace(/\\/g, "/")}.d.ts`;
+        options.entrypointTypes ?? `${normalizedPath}.d.ts`;
       this.package.addField("types", entrypointTypes);
     }
 


### PR DESCRIPTION
Related to #3284 

## Changes

### 1. Change in Jest

1. I found that paths were changing between Windows and WSL in a `TypeScriptProject` that uses Jest. I updated it to use `normalizePersistedPath`. It occurs when the jest `testdir` has the prefix `src/` like in `src/tests`.
![image](https://github.com/projen/projen/assets/22875166/abdbaca0-1c1b-443b-b004-bf7a14972082)
1. For this case, I tested locally in the project that I mentioned and it worked correctly, using POSIX separators (/) in both WSL and Windows. No test were added.

### 2. Refactor to use normalizePersistedPath

1. Also, I searched for the duplicated of the logic in `normalizePersistedPath`, which currently is only the regex matching of `/\\/g`.
1. I didn't test this one. I think it's safe.
1. If the change is accepted, I think there is room to create an Eslint rule for semantics in case a similar logic is used. That would be in a separate MR, but something along the lines:
```typescript
const normalized = p.replace(/\\/g, path.posix.sep); // warning/error: Consider using normalizePersistedPath to express intention
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
