### PR TITLE
fix(subprojects)!: conflicting projenDevDependency is added to subprojects by default

### DIFF
--- a/docs/api/awscdk.md
+++ b/docs/api/awscdk.md
@@ -11984,7 +11984,7 @@ public readonly projenDevDependency: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* true
+- *Default:* true if not a subproject
 
 Indicates of "projen" should be installed as a devDependency.
 
@@ -17214,7 +17214,7 @@ public readonly projenDevDependency: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* true
+- *Default:* true if not a subproject
 
 Indicates of "projen" should be installed as a devDependency.
 
@@ -20237,7 +20237,7 @@ public readonly projenDevDependency: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* true
+- *Default:* true if not a subproject
 
 Indicates of "projen" should be installed as a devDependency.
 

--- a/docs/api/cdk.md
+++ b/docs/api/cdk.md
@@ -5503,7 +5503,7 @@ public readonly projenDevDependency: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* true
+- *Default:* true if not a subproject
 
 Indicates of "projen" should be installed as a devDependency.
 
@@ -8696,7 +8696,7 @@ public readonly projenDevDependency: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* true
+- *Default:* true if not a subproject
 
 Indicates of "projen" should be installed as a devDependency.
 

--- a/docs/api/cdk8s.md
+++ b/docs/api/cdk8s.md
@@ -8371,7 +8371,7 @@ public readonly projenDevDependency: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* true
+- *Default:* true if not a subproject
 
 Indicates of "projen" should be installed as a devDependency.
 
@@ -10807,7 +10807,7 @@ public readonly projenDevDependency: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* true
+- *Default:* true if not a subproject
 
 Indicates of "projen" should be installed as a devDependency.
 

--- a/docs/api/cdktf.md
+++ b/docs/api/cdktf.md
@@ -3345,7 +3345,7 @@ public readonly projenDevDependency: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* true
+- *Default:* true if not a subproject
 
 Indicates of "projen" should be installed as a devDependency.
 

--- a/docs/api/javascript.md
+++ b/docs/api/javascript.md
@@ -9754,7 +9754,7 @@ public readonly projenDevDependency: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* true
+- *Default:* true if not a subproject
 
 Indicates of "projen" should be installed as a devDependency.
 

--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -7363,7 +7363,7 @@ public readonly projenDevDependency: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* true
+- *Default:* true if not a subproject
 
 Indicates of "projen" should be installed as a devDependency.
 
@@ -9640,7 +9640,7 @@ public readonly projenDevDependency: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* true
+- *Default:* true if not a subproject
 
 Indicates of "projen" should be installed as a devDependency.
 

--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -8356,7 +8356,7 @@ public readonly projenDevDependency: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* true
+- *Default:* true if not a subproject
 
 Indicates of "projen" should be installed as a devDependency.
 
@@ -10391,7 +10391,7 @@ public readonly projenDevDependency: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* true
+- *Default:* true if not a subproject
 
 Indicates of "projen" should be installed as a devDependency.
 
@@ -12722,7 +12722,7 @@ public readonly projenDevDependency: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* true
+- *Default:* true if not a subproject
 
 Indicates of "projen" should be installed as a devDependency.
 
@@ -14925,7 +14925,7 @@ public readonly projenDevDependency: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* true
+- *Default:* true if not a subproject
 
 Indicates of "projen" should be installed as a devDependency.
 

--- a/src/javascript/node-project.ts
+++ b/src/javascript/node-project.ts
@@ -84,7 +84,7 @@ export interface NodeProjectOptions
   /**
    * Indicates of "projen" should be installed as a devDependency.
    *
-   * @default true
+   * @default - true if not a subproject
    */
   readonly projenDevDependency?: boolean;
 
