### PR TITLE
fix(jsii): running `projen package` on windows fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,10 +198,6 @@ jobs:
       - name: build
         run: node ./projen.js build
         if: ${{ matrix.runner.primary_build }}
-      - name: build on windows
-        run: node ./projen.js default && node ./projen.js pre-compile && node ./projen.js compile && node ./projen.js post-compile && node ./projen.js test
-        shell: cmd
-        if: ${{ !matrix.runner.primary_build }}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,6 +184,10 @@ jobs:
     env:
       CI: "true"
     steps:
+      - name: Install rsync on Windows
+        if: matrix.runner.os == 'windows-latest'
+        run: choco install --no-progress rsync
+        shell: pwsh
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,7 +201,6 @@ jobs:
         run: yarn install --check-files
       - name: build
         run: node ./projen.js build
-        if: ${{ matrix.runner.primary_build }}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,6 +201,12 @@ jobs:
         run: yarn install --check-files
       - name: build
         run: node ./projen.js build
+        if: ${{ matrix.runner.shell }} == 'bash'
+        shell: bash
+      - name: build
+        run: node ./projen.js build
+        if: ${{ matrix.runner.shell }} == 'cmd'
+        shell: cmd
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,12 +201,12 @@ jobs:
         run: yarn install --check-files
       - name: build (bash)
         run: node ./projen.js build
-        if: ${{ matrix.runner.shell }} == 'bash'
         shell: bash
+        if: matrix.runner.shell == 'bash'
       - name: build (cmd)
         run: node ./projen.js build
-        if: ${{ matrix.runner.shell }} == 'cmd'
         shell: cmd
+        if: matrix.runner.shell == 'cmd'
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,11 +199,11 @@ jobs:
           node-version: 18.18.0
       - name: Install dependencies
         run: yarn install --check-files
-      - name: build
+      - name: build (bash)
         run: node ./projen.js build
         if: ${{ matrix.runner.shell }} == 'bash'
         shell: bash
-      - name: build
+      - name: build (cmd)
         run: node ./projen.js build
         if: ${{ matrix.runner.shell }} == 'cmd'
         shell: cmd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,7 +187,6 @@ jobs:
       - name: Install rsync on Windows
         if: matrix.runner.os == 'windows-latest'
         run: choco install --no-progress rsync
-        shell: pwsh
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -199,14 +198,8 @@ jobs:
           node-version: 18.18.0
       - name: Install dependencies
         run: yarn install --check-files
-      - name: build (bash)
+      - name: build
         run: node ./projen.js build
-        shell: bash
-        if: matrix.runner.shell == 'bash'
-      - name: build (cmd)
-        run: node ./projen.js build
-        shell: cmd
-        if: matrix.runner.shell == 'cmd'
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
@@ -247,11 +240,9 @@ jobs:
         runner:
           - os: ubuntu-latest
             primary_build: true
-            shell: bash
             allow_failure: false
           - os: windows-latest
             primary_build: false
-            shell: cmd
             allow_failure: false
     continue-on-error: ${{ matrix.runner.allow_failure }}
   build:

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -216,7 +216,7 @@
       "description": "Creates the distribution package",
       "steps": [
         {
-          "exec": "test -n \"${CI}\" && ((rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist) || exit 1) || node ./projen.js package-all"
+          "exec": "(test -n \"${CI}\" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || (test -n \"${CI}\" || (node ./projen.js package-all))"
         }
       ]
     },

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -216,7 +216,12 @@
       "description": "Creates the distribution package",
       "steps": [
         {
-          "exec": "(test -n \"${CI}\" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || (test -n \"${CI}\" || (node ./projen.js package-all))"
+          "exec": "rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist",
+          "condition": "! test -z ${CI}"
+        },
+        {
+          "spawn": "package-all",
+          "condition": "test -z ${CI}"
         }
       ]
     },

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -217,11 +217,11 @@
       "steps": [
         {
           "exec": "rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist",
-          "condition": "! test -z ${CI}"
+          "condition": "node -e \"if (!process.env.CI) process.exit(1)\""
         },
         {
           "spawn": "package-all",
-          "condition": "test -z ${CI}"
+          "condition": "node -e \"if (process.env.CI) process.exit(1)\""
         }
       ]
     },

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -216,7 +216,7 @@
       "description": "Creates the distribution package",
       "steps": [
         {
-          "exec": "if [ ! -z ${CI} ]; then rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist; else node ./projen.js package-all; fi"
+          "exec": "(test -n \"${CI}\" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || node ./projen.js package-all"
         }
       ]
     },

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -216,7 +216,7 @@
       "description": "Creates the distribution package",
       "steps": [
         {
-          "exec": "(test -n \"${CI}\" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || node ./projen.js package-all"
+          "exec": "test -n \"${CI}\" && ((rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist) || exit 1) || node ./projen.js package-all"
         }
       ]
     },

