### PR TITLE
fix(eslint): use import/no-duplicates instead of no-duplicate-imports for eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -76,7 +76,7 @@
         }
       }
     ],
-    "no-duplicate-imports": [
+    "import/no-duplicates": [
       "error"
     ],
     "no-shadow": [

--- a/src/javascript/eslint.ts
+++ b/src/javascript/eslint.ts
@@ -283,7 +283,7 @@ export class Eslint extends Component {
       ],
 
       // Cannot import from the same module twice
-      "no-duplicate-imports": ["error"],
+      "import/no-duplicates": ["error"],
 
       // Cannot shadow names
       "no-shadow": ["off"],

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -172,7 +172,7 @@ exports[`cdk-watchful 1`] = `
         }
       }
     ],
-    "no-duplicate-imports": [
+    "import/no-duplicates": [
       "error"
     ],
     "no-shadow": [
@@ -1699,7 +1699,7 @@ exports[`cdk8s 1`] = `
         }
       }
     ],
-    "no-duplicate-imports": [
+    "import/no-duplicates": [
       "error"
     ],
     "no-shadow": [
@@ -2896,7 +2896,7 @@ exports[`cdk8s-cli 1`] = `
         }
       }
     ],
-    "no-duplicate-imports": [
+    "import/no-duplicates": [
       "error"
     ],
     "no-shadow": [

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -110,6 +110,9 @@ exports[`JsiiProject with default settings synthesizes 1`] = `
       "dot-notation": [
         "error",
       ],
+      "import/no-duplicates": [
+        "error",
+      ],
       "import/no-extraneous-dependencies": [
         "error",
         {
@@ -158,9 +161,6 @@ exports[`JsiiProject with default settings synthesizes 1`] = `
         },
       ],
       "no-bitwise": [
-        "error",
-      ],
-      "no-duplicate-imports": [
         "error",
       ],
       "no-multi-spaces": [

--- a/test/javascript/__snapshots__/eslint.test.ts.snap
+++ b/test/javascript/__snapshots__/eslint.test.ts.snap
@@ -109,6 +109,9 @@ exports[`devdirs 1`] = `
     "dot-notation": [
       "error",
     ],
+    "import/no-duplicates": [
+      "error",
+    ],
     "import/no-extraneous-dependencies": [
       "error",
       {
@@ -157,9 +160,6 @@ exports[`devdirs 1`] = `
       },
     ],
     "no-bitwise": [
-      "error",
-    ],
-    "no-duplicate-imports": [
       "error",
     ],
     "no-multi-spaces": [
@@ -306,6 +306,9 @@ exports[`prettier snapshot 1`] = `
     "dot-notation": [
       "error",
     ],
+    "import/no-duplicates": [
+      "error",
+    ],
     "import/no-extraneous-dependencies": [
       "error",
       {
@@ -334,9 +337,6 @@ exports[`prettier snapshot 1`] = `
       "error",
     ],
     "no-bitwise": [
-      "error",
-    ],
-    "no-duplicate-imports": [
       "error",
     ],
     "no-multiple-empty-lines": [

--- a/test/jsii/__snapshots__/jsii.test.ts.snap
+++ b/test/jsii/__snapshots__/jsii.test.ts.snap
@@ -110,6 +110,9 @@ exports[`JsiiProject with default settings synthesizes 1`] = `
       "dot-notation": [
         "error",
       ],
+      "import/no-duplicates": [
+        "error",
+      ],
       "import/no-extraneous-dependencies": [
         "error",
         {
@@ -158,9 +161,6 @@ exports[`JsiiProject with default settings synthesizes 1`] = `
         },
       ],
       "no-bitwise": [
-        "error",
-      ],
-      "no-duplicate-imports": [
         "error",
       ],
       "no-multi-spaces": [
@@ -1611,6 +1611,9 @@ exports[`JsiiProject with jsiiVersion: '*' synthesizes 1`] = `
       "dot-notation": [
         "error",
       ],
+      "import/no-duplicates": [
+        "error",
+      ],
       "import/no-extraneous-dependencies": [
         "error",
         {
@@ -1659,9 +1662,6 @@ exports[`JsiiProject with jsiiVersion: '*' synthesizes 1`] = `
         },
       ],
       "no-bitwise": [
-        "error",
-      ],
-      "no-duplicate-imports": [
         "error",
       ],
       "no-multi-spaces": [
@@ -3095,6 +3095,9 @@ exports[`JsiiProject with jsiiVersion: '^1.78.1' synthesizes 1`] = `
       "dot-notation": [
         "error",
       ],
+      "import/no-duplicates": [
+        "error",
+      ],
       "import/no-extraneous-dependencies": [
         "error",
         {
@@ -3143,9 +3146,6 @@ exports[`JsiiProject with jsiiVersion: '^1.78.1' synthesizes 1`] = `
         },
       ],
       "no-bitwise": [
-        "error",
-      ],
-      "no-duplicate-imports": [
         "error",
       ],
       "no-multi-spaces": [
@@ -4574,6 +4574,9 @@ exports[`JsiiProject with jsiiVersion: '~5.0.0' synthesizes 1`] = `
       "dot-notation": [
         "error",
       ],
+      "import/no-duplicates": [
+        "error",
+      ],
       "import/no-extraneous-dependencies": [
         "error",
         {
@@ -4622,9 +4625,6 @@ exports[`JsiiProject with jsiiVersion: '~5.0.0' synthesizes 1`] = `
         },
       ],
       "no-bitwise": [
-        "error",
-      ],
-      "no-duplicate-imports": [
         "error",
       ],
       "no-multi-spaces": [

--- a/test/typescript/__snapshots__/typescript.test.ts.snap
+++ b/test/typescript/__snapshots__/typescript.test.ts.snap
@@ -110,6 +110,9 @@ exports[`TypeScriptProject with default settings synthesizes 1`] = `
       "dot-notation": [
         "error",
       ],
+      "import/no-duplicates": [
+        "error",
+      ],
       "import/no-extraneous-dependencies": [
         "error",
         {
@@ -158,9 +161,6 @@ exports[`TypeScriptProject with default settings synthesizes 1`] = `
         },
       ],
       "no-bitwise": [
-        "error",
-      ],
-      "no-duplicate-imports": [
         "error",
       ],
       "no-multi-spaces": [

--- a/test/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/react-ts-project.test.ts.snap
@@ -110,6 +110,9 @@ exports[`defaults 1`] = `
       "dot-notation": [
         "error",
       ],
+      "import/no-duplicates": [
+        "error",
+      ],
       "import/no-extraneous-dependencies": [
         "error",
         {
@@ -158,9 +161,6 @@ exports[`defaults 1`] = `
         },
       ],
       "no-bitwise": [
-        "error",
-      ],
-      "no-duplicate-imports": [
         "error",
       ],
       "no-multi-spaces": [


### PR DESCRIPTION
Fixes https://github.com/projen/projen/issues/3415

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
