### PR TITLE
fix(task-runner): task env vars handed to spawn no longer get left behind

### DIFF
--- a/docs/api/projen.md
+++ b/docs/api/projen.md
@@ -15255,7 +15255,7 @@ new TaskRuntime(workdir: string)
 ##### `runTask` <a name="runTask" id="projen.TaskRuntime.runTask"></a>
 
 ```typescript
-public runTask(name: string, parents?: string[], args?: string | number[]): void
+public runTask(name: string, parents?: string[], args?: string | number[], env?: {[ key: string ]: string}): void
 ```
 
 Runs the task.
@@ -15277,6 +15277,12 @@ The task name.
 ###### `args`<sup>Optional</sup> <a name="args" id="projen.TaskRuntime.runTask.parameter.args"></a>
 
 - *Type:* string | number[]
+
+---
+
+###### `env`<sup>Optional</sup> <a name="env" id="projen.TaskRuntime.runTask.parameter.env"></a>
+
+- *Type:* {[ key: string ]: string}
 
 ---
 

--- a/src/task-runtime.ts
+++ b/src/task-runtime.ts
@@ -66,14 +66,15 @@ export class TaskRuntime {
   public runTask(
     name: string,
     parents: string[] = [],
-    args: Array<string | number> = []
+    args: Array<string | number> = [],
+    env: { [name: string]: string } = {}
   ) {
     const task = this.tryFindTask(name);
     if (!task) {
       throw new Error(`cannot find command ${task}`);
     }
 
-    new RunTask(this, task, parents, args);
+    new RunTask(this, task, parents, args, env);
   }
 }
 
@@ -87,7 +88,8 @@ class RunTask {
     private readonly runtime: TaskRuntime,
     private readonly task: TaskSpec,
     parents: string[] = [],
-    args: Array<string | number> = []
+    args: Array<string | number> = [],
+    envParam: { [name: string]: string } = {}
   ) {
     this.workdir = task.cwd ?? this.runtime.workdir;
 
@@ -98,7 +100,7 @@ class RunTask {
       return;
     }
 
-    this.env = this.resolveEnvironment(parents);
+    this.env = this.resolveEnvironment(envParam, parents);
 
     const envlogs = [];
     for (const [k, v] of Object.entries(this.env)) {
@@ -153,7 +155,8 @@ class RunTask {
         this.runtime.runTask(
           step.spawn,
           [...this.parents, this.task.name],
-          argsList
+          argsList,
+          step.env
         );
       }
 
@@ -270,7 +273,10 @@ class RunTask {
    * `$(xx)` for allowing environment to be evaluated by executing a shell
    * command and obtaining its result.
    */
-  private resolveEnvironment(parents: string[]) {
+  private resolveEnvironment(
+    envParam: { [name: string]: string },
+    parents: string[]
+  ) {
     let env = this.runtime.manifest.env ?? {};
 
     // add env from all parent tasks one by one
@@ -281,10 +287,11 @@ class RunTask {
       };
     }
 
-    // apply the task environment last
+    // apply task environment, then the specific env last
     env = {
       ...env,
       ...(this.task.env ?? {}),
+      ...envParam,
     };
 
     return this.evalEnvironment(env ?? {});

--- a/src/task-runtime.ts
+++ b/src/task-runtime.ts
@@ -89,7 +89,7 @@ class RunTask {
     private readonly task: TaskSpec,
     parents: string[] = [],
     args: Array<string | number> = [],
-    envParam: { [name: string]: string } = {}
+    env: { [name: string]: string } = {}
   ) {
     this.workdir = task.cwd ?? this.runtime.workdir;
 
@@ -100,7 +100,7 @@ class RunTask {
       return;
     }
 
-    this.env = this.resolveEnvironment(envParam, parents);
+    this.env = this.resolveEnvironment(env, parents);
 
     const envlogs = [];
     for (const [k, v] of Object.entries(this.env)) {

--- a/src/task-runtime.ts
+++ b/src/task-runtime.ts
@@ -89,7 +89,7 @@ class RunTask {
     private readonly task: TaskSpec,
     parents: string[] = [],
     args: Array<string | number> = [],
-    env: { [name: string]: string } = {}
+    envParam: { [name: string]: string } = {}
   ) {
     this.workdir = task.cwd ?? this.runtime.workdir;
 
@@ -100,7 +100,7 @@ class RunTask {
       return;
     }
 
-    this.env = this.resolveEnvironment(env, parents);
+    this.env = this.resolveEnvironment(envParam, parents);
 
     const envlogs = [];
     for (const [k, v] of Object.entries(this.env)) {

--- a/test/tasks/runtime.test.ts
+++ b/test/tasks/runtime.test.ts
@@ -204,6 +204,23 @@ describe("environment variables", () => {
     // THEN
     expect(executeTask(p, "test:env")).toEqual(["1!"]);
   });
+
+  test("spawn env params are respected", () => {
+    // GIVEN
+    const p = new TestProject();
+
+    // WHEN
+    const spawnee = p.addTask("test:env:spawn", {
+      exec: "echo ${VALUE}",
+      env: { VALUE: "bar" },
+    });
+
+    const spawner = p.addTask("test:env:spawner");
+    spawner.spawn(spawnee, { env: { VALUE: "foo" } });
+
+    // THEN
+    expect(executeTask(p, "test:env:spawner")).toEqual(["foo"]);
+  });
 });
 
 describe("task condition", () => {


### PR DESCRIPTION
Fixes https://github.com/projen/projen/issues/3493

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