--- a/projenrc/windows-build.ts
+++ b/projenrc/windows-build.ts
@@ -131,10 +131,7 @@ function convertStepToShellMatrix(
 ) {
   return [
     JsonPatch.add(`${pathToStep}/name`, `${name} (${shell})`),
-    JsonPatch.add(
-      `${pathToStep}/if`,
-      `\${{ matrix.runner.shell }} == '${shell}'`
-    ),
     JsonPatch.add(`${pathToStep}/shell`, shell),
+    JsonPatch.add(`${pathToStep}/if`, `matrix.runner.shell == '${shell}'`),
   ];
 }

--- a/projenrc/windows-build.ts
+++ b/projenrc/windows-build.ts
@@ -38,7 +38,7 @@ export class WindowsBuild extends Component {
       )
     );
 
-    // Add windows-latest runner
+    // Setup runner matrix
     buildWorkflowFile?.patch(
       JsonPatch.add(buildJobPath("/strategy"), {
         matrix: {
@@ -58,25 +58,21 @@ export class WindowsBuild extends Component {
           ],
         },
       }),
+
+      // Run job on os from matrix
       JsonPatch.add(buildJobPath("/runs-on"), "${{ matrix.runner.os }}"),
 
-      // Allow some builds to fail
+      // Allow builds to fail based on matrix
       JsonPatch.add(
         buildJobPath("/continue-on-error"),
         "${{ matrix.runner.allow_failure }}"
       ),
 
+      // Add conditions to steps that should only run on the primary build
       JsonPatch.add(
         buildJobPath("/steps/6/if"),
         "${{ steps.self_mutation.outputs.self_mutation_happened && matrix.runner.primary_build }}"
       ),
-
-      JsonPatch.add(
-        buildJobPath("/steps/3/if"),
-        "${{ matrix.runner.primary_build }}"
-      ),
-
-      // Skip steps that shouldn't run on Windows
       ...skippedStepPatches,
 
       // Install rsync on Windows

--- a/projenrc/windows-build.ts
+++ b/projenrc/windows-build.ts
@@ -76,11 +76,11 @@ export class WindowsBuild extends Component {
       ...skippedStepPatches,
 
       // Convert original build step to a bash shell matrix step
-      ...convertStepToShellMatrix(buildJobPath("/steps/3"), "bash"),
+      ...convertStepToShellMatrix("build", buildJobPath("/steps/3"), "bash"),
 
       // Copy original build step as a cmd shell matrix step
       JsonPatch.copy(buildJobPath("/steps/3"), buildJobPath("/steps/4")),
-      ...convertStepToShellMatrix(buildJobPath("/steps/4"), "cmd"),
+      ...convertStepToShellMatrix("build", buildJobPath("/steps/4"), "cmd"),
 
       // Install rsync on Windows
       JsonPatch.add(buildJobPath("/steps/0"), {
@@ -124,8 +124,13 @@ export class WindowsBuild extends Component {
  * Helper function to convert an existing step to a fake shell matrix step.
  * This is because 'shell' currently does not support expressions and thus matrix inputs.
  */
-function convertStepToShellMatrix(pathToStep: string, shell: string) {
+function convertStepToShellMatrix(
+  name: string,
+  pathToStep: string,
+  shell: string
+) {
   return [
+    JsonPatch.add(`${pathToStep}/name`, `${name} (${shell})`),
     JsonPatch.add(
       `${pathToStep}/if`,
       `\${{ matrix.runner.shell }} == '${shell}'`

--- a/projenrc/windows-build.ts
+++ b/projenrc/windows-build.ts
@@ -79,10 +79,21 @@ export class WindowsBuild extends Component {
       // Skip steps that shouldn't run on Windows
       ...skippedStepPatches,
 
-      // Rename workflow
+      // Install rsync on Windows
+      JsonPatch.add(buildJobPath("/steps/0"), {
+        name: "Install rsync on Windows",
+        if: `matrix.runner.os == 'windows-latest'`,
+        run: "choco install --no-progress rsync",
+        shell: "pwsh",
+      })
+    );
+
+    // Add the join target job for branch protection
+    buildWorkflowFile?.patch(
+      // Rename old workflow
       JsonPatch.move(buildJobPath(), `/jobs/${JOB_BUILD_MATRIX}`),
 
-      // Add the join target job for branch protection
+      // Insert new meta job
       JsonPatch.add(buildJobPath(), {
         "runs-on": "ubuntu-latest",
         needs: [JOB_BUILD_MATRIX],

--- a/projenrc/windows-build.ts
+++ b/projenrc/windows-build.ts
@@ -31,18 +31,6 @@ export class WindowsBuild extends Component {
       9,
     ];
 
-    const windowsBuildTasks = [
-      "default",
-      "pre-compile",
-      "compile",
-      "post-compile",
-      "test",
-    ];
-    const windowsBuildCommands = windowsBuildTasks.map(
-      (task) => `${this.project.projenCommand} ${task}`
-    );
-    const windowsBuild = windowsBuildCommands.join(" && ");
-
     const skippedStepPatches = skippedStepIndexes.map((stepIndex) =>
       JsonPatch.add(
         buildJobPath(`/steps/${stepIndex}/if`),
@@ -90,13 +78,6 @@ export class WindowsBuild extends Component {
 
       // Skip steps that shouldn't run on Windows
       ...skippedStepPatches,
-
-      JsonPatch.add(buildJobPath("/steps/4"), {
-        name: "build on windows",
-        run: windowsBuild,
-        shell: "cmd",
-        if: "${{ !matrix.runner.primary_build }}",
-      }),
 
       // Rename workflow
       JsonPatch.move(buildJobPath(), `/jobs/${JOB_BUILD_MATRIX}`),

--- a/src/cdk/jsii-project.ts
+++ b/src/cdk/jsii-project.ts
@@ -277,10 +277,12 @@ export class JsiiProject extends TypeScriptProject {
     // takes place in separate tasks.
     // outside of CI (i.e locally) we simply package all targets.
     this.packageTask.reset(prepareRepoForCI, {
-      condition: "! test -z ${CI}",
+      // Only run in CI
+      condition: `node -e "if (!process.env.CI) process.exit(1)"`,
     });
     this.packageTask.spawn(this.packageAllTask, {
-      condition: "test -z ${CI}",
+      // Don't run in CI
+      condition: `node -e "if (process.env.CI) process.exit(1)"`,
     });
 
     const targets: Record<string, any> = {};

--- a/src/cdk/jsii-project.ts
+++ b/src/cdk/jsii-project.ts
@@ -3,7 +3,6 @@ import { Range, major } from "semver";
 import { JsiiPacmakTarget, JSII_TOOLCHAIN } from "./consts";
 import { JsiiDocgen } from "./jsii-docgen";
 import { Task } from "..";
-import { shxIf } from "../github/util";
 import { Job, Step } from "../github/workflows-model";
 import { Eslint, NodePackageManager } from "../javascript";
 import {
@@ -277,13 +276,12 @@ export class JsiiProject extends TypeScriptProject {
     // when running inside CI we just prepare the repo for packaging, which
     // takes place in separate tasks.
     // outside of CI (i.e locally) we simply package all targets.
-    this.packageTask.reset(
-      shxIf(
-        `test -n "\${CI}"`,
-        prepareRepoForCI,
-        this.runTaskCommand(this.packageAllTask)
-      )
-    );
+    this.packageTask.reset(prepareRepoForCI, {
+      condition: "! test -z ${CI}",
+    });
+    this.packageTask.spawn(this.packageAllTask, {
+      condition: "test -z ${CI}",
+    });
 
     const targets: Record<string, any> = {};
 

--- a/src/cdk/jsii-project.ts
+++ b/src/cdk/jsii-project.ts
@@ -3,6 +3,7 @@ import { Range, major } from "semver";
 import { JsiiPacmakTarget, JSII_TOOLCHAIN } from "./consts";
 import { JsiiDocgen } from "./jsii-docgen";
 import { Task } from "..";
+import { shxIf } from "../github/util";
 import { Job, Step } from "../github/workflows-model";
 import { Eslint, NodePackageManager } from "../javascript";
 import {
@@ -277,9 +278,11 @@ export class JsiiProject extends TypeScriptProject {
     // takes place in separate tasks.
     // outside of CI (i.e locally) we simply package all targets.
     this.packageTask.reset(
-      `(test -n "\${CI}" && (${prepareRepoForCI})) || ${this.runTaskCommand(
-        this.packageAllTask
-      )}`
+      shxIf(
+        `test -n "\${CI}"`,
+        prepareRepoForCI,
+        this.runTaskCommand(this.packageAllTask)
+      )
     );
 
     const targets: Record<string, any> = {};

--- a/src/cdk/jsii-project.ts
+++ b/src/cdk/jsii-project.ts
@@ -277,9 +277,9 @@ export class JsiiProject extends TypeScriptProject {
     // takes place in separate tasks.
     // outside of CI (i.e locally) we simply package all targets.
     this.packageTask.reset(
-      `if [ ! -z \${CI} ]; then ${prepareRepoForCI}; else ${this.runTaskCommand(
+      `(test -n "\${CI}" && (${prepareRepoForCI})) || ${this.runTaskCommand(
         this.packageAllTask
-      )}; fi`
+      )}`
     );
 
     const targets: Record<string, any> = {};

--- a/src/github/util.ts
+++ b/src/github/util.ts
@@ -1,34 +1,3 @@
 export function secretToString(secretName: string): string {
   return `\${{ secrets.${secretName} }}`;
 }
-
-/**
- * Bash if equivalent execution of scripts that is compatible with shx.
- * Execution will fail, if the when or then command fails.
- *
- * @param when The condition to evaluate. Usually a `test` command. This command may be executed twice. Make sure it is non mutating.
- * @param then The script to run if the condition is true.
- * @param otherwise The script to run if the condition is false.
- */
-export function shxIf(when: string, then: string, otherwise?: string): string {
-  // Connect the condition and the 'then' command with a logical AND.
-  // If the condition is true, this will execute the 'then' command.
-  // This case is equivalent to TRUE && then()
-  // If the condition is false, this will exit with a non-zero status code
-  // (indicating an error) without executing the 'then' command.
-  // This case is equivalent to FALSE && then()
-  const if_clause = `${when} && (${then})`;
-
-  // For the else clause, we need to check the 'when' condition again,
-  // because the if clause can also return FALSE if the 'then' command fails.
-  // However in this situation we don't want to execute the else clause but report an error.
-  const else_clause = `${when} || (${otherwise})`;
-
-  // Try the if_clause first. If it fails try the else clause.
-  if (otherwise) {
-    return `(${if_clause}) || (${else_clause})`;
-  }
-
-  // Just run the if clause
-  return if_clause;
-}

--- a/src/github/util.ts
+++ b/src/github/util.ts
@@ -6,14 +6,29 @@ export function secretToString(secretName: string): string {
  * Bash if equivalent execution of scripts that is compatible with shx.
  * Execution will fail, if the when or then command fails.
  *
- * @param condition The condition to evaluate. Usually a `test`
- * @param when The script to run when the condition is true.
- * @param then The script to run when the condition is false.
+ * @param when The condition to evaluate. Usually a `test` command. This command may be executed twice. Make sure it is non mutating.
+ * @param then The script to run if the condition is true.
+ * @param otherwise The script to run if the condition is false.
  */
-export function shxIf(
-  condition: string,
-  when: string,
-  then: string = 'echo "OK"'
-): string {
-  return `${condition} && ((${when}) || exit 1) || ${then}`;
+export function shxIf(when: string, then: string, otherwise?: string): string {
+  // Connect the condition and the 'then' command with a logical AND.
+  // If the condition is true, this will execute the 'then' command.
+  // This case is equivalent to TRUE && then()
+  // If the condition is false, this will exit with a non-zero status code
+  // (indicating an error) without executing the 'then' command.
+  // This case is equivalent to FALSE && then()
+  const if_clause = `${when} && (${then})`;
+
+  // For the else clause, we need to check the 'when' condition again,
+  // because the if clause can also return FALSE if the 'then' command fails.
+  // However in this situation we don't want to execute the else clause but report an error.
+  const else_clause = `${when} || (${otherwise})`;
+
+  // Try the if_clause first. If it fails try the else clause.
+  if (otherwise) {
+    return `(${if_clause}) || (${else_clause})`;
+  }
+
+  // Just run the if clause
+  return if_clause;
 }

--- a/src/github/util.ts
+++ b/src/github/util.ts
@@ -1,3 +1,19 @@
 export function secretToString(secretName: string): string {
   return `\${{ secrets.${secretName} }}`;
 }
+
+/**
+ * Bash if equivalent execution of scripts that is compatible with shx.
+ * Execution will fail, if the when or then command fails.
+ *
+ * @param condition The condition to evaluate. Usually a `test`
+ * @param when The script to run when the condition is true.
+ * @param then The script to run when the condition is false.
+ */
+export function shxIf(
+  condition: string,
+  when: string,
+  then: string = 'echo "OK"'
+): string {
+  return `${condition} && ((${when}) || exit 1) || ${then}`;
+}

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -1042,7 +1042,7 @@ tsconfig.tsbuildinfo
       "description": "Creates the distribution package",
       "steps": [
         {
-          "exec": "if [ ! -z \${CI} ]; then rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist; else npx projen package-all; fi"
+          "exec": "(test -n \\"\${CI}\\" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || npx projen package-all"
         }
       ]
     },
@@ -2127,7 +2127,7 @@ tsconfig.tsbuildinfo
       "description": "Creates the distribution package",
       "steps": [
         {
-          "exec": "if [ ! -z \${CI} ]; then rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist; else npx projen package-all; fi"
+          "exec": "(test -n \\"\${CI}\\" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || npx projen package-all"
         }
       ]
     },

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -1042,7 +1042,7 @@ tsconfig.tsbuildinfo
       "description": "Creates the distribution package",
       "steps": [
         {
-          "exec": "test -n \\"\${CI}\\" && ((rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist) || exit 1) || npx projen package-all"
+          "exec": "(test -n \\"\${CI}\\" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || (test -n \\"\${CI}\\" || (npx projen package-all))"
         }
       ]
     },
@@ -2127,7 +2127,7 @@ tsconfig.tsbuildinfo
       "description": "Creates the distribution package",
       "steps": [
         {
-          "exec": "test -n \\"\${CI}\\" && ((rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist) || exit 1) || npx projen package-all"
+          "exec": "(test -n \\"\${CI}\\" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || (test -n \\"\${CI}\\" || (npx projen package-all))"
         }
       ]
     },

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -1043,11 +1043,11 @@ tsconfig.tsbuildinfo
       "steps": [
         {
           "exec": "rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist",
-          "condition": "! test -z \${CI}"
+          "condition": "node -e \\"if (!process.env.CI) process.exit(1)\\""
         },
         {
           "spawn": "package-all",
-          "condition": "test -z \${CI}"
+          "condition": "node -e \\"if (process.env.CI) process.exit(1)\\""
         }
       ]
     },
@@ -2133,11 +2133,11 @@ tsconfig.tsbuildinfo
       "steps": [
         {
           "exec": "rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist",
-          "condition": "! test -z \${CI}"
+          "condition": "node -e \\"if (!process.env.CI) process.exit(1)\\""
         },
         {
           "spawn": "package-all",
-          "condition": "test -z \${CI}"
+          "condition": "node -e \\"if (process.env.CI) process.exit(1)\\""
         }
       ]
     },

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -1042,7 +1042,12 @@ tsconfig.tsbuildinfo
       "description": "Creates the distribution package",
       "steps": [
         {
-          "exec": "(test -n \\"\${CI}\\" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || (test -n \\"\${CI}\\" || (npx projen package-all))"
+          "exec": "rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist",
+          "condition": "! test -z \${CI}"
+        },
+        {
+          "spawn": "package-all",
+          "condition": "test -z \${CI}"
         }
       ]
     },
@@ -2127,7 +2132,12 @@ tsconfig.tsbuildinfo
       "description": "Creates the distribution package",
       "steps": [
         {
-          "exec": "(test -n \\"\${CI}\\" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || (test -n \\"\${CI}\\" || (npx projen package-all))"
+          "exec": "rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist",
+          "condition": "! test -z \${CI}"
+        },
+        {
+          "spawn": "package-all",
+          "condition": "test -z \${CI}"
         }
       ]
     },

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -1042,7 +1042,7 @@ tsconfig.tsbuildinfo
       "description": "Creates the distribution package",
       "steps": [
         {
-          "exec": "(test -n \\"\${CI}\\" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || npx projen package-all"
+          "exec": "test -n \\"\${CI}\\" && ((rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist) || exit 1) || npx projen package-all"
         }
       ]
     },
@@ -2127,7 +2127,7 @@ tsconfig.tsbuildinfo
       "description": "Creates the distribution package",
       "steps": [
         {
-          "exec": "(test -n \\"\${CI}\\" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || npx projen package-all"
+          "exec": "test -n \\"\${CI}\\" && ((rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist) || exit 1) || npx projen package-all"
         }
       ]
     },

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -994,7 +994,12 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": [
           {
-            "exec": "(test -n "\${CI}" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || (test -n "\${CI}" || (npx projen package-all))",
+            "condition": "! test -z \${CI}",
+            "exec": "rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist",
+          },
+          {
+            "condition": "test -z \${CI}",
+            "spawn": "package-all",
           },
         ],
       },

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -994,7 +994,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": [
           {
-            "exec": "if [ ! -z \${CI} ]; then rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist; else npx projen package-all; fi",
+            "exec": "(test -n "\${CI}" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || npx projen package-all",
           },
         ],
       },

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -994,11 +994,11 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": [
           {
-            "condition": "! test -z \${CI}",
+            "condition": "node -e "if (!process.env.CI) process.exit(1)"",
             "exec": "rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist",
           },
           {
-            "condition": "test -z \${CI}",
+            "condition": "node -e "if (process.env.CI) process.exit(1)"",
             "spawn": "package-all",
           },
         ],

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -994,7 +994,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": [
           {
-            "exec": "(test -n "\${CI}" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || npx projen package-all",
+            "exec": "test -n "\${CI}" && ((rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist) || exit 1) || npx projen package-all",
           },
         ],
       },

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -994,7 +994,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": [
           {
-            "exec": "test -n "\${CI}" && ((rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist) || exit 1) || npx projen package-all",
+            "exec": "(test -n "\${CI}" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || (test -n "\${CI}" || (npx projen package-all))",
           },
         ],
       },

--- a/test/jsii/__snapshots__/jsii.test.ts.snap
+++ b/test/jsii/__snapshots__/jsii.test.ts.snap
@@ -994,7 +994,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": [
           {
-            "exec": "(test -n "\${CI}" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || npx projen package-all",
+            "exec": "test -n "\${CI}" && ((rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist) || exit 1) || npx projen package-all",
           },
         ],
       },
@@ -2480,7 +2480,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": [
           {
-            "exec": "(test -n "\${CI}" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || npx projen package-all",
+            "exec": "test -n "\${CI}" && ((rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist) || exit 1) || npx projen package-all",
           },
         ],
       },
