### PR TITLE
fix(next): use module commonjs for dev tsconfig

### DIFF
--- a/src/web/next.ts
+++ b/src/web/next.ts
@@ -166,6 +166,13 @@ export class NextJsTypeScriptProject extends TypeScriptAppProject {
           },
         },
       },
+      // ts-config for projen default needs to be overridden to commonjs
+      // https://stackoverflow.com/questions/67089549/is-it-ok-to-use-module-commonjs-in-tsconfig-json-for-a-next-js-project-usi
+      tsconfigDev: {
+        compilerOptions: {
+          module: "commonjs",
+        },
+      },
     };
 
     // never generate default TypeScript sample code, since this class provides its own

--- a/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -1071,7 +1071,7 @@ export default function Home() {
         "dom.iterable",
         "esnext",
       ],
-      "module": "esnext",
+      "module": "commonjs",
       "moduleResolution": "bundler",
       "noEmit": true,
       "noEmitOnError": false,


### PR DESCRIPTION
Fixes https://github.com/projen/projen/issues/3442

As far as I understand tsconfig.dev.json will only used for projen synthing, so that the module could switch to commonjs without effecting the standard tsconfig for nextjs.
Another approach could be to switch to `npx tsx .projenrc.ts ` as default task for projen (https://www.typescriptlang.org/docs/handbook/modules/guides/choosing-compiler-options.html#im-using-tsx)


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
