### PR TITLE
feat(github): add support for github issue templates

### DIFF
--- a/docs/api/github.md
+++ b/docs/api/github.md
@@ -2349,6 +2349,171 @@ contexts.
 ---
 
 
+### IssueTemplate <a name="IssueTemplate" id="projen.github.IssueTemplate"></a>
+
+Generates Issue Templates for GitHub repositories see  {@link https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests}.
+
+#### Initializers <a name="Initializers" id="projen.github.IssueTemplate.Initializer"></a>
+
+```typescript
+import { github } from 'projen'
+
+new github.IssueTemplate(github: GitHub, options: IssueTemplateOptions)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen.github.IssueTemplate.Initializer.parameter.github">github</a></code> | <code><a href="#projen.github.GitHub">GitHub</a></code> | *No description.* |
+| <code><a href="#projen.github.IssueTemplate.Initializer.parameter.options">options</a></code> | <code><a href="#projen.github.IssueTemplateOptions">IssueTemplateOptions</a></code> | *No description.* |
+
+---
+
+##### `github`<sup>Required</sup> <a name="github" id="projen.github.IssueTemplate.Initializer.parameter.github"></a>
+
+- *Type:* <a href="#projen.github.GitHub">GitHub</a>
+
+---
+
+##### `options`<sup>Required</sup> <a name="options" id="projen.github.IssueTemplate.Initializer.parameter.options"></a>
+
+- *Type:* <a href="#projen.github.IssueTemplateOptions">IssueTemplateOptions</a>
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#projen.github.IssueTemplate.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#projen.github.IssueTemplate.postSynthesize">postSynthesize</a></code> | Called after synthesis. |
+| <code><a href="#projen.github.IssueTemplate.preSynthesize">preSynthesize</a></code> | Called before synthesis. |
+| <code><a href="#projen.github.IssueTemplate.synthesize">synthesize</a></code> | Synthesizes files to the project output directory. |
+
+---
+
+##### `toString` <a name="toString" id="projen.github.IssueTemplate.toString"></a>
+
+```typescript
+public toString(): string
+```
+
+Returns a string representation of this construct.
+
+##### `postSynthesize` <a name="postSynthesize" id="projen.github.IssueTemplate.postSynthesize"></a>
+
+```typescript
+public postSynthesize(): void
+```
+
+Called after synthesis.
+
+Order is *not* guaranteed.
+
+##### `preSynthesize` <a name="preSynthesize" id="projen.github.IssueTemplate.preSynthesize"></a>
+
+```typescript
+public preSynthesize(): void
+```
+
+Called before synthesis.
+
+##### `synthesize` <a name="synthesize" id="projen.github.IssueTemplate.synthesize"></a>
+
+```typescript
+public synthesize(): void
+```
+
+Synthesizes files to the project output directory.
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#projen.github.IssueTemplate.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#projen.github.IssueTemplate.isComponent">isComponent</a></code> | Test whether the given construct is a component. |
+
+---
+
+##### `isConstruct` <a name="isConstruct" id="projen.github.IssueTemplate.isConstruct"></a>
+
+```typescript
+import { github } from 'projen'
+
+github.IssueTemplate.isConstruct(x: any)
+```
+
+Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
+
+###### `x`<sup>Required</sup> <a name="x" id="projen.github.IssueTemplate.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+Any object.
+
+---
+
+##### `isComponent` <a name="isComponent" id="projen.github.IssueTemplate.isComponent"></a>
+
+```typescript
+import { github } from 'projen'
+
+github.IssueTemplate.isComponent(x: any)
+```
+
+Test whether the given construct is a component.
+
+###### `x`<sup>Required</sup> <a name="x" id="projen.github.IssueTemplate.isComponent.parameter.x"></a>
+
+- *Type:* any
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen.github.IssueTemplate.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#projen.github.IssueTemplate.property.project">project</a></code> | <code>projen.Project</code> | *No description.* |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="projen.github.IssueTemplate.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- *Type:* constructs.Node
+
+The tree node.
+
+---
+
+##### `project`<sup>Required</sup> <a name="project" id="projen.github.IssueTemplate.property.project"></a>
+
+```typescript
+public readonly project: Project;
+```
+
+- *Type:* projen.Project
+
+---
+
+
 ### Mergify <a name="Mergify" id="projen.github.Mergify"></a>
 
 #### Initializers <a name="Initializers" id="projen.github.Mergify.Initializer"></a>
@@ -4629,6 +4794,62 @@ The name of the artifact the patch is stored as.
 
 ---
 
+### ContactLinks <a name="ContactLinks" id="projen.github.ContactLinks"></a>
+
+#### Initializer <a name="Initializer" id="projen.github.ContactLinks.Initializer"></a>
+
+```typescript
+import { github } from 'projen'
+
+const contactLinks: github.ContactLinks = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen.github.ContactLinks.property.about">about</a></code> | <code>string</code> | A brief description of the contact link. |
+| <code><a href="#projen.github.ContactLinks.property.name">name</a></code> | <code>string</code> | The name of the contact link. |
+| <code><a href="#projen.github.ContactLinks.property.url">url</a></code> | <code>string</code> | The URL of the contact link. |
+
+---
+
+##### `about`<sup>Required</sup> <a name="about" id="projen.github.ContactLinks.property.about"></a>
+
+```typescript
+public readonly about: string;
+```
+
+- *Type:* string
+
+A brief description of the contact link.
+
+---
+
+##### `name`<sup>Required</sup> <a name="name" id="projen.github.ContactLinks.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* string
+
+The name of the contact link.
+
+---
+
+##### `url`<sup>Required</sup> <a name="url" id="projen.github.ContactLinks.property.url"></a>
+
+```typescript
+public readonly url: string;
+```
+
+- *Type:* string
+
+The URL of the contact link.
+
+---
+
 ### ContributorStatementOptions <a name="ContributorStatementOptions" id="projen.github.ContributorStatementOptions"></a>
 
 Options for requiring a contributor statement on Pull Requests.
