### PR TITLE
fix(typescript): TSConfig `compilerOptions` can be optional

### DIFF
--- a/docs/api/javascript.md
+++ b/docs/api/javascript.md
@@ -4212,12 +4212,12 @@ Test whether the given construct is a component.
 | --- | --- | --- |
 | <code><a href="#projen.javascript.TypescriptConfig.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#projen.javascript.TypescriptConfig.property.project">project</a></code> | <code>projen.Project</code> | *No description.* |
-| <code><a href="#projen.javascript.TypescriptConfig.property.compilerOptions">compilerOptions</a></code> | <code><a href="#projen.javascript.TypeScriptCompilerOptions">TypeScriptCompilerOptions</a></code> | *No description.* |
 | <code><a href="#projen.javascript.TypescriptConfig.property.exclude">exclude</a></code> | <code>string[]</code> | *No description.* |
 | <code><a href="#projen.javascript.TypescriptConfig.property.extends">extends</a></code> | <code>string[]</code> | Array of base `tsconfig.json` paths. Any absolute paths are resolved relative to this instance, while any relative paths are used as is. |
 | <code><a href="#projen.javascript.TypescriptConfig.property.file">file</a></code> | <code>projen.JsonFile</code> | *No description.* |
 | <code><a href="#projen.javascript.TypescriptConfig.property.fileName">fileName</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#projen.javascript.TypescriptConfig.property.include">include</a></code> | <code>string[]</code> | *No description.* |
+| <code><a href="#projen.javascript.TypescriptConfig.property.compilerOptions">compilerOptions</a></code> | <code><a href="#projen.javascript.TypeScriptCompilerOptions">TypeScriptCompilerOptions</a></code> | *No description.* |
 
 ---
 
@@ -4240,16 +4240,6 @@ public readonly project: Project;
 ```
 
 - *Type:* projen.Project
-
----
-
-##### `compilerOptions`<sup>Required</sup> <a name="compilerOptions" id="projen.javascript.TypescriptConfig.property.compilerOptions"></a>
-
-```typescript
-public readonly compilerOptions: TypeScriptCompilerOptions;
-```
-
-- *Type:* <a href="#projen.javascript.TypeScriptCompilerOptions">TypeScriptCompilerOptions</a>
 
 ---
 
@@ -4302,6 +4292,16 @@ public readonly include: string[];
 ```
 
 - *Type:* string[]
+
+---
+
+##### `compilerOptions`<sup>Optional</sup> <a name="compilerOptions" id="projen.javascript.TypescriptConfig.property.compilerOptions"></a>
+
+```typescript
+public readonly compilerOptions: TypeScriptCompilerOptions;
+```
+
+- *Type:* <a href="#projen.javascript.TypeScriptCompilerOptions">TypeScriptCompilerOptions</a>
 
 ---
 
@@ -11512,7 +11512,7 @@ const typescriptConfigOptions: javascript.TypescriptConfigOptions = { ... }
 
 ---
 
-##### `compilerOptions`<sup>Required</sup> <a name="compilerOptions" id="projen.javascript.TypescriptConfigOptions.property.compilerOptions"></a>
+##### `compilerOptions`<sup>Optional</sup> <a name="compilerOptions" id="projen.javascript.TypescriptConfigOptions.property.compilerOptions"></a>
 
 ```typescript
 public readonly compilerOptions: TypeScriptCompilerOptions;

--- a/src/javascript/typescript-config.ts
+++ b/src/javascript/typescript-config.ts
@@ -13,6 +13,9 @@ export interface TypescriptConfigOptions {
 
   /**
    * Base `tsconfig.json` configuration(s) to inherit from.
+   *
+   * @remarks
+   * Must provide either `extends` or `compilerOptions` (or both).
    */
   readonly extends?: TypescriptConfigExtends;
 
@@ -32,8 +35,11 @@ export interface TypescriptConfigOptions {
 
   /**
    * Compiler options to use.
+   *
+   * @remarks
+   * Must provide either `extends` or `compilerOptions` (or both).
    */
-  readonly compilerOptions: TypeScriptCompilerOptions;
+  readonly compilerOptions?: TypeScriptCompilerOptions;
 }
 
 /**
@@ -661,7 +667,7 @@ export class TypescriptConfigExtends {
 
 export class TypescriptConfig extends Component {
   private _extends: TypescriptConfigExtends;
-  public readonly compilerOptions: TypeScriptCompilerOptions;
+  public readonly compilerOptions?: TypeScriptCompilerOptions;
   public readonly include: string[];
   public readonly exclude: string[];
   public readonly fileName: string;
@@ -670,6 +676,12 @@ export class TypescriptConfig extends Component {
   constructor(project: Project, options: TypescriptConfigOptions) {
     super(project);
     const fileName = options.fileName ?? "tsconfig.json";
+
+    if (!options.extends && !options.compilerOptions) {
+      throw new Error(
+        "TypescriptConfig: Must provide either `extends` or `compilerOptions` (or both)."
+      );
+    }
 
     this._extends = options.extends ?? TypescriptConfigExtends.fromPaths([]);
     this.include = options.include ?? ["**/*.ts"];

--- a/test/javascript/typescript-config.test.ts
+++ b/test/javascript/typescript-config.test.ts
@@ -103,6 +103,46 @@ describe("TypescriptConfig", () => {
     });
   });
 
+  test("TypeScript should allow parse package for extends witout compilerOptions.", () => {
+    withProjectDir((outdir) => {
+      const project = new NodeProject({
+        name: "project",
+        defaultReleaseBranch: "main",
+        outdir,
+      });
+      const baseConfig = new TypescriptConfig(project, {
+        // No compilerOptions
+        extends: TypescriptConfigExtends.fromPaths([
+          "@tsconfig/recommended/tsconfig.json",
+        ]),
+      });
+      project.synth();
+
+      const loadedConfig = ts.readConfigFile(
+        baseConfig.file.absolutePath,
+        ts.sys.readFile
+      );
+      expect(loadedConfig.error).toBeUndefined();
+      expect(loadedConfig.config).toHaveProperty(
+        "extends",
+        "@tsconfig/recommended/tsconfig.json"
+      );
+    });
+  });
+
+  test("TypescriptConfig requires either extends or compilerOptions.", () => {
+    expect(() => {
+      const project = new NodeProject({
+        name: "project",
+        defaultReleaseBranch: "main",
+      });
+      new TypescriptConfig(project, {
+        // No compilerOptions
+        // No extends
+      });
+    }).toThrowError(/Must provide either `extends` or `compilerOptions`/);
+  });
+
   test("TypeScript should parse generated config with multiple extensions", () => {
     withProjectDir((outdir) => {
       const project = new NodeProject({


### PR DESCRIPTION
Fixes #3411

Note: Still unable to make an empty `compilerOptions` (without providing one with everything explicitly set to `undefined`) due to `TypeScriptProject` forcing an override. I'll make another issue and PR for that.

Apologies to @coleHafner if they've already spent time on this

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