@@ -3964,7 +3964,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": [
           {
-            "exec": "(test -n "\${CI}" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || npx projen package-all",
+            "exec": "test -n "\${CI}" && ((rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist) || exit 1) || npx projen package-all",
           },
         ],
       },
@@ -5445,7 +5445,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": [
           {
-            "exec": "(test -n "\${CI}" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || npx projen package-all",
+            "exec": "test -n "\${CI}" && ((rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist) || exit 1) || npx projen package-all",
           },
         ],
       },

--- a/test/jsii/__snapshots__/jsii.test.ts.snap
+++ b/test/jsii/__snapshots__/jsii.test.ts.snap
@@ -994,7 +994,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": [
           {
-            "exec": "test -n "\${CI}" && ((rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist) || exit 1) || npx projen package-all",
+            "exec": "(test -n "\${CI}" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || (test -n "\${CI}" || (npx projen package-all))",
           },
         ],
       },
@@ -2480,7 +2480,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": [
           {
-            "exec": "test -n "\${CI}" && ((rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist) || exit 1) || npx projen package-all",
+            "exec": "(test -n "\${CI}" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || (test -n "\${CI}" || (npx projen package-all))",
           },
         ],
       },
@@ -3964,7 +3964,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": [
           {
-            "exec": "test -n "\${CI}" && ((rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist) || exit 1) || npx projen package-all",
+            "exec": "(test -n "\${CI}" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || (test -n "\${CI}" || (npx projen package-all))",
           },
         ],
       },
