### PR TITLE
chore: make `bundle:task-runner` use single esbuild command

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -47,15 +47,7 @@
       "description": "Bundle the run-task script needed for \"projen eject\"",
       "steps": [
         {
-          "exec": "esbuild src/task-runtime.ts --outfile=lib/run-task.js --bundle --platform=node --external:\"*/package.json\""
-        },
-        {
-          "exec": "echo \"#!/usr/bin/env node\" | cat - lib/run-task.js | tee lib/run-task.js > /dev/null",
-          "name": "Insert Node shebang to beginning of the file"
-        },
-        {
-          "exec": "echo \"const runtime = new TaskRuntime(\\\".\\\");\nruntime.runTask(process.argv[2]);\" >> lib/run-task.js",
-          "name": "Add driver code to end of the file"
+          "exec": "esbuild src/task-runtime.ts --outfile=lib/run-task.js --bundle --platform=node --external:\"*/package.json\" --banner:js=\"#!/usr/bin/env node\" --footer:js=\"const runtime = new TaskRuntime(\\\".\\\");\nruntime.runTask(process.argv[2]);\""
         }
       ]
     },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -375,23 +375,19 @@ function setupIntegTest() {
 
 // build `run-task` script needed for "projen eject" functionality
 function setupBundleTaskRunner() {
+  // TODO: use project.bundler.addBundle instead - currently it's too inflexible on where the output goes
   const taskRunnerPath = "lib/run-task.js";
   const task = project.addTask("bundle:task-runner", {
     description: 'Bundle the run-task script needed for "projen eject"',
-    exec: `esbuild src/task-runtime.ts --outfile=${taskRunnerPath} --bundle --platform=node --external:"*/package.json"`,
+    exec:
+      `esbuild src/task-runtime.ts ` +
+      `--outfile=${taskRunnerPath} ` +
+      `--bundle ` +
+      `--platform=node ` +
+      `--external:"*/package.json" ` +
+      `--banner:js="#!/usr/bin/env node" ` +
+      `--footer:js="const runtime = new TaskRuntime(\\".\\");\nruntime.runTask(process.argv[2]);"`,
   });
-  task.exec(
-    `echo "#!/usr/bin/env node" | cat - lib/run-task.js | tee lib/run-task.js > /dev/null`,
-    {
-      name: "Insert Node shebang to beginning of the file",
-    }
-  );
-  task.exec(
-    `echo "const runtime = new TaskRuntime(\\".\\");\nruntime.runTask(process.argv[2]);" >> ${taskRunnerPath}`,
-    {
-      name: "Add driver code to end of the file",
-    }
-  );
   project.postCompileTask.spawn(task);
 }
 


### PR DESCRIPTION
Doesn't fix a current bug, but will help with windows support.

Instead of `bash`-isms that aren't portable (`echo ... | cat - ... | tee ... > /dev/null`) use `--banner:js=` and `--footer:js=` built-in capabilities of `esbuild`.

The resulting `lib/run-task.js` is identical in both cases.

Aside: it would be nice if we could use the work we've done in `Bundler` but alas, it doesn't give us control of the name of the task or where the output goes.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