@@ -590,7 +590,7 @@ export class NodeProject extends GitHubProject {
 
     this.npmignore?.exclude(`/${PROJEN_DIR}/`);
 
-    const projen = options.projenDevDependency ?? true;
+    const projen = options.projenDevDependency ?? (this.parent ? false : true);
     if (projen && !this.ejected) {
       const postfix = options.projenVersion ? `@${options.projenVersion}` : "";
       this.addDevDeps(`projen${postfix}`);

--- a/test/__snapshots__/inventory.test.ts.snap
+++ b/test/__snapshots__/inventory.test.ts.snap
@@ -4486,7 +4486,7 @@ exports[`inventory 1`] = `
         "switch": "projen-credentials",
       },
       {
-        "default": "true",
+        "default": "- true if not a subproject",
         "docs": "Indicates of "projen" should be installed as a devDependency.",
         "featured": false,
         "fullType": {
@@ -7603,7 +7603,7 @@ exports[`inventory 1`] = `
         "switch": "projen-credentials",
       },
       {
-        "default": "true",
+        "default": "- true if not a subproject",
         "docs": "Indicates of "projen" should be installed as a devDependency.",
         "featured": false,
         "fullType": {
@@ -11856,7 +11856,7 @@ exports[`inventory 1`] = `
         "switch": "projen-credentials",
       },
       {
-        "default": "true",
+        "default": "- true if not a subproject",
         "docs": "Indicates of "projen" should be installed as a devDependency.",
         "featured": false,
         "fullType": {
@@ -14760,7 +14760,7 @@ exports[`inventory 1`] = `
         "switch": "projen-credentials",
       },
       {
-        "default": "true",
+        "default": "- true if not a subproject",
         "docs": "Indicates of "projen" should be installed as a devDependency.",
         "featured": false,
         "fullType": {
@@ -17723,7 +17723,7 @@ exports[`inventory 1`] = `
         "switch": "projen-credentials",
       },
       {
-        "default": "true",
+        "default": "- true if not a subproject",
         "docs": "Indicates of "projen" should be installed as a devDependency.",
         "featured": false,
         "fullType": {
@@ -21488,7 +21488,7 @@ exports[`inventory 1`] = `
         "switch": "projen-credentials",
       },
       {
-        "default": "true",
+        "default": "- true if not a subproject",
         "docs": "Indicates of "projen" should be installed as a devDependency.",
         "featured": false,
         "fullType": {
@@ -24118,7 +24118,7 @@ exports[`inventory 1`] = `
         "switch": "projen-credentials",
       },
       {
-        "default": "true",
+        "default": "- true if not a subproject",
         "docs": "Indicates of "projen" should be installed as a devDependency.",
         "featured": false,
         "fullType": {
@@ -26633,7 +26633,7 @@ exports[`inventory 1`] = `
         "switch": "projen-credentials",
       },
       {
-        "default": "true",
+        "default": "- true if not a subproject",
         "docs": "Indicates of "projen" should be installed as a devDependency.",
         "featured": false,
         "fullType": {
@@ -29136,7 +29136,7 @@ exports[`inventory 1`] = `
         "switch": "projen-credentials",
       },
       {
-        "default": "true",
+        "default": "- true if not a subproject",
         "docs": "Indicates of "projen" should be installed as a devDependency.",
         "featured": false,
         "fullType": {
@@ -32701,7 +32701,7 @@ exports[`inventory 1`] = `
         "switch": "projen-credentials",
       },
       {
-        "default": "true",
+        "default": "- true if not a subproject",
         "docs": "Indicates of "projen" should be installed as a devDependency.",
         "featured": false,
         "fullType": {
@@ -35204,7 +35204,7 @@ exports[`inventory 1`] = `
         "switch": "projen-credentials",
       },
       {
-        "default": "true",
+        "default": "- true if not a subproject",
         "docs": "Indicates of "projen" should be installed as a devDependency.",
         "featured": false,
         "fullType": {
@@ -37850,7 +37850,7 @@ exports[`inventory 1`] = `
         "switch": "projen-credentials",
       },
       {
-        "default": "true",
+        "default": "- true if not a subproject",
         "docs": "Indicates of "projen" should be installed as a devDependency.",
         "featured": false,
         "fullType": {
@@ -40474,7 +40474,7 @@ exports[`inventory 1`] = `
         "switch": "projen-credentials",
       },
       {
-        "default": "true",
+        "default": "- true if not a subproject",
         "docs": "Indicates of "projen" should be installed as a devDependency.",
         "featured": false,
         "fullType": {


### PR DESCRIPTION
Partially addresses: #3304

BREAKING CHANGE: by default `projen` will not be installed in subproject directories. To install `projen` in a subproject directory, explicitly set `projenDevDependency: true` in the subproject.

Installing projen in sub-projects leads to weird behavior where the sub-project is referencing different source than the parent project - which breaks things like `instanceof` expressions when the two class objects are from different sources. I think it makes more sense to only install a single copy of `projen` for an entire project graph.
I suspect that enabling sub-project installation by default was an oversight originally since it makes sense to have that default for the root project. So I think its safe to consider this a non-breaking change since the default will stay unchanged for a root project.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