@@ -5445,7 +5445,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": [
           {
-            "exec": "test -n "\${CI}" && ((rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist) || exit 1) || npx projen package-all",
+            "exec": "(test -n "\${CI}" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || (test -n "\${CI}" || (npx projen package-all))",
           },
         ],
       },

--- a/test/jsii/__snapshots__/jsii.test.ts.snap
+++ b/test/jsii/__snapshots__/jsii.test.ts.snap
@@ -994,7 +994,12 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": [
           {
-            "exec": "(test -n "\${CI}" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || (test -n "\${CI}" || (npx projen package-all))",
+            "condition": "! test -z \${CI}",
+            "exec": "rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist",
+          },
+          {
+            "condition": "test -z \${CI}",
+            "spawn": "package-all",
           },
         ],
       },
@@ -2480,7 +2485,12 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": [
           {
-            "exec": "(test -n "\${CI}" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || (test -n "\${CI}" || (npx projen package-all))",
+            "condition": "! test -z \${CI}",
+            "exec": "rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist",
+          },
+          {
+            "condition": "test -z \${CI}",
+            "spawn": "package-all",
           },
         ],
       },
@@ -3964,7 +3974,12 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": [
           {
-            "exec": "(test -n "\${CI}" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || (test -n "\${CI}" || (npx projen package-all))",
+            "condition": "! test -z \${CI}",
+            "exec": "rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist",
+          },
+          {
+            "condition": "test -z \${CI}",
+            "spawn": "package-all",
           },
         ],
       },
