### PR TITLE
fix(gitlab): use WorkflowWhen in WorkflowRule

### DIFF
--- a/docs/api/gitlab.md
+++ b/docs/api/gitlab.md
@@ -4315,7 +4315,7 @@ const workflowRule: gitlab.WorkflowRule = { ... }
 | <code><a href="#projen.gitlab.WorkflowRule.property.exists">exists</a></code> | <code>string[]</code> | *No description.* |
 | <code><a href="#projen.gitlab.WorkflowRule.property.if">if</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#projen.gitlab.WorkflowRule.property.variables">variables</a></code> | <code>{[ key: string ]: string \| number}</code> | *No description.* |
-| <code><a href="#projen.gitlab.WorkflowRule.property.when">when</a></code> | <code><a href="#projen.gitlab.JobWhen">JobWhen</a></code> | *No description.* |
+| <code><a href="#projen.gitlab.WorkflowRule.property.when">when</a></code> | <code><a href="#projen.gitlab.WorkflowWhen">WorkflowWhen</a></code> | *No description.* |
 
 ---
 
@@ -4362,10 +4362,10 @@ public readonly variables: {[ key: string ]: string | number};
 ##### `when`<sup>Optional</sup> <a name="when" id="projen.gitlab.WorkflowRule.property.when"></a>
 
 ```typescript
-public readonly when: JobWhen;
+public readonly when: WorkflowWhen;
 ```
 
-- *Type:* <a href="#projen.gitlab.JobWhen">JobWhen</a>
+- *Type:* <a href="#projen.gitlab.WorkflowWhen">WorkflowWhen</a>
 
 ---
 

--- a/src/gitlab/configuration-model.ts
+++ b/src/gitlab/configuration-model.ts
@@ -645,7 +645,7 @@ export interface WorkflowRule {
   /* Use variables in rules to define variables for specific conditions. */
   readonly variables?: Record<string, number | string>;
   /* Conditions for when to run the job. Defaults to 'on_success' */
-  readonly when?: JobWhen;
+  readonly when?: WorkflowWhen;
 }
 
 /**


### PR DESCRIPTION
The WorkflowRule has the type JobWhen for the when field. When in a workflow rule can be only `always` and `never`: https://docs.gitlab.com/ee/ci/yaml/#workflowrules
If used in jobs it could have more inputs: https://docs.gitlab.com/ee/ci/yaml/#when

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
