### PR TITLE
feat: support paths option for continuous release trigger

### DIFF
--- a/docs/api/release.md
+++ b/docs/api/release.md
@@ -960,6 +960,36 @@ Additional tools to install in the publishing job.
 
 ---
 
+### ContinuousReleaseOptions <a name="ContinuousReleaseOptions" id="projen.release.ContinuousReleaseOptions"></a>
+
+#### Initializer <a name="Initializer" id="projen.release.ContinuousReleaseOptions.Initializer"></a>
+
+```typescript
+import { release } from 'projen'
+
+const continuousReleaseOptions: release.ContinuousReleaseOptions = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen.release.ContinuousReleaseOptions.property.paths">paths</a></code> | <code>string[]</code> | Paths for which pushes should trigger a release. |
+
+---
+
+##### `paths`<sup>Optional</sup> <a name="paths" id="projen.release.ContinuousReleaseOptions.property.paths"></a>
+
+```typescript
+public readonly paths: string[];
+```
+
+- *Type:* string[]
+
+Paths for which pushes should trigger a release.
+
+---
+
 ### GitHubReleasesPublishOptions <a name="GitHubReleasesPublishOptions" id="projen.release.GitHubReleasesPublishOptions"></a>
 
 Publishing options for GitHub releases.
@@ -4021,12 +4051,18 @@ and release artifact automation
 ```typescript
 import { release } from 'projen'
 
-release.ReleaseTrigger.continuous()
+release.ReleaseTrigger.continuous(options?: ContinuousReleaseOptions)
 ```
 
 Creates a continuous release trigger.
 
 Automated releases will occur on every commit.
+
+###### `options`<sup>Optional</sup> <a name="options" id="projen.release.ReleaseTrigger.continuous.parameter.options"></a>
+
+- *Type:* <a href="#projen.release.ContinuousReleaseOptions">ContinuousReleaseOptions</a>
+
+---
 
 ##### `manual` <a name="manual" id="projen.release.ReleaseTrigger.manual"></a>
 
@@ -4086,6 +4122,7 @@ release options.
 | <code><a href="#projen.release.ReleaseTrigger.property.isManual">isManual</a></code> | <code>boolean</code> | Whether or not this is a manual release trigger. |
 | <code><a href="#projen.release.ReleaseTrigger.property.changelogPath">changelogPath</a></code> | <code>string</code> | Project-level changelog file path. |
 | <code><a href="#projen.release.ReleaseTrigger.property.gitPushCommand">gitPushCommand</a></code> | <code>string</code> | Override git-push command used when releasing manually. |
+| <code><a href="#projen.release.ReleaseTrigger.property.paths">paths</a></code> | <code>string[]</code> | Paths for which pushes will trigger a release when `isContinuous` is `true`. |
 | <code><a href="#projen.release.ReleaseTrigger.property.schedule">schedule</a></code> | <code>string</code> | Cron schedule for releases. |
 
 ---
@@ -4137,6 +4174,18 @@ public readonly gitPushCommand: string;
 Override git-push command used when releasing manually.
 
 Set to an empty string to disable pushing.
+
+---
+
+##### `paths`<sup>Optional</sup> <a name="paths" id="projen.release.ReleaseTrigger.property.paths"></a>
+
+```typescript
+public readonly paths: string[];
+```
+
+- *Type:* string[]
+
+Paths for which pushes will trigger a release when `isContinuous` is `true`.
 
 ---
 

--- a/src/release/release-trigger.ts
+++ b/src/release/release-trigger.ts
@@ -34,6 +34,13 @@ export interface ManualReleaseOptions {
   readonly gitPushCommand?: string;
 }
 
+export interface ContinuousReleaseOptions {
+  /**
+   * Paths for which pushes should trigger a release
+   */
+  readonly paths?: string[];
+}
+
 interface ReleaseTriggerOptions {
   /**
    * Project-level changelog file path.
@@ -48,6 +55,11 @@ interface ReleaseTriggerOptions {
    * @default false
    */
   readonly continuous?: boolean;
+
+  /**
+   * Paths for which pushes (continuous release) should trigger a release
+   */
+  readonly paths?: string[];
 
   /**
    * Cron schedule for release.
@@ -119,9 +131,10 @@ export class ReleaseTrigger {
    *
    * Automated releases will occur on every commit.
    */
-  public static continuous() {
+  public static continuous(options: ContinuousReleaseOptions = {}) {
     return new ReleaseTrigger({
       continuous: true,
+      paths: options.paths,
     });
   }
 
@@ -145,6 +158,11 @@ export class ReleaseTrigger {
   public readonly isContinuous: boolean;
 
   /**
+   * Paths for which pushes will trigger a release when `isContinuous` is `true`
+   */
+  public readonly paths?: string[];
+
+  /**
    * Override git-push command used when releasing manually.
    *
    * Set to an empty string to disable pushing.
@@ -153,6 +171,7 @@ export class ReleaseTrigger {
 
   private constructor(options: ReleaseTriggerOptions = {}) {
     this.isContinuous = options.continuous ?? false;
+    this.paths = options.paths;
     this.schedule = options.schedule;
     this.changelogPath = options.changelogPath;
     this.gitPushCommand = options.gitPushCommand;

--- a/src/release/release.ts
+++ b/src/release/release.ts
@@ -707,7 +707,7 @@ export class Release extends Component {
           ? [{ cron: this.releaseTrigger.schedule }]
           : undefined,
         push: this.releaseTrigger.isContinuous
-          ? { branches: [branchName] }
+          ? { branches: [branchName], paths: this.releaseTrigger.paths }
           : undefined,
         workflowDispatch: {}, // allow manual triggering
       });

--- a/test/release/release-trigger.test.ts
+++ b/test/release/release-trigger.test.ts
@@ -73,6 +73,20 @@ describe("continuous release", () => {
   test("does not have a changelog", () => {
     expect(releaseTrigger.changelogPath).toBeUndefined();
   });
+
+  test("does not set path by default", () => {
+    expect(releaseTrigger.paths).toBeUndefined();
+  });
+
+  describe("path configuration", () => {
+    beforeAll(() => {
+      releaseTrigger = ReleaseTrigger.continuous({ paths: ["foo/**"] });
+    });
+
+    test("it has path configured", () => {
+      expect(releaseTrigger.paths).toEqual(["foo/**"]);
+    });
+  });
 });
 
 describe("scheduled release", () => {


### PR DESCRIPTION
Partially addresses #3304

Adds an optional `paths` option for `ReleaseTrigger.continuous()`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