@@ -5445,7 +5460,12 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": [
           {
-            "exec": "(test -n "\${CI}" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || (test -n "\${CI}" || (npx projen package-all))",
+            "condition": "! test -z \${CI}",
+            "exec": "rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist",
+          },
+          {
+            "condition": "test -z \${CI}",
+            "spawn": "package-all",
           },
         ],
       },

--- a/test/jsii/__snapshots__/jsii.test.ts.snap
+++ b/test/jsii/__snapshots__/jsii.test.ts.snap
@@ -994,7 +994,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": [
           {
-            "exec": "if [ ! -z \${CI} ]; then rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist; else npx projen package-all; fi",
+            "exec": "(test -n "\${CI}" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || npx projen package-all",
           },
         ],
       },
@@ -2480,7 +2480,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": [
           {
-            "exec": "if [ ! -z \${CI} ]; then rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist; else npx projen package-all; fi",
+            "exec": "(test -n "\${CI}" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || npx projen package-all",
           },
         ],
       },
@@ -3964,7 +3964,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": [
           {
-            "exec": "if [ ! -z \${CI} ]; then rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist; else npx projen package-all; fi",
+            "exec": "(test -n "\${CI}" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || npx projen package-all",
           },
         ],
       },
@@ -5445,7 +5445,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": [
           {
-            "exec": "if [ ! -z \${CI} ]; then rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist; else npx projen package-all; fi",
+            "exec": "(test -n "\${CI}" && (rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist)) || npx projen package-all",
           },
         ],
       },

