### PR TITLE
fix(github): bump version of actions/setup-go to v5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -244,8 +244,12 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build_matrix
+    if: always()
     outputs:
       self_mutation_happened: ${{ needs.build_matrix.outputs.self_mutation_happened }}
     steps:
-      - name: OK
-        run: echo "OK"
+      - name: Build result
+        run: echo ${{needs.build_matrix.result}}
+      - if: ${{ needs.build_matrix.result != 'success' }}
+        name: Set status based on matrix build
+        run: exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18.14.2
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: ^1.16.0
       - name: Download build artifacts
@@ -156,7 +156,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: 1.16.x
       - name: Download build artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,7 +271,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18.14.2
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: ^1.16.0
       - name: Download build artifacts

--- a/projenrc/windows-build.ts
+++ b/projenrc/windows-build.ts
@@ -71,13 +71,19 @@ export class WindowsBuild extends Component {
       JsonPatch.add(buildJobPath(), {
         "runs-on": "ubuntu-latest",
         needs: [JOB_BUILD_MATRIX],
+        if: "always()",
         outputs: {
           self_mutation_happened: `\${{ needs.${JOB_BUILD_MATRIX}.outputs.self_mutation_happened }}`,
         },
         steps: [
           {
-            name: "OK",
-            run: 'echo "OK"',
+            name: "Build result",
+            run: `echo \${{needs.${JOB_BUILD_MATRIX}.result}}`,
+          },
+          {
+            if: `\${{ needs.${JOB_BUILD_MATRIX}.result != 'success' }}`,
+            name: "Set status based on matrix build",
+            run: "exit 1",
           },
         ],
       })

--- a/src/github/workflows.ts
+++ b/src/github/workflows.ts
@@ -387,7 +387,7 @@ function setupTools(tools: workflows.Tools) {
 
   if (tools.go) {
     steps.push({
-      uses: "actions/setup-go@v3",
+      uses: "actions/setup-go@v5",
       with: { "go-version": tools.go.version },
     });
   }

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -1598,7 +1598,7 @@ exports[`language bindings release workflow includes release_golang job 1`] = `
       },
     },
     {
-      "uses": "actions/setup-go@v3",
+      "uses": "actions/setup-go@v5",
       "with": {
         "go-version": "^1.16.0",
       },
@@ -1963,7 +1963,7 @@ exports[`language bindings snapshot go 1`] = `
       },
     },
     {
-      "uses": "actions/setup-go@v3",
+      "uses": "actions/setup-go@v5",
       "with": {
         "go-version": "^1.16.0",
       },
@@ -2284,7 +2284,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18.x
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: ^1.16.0
       - name: Download build artifacts
@@ -2447,7 +2447,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18.x
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: ^1.16.0
       - name: Download build artifacts

--- a/test/release/__snapshots__/release.test.ts.snap
+++ b/test/release/__snapshots__/release.test.ts.snap
@@ -4387,7 +4387,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18.x
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: ^1.16.0
       - name: Download build artifacts


### PR DESCRIPTION
Resolves runtime deprecation warnings.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
