### PR TITLE
feat(jsii)!: upgrade jsii toolchain sdks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11.x
+          java-version: 20.x
       - uses: actions/setup-node@v4
         with:
           node-version: 18.18.0
@@ -129,7 +129,7 @@ jobs:
           node-version: 18.18.0
       - uses: actions/setup-go@v5
         with:
-          go-version: ^1.16.0
+          go-version: ^1.18.0
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:

--- a/src/cdk/consts.ts
+++ b/src/cdk/consts.ts
@@ -7,8 +7,8 @@ export type JsiiPacmakTarget = "js" | "go" | "java" | "python" | "dotnet";
  */
 export const JSII_TOOLCHAIN: Record<JsiiPacmakTarget, Tools> = {
   js: {},
-  java: { java: { version: "11.x" } },
+  java: { java: { version: "20.x" } },
   python: { python: { version: "3.x" } },
-  go: { go: { version: "^1.16.0" } },
-  dotnet: { dotnet: { version: "3.x" } },
+  go: { go: { version: "^1.18.0" } },
+  dotnet: { dotnet: { version: "6.x" } },
 };

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -380,7 +380,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11.x
+          java-version: 20.x
       - uses: actions/setup-node@v4
         with:
           node-version: 16.0.0

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -1917,7 +1917,7 @@ exports[`language bindings snapshot dotnet 1`] = `
     {
       "uses": "actions/setup-dotnet@v4",
       "with": {
-        "dotnet-version": "3.x",
+        "dotnet-version": "6.x",
       },
     },
     {
@@ -1969,7 +1969,7 @@ exports[`language bindings snapshot go 1`] = `
     {
       "uses": "actions/setup-go@v5",
       "with": {
-        "go-version": "^1.16.0",
+        "go-version": "^1.18.0",
       },
     },
     {
@@ -2016,7 +2016,7 @@ exports[`language bindings snapshot java 1`] = `
       "uses": "actions/setup-java@v4",
       "with": {
         "distribution": "temurin",
-        "java-version": "11.x",
+        "java-version": "20.x",
       },
     },
     {


### PR DESCRIPTION
Fixes #3687

BREAKING CHANGE: Aligns SDK versions used in the package GitHub Actions Workflows to the [official JSII superchain](https://github.com/aws/jsii/blob/v1.101.0/superchain/README.md#included-language-sdks) versions. Use low-level [Object File Patches](https://projen.io/docs/concepts/escape-hatches#object-file-patches) to revert to previous versions.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