--- a/test/jsii/__snapshots__/jsii.test.ts.snap
+++ b/test/jsii/__snapshots__/jsii.test.ts.snap
@@ -994,11 +994,11 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": [
           {
-            "condition": "! test -z \${CI}",
+            "condition": "node -e "if (!process.env.CI) process.exit(1)"",
             "exec": "rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist",
           },
           {
-            "condition": "test -z \${CI}",
+            "condition": "node -e "if (process.env.CI) process.exit(1)"",
             "spawn": "package-all",
           },
         ],
@@ -2485,11 +2485,11 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": [
           {
-            "condition": "! test -z \${CI}",
+            "condition": "node -e "if (!process.env.CI) process.exit(1)"",
             "exec": "rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist",
           },
           {
-            "condition": "test -z \${CI}",
+            "condition": "node -e "if (process.env.CI) process.exit(1)"",
             "spawn": "package-all",
           },
         ],
@@ -3974,11 +3974,11 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": [
           {
-            "condition": "! test -z \${CI}",
+            "condition": "node -e "if (!process.env.CI) process.exit(1)"",
             "exec": "rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist",
           },
           {
-            "condition": "test -z \${CI}",
+            "condition": "node -e "if (process.env.CI) process.exit(1)"",
             "spawn": "package-all",
           },
         ],
@@ -5460,11 +5460,11 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "package",
         "steps": [
           {
-            "condition": "! test -z \${CI}",
+            "condition": "node -e "if (!process.env.CI) process.exit(1)"",
             "exec": "rsync -a . .repo --exclude .git --exclude node_modules && rm -rf dist && mv .repo dist",
           },
           {
-            "condition": "test -z \${CI}",
+            "condition": "node -e "if (process.env.CI) process.exit(1)"",
             "spawn": "package-all",
           },
         ],


### PR DESCRIPTION
Fixes the failing packaging step in windows builds.

Instead of a complex bash expression, this now leverages  a feature of the projen task runner.
- Firstly, replacing the `if` statement with task step conditions 
- Secondly, use `node` to check if we are in CI. Unlike bash commands, node should always be available
- Thirdly, installing `rsync` on windows runners

Additionally this reverts the special treatment of packaging in Windows builds.

Resolves #2761

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
