### PR TITLE
fix(node): build workflow options pre build steps configuration overriding setup steps

### DIFF
--- a/src/javascript/node-project.ts
+++ b/src/javascript/node-project.ts
@@ -630,6 +630,9 @@ export class NodeProject extends GitHubProject {
         containerImage: options.workflowContainerImage,
         gitIdentity: this.workflowGitIdentity,
         mutableBuild: options.mutableBuild,
+        workflowTriggers: options.buildWorkflowTriggers,
+        permissions: workflowPermissions,
+        ...buildWorkflowOptions,
         preBuildSteps: this.renderWorkflowSetup({
           installStepConfiguration: {
             workingDirectory: this.determineInstallWorkingDirectory(),
@@ -642,9 +645,6 @@ export class NodeProject extends GitHubProject {
           options.workflowRunsOn,
           options.workflowRunsOnGroup
         ),
-        workflowTriggers: options.buildWorkflowTriggers,
-        permissions: workflowPermissions,
-        ...buildWorkflowOptions,
       });
 
       this.buildWorkflow.addPostBuildSteps(

--- a/test/javascript/__snapshots__/node-project.test.ts.snap
+++ b/test/javascript/__snapshots__/node-project.test.ts.snap
@@ -323,6 +323,55 @@ permissions-backup.acl
 "
 `;
 
+exports[`provided preBuildSteps for build workflow get combined with setup steps 1`] = `
+[
+  {
+    "name": "Checkout",
+    "uses": "actions/checkout@v4",
+    "with": {
+      "ref": "\${{ github.event.pull_request.head.ref }}",
+      "repository": "\${{ github.event.pull_request.head.repo.full_name }}",
+    },
+  },
+  {
+    "name": "Install dependencies",
+    "run": "yarn install --check-files",
+  },
+  {
+    "name": "hello",
+    "run": "echo hello",
+  },
+  {
+    "name": "build",
+    "run": "npx projen build",
+  },
+  {
+    "id": "self_mutation",
+    "name": "Find mutations",
+    "run": "git add .
+git diff --staged --patch --exit-code > .repo.patch || echo "self_mutation_happened=true" >> $GITHUB_OUTPUT",
+    "working-directory": "./",
+  },
+  {
+    "if": "steps.self_mutation.outputs.self_mutation_happened",
+    "name": "Upload patch",
+    "uses": "actions/upload-artifact@v4",
+    "with": {
+      "name": ".repo.patch",
+      "overwrite": true,
+      "path": ".repo.patch",
+    },
+  },
+  {
+    "if": "steps.self_mutation.outputs.self_mutation_happened",
+    "name": "Fail build on mutation",
+    "run": "echo "::error::Files were changed during build (see build log). If this was triggered from a fork, you will need to update your branch."
+cat .repo.patch
+exit 1",
+  },
+]
+`;
+
 exports[`renovatebot ignored dependency overrides 1`] = `
 {
   "extends": [

--- a/test/javascript/node-project.test.ts
+++ b/test/javascript/node-project.test.ts
@@ -770,6 +770,23 @@ test("disabling mutableBuild will skip pushing changes to PR branches", () => {
   expect(Object.keys(workflow.jobs)).not.toContain("self-mutation");
 });
 
+test("provided preBuildSteps for build workflow get combined with setup steps", () => {
+  // WHEN
+  const project = new TestNodeProject({
+    buildWorkflowOptions: {
+      preBuildSteps: [{ name: "hello", run: "echo hello" }],
+    },
+  });
+
+  // THEN
+  const workflowYaml = synthSnapshot(project)[".github/workflows/build.yml"];
+  const workflow = yaml.parse(workflowYaml);
+  expect(workflow.jobs.build.steps).toMatchSnapshot();
+  expect(workflow.jobs.build.steps[0]?.name).toEqual("Checkout");
+  expect(workflow.jobs.build.steps[1]?.name).toEqual("Install dependencies");
+  expect(workflow.jobs.build.steps[2]?.name).toEqual("hello");
+});
+
 test("projen synth is only executed for subprojects", () => {
   // GIVEN
   const root = new TestNodeProject();


### PR DESCRIPTION
Followup to #3449.

As pointed out by [this comment](https://github.com/projen/projen/pull/3449/files/5b3b3492ae87436dc7566d2f46016ebc5e44d6e6#r1551681459), the `...buildWorkflowOptions` spread was passed to in the wrong place relative to `preBuildSteps` which should contain both setup/install steps plus provided step. So `buildWorkflowOptions.preBuildSteps` was overriding the setup/install steps.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
