### PR TITLE
fix(github): bump version of actions/setup-dotnet to v4

### DIFF
--- a/src/github/workflows.ts
+++ b/src/github/workflows.ts
@@ -394,7 +394,7 @@ function setupTools(tools: workflows.Tools) {
 
   if (tools.dotnet) {
     steps.push({
-      uses: "actions/setup-dotnet@v3",
+      uses: "actions/setup-dotnet@v4",
       with: { "dotnet-version": tools.dotnet.version },
     });
   }

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -1789,7 +1789,7 @@ exports[`language bindings release workflow includes release_nuget job 1`] = `
       },
     },
     {
-      "uses": "actions/setup-dotnet@v3",
+      "uses": "actions/setup-dotnet@v4",
       "with": {
         "dotnet-version": "3.x",
       },
@@ -1911,7 +1911,7 @@ exports[`language bindings snapshot dotnet 1`] = `
       },
     },
     {
-      "uses": "actions/setup-dotnet@v3",
+      "uses": "actions/setup-dotnet@v4",
       "with": {
         "dotnet-version": "3.x",
       },
@@ -2607,7 +2607,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18.x
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 3.x
       - name: Download build artifacts
@@ -2765,7 +2765,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18.x
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 3.x
       - name: Download build artifacts

--- a/test/release/__snapshots__/release.test.ts.snap
+++ b/test/release/__snapshots__/release.test.ts.snap
@@ -3135,7 +3135,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18.x
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 3.x
       - name: Download build artifacts
@@ -4470,7 +4470,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18.x
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 3.x
       - name: Download build artifacts


### PR DESCRIPTION
Resolves runtime deprecation warnings.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