@@ -6389,6 +6610,128 @@ public readonly name: string;
 - *Type:* string
 
 The name of the user.
+
+---
+
+### IssueTemplateConfigOptions <a name="IssueTemplateConfigOptions" id="projen.github.IssueTemplateConfigOptions"></a>
+
+Options for configuring issue templates in a repository.
+
+> [{@link https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser}]({@link https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser})
+
+#### Initializer <a name="Initializer" id="projen.github.IssueTemplateConfigOptions.Initializer"></a>
+
+```typescript
+import { github } from 'projen'
+
+const issueTemplateConfigOptions: github.IssueTemplateConfigOptions = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen.github.IssueTemplateConfigOptions.property.blankIssuesEnabled">blankIssuesEnabled</a></code> | <code>boolean</code> | Indicates whether blank issues (issues without a template) are allowed. |
+| <code><a href="#projen.github.IssueTemplateConfigOptions.property.contactLinks">contactLinks</a></code> | <code><a href="#projen.github.ContactLinks">ContactLinks</a>[]</code> | An array of contact links to display in the issue template chooser. |
+
+---
+
+##### `blankIssuesEnabled`<sup>Optional</sup> <a name="blankIssuesEnabled" id="projen.github.IssueTemplateConfigOptions.property.blankIssuesEnabled"></a>
+
+```typescript
+public readonly blankIssuesEnabled: boolean;
+```
+
+- *Type:* boolean
+
+Indicates whether blank issues (issues without a template) are allowed.
+
+---
+
+##### `contactLinks`<sup>Optional</sup> <a name="contactLinks" id="projen.github.IssueTemplateConfigOptions.property.contactLinks"></a>
+
+```typescript
+public readonly contactLinks: ContactLinks[];
+```
+
+- *Type:* <a href="#projen.github.ContactLinks">ContactLinks</a>[]
+
+An array of contact links to display in the issue template chooser.
+
+---
+
+### IssueTemplateOptions <a name="IssueTemplateOptions" id="projen.github.IssueTemplateOptions"></a>
+
+Options for `IssueTemplate`.
+
+#### Initializer <a name="Initializer" id="projen.github.IssueTemplateOptions.Initializer"></a>
+
+```typescript
+import { github } from 'projen'
+
+const issueTemplateOptions: github.IssueTemplateOptions = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen.github.IssueTemplateOptions.property.templates">templates</a></code> | <code>{[ key: string ]: string}</code> | An array of issue template file names and their contents. |
+| <code><a href="#projen.github.IssueTemplateOptions.property.configOptions">configOptions</a></code> | <code><a href="#projen.github.IssueTemplateConfigOptions">IssueTemplateConfigOptions</a></code> | Configuration options for the config.yml file. Only applicable if includeConfig is true. |
+| <code><a href="#projen.github.IssueTemplateOptions.property.includeConfig">includeConfig</a></code> | <code>boolean</code> | Whether to include a config.yml file for configuring the issue template chooser. Defaults to false. |
+| <code><a href="#projen.github.IssueTemplateOptions.property.templatePath">templatePath</a></code> | <code>string</code> | The path within the repository where the issue templates should be created. |
+
+---
+
+##### `templates`<sup>Required</sup> <a name="templates" id="projen.github.IssueTemplateOptions.property.templates"></a>
+
+```typescript
+public readonly templates: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
+
+An array of issue template file names and their contents.
+
+The file names should include the extension (.md or .yml).
+
+---
+
+##### `configOptions`<sup>Optional</sup> <a name="configOptions" id="projen.github.IssueTemplateOptions.property.configOptions"></a>
+
+```typescript
+public readonly configOptions: IssueTemplateConfigOptions;
+```
+
+- *Type:* <a href="#projen.github.IssueTemplateConfigOptions">IssueTemplateConfigOptions</a>
+
+Configuration options for the config.yml file. Only applicable if includeConfig is true.
+
+---
+
+##### `includeConfig`<sup>Optional</sup> <a name="includeConfig" id="projen.github.IssueTemplateOptions.property.includeConfig"></a>
+
+```typescript
+public readonly includeConfig: boolean;
+```
+
+- *Type:* boolean
+
+Whether to include a config.yml file for configuring the issue template chooser. Defaults to false.
+
+---
+
+##### `templatePath`<sup>Optional</sup> <a name="templatePath" id="projen.github.IssueTemplateOptions.property.templatePath"></a>
+
+```typescript
+public readonly templatePath: string;
+```
+
+- *Type:* string
+
+The path within the repository where the issue templates should be created.
+
+Defaults to '.github/ISSUE_TEMPLATE'.
 
 ---
 

--- a/docs/api/github.md
+++ b/docs/api/github.md
@@ -6695,7 +6695,6 @@ const issueTemplateOptions: github.IssueTemplateOptions = { ... }
 | --- | --- | --- |
 | <code><a href="#projen.github.IssueTemplateOptions.property.templates">templates</a></code> | <code>{[ key: string ]: string}</code> | An array of issue template file names and their contents. |
 | <code><a href="#projen.github.IssueTemplateOptions.property.configOptions">configOptions</a></code> | <code><a href="#projen.github.IssueTemplateConfigOptions">IssueTemplateConfigOptions</a></code> | Configuration options for the config.yml file. Only applicable if includeConfig is true. |
-| <code><a href="#projen.github.IssueTemplateOptions.property.templatePath">templatePath</a></code> | <code>string</code> | The path within the repository where the issue templates should be created. |
 
 ---
 
@@ -6722,20 +6721,6 @@ public readonly configOptions: IssueTemplateConfigOptions;
 - *Type:* <a href="#projen.github.IssueTemplateConfigOptions">IssueTemplateConfigOptions</a>
 
 Configuration options for the config.yml file. Only applicable if includeConfig is true.
-
----
-
-##### `templatePath`<sup>Optional</sup> <a name="templatePath" id="projen.github.IssueTemplateOptions.property.templatePath"></a>
-
-```typescript
-public readonly templatePath: string;
-```
-
-- *Type:* string
-
-The path within the repository where the issue templates should be created.
-
-Defaults to '.github/ISSUE_TEMPLATE'.
 
 ---
 

--- a/docs/api/github.md
+++ b/docs/api/github.md
@@ -2358,19 +2358,19 @@ Generates Issue Templates for GitHub repositories see  {@link https://docs.githu
 ```typescript
 import { github } from 'projen'
 
