### PR TITLE
chore(docusaurus): bump versions of pages actions

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -24,7 +24,7 @@ jobs:
           yarn install --check-files --frozen-lockfile
           yarn build
       - name: Build website artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: "docusaurus/build"
   deploy:
@@ -39,4 +39,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Resolves runtime deprecation warnings.
https://github.com/projen/projen/actions/runs/9254951219

https://github.com/actions/upload-pages-artifact: v2 to v3
https://github.com/actions/deploy-pages: v3 to v4

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
