### PR TITLE
fix(node): use `--pack-destination` instead of `mv`

### DIFF
--- a/src/javascript/node-project.ts
+++ b/src/javascript/node-project.ts
@@ -829,9 +829,9 @@ export class NodeProject extends GitHubProject {
       const pkgMgr =
         this.package.packageManager === NodePackageManager.PNPM
           ? "pnpm"
-          : "npm"; // sadly we cannot use --pack-destination because it is not supported by older npm
+          : "npm";
       this.packageTask.exec(
-        `mv $(${pkgMgr} pack) ${this.artifactsJavascriptDirectory}/`
+        `${pkgMgr} pack --pack-destination ${this.artifactsJavascriptDirectory}`
       );
     }
 

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -3304,7 +3304,7 @@ tsconfig.tsbuildinfo
           "exec": "mkdir -p dist/js"
         },
         {
-          "exec": "mv $(npm pack) dist/js/"
+          "exec": "npm pack --pack-destination dist/js"
         }
       ]
     },
@@ -4399,7 +4399,7 @@ resolution-mode=highest
           "exec": "mkdir -p dist/js"
         },
         {
-          "exec": "mv $(pnpm pack) dist/js/"
+          "exec": "pnpm pack --pack-destination dist/js"
         }
       ]
     },

--- a/test/typescript/__snapshots__/typescript.test.ts.snap
+++ b/test/typescript/__snapshots__/typescript.test.ts.snap
@@ -864,7 +864,7 @@ tsconfig.tsbuildinfo
             "exec": "mkdir -p dist/js",
           },
           {
-            "exec": "mv $(npm pack) dist/js/",
+            "exec": "npm pack --pack-destination dist/js",
           },
         ],
       },

--- a/test/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-project.test.ts.snap
@@ -573,7 +573,7 @@ permissions-backup.acl
             "exec": "mkdir -p dist/js",
           },
           {
-            "exec": "mv $(npm pack) dist/js/",
+            "exec": "npm pack --pack-destination dist/js",
           },
         ],
       },

--- a/test/web/__snapshots__/react-project.test.ts.snap
+++ b/test/web/__snapshots__/react-project.test.ts.snap
@@ -549,7 +549,7 @@ permissions-backup.acl
             "exec": "mkdir -p dist/js",
           },
           {
-            "exec": "mv $(npm pack) dist/js/",
+            "exec": "npm pack --pack-destination dist/js",
           },
         ],
       },


### PR DESCRIPTION
Fixes #1933

`npm pack --pack-destination` is supported by v7+. The `minNodeVersion` of projen is [v16.0.0](https://github.com/projen/projen/blob/a4de88eeeb06f9465e063653abee9fa116fcd361/.projenrc.ts#L90) which is [shipped with npm v7.x](https://nodejs.org/en/blog/release/v16.0.0). Happily we can use `--pack-destination` because it is now supported by active npm versions😃. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
