### PR TITLE
chore: fix missing type in building your own project docs

### DIFF
--- a/docs/concepts/projects/building-your-own.md
+++ b/docs/concepts/projects/building-your-own.md
@@ -254,7 +254,7 @@ export class MyMicroserviceProject extends TypeScriptProject {
 }
 ```
 
-Let's also add an optional `mention` property that will mention a specific user in the PR template.
+Let's also add an optional `prMention` property that will mention a specific user in the PR template.
 
 We need to first update the `MyMicroserviceProjectOptions` interface in the `my-microservice-project.ts` file to:
 

--- a/docs/concepts/projects/building-your-own.md
+++ b/docs/concepts/projects/building-your-own.md
@@ -159,6 +159,7 @@ describe('MyMicroserviceProject', () => {
     // GIVEN
     const project = new MyMicroserviceProject({
       name: 'my-microservice',
+      defaultReleaseBranch: 'main',
     });
 
     // WHEN
@@ -295,6 +296,7 @@ Now, we can add the `prMention` property to the options object when we create a 
 ```typescript
 const project = new MyMicroserviceProject({
   name: 'my-microservice',
+  defaultReleaseBranch: 'main',
   prMention: '@someuser',
 });
 ```
@@ -317,6 +319,7 @@ describe('MyMicroserviceProject', () => {
     // GIVEN
     const project = new MyMicroserviceProject({
       name: 'my-microservice',
+      defaultReleaseBranch: 'main',
     });
 
     // WHEN
@@ -348,6 +351,7 @@ describe('MyMicroserviceProject', () => {
     // GIVEN
     const project = new MyMicroserviceProject({
       name: 'my-microservice',
+      defaultReleaseBranch: 'main',
       prMention: 'someoone',
     });
 
@@ -381,6 +385,7 @@ describe('MyMicroserviceProject', () => {
     // GIVEN
     const project = new MyMicroserviceProject({
       name: 'my-microservice',
+      defaultReleaseBranch: 'main',
       prMention: '@someoone',
     });
 

--- a/docs/concepts/projects/building-your-own.md
+++ b/docs/concepts/projects/building-your-own.md
@@ -159,7 +159,6 @@ describe('MyMicroserviceProject', () => {
     // GIVEN
     const project = new MyMicroserviceProject({
       name: 'my-microservice',
-      defaultReleaseBranch: 'main',
     });
 
     // WHEN
@@ -256,7 +255,16 @@ export class MyMicroserviceProject extends TypeScriptProject {
 ```
 
 Let's also add an optional `mention` property that will mention a specific user in the PR template.
-We start by making this property part of the incoming `options` object in the constructor, so modify the `MyMicroserviceProjectOptions` interface:
+
+We need to first update the `MyMicroserviceProjectOptions` interface in the `my-microservice-project.ts` file to:
+
+```typescript
+export interface MyMicroserviceProjectOptions extends TypeScriptProjectOptions {
+  readonly prMention?: string;
+}
+```
+
+Then, we write the logic code to handle `options.prMention` in the constructor, pushing new lines to the PR template if the property is set:
 
 ```typescript
 export class MyMicroserviceProject extends TypeScriptProject {
@@ -287,7 +295,6 @@ Now, we can add the `prMention` property to the options object when we create a 
 ```typescript
 const project = new MyMicroserviceProject({
   name: 'my-microservice',
-  defaultReleaseBranch: 'main',
   prMention: '@someuser',
 });
 ```
@@ -310,7 +317,6 @@ describe('MyMicroserviceProject', () => {
     // GIVEN
     const project = new MyMicroserviceProject({
       name: 'my-microservice',
-      defaultReleaseBranch: 'main',
     });
 
     // WHEN
@@ -342,7 +348,6 @@ describe('MyMicroserviceProject', () => {
     // GIVEN
     const project = new MyMicroserviceProject({
       name: 'my-microservice',
-      defaultReleaseBranch: 'main',
       prMention: 'someoone',
     });
 
@@ -376,7 +381,6 @@ describe('MyMicroserviceProject', () => {
     // GIVEN
     const project = new MyMicroserviceProject({
       name: 'my-microservice',
-      defaultReleaseBranch: 'main',
       prMention: '@someoone',
     });
 

--- a/src/javascript/node-project.ts
+++ b/src/javascript/node-project.ts
@@ -139,7 +139,7 @@ export interface NodeProjectOptions
    *
    * @default "main"
    */
-  readonly defaultReleaseBranch: string;
+  readonly defaultReleaseBranch?: string;
 
   /**
    * Workflow steps to use in order to bootstrap this repo.
@@ -568,12 +568,6 @@ export class NodeProject extends GitHubProject {
       const postfix = options.projenVersion ? `@${options.projenVersion}` : "";
       this.addDevDeps(`projen${postfix}`);
       this.addDevDeps(`constructs@^10.0.0`);
-    }
-
-    if (!options.defaultReleaseBranch) {
-      throw new Error(
-        '"defaultReleaseBranch" is temporarily a required option while we migrate its default value from "master" to "main"'
-      );
     }
 
     const buildEnabled = options.buildWorkflow ?? (this.parent ? false : true);

--- a/src/javascript/node-project.ts
+++ b/src/javascript/node-project.ts
@@ -139,7 +139,7 @@ export interface NodeProjectOptions
    *
    * @default "main"
    */
-  readonly defaultReleaseBranch?: string;
+  readonly defaultReleaseBranch: string;
 
   /**
    * Workflow steps to use in order to bootstrap this repo.
@@ -568,6 +568,12 @@ export class NodeProject extends GitHubProject {
       const postfix = options.projenVersion ? `@${options.projenVersion}` : "";
       this.addDevDeps(`projen${postfix}`);
       this.addDevDeps(`constructs@^10.0.0`);
+    }
+
+    if (!options.defaultReleaseBranch) {
+      throw new Error(
+        '"defaultReleaseBranch" is temporarily a required option while we migrate its default value from "master" to "main"'
+      );
     }
 
     const buildEnabled = options.buildWorkflow ?? (this.parent ? false : true);


### PR DESCRIPTION
Fixes
prMention missing in the MyMicroserviceProjectOptions interface
defaultReleaseBranch shouldn't be there in the example because this example should solely help with the goal of adding new prMention property, not dragging in what the default options the parent class has.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
