### PR TITLE
fix(web-react): react-scripts incorrectly listed as dep; should be devDep

### DIFF
--- a/src/web/react.ts
+++ b/src/web/react.ts
@@ -205,8 +205,9 @@ export class ReactComponent extends Component {
     // No compile for react app
     project.compileTask.reset();
 
-    project.addDeps("react", "react-dom", "react-scripts@^5", "web-vitals");
+    project.addDeps("react", "react-dom", "web-vitals");
     project.addDevDeps(
+      "react-scripts@^5",
       "@testing-library/jest-dom",
       "@testing-library/react",
       "@testing-library/user-event"

--- a/test/web/__snapshots__/react-project.test.ts.snap
+++ b/test/web/__snapshots__/react-project.test.ts.snap
@@ -396,6 +396,11 @@ permissions-backup.acl
         "type": "build",
       },
       {
+        "name": "react-scripts",
+        "type": "build",
+        "version": "^5",
+      },
+      {
         "name": "standard-version",
         "type": "build",
         "version": "^9",
@@ -407,11 +412,6 @@ permissions-backup.acl
       {
         "name": "react-dom",
         "type": "runtime",
-      },
-      {
-        "name": "react-scripts",
-        "type": "runtime",
-        "version": "^5",
       },
       {
         "name": "web-vitals",
@@ -628,7 +628,7 @@ permissions-backup.acl
             "exec": "yarn install --check-files",
           },
           {
-            "exec": "yarn upgrade @testing-library/jest-dom @testing-library/react @testing-library/user-event constructs projen standard-version react react-dom react-scripts web-vitals",
+            "exec": "yarn upgrade @testing-library/jest-dom @testing-library/react @testing-library/user-event constructs projen react-scripts standard-version react react-dom web-vitals",
           },
           {
             "exec": "npx projen",
@@ -861,7 +861,6 @@ permissions-backup.acl
     "dependencies": {
       "react": "*",
       "react-dom": "*",
-      "react-scripts": "^5",
       "web-vitals": "*",
     },
     "devDependencies": {
@@ -870,6 +869,7 @@ permissions-backup.acl
       "@testing-library/user-event": "*",
       "constructs": "^10.0.0",
       "projen": "*",
+      "react-scripts": "^5",
       "standard-version": "^9",
     },
     "eslintConfig": {

--- a/test/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/react-ts-project.test.ts.snap
@@ -601,6 +601,11 @@ tsconfig.tsbuildinfo
         "type": "build",
       },
       {
+        "name": "react-scripts",
+        "type": "build",
+        "version": "^5",
+      },
+      {
         "name": "typescript",
         "type": "build",
         "version": "^4.0.3",
@@ -622,11 +627,6 @@ tsconfig.tsbuildinfo
       {
         "name": "react-dom",
         "type": "runtime",
-      },
-      {
-        "name": "react-scripts",
-        "type": "runtime",
-        "version": "^5",
       },
       {
         "name": "web-vitals",
@@ -793,7 +793,7 @@ tsconfig.tsbuildinfo
             "exec": "yarn install --check-files",
           },
           {
-            "exec": "yarn upgrade @testing-library/jest-dom @testing-library/react @testing-library/user-event @types/jest @types/node @types/react @types/react-dom @typescript-eslint/eslint-plugin @typescript-eslint/parser constructs eslint-import-resolver-typescript eslint-plugin-import eslint projen typescript react react-dom react-scripts web-vitals",
+            "exec": "yarn upgrade @testing-library/jest-dom @testing-library/react @testing-library/user-event @types/jest @types/node @types/react @types/react-dom @typescript-eslint/eslint-plugin @typescript-eslint/parser constructs eslint-import-resolver-typescript eslint-plugin-import eslint projen react-scripts typescript react react-dom web-vitals",
           },
           {
             "exec": "npx projen",
@@ -1035,7 +1035,6 @@ tsconfig.tsbuildinfo
     "dependencies": {
       "react": "*",
       "react-dom": "*",
-      "react-scripts": "^5",
       "web-vitals": "*",
     },
     "devDependencies": {
@@ -1053,6 +1052,7 @@ tsconfig.tsbuildinfo
       "eslint-import-resolver-typescript": "*",
       "eslint-plugin-import": "*",
       "projen": "*",
+      "react-scripts": "^5",
       "typescript": "^4.0.3",
     },
     "eslintConfig": {


### PR DESCRIPTION
Fixes # NA

This PR moves the `react-scripts` dependency from the "deps" to the "devDeps".
react-scripts is not required to be a dependency of the project given that it's a dev tools that it's not bundled together with the rest of the project dependencies.

This also helps to address potential false positive that derive from `npm audit` command which can be instrumented to inspect only `--production-only` dependencies [ref](https://github.com/facebook/create-react-app/issues/11174)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