-new github.IssueTemplate(github: GitHub, options: IssueTemplateOptions)
+new github.IssueTemplate(scope: IConstruct, options: IssueTemplateOptions)
 ```
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#projen.github.IssueTemplate.Initializer.parameter.github">github</a></code> | <code><a href="#projen.github.GitHub">GitHub</a></code> | *No description.* |
+| <code><a href="#projen.github.IssueTemplate.Initializer.parameter.scope">scope</a></code> | <code>constructs.IConstruct</code> | *No description.* |
 | <code><a href="#projen.github.IssueTemplate.Initializer.parameter.options">options</a></code> | <code><a href="#projen.github.IssueTemplateOptions">IssueTemplateOptions</a></code> | *No description.* |
 
 ---
 
-##### `github`<sup>Required</sup> <a name="github" id="projen.github.IssueTemplate.Initializer.parameter.github"></a>
+##### `scope`<sup>Required</sup> <a name="scope" id="projen.github.IssueTemplate.Initializer.parameter.scope"></a>
 
-- *Type:* <a href="#projen.github.GitHub">GitHub</a>
+- *Type:* constructs.IConstruct
 
 ---
 
@@ -2388,6 +2388,7 @@ new github.IssueTemplate(github: GitHub, options: IssueTemplateOptions)
 | <code><a href="#projen.github.IssueTemplate.postSynthesize">postSynthesize</a></code> | Called after synthesis. |
 | <code><a href="#projen.github.IssueTemplate.preSynthesize">preSynthesize</a></code> | Called before synthesis. |
 | <code><a href="#projen.github.IssueTemplate.synthesize">synthesize</a></code> | Synthesizes files to the project output directory. |
+| <code><a href="#projen.github.IssueTemplate.addTemplates">addTemplates</a></code> | Adds issue templates to the project. |
 
 ---
 
@@ -2424,6 +2425,22 @@ public synthesize(): void
 ```
 
 Synthesizes files to the project output directory.
