### PR TITLE
feat(tsconfig): TypeScriptProject now offers means to not enforce tsconfig defaults

### DIFF
--- a/src/typescript/typescript.ts
+++ b/src/typescript/typescript.ts
@@ -823,10 +823,13 @@ export function mergeTsconfigOptions(
       ...current,
       include: [...(previous.include ?? []), ...(current.include ?? [])],
       exclude: [...(previous.exclude ?? []), ...(current.exclude ?? [])],
-      compilerOptions: {
-        ...previous.compilerOptions,
-        ...current.compilerOptions,
-      },
+      compilerOptions:
+        current.compilerOptions === undefined
+          ? undefined
+          : {
+              ...previous.compilerOptions,
+              ...current.compilerOptions,
+            },
     }),
     { compilerOptions: {} }
   );

--- a/test/typescript/typescript.test.ts
+++ b/test/typescript/typescript.test.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { Logger, TaskRuntime } from "../../src";
 import { DEFAULT_PROJEN_RC_JS_FILENAME } from "../../src/common";
-import { Transform } from "../../src/javascript";
+import { Transform, TypescriptConfigExtends } from "../../src/javascript";
 import {
   mergeTsconfigOptions,
   TsJestTsconfig,
@@ -93,6 +93,62 @@ describe("mergeTsconfigOptions", () => {
         },
       })
     );
+  });
+
+  test("merging compilerOptions: undefined to erase", () => {
+    const mergedTsconfigOptions = mergeTsconfigOptions(
+      {
+        compilerOptions: {
+          esModuleInterop: false,
+        },
+      },
+      {
+        compilerOptions: undefined,
+      }
+    );
+
+    console.dir(mergedTsconfigOptions, { depth: null });
+    expect(mergedTsconfigOptions).toEqual(
+      expect.not.objectContaining({
+        compilerOptions: {
+          esModuleInterop: false,
+        },
+      })
+    );
+  });
+});
+
+describe("tsconfigOptions with exends", () => {
+  test("tsconfigOptions can be undefined with exends", () => {
+    // yeah, expect(...).not.toThrow() is redundant, but expresses the intention
+    expect(() => {
+      const prj = new TypeScriptProject({
+        name: "test",
+        defaultReleaseBranch: "test",
+        tsconfig: {
+          include: ["typescript.test.ts"],
+          extends: TypescriptConfigExtends.fromPaths(["tsconfig.base.json"]),
+          // no compilerOptions,
+        },
+      });
+
+      synthSnapshot(prj);
+    }).not.toThrow();
+  });
+  test("tsconfigOptions cannot be undefined with exends undefined", () => {
+    expect(() => {
+      const prj = new TypeScriptProject({
+        name: "test",
+        defaultReleaseBranch: "test",
+        tsconfig: {
+          // extends: TypescriptConfigExtends.fromPaths(["tsconfig.base.json"]),
+          // no compilerOptions,
+          compilerOptions: undefined,
+        },
+      });
+
+      synthSnapshot(prj);
+    }).toThrow(/Must provide either `extends` or `compilerOptions`/);
   });
 });
 


### PR DESCRIPTION
Fixes #3437

Current mechanism is to provide `compilerOptions: undefined` - see discussion in issue for details

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
