### PR TITLE
feat(python)!: introduce `pythonCompatibleVersion` and `pythonSemanticVersion` props

### DIFF
--- a/src/python/python-project.ts
+++ b/src/python/python-project.ts
@@ -30,6 +30,19 @@ export interface PythonExecutableOptions {
    * @default "python"
    */
   readonly pythonExec?: string;
+
+  /**
+   * Defines the Python version that the project can work with.
+   * This version follows the caret (^) notation from the SemVer standard.
+   * @default "3.8"
+   */
+  readonly pythonCompatibleVersion?: string;
+
+  /**
+   * A specific Python version constraint following the SemVer standard.
+   * This version takes precedence over `pythonCompatibleVersion`.
+   */
+  readonly pythonSemanticVersion?: string;
 }
 
 /**
@@ -317,6 +330,8 @@ export class PythonProject extends GitHubProject {
         homepage: options.homepage,
         classifiers: options.classifiers,
         pythonExec: options.pythonExec,
+        pythonCompatibleVersion: options.pythonCompatibleVersion,
+        pythonSemanticVersion: options.pythonSemanticVersion,
         poetryOptions: {
           readme: options.readme?.filename ?? "README.md",
           ...options.poetryOptions,


### PR DESCRIPTION
After giving it considerable thought, the concepts of `minPythonVersion` and `maxPythonVersion` didn't look like a good idea. A better approach, I realized, would be to introduce properties for defining compatible Python versions and another for specifying complex version requirements. Currently, the default version is set to `"^3.8"` which is somewhat useless given that Python incompatibilities usually occur between different minor versions. Ideally, the default should be `"^3.8.0"`, though that's a topic for future discussions.

In this PR, my aim is to add the `pythonCompatibleVersion` property for those primarily concerned with specifying a Python version to ensure compatibility, such as ensuring Python `3.11.x` is used without automatically upgrading to Python `3.12.x`. Additionally, the `pythonSemanticVersion` property is introduced for users who require more advanced version control.

Presently, to change the default Python version in a project, one must use `project.add_dependency`, which is not only cumbersome but also obscures how to properly set a specific Python version, as there's no direct property for it and it lacks documentation visibility (automatic docgen doesn't cover this scenario).

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
