### PR TITLE
fix(release): provenance statement not being generated because of missing quotes in YAML

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.14.0
+          node-version: 18.14.2
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -97,7 +97,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.14.0
+          node-version: 18.14.2
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -126,7 +126,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.14.0
+          node-version: 18.14.2
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -151,7 +151,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.14.0
+          node-version: 18.14.2
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -179,7 +179,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.14.0
+          node-version: 18.14.2
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,7 @@ jobs:
         env:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
-          NPM_CONFIG_PROVENANCE: true
+          NPM_CONFIG_PROVENANCE: "true"
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx -p publib@latest publib-npm
       - name: Extract Version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.14.0
+          node-version: 18.14.2
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -70,7 +70,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.14.0
+          node-version: 18.14.2
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -114,7 +114,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.14.0
+          node-version: 18.14.2
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -166,7 +166,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.14.0
+          node-version: 18.14.2
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -216,7 +216,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.14.0
+          node-version: 18.14.2
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -265,7 +265,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.14.0
+          node-version: 18.14.2
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0

--- a/.github/workflows/upgrade-bundled-main.yml
+++ b/.github/workflows/upgrade-bundled-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.14.0
+          node-version: 18.14.2
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.14.0
+          node-version: 18.14.2
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -78,7 +78,7 @@ const project = new cdk.JsiiProject({
   projenDevDependency: false, // because I am projen
   releaseToNpm: true,
   minNodeVersion: "16.0.0", // Do not change this before a version has been EOL for a while
-  workflowNodeVersion: "18.14.0",
+  workflowNodeVersion: "18.14.2",
 
   codeCov: true,
   prettier: true,

--- a/src/release/publisher.ts
+++ b/src/release/publisher.ts
@@ -353,7 +353,7 @@ export class Publisher extends Component {
         );
       }
 
-      const npmProvenance = options.npmProvenance ? true : undefined;
+      const npmProvenance = options.npmProvenance ? "true" : undefined;
       const needsIdTokenWrite = isAwsCodeArtifactWithOidc || npmProvenance;
 
       return {

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -575,7 +575,7 @@ jobs:
         env:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
-          NPM_CONFIG_PROVENANCE: true
+          NPM_CONFIG_PROVENANCE: "true"
           NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
         run: npx -p publib@latest publib-npm
   release_maven:

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -508,7 +508,7 @@ jobs:
         env:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
-          NPM_CONFIG_PROVENANCE: true
+          NPM_CONFIG_PROVENANCE: "true"
           NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
         run: npx -p publib@latest publib-npm
 ",
@@ -1756,7 +1756,7 @@ exports[`language bindings release workflow includes release_npm job 1`] = `
     },
     {
       "env": {
-        "NPM_CONFIG_PROVENANCE": true,
+        "NPM_CONFIG_PROVENANCE": "true",
         "NPM_DIST_TAG": "latest",
         "NPM_REGISTRY": "registry.npmjs.org",
         "NPM_TOKEN": "\${{ secrets.NPM_TOKEN }}",
@@ -2263,7 +2263,7 @@ jobs:
         env:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
-          NPM_CONFIG_PROVENANCE: true
+          NPM_CONFIG_PROVENANCE: "true"
           NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
         run: npx -p publib@latest publib-npm
   release_golang:
@@ -2423,7 +2423,7 @@ jobs:
         env:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
-          NPM_CONFIG_PROVENANCE: true
+          NPM_CONFIG_PROVENANCE: "true"
           NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
         run: npx -p publib@latest publib-npm
   release_golang:
@@ -2580,7 +2580,7 @@ jobs:
         env:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
-          NPM_CONFIG_PROVENANCE: true
+          NPM_CONFIG_PROVENANCE: "true"
           NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
         run: npx -p publib@latest publib-npm
   release_nuget:
@@ -2735,7 +2735,7 @@ jobs:
         env:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
-          NPM_CONFIG_PROVENANCE: true
+          NPM_CONFIG_PROVENANCE: "true"
           NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
         run: npx -p publib@latest publib-npm
   release_nuget:

--- a/test/jsii/__snapshots__/jsii.test.ts.snap
+++ b/test/jsii/__snapshots__/jsii.test.ts.snap
@@ -508,7 +508,7 @@ jobs:
         env:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
-          NPM_CONFIG_PROVENANCE: true
+          NPM_CONFIG_PROVENANCE: "true"
           NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
         run: npx -p publib@latest publib-npm
 ",
@@ -2001,7 +2001,7 @@ jobs:
         env:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
-          NPM_CONFIG_PROVENANCE: true
+          NPM_CONFIG_PROVENANCE: "true"
           NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
         run: npx -p publib@latest publib-npm
 ",
@@ -3476,7 +3476,7 @@ jobs:
         env:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
-          NPM_CONFIG_PROVENANCE: true
+          NPM_CONFIG_PROVENANCE: "true"
           NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
         run: npx -p publib@latest publib-npm
 ",
@@ -4948,7 +4948,7 @@ jobs:
         env:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
-          NPM_CONFIG_PROVENANCE: true
+          NPM_CONFIG_PROVENANCE: "true"
           NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
         run: npx -p publib@latest publib-npm
 ",

--- a/test/release/release.test.ts
+++ b/test/release/release.test.ts
@@ -829,7 +829,7 @@ describe("Single Project", () => {
     const releaseWorkflow = YAML.parse(files[".github/workflows/release.yml"]);
 
     expect(releaseWorkflow.jobs.release_npm.steps[3].env).toStrictEqual({
-      NPM_CONFIG_PROVENANCE: true,
+      NPM_CONFIG_PROVENANCE: "true",
       NPM_DIST_TAG: "latest",
       NPM_TOKEN: "${{ secrets.NPM_TOKEN }}",
     });


### PR DESCRIPTION
By looking into [projen in NPM](https://www.npmjs.com/package/projen), I noticed that it didn't have the provenance widget in the page. Then, looking into the [Github action run](https://github.com/projen/projen/actions/runs/7942036715/job/21685009089), I verified that it wasn't generated.

I realized, I made a mistake in [#3300](https://github.com/projen/projen/pull/3330) because the value `true` should be quoted in YAML. 

Before, wrong
```yaml
- name: Release
        env:
          NPM_DIST_TAG: latest
          NPM_REGISTRY: registry.npmjs.org
          NPM_CONFIG_PROVENANCE: true
          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
```
After, correct
```yaml
- name: Release
        env:
          NPM_DIST_TAG: latest
          NPM_REGISTRY: registry.npmjs.org
          NPM_CONFIG_PROVENANCE: "true"
          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
```

I tested this fix in one of my projects and it worked correctly
https://github.com/gmeligio/project-gen/actions/runs/7950505218/job/21702908858#step:10:57

Sorry for the mistake.

## Change 1 NPM_CONFIG_PROVENANCE

1. Add quotes to `"true"` so it's passed as an string to resulting YAML workflow.
2. Update `release.test.ts` with the new value where needed.

##  Change 2 workflowNodeVersion

1. Upgrade workflowNodeVersion to v18.14.2. According to [nodejs.org/dist/index.json](https://nodejs.org/dist/index.json), it's the first version in `18.14.X` that supports provenance statements.
```bash
❯ nvm use 18.14.2
Now using node v18.14.2 (npm v9.5.0)
```

## Future improvements

I received a warning in my downstream project but didn't see it in `projen`
```bash
👾 Received non-string value for environment variable NPM_CONFIG_PROVENANCE. Value will be stringified.
```
This helped me to confirm again the issue, but I was surprised of how come it doesn't show up when running `rm -rf lib && yarn projen` in the projen repository. I haven't investigated that yet, but maybe it would be nice if the message is also shown in the projen repository.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
