### PR TITLE
chore(docs): documentation for GitHub OIDC usage when authenticating to CodeArtifact

### DIFF
--- a/docs/publishing/publisher-component.md
+++ b/docs/publishing/publisher-component.md
@@ -102,13 +102,18 @@ publisher.publishToMaven({
 
 The NPM target comes with dynamic defaults that support AWS CodeArtifact.
 If the respective registry URL is detected to be AWS CodeArtifact, other relevant options will automatically be set to fitting values.
-The authentication will done using [AWS CLI](https://docs.aws.amazon.com/codeartifact/latest/ug/tokens-authentication.html). It is neccessary to provide AWS IAM CLI `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` in GitHub Secrets.
+
+Authentication to CodeArtifact is performed using the [AWS CLI](https://docs.aws.amazon.com/codeartifact/latest/ug/tokens-authentication.html). As such, the workflow needs access to the AWS Account containing your CodeArtifact repository. Access can be provided via the `CodeArtifactAuthProvider.GITHUB_OIDC` (recommended) or `CodeArtifactAuthProvider.ACCESS_AND_SECRET_KEY_PAIR` (not recommended) AWS auth providers.
 
 **npm**
 
 ```ts
 publisher.publishToNpm({ 
   registry: 'my-domain-111122223333.d.codeartifact.us-west-2.amazonaws.com/npm/my_repo/',
+  codeArtifactOptions: {
+    authProvider: CodeArtifactAuthProvider.GITHUB_OIDC,
+    roleToAssume: 'arn:aws:iam::123456789012:role/your-github-actions-role'
+  },
 });
 ```
 


### PR DESCRIPTION
I was reviewing the documentation for [publishing to AWS CodeArtifact](https://projen.io/docs/publishing/publisher-component#publishing-to-aws-codeartifact), and noticed the existing guidance is to leverage static AWS access keys. This was fairly surprising, so I doubled checked Projen's source code and found [configuration options that allow GitHub OIDC to be used for CodeArtifact auth](https://github.com/projen/projen/blob/5cf621a0e4716da2bc26d06a1c8e1b9437ff06ec/src/release/publisher.ts#L974-L1014).

IMO Projen should recommend this approach instead of static credentials. I've performed a small edit of the `Publishing to AWS CodeArtifact` section that includes this guidance, as well as an example.

As a sidenote, this documentation is likely to be viewed by folks who are bit by [GitHub Packages' continued lack of Python support](https://github.com/orgs/community/discussions/8542), so adding a `publishToPypi` example would be helpful. I'm happy to contribute this as well once I've performed some testing.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
