### PR TITLE
fix: use actions/create-github-app-token when not using permissions option

### DIFF
--- a/src/github/github-credentials.ts
+++ b/src/github/github-credentials.ts
@@ -59,23 +59,21 @@ export class GithubCredentials {
     const appIdSecret = options.appIdSecret ?? "PROJEN_APP_ID";
     const privateKeySecret =
       options.privateKeySecret ?? "PROJEN_APP_PRIVATE_KEY";
-    const permissions = options.permissions
-      ? JSON.stringify(snakeCaseKeys(options.permissions))
-      : undefined;
-    const uses = permissions
-      ? "tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a"
-      : "actions/create-github-app-token@v1";
 
     return new GithubCredentials({
       setupSteps: [
         {
           name: "Generate token",
           id: "generate_token",
-          uses: uses,
+          uses: options.permissions
+            ? "tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a"
+            : "actions/create-github-app-token@v1",
           with: {
             app_id: `\${{ secrets.${appIdSecret} }}`,
             private_key: `\${{ secrets.${privateKeySecret} }}`,
-            permissions: permissions,
+            permissions: options.permissions
+              ? JSON.stringify(snakeCaseKeys(options.permissions))
+              : undefined,
           },
         },
       ],

--- a/src/github/github-credentials.ts
+++ b/src/github/github-credentials.ts
@@ -59,19 +59,23 @@ export class GithubCredentials {
     const appIdSecret = options.appIdSecret ?? "PROJEN_APP_ID";
     const privateKeySecret =
       options.privateKeySecret ?? "PROJEN_APP_PRIVATE_KEY";
+    const permissions = options.permissions
+      ? JSON.stringify(snakeCaseKeys(options.permissions))
+      : undefined;
+    const uses = permissions
+      ? "tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a"
+      : "actions/create-github-app-token@v1";
 
     return new GithubCredentials({
       setupSteps: [
         {
           name: "Generate token",
           id: "generate_token",
-          uses: "tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a",
+          uses: uses,
           with: {
             app_id: `\${{ secrets.${appIdSecret} }}`,
             private_key: `\${{ secrets.${privateKeySecret} }}`,
-            permissions: options.permissions
-              ? JSON.stringify(snakeCaseKeys(options.permissions))
-              : undefined,
+            permissions: permissions,
           },
         },
       ],

--- a/test/javascript/__snapshots__/upgrade-dependencies.test.ts.snap
+++ b/test/javascript/__snapshots__/upgrade-dependencies.test.ts.snap
@@ -1150,7 +1150,7 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        uses: actions/create-github-app-token@v1
         with:
           app_id: \${{ secrets.PROJEN_APP_ID }}
           private_key: \${{ secrets.PROJEN_APP_PRIVATE_KEY }}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.