### PR TITLE
chore(docs): improve how to set up a a github app for projen 

### DIFF
--- a/docs/integrations/github/index.md
+++ b/docs/integrations/github/index.md
@@ -44,7 +44,9 @@ Add the token as a secret to your repo under the name `PROJEN_GITHUB_TOKEN`.
 
 Follow the [GitHub docs instructions](https://docs.github.com/en/developers/apps/building-github-apps/creating-a-github-app) for creating a GitHub App. Enable read & write permission for "Contents" and "Pull Request" scopes.
 
-Add the App ID as a secret to your repo under the name `PROJEN_APP_ID` and the private key you generate as a secret to your repo under the name `PROJEN_APP_PRIVATE_KEY`.
+Add the App ID as a secret to your repo under the name `PROJEN_APP_ID` and generate a private key for the app to store as a secret to your repo under the name `PROJEN_APP_PRIVATE_KEY`.
+
+[Install the application](https://docs.github.com/en/apps/using-github-apps/installing-your-own-github-app) ensuring that the repo(s) that you wish to grant access to are selected.
 
 Then, configure your projenrc file to use the GitHub app for API access:
 


### PR DESCRIPTION
I found that the instructions for setting up the github actions via a github app were not quite a clear as they could have been, so raising this change to help clarify it.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
