### PR TITLE
fix(bun): `npx` used when `bun` is package manager to print `PATH`

### DIFF
--- a/src/javascript/node-project.ts
+++ b/src/javascript/node-project.ts
@@ -516,6 +516,8 @@ export class NodeProject extends GitHubProject {
       switch (this.packageManager) {
         case NodePackageManager.PNPM:
           return '$(pnpm -c exec "node --print process.env.PATH")';
+        case NodePackageManager.BUN:
+          return '$(bun --eval "console.log(process.env.PATH)")';
         default:
           return '$(npx -c "node --print process.env.PATH")';
       }

--- a/test/javascript/node-project.test.ts
+++ b/test/javascript/node-project.test.ts
@@ -1756,6 +1756,10 @@ describe("package manager env", () => {
       packageManager: NodePackageManager.PNPM,
       cmd: '$(pnpm -c exec "node --print process.env.PATH")',
     },
+    {
+      packageManager: NodePackageManager.BUN,
+      cmd: '$(bun --eval "console.log(process.env.PATH)")',
+    },
   ].forEach((testCase) => {
     test(testCase.packageManager, () => {
       // GIVEN / WHEN


### PR DESCRIPTION
This is important because https://bun.sh is not only a npm alternative, but also a node and npx alternative.

Systems with bun installed may not have node or npm, but if `NodePackageManager.BUN` is chosen, we do know that `bun` is available, and can print the `PATH` that way.

Fixes #3490 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
