### PR TITLE
fix(docs): remove typo in JSDoc

### DIFF
--- a/src/awscdk/awscdk-construct.ts
+++ b/src/awscdk/awscdk-construct.ts
@@ -43,7 +43,7 @@ export interface AwsCdkConstructLibraryOptions
 
   /**
    * Automatically discovers and creates integration tests for each `.integ.ts`
-   * file in under your test directory.
+   * file under your test directory.
    *
    * @default true
    */


### PR DESCRIPTION
Fixes double preposition.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
