### PR TITLE
fix(node): some directory separators are still inconsistent between platforms in tasks.json and package.json

### DIFF
--- a/src/javascript/util.ts
+++ b/src/javascript/util.ts
@@ -27,7 +27,7 @@ export function renderBundleName(entrypoint: string) {
     parts.shift(); // just remove 'src' if its the first element for ergonomics
   }
 
-  const p = parts.join(sep);
+  const p = parts.join(posix.sep);
   const dir = dirname(p);
   const base = basename(p, extname(p));
   return posix.join(dir, base);


### PR DESCRIPTION
Related to https://github.com/projen/projen/issues/3284#issuecomment-1964163891

This is the second attempt at fixing the directory separator issue for lambda entrypoints, which was started in https://github.com/projen/projen/pull/3387. 

I tried adding unit tests for `renderBundleName`. Unfortunately, this can't be unit-tested now because NodeJS exports the `path` package for the Linux platform instead of Windows at import time and not at runtime.
https://github.com/nodejs/node/blob/f28ccd3941e70a825786eff7e28f59014ac76ac9/lib/path.js#L1546

I tested it locally in an example project, and it looks like it's fixed now.
![image](https://github.com/projen/projen/assets/22875166/4f98fb92-0a45-4d83-845c-152e48ded763)


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
