### PR TITLE
fix(publisher)!: cannot publish to Maven due to release plugin incompatible with workflow jdk

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,8 +69,8 @@ jobs:
     steps:
       - uses: actions/setup-java@v4
         with:
-          distribution: temurin
-          java-version: 20.x
+          distribution: corretto
+          java-version: "11"
       - uses: actions/setup-node@v4
         with:
           node-version: 18.18.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,8 +167,8 @@ jobs:
     steps:
       - uses: actions/setup-java@v4
         with:
-          distribution: temurin
-          java-version: 20.x
+          distribution: corretto
+          java-version: "11"
       - uses: actions/setup-node@v4
         with:
           node-version: 18.18.0

--- a/src/cdk/consts.ts
+++ b/src/cdk/consts.ts
@@ -7,7 +7,7 @@ export type JsiiPacmakTarget = "js" | "go" | "java" | "python" | "dotnet";
  */
 export const JSII_TOOLCHAIN: Record<JsiiPacmakTarget, Tools> = {
   js: {},
-  java: { java: { version: "20.x" } },
+  java: { java: { version: "11" } },
   python: { python: { version: "3.x" } },
   go: { go: { version: "^1.18.0" } },
   dotnet: { dotnet: { version: "6.x" } },

--- a/src/github/workflows.ts
+++ b/src/github/workflows.ts
@@ -367,7 +367,7 @@ function setupTools(tools: workflows.Tools) {
   if (tools.java) {
     steps.push({
       uses: "actions/setup-java@v4",
-      with: { distribution: "temurin", "java-version": tools.java.version },
+      with: { distribution: "corretto", "java-version": tools.java.version },
     });
   }
 

--- a/src/release/publisher.ts
+++ b/src/release/publisher.ts
@@ -24,7 +24,7 @@ const GITHUB_PACKAGES_NUGET_REPOSITORY = "https://nuget.pkg.github.com";
 const AWS_CODEARTIFACT_REGISTRY_REGEX = /.codeartifact.*.amazonaws.com/;
 const PUBLIB_TOOLCHAIN = {
   js: {},
-  java: { java: { version: "20.x" } },
+  java: { java: { version: "11" } },
   python: { python: { version: "3.x" } },
   go: { go: { version: "^1.18.0" } },
   dotnet: { dotnet: { version: "6.x" } },

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -380,7 +380,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: corretto
-          java-version: "16"
+          java-version: "11"
       - uses: actions/setup-node@v4
         with:
           node-version: 16.0.0
@@ -594,7 +594,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: corretto
-          java-version: "16"
+          java-version: "11"
       - uses: actions/setup-node@v4
         with:
           node-version: 16.0.0

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -379,8 +379,8 @@ jobs:
     steps:
       - uses: actions/setup-java@v4
         with:
-          distribution: temurin
-          java-version: 20.x
+          distribution: corretto
+          java-version: "16"
       - uses: actions/setup-node@v4
         with:
           node-version: 16.0.0
@@ -593,8 +593,8 @@ jobs:
     steps:
       - uses: actions/setup-java@v4
         with:
-          distribution: temurin
-          java-version: 20.x
+          distribution: corretto
+          java-version: "16"
       - uses: actions/setup-node@v4
         with:
           node-version: 16.0.0

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -1663,7 +1663,7 @@ exports[`language bindings release workflow includes release_maven job 1`] = `
       "uses": "actions/setup-java@v4",
       "with": {
         "distribution": "corretto",
-        "java-version": "16",
+        "java-version": "11",
       },
     },
     {
@@ -2016,7 +2016,7 @@ exports[`language bindings snapshot java 1`] = `
       "uses": "actions/setup-java@v4",
       "with": {
         "distribution": "corretto",
-        "java-version": "16",
+        "java-version": "11",
       },
     },
     {

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -1662,8 +1662,8 @@ exports[`language bindings release workflow includes release_maven job 1`] = `
     {
       "uses": "actions/setup-java@v4",
       "with": {
-        "distribution": "temurin",
-        "java-version": "20.x",
+        "distribution": "corretto",
+        "java-version": "16",
       },
     },
     {
@@ -2015,8 +2015,8 @@ exports[`language bindings snapshot java 1`] = `
     {
       "uses": "actions/setup-java@v4",
       "with": {
-        "distribution": "temurin",
-        "java-version": "20.x",
+        "distribution": "corretto",
+        "java-version": "16",
       },
     },
     {

--- a/test/release/__snapshots__/release.test.ts.snap
+++ b/test/release/__snapshots__/release.test.ts.snap
@@ -3103,7 +3103,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: corretto
-          java-version: "16"
+          java-version: "11"
       - uses: actions/setup-node@v4
         with:
           node-version: 18.x
@@ -4415,7 +4415,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: corretto
-          java-version: "16"
+          java-version: "11"
       - uses: actions/setup-node@v4
         with:
           node-version: 18.x

--- a/test/release/__snapshots__/release.test.ts.snap
+++ b/test/release/__snapshots__/release.test.ts.snap
@@ -3102,8 +3102,8 @@ jobs:
     steps:
       - uses: actions/setup-java@v4
         with:
-          distribution: temurin
-          java-version: 20.x
+          distribution: corretto
+          java-version: "16"
       - uses: actions/setup-node@v4
         with:
           node-version: 18.x
@@ -4414,8 +4414,8 @@ jobs:
     steps:
       - uses: actions/setup-java@v4
         with:
-          distribution: temurin
-          java-version: 20.x
+          distribution: corretto
+          java-version: "16"
       - uses: actions/setup-node@v4
         with:
           node-version: 18.x


### PR DESCRIPTION
Fixes #3707

We tried upgrading the version of java in https://github.com/projen/projen/pull/3688 and https://github.com/projen/projen/pull/3694, however this caused failing Maven releases due to an apparent incompatibility with nexus-staging-maven-plugin used by publib.

Tested here: https://github.com/projen/canary-testing/actions/runs/9844843704/job/27179142549
 
BREAKING CHANGE: Changes the OpenJDK Java version used in the Publisher GitHub Actions Workflow to Amazon Corretto and Java 11. Use low-level [Object File Patches](https://projen.io/docs/concepts/escape-hatches#object-file-patches) to change to other versions.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
