### PR TITLE
fix(task-runtime): call cat command with shx on Windows

### DIFF
--- a/src/task-runtime.ts
+++ b/src/task-runtime.ts
@@ -172,7 +172,7 @@ class RunTask {
         const cmd = exec.split(" ")[0];
         if (
           platform() == "win32" &&
-          ["mkdir", "mv", "rm", "cp"].includes(cmd)
+          ["cat", "cp", "mkdir", "mv", "rm"].includes(cmd)
         ) {
           command = `shx ${exec}`;
         } else {


### PR DESCRIPTION
Related to #https://github.com/projen/projen/issues/3384

## Motivation

I was getting the following error when running `yarn post-compile` in the projen repository:
```bash
❯ yarn post-compile
yarn run v1.22.19
$ node ./projen.js post-compile
👾 post-compile » docgen | jsii-docgen .jsii -o docs/api/projen --split-by-submodule
👾 post-compile » readme-macros | shx mv README.md README.md.bak
👾 post-compile » readme-macros | cat README.md.bak | markmac > README.md
'cat' is not recognized as an internal or external command,
operable program or batch file.
👾 Task "post-compile » readme-macros" failed when executing "cat README.md.bak | markmac > README.md" (cwd: D:\Workspace\projen)
Failed to execute command: node bin/projen post-compile Error: Command failed: node bin/projen post-compile
    at checkExecSyncError (node:child_process:890:11)
    at execSync (node:child_process:962:15)
    at execCommand (D:\Workspace\projen\projen.js:9:5)
    at Object.<anonymous> (D:\Workspace\projen\projen.js:41:1)
    at Module._compile (node:internal/modules/cjs/loader:1376:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)
    at Module.load (node:internal/modules/cjs/loader:1207:32)
    at Module._load (node:internal/modules/cjs/loader:1023:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:135:12) {
  status: 1,
  signal: null,
  output: [ null, null, null ],
  pid: 14812,
  stdout: null,
  stderr: null
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

The command causing the problem was `cat README.md.bak | markmac > README.md`. This should have failed on the Github Actions job **build / build_matrix (windows-latest, true)** 

It works on Github Actions for some reason.

But in my local machine the PowerShell alias is defined but not loading when running `yarn post-compile` for some reason. I tried with `yarn build` too and got the same error.
```bash
❯ Get-Alias cat   

CommandType     Name                                               Version    Source
-----------     ----                                               -------    ------
Alias           cat -> Get-Content
```

Github Actions versions https://github.com/projen/projen/actions/runs/9067389868/job/24912389676:
Microsoft Windows Server 2022: 10.0.20348
NodeJS: 18.14.2
Yarn: v1.22.22

My local versions:
Windows 11: 10.0.22631.0
NodeJS: v20.10.0
Yarn: v1.22.19

If I run `cat README.md` directly on the PowerShell terminal it does work but it fails when running on cmd terminal. It seems that the Node process is running on cmd instead of PowerShell and it's not loading the aliases.
```bash
❯ npm config ls -l | Select-String shell

script-shell = null
shell = "C:\\Windows\\system32\\cmd.exe"
```

Investigating more on the [`windows-latest` runner page](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md#shells), it provides always bash instead of cmd.
> | Name          | Target                            |
> | ------------- | --------------------------------- |
> | gitbash.exe   | C:\Program Files\Git\bin\bash.exe |
> | msys2bash.cmd | C:\msys64\usr\bin\bash.exe        |
> | wslbash.exe   | C:\Windows\System32\bash.exe      |

Then it makes sense that `cat` works on Github Actions because it runs on bash, while it runs on cmd in my local. This guess can be also confirmed with the [NPM documentation about `script-shell`](https://docs.npmjs.com/cli/v9/using-npm/config#script-shell)
> Default: '/bin/sh' on POSIX systems, 'cmd.exe' on Windows

## Changelog

I added `cat` to the command list of shx. I think most local systems will likely have cmd instead of bash.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