+
+##### `addTemplates` <a name="addTemplates" id="projen.github.IssueTemplate.addTemplates"></a>
+
+```typescript
+public addTemplates(options: IssueTemplateOptions): void
+```
+
+Adds issue templates to the project.
+
+###### `options`<sup>Required</sup> <a name="options" id="projen.github.IssueTemplate.addTemplates.parameter.options"></a>
+
+- *Type:* <a href="#projen.github.IssueTemplateOptions">IssueTemplateOptions</a>
+
+The options for adding issue templates.
+
+---
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
@@ -6678,7 +6695,6 @@ const issueTemplateOptions: github.IssueTemplateOptions = { ... }
 | --- | --- | --- |
 | <code><a href="#projen.github.IssueTemplateOptions.property.templates">templates</a></code> | <code>{[ key: string ]: string}</code> | An array of issue template file names and their contents. |
 | <code><a href="#projen.github.IssueTemplateOptions.property.configOptions">configOptions</a></code> | <code><a href="#projen.github.IssueTemplateConfigOptions">IssueTemplateConfigOptions</a></code> | Configuration options for the config.yml file. Only applicable if includeConfig is true. |
-| <code><a href="#projen.github.IssueTemplateOptions.property.includeConfig">includeConfig</a></code> | <code>boolean</code> | Whether to include a config.yml file for configuring the issue template chooser. Defaults to false. |
 | <code><a href="#projen.github.IssueTemplateOptions.property.templatePath">templatePath</a></code> | <code>string</code> | The path within the repository where the issue templates should be created. |
 
 ---
