### PR TITLE
fix(javascript): correct strict boolean compiler options to `boolean` type

### DIFF
--- a/src/javascript/typescript-config.ts
+++ b/src/javascript/typescript-config.ts
@@ -636,7 +636,7 @@ export interface TypeScriptCompilerOptions {
    *
    * @see https://www.typescriptlang.org/tsconfig#allowUnusedLabels
    */
-  readonly allowUnusedLabels?: false;
+  readonly allowUnusedLabels?: boolean;
 
   /**
    * Allow Unreachable Code
@@ -651,7 +651,7 @@ export interface TypeScriptCompilerOptions {
    *
    * @see https://www.typescriptlang.org/tsconfig#allowUnreachableCode
    */
-  readonly allowUnreachableCode?: false;
+  readonly allowUnreachableCode?: boolean;
 
   /**
    * Check JS
@@ -662,7 +662,7 @@ export interface TypeScriptCompilerOptions {
    *
    * @see https://www.typescriptlang.org/tsconfig#checkJs
    */
-  readonly checkJs?: true;
+  readonly checkJs?: boolean;
 }
 
 /**


### PR DESCRIPTION
Signed-off-by: Braden Mars <bradenmars@bradenmars.me>

Fixes #3689

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