@@ -6706,18 +6722,6 @@ public readonly configOptions: IssueTemplateConfigOptions;
 - *Type:* <a href="#projen.github.IssueTemplateConfigOptions">IssueTemplateConfigOptions</a>
 
 Configuration options for the config.yml file. Only applicable if includeConfig is true.
-
----
-
-##### `includeConfig`<sup>Optional</sup> <a name="includeConfig" id="projen.github.IssueTemplateOptions.property.includeConfig"></a>
-
-```typescript
-public readonly includeConfig: boolean;
-```
-
-- *Type:* boolean
-
-Whether to include a config.yml file for configuring the issue template chooser. Defaults to false.
 
 ---
 

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -5,6 +5,7 @@ export * from "./workflows";
 export * from "./actions-provider";
 export * from "./mergify";
 export * from "./pr-template";
+export * from "./issue-template";
 export * from "./auto-merge";
 export * from "./auto-approve";
 export * from "./stale";

--- a/src/github/issue-template.ts
+++ b/src/github/issue-template.ts
@@ -67,7 +67,6 @@ export interface IssueTemplateOptions {
 export class IssueTemplate extends Component {
   constructor(scope: IConstruct, options: IssueTemplateOptions) {
     super(scope);
-    const project = this.project;
 
     // Create issue template files
     this.addTemplates(options);
@@ -77,7 +76,7 @@ export class IssueTemplate extends Component {
       const blankIssues = options.configOptions?.blankIssuesEnabled;
       const contactLinks = options.configOptions?.contactLinks;
 
-      new YamlFile(project, ".github/config.yml", {
+      new YamlFile(this, ".github/config.yml", {
         obj: {
           blank_issues_enabled: blankIssues,
           contact_links: contactLinks,
@@ -103,14 +102,14 @@ export class IssueTemplate extends Component {
       const fileExtension = path.extname(fileName).toLowerCase();
       switch (fileExtension) {
         case ".md":
-          new TextFile(this.project, filePath, {
+          new TextFile(this, filePath, {
             lines: [content],
             marker: false,
             committed: true,
           });
           break;
         case ".yml":
-          new YamlFile(this.project, filePath, {
+          new YamlFile(this, filePath, {
             obj: YAML.parse(content),
             marker: false,
             committed: true,

--- a/src/github/issue-template.ts
+++ b/src/github/issue-template.ts
@@ -1,0 +1,126 @@
+import * as path from "path";
+import { GitHub } from "./github";
+import { Component } from "../component";
+import { TextFile } from "../textfile";
+import { YamlFile } from "../yaml";
+
+export interface ContactLinks {
+  /**
+   * The name of the contact link.
+   */
+  readonly name: string;
+
+  /**
+   * The URL of the contact link.
+   */
+  readonly url: string;
+
+  /**
+   * A brief description of the contact link.
+   */
+  readonly about: string;
+}
+
+/**
+ * Options for configuring issue templates in a repository.
+ *
+ * @interface IssueTemplateConfigOptions
+ * @see {@link https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser}
+ */
+export interface IssueTemplateConfigOptions {
+  /**
+   * Indicates whether blank issues (issues without a template) are allowed.
+   *
+   * @type {boolean} [blankIssuesEnabled=false]
+   */
+  readonly blankIssuesEnabled?: boolean;
+
+  /**
+   * An array of contact links to display in the issue template chooser.
+   *
+   */
+  readonly contactLinks?: ContactLinks[];
+}
+
+/**
+ * Options for `IssueTemplate`.
+ */
+export interface IssueTemplateOptions {
+  /**
+   * An array of issue template file names and their contents.
+   * The file names should include the extension (.md or .yml).
+   */
+  readonly templates: { [fileName: string]: string };
+
+  /**
+   * The path within the repository where the issue templates should be created.
+   * Defaults to '.github/ISSUE_TEMPLATE'.
+   */
+  readonly templatePath?: string;
+
+  /**
+   * Whether to include a config.yml file for configuring the issue template chooser.
+   * Defaults to false.
+   */
+  readonly includeConfig?: boolean;
+
+  /**
+   * Configuration options for the config.yml file.
+   * Only applicable if includeConfig is true.
+   */
+  readonly configOptions?: IssueTemplateConfigOptions;
+}
+
+/**
+ * Generates Issue Templates for GitHub repositories
+ * see  {@link https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests}
+ */
+export class IssueTemplate extends Component {
+  constructor(github: GitHub, options: IssueTemplateOptions) {
+    super(github.project);
+    const project = github.project;
+
+    const templatePath = options.templatePath || ".github/ISSUE_TEMPLATE";
+
+    // Create issue template files
+    for (const [fileName, content] of Object.entries(options.templates)) {
+      const filePath = path.join(templatePath, fileName);
+      const fileExtension = path.extname(fileName).toLowerCase();
+      switch (fileExtension) {
+        case ".md":
+          new TextFile(project, filePath, {
+            lines: [content],
+            marker: false,
+            committed: true,
+          });
+          break;
+        case ".yml":
+          new YamlFile(project, filePath, {
+            obj: content,
+            marker: false,
+            committed: true,
+          });
+          break;
+        default:
+          throw new Error(`Unsupported file extension: ${fileExtension}`);
+      }
+    }
+
+    const includeConfig = options.includeConfig ?? false;
+
+    // Create config.yml file if requested
+    if (includeConfig) {
+      const blankIssues = options.configOptions?.blankIssuesEnabled;
+      const contactLinks = options.configOptions?.contactLinks;
+
+      new YamlFile(project, ".github/config.yml", {
+        obj: {
+          blank_issues_enabled: blankIssues,
+          contact_links: contactLinks,
+        },
+        marker: false,
+        committed: true,
+      });
+    }
+  }
+}

--- a/src/github/issue-template.ts
+++ b/src/github/issue-template.ts
@@ -54,12 +54,6 @@ export interface IssueTemplateOptions {
   readonly templates: { [fileName: string]: string };
 
   /**
-   * The path within the repository where the issue templates should be created.
-   * Defaults to '.github/ISSUE_TEMPLATE'.
-   */
-  readonly templatePath?: string;
-
-  /**
    * Configuration options for the config.yml file.
    * Only applicable if includeConfig is true.
    */

--- a/test/github/__snapshots__/issue-template.test.ts.snap
+++ b/test/github/__snapshots__/issue-template.test.ts.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`issue-template include config 1`] = `
+"
+blank_issues_enabled: false
+contact_links:
+  - name: Support
+    url: https://example.com/support
+    about: Get support for this project
+"
+`;
+
+exports[`issue-template includes bug-report.md 1`] = `"<!-- Bug report template content -->"`;
+
+exports[`issue-template includes feature-request.yml 1`] = `
+"
+<!-- Feature request template content -->
+"
+`;

--- a/test/github/__snapshots__/issue-template.test.ts.snap
+++ b/test/github/__snapshots__/issue-template.test.ts.snap
@@ -14,6 +14,12 @@ exports[`issue-template includes bug-report.md 1`] = `"<!-- Bug report template 
 
 exports[`issue-template includes feature-request.yml 1`] = `
 "
-<!-- Feature request template content -->
+name: Feature Request
+description: Suggest a new feature for the project
+title: "[FEATURE] "
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to fill out this feature request
 "
 `;

--- a/test/github/issue-template.test.ts
+++ b/test/github/issue-template.test.ts
@@ -1,0 +1,62 @@
+import { IssueTemplate } from "../../src/github/issue-template";
+import { synthSnapshot, TestProject } from "../util";
+
+describe("issue-template", () => {
+  test("default project behavior", () => {
+    const project = new TestProject();
+    expect(
+      synthSnapshot(project)[".github/ISSUE_TEMPLATE/bug-report.md"]
+    ).toBeUndefined();
+  });
+
+  test("include config", () => {
+    const project = new TestProject();
+    new IssueTemplate(project.github!, {
+      templates: {
+        "bug-report.md": "<!-- Bug report template content -->",
+      },
+      includeConfig: true,
+      configOptions: {
+        blankIssuesEnabled: false,
+        contactLinks: [
+          {
+            name: "Support",
+            url: "https://example.com/support",
+            about: "Get support for this project",
+          },
+        ],
+      },
+    });
+    const snapshot = synthSnapshot(project);
+    const issueTemplateConfig = snapshot[".github/config.yml"];
+    expect(issueTemplateConfig).toContain("blank_issues_enabled: false");
+    expect(issueTemplateConfig).toContain("contact_links");
+    expect(issueTemplateConfig).toMatchSnapshot();
+  });
+
+  test("includes bug-report.md", () => {
+    const project = new TestProject();
+    new IssueTemplate(project.github!, {
+      templates: {
+        "bug-report.md": "<!-- Bug report template content -->",
+      },
+    });
+
+    expect(
+      synthSnapshot(project)[".github/ISSUE_TEMPLATE/bug-report.md"]
+    ).toMatchSnapshot();
+  });
+
+  test("includes feature-request.yml", () => {
+    const project = new TestProject();
+    new IssueTemplate(project.github!, {
+      templates: {
+        "feature-request.yml": "<!-- Feature request template content -->",
+      },
+    });
+
+    expect(
+      synthSnapshot(project)[".github/ISSUE_TEMPLATE/feature-request.yml"]
+    ).toMatchSnapshot();
+  });
+});

--- a/test/github/issue-template.test.ts
+++ b/test/github/issue-template.test.ts
@@ -1,3 +1,4 @@
+import * as YAML from "yaml";
 import { IssueTemplate } from "../../src/github/issue-template";
 import { synthSnapshot, TestProject } from "../util";
 
@@ -11,11 +12,10 @@ describe("issue-template", () => {
 
   test("include config", () => {
     const project = new TestProject();
-    new IssueTemplate(project.github!, {
+    new IssueTemplate(project, {
       templates: {
         "bug-report.md": "<!-- Bug report template content -->",
       },
-      includeConfig: true,
       configOptions: {
         blankIssuesEnabled: false,
         contactLinks: [
@@ -36,7 +36,7 @@ describe("issue-template", () => {
 
   test("includes bug-report.md", () => {
     const project = new TestProject();
-    new IssueTemplate(project.github!, {
+    new IssueTemplate(project, {
       templates: {
         "bug-report.md": "<!-- Bug report template content -->",
       },
@@ -49,14 +49,43 @@ describe("issue-template", () => {
 
   test("includes feature-request.yml", () => {
     const project = new TestProject();
-    new IssueTemplate(project.github!, {
+    const data = {
+      name: "Feature Request",
+      description: "Suggest a new feature for the project",
+      title: "[FEATURE] ",
+      body: [
+        {
+          type: "markdown",
+          attributes: {
+            value:
+              "Thanks for taking the time to fill out this feature request",
+          },
+        },
+      ],
+    };
+
+    new IssueTemplate(project, {
       templates: {
-        "feature-request.yml": "<!-- Feature request template content -->",
+        "feature-request.yml": YAML.stringify(data),
       },
     });
 
     expect(
       synthSnapshot(project)[".github/ISSUE_TEMPLATE/feature-request.yml"]
     ).toMatchSnapshot();
+  });
+
+  test("throws error if file extension is not supported", () => {
+    const project = new TestProject();
+    // Define a function that creates an IssueTemplate with invalid file extension
+    const createIssueTemplateWithInvalidExtension = () => {
+      new IssueTemplate(project, {
+        templates: {
+          "feature-request.txt": "<!-- some unsupported text -->",
+        },
+      });
+    };
+
+    expect(createIssueTemplateWithInvalidExtension).toThrow();
   });
 });


### PR DESCRIPTION
adds support for github issue templates. Closes #3567. Tested this by setting up a local project and adding this snippet to the `.projenrc.ts`

```
new IssueTemplate(project.github!, {
  templates: {
    'bug-report.md': '<!-- Bug report template content -->',
    'feature-request.yml': '<!-- Feature request template content -->',
  },
});
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
