### PR TITLE
fix(typescript): Jest `testMatch` doesn't match compiled JS files

### DIFF
--- a/src/typescript/typescript.ts
+++ b/src/typescript/typescript.ts
@@ -626,7 +626,7 @@ export class TypeScriptProject extends NodeProject {
     jest.discoverTestMatchPatternsForDirs([libtest], {
       fileExtensionPattern: this.tsconfig?.compilerOptions?.allowJs
         ? undefined
-        : "ts?(x)",
+        : "js?(x)",
     });
     jest.addWatchIgnorePattern(`/${this.srcdir}/`);
 

--- a/test/javascript/jest.test.ts
+++ b/test/javascript/jest.test.ts
@@ -180,7 +180,7 @@ test("jestOptions.typeScriptCompilerOptions is deprecated", () => {
   );
 });
 
-test("testdir is under src", () => {
+test("testdir is under src discovers compiled js tests", () => {
   // WHEN
   const project = new TypeScriptProject({
     defaultReleaseBranch: "master",
@@ -192,9 +192,12 @@ test("testdir is under src", () => {
   // THEN
   const files = synthSnapshot(project);
   expect(files["package.json"].jest.testMatch).toStrictEqual([
-    "<rootDir>/@(lib/boom/bam/__tests)/**/*(*.)@(spec|test).ts?(x)",
-    "<rootDir>/@(lib/boom/bam/__tests)/**/__tests__/**/*.ts?(x)",
+    "<rootDir>/@(lib/boom/bam/__tests)/**/*(*.)@(spec|test).js?(x)",
+    "<rootDir>/@(lib/boom/bam/__tests)/**/__tests__/**/*.js?(x)",
   ]);
+  files["package.json"].jest.testMatch.forEach((testMatch: string) =>
+    expect(testMatch).toContain(".js")
+  );
 });
 
 test("default testMatch patterns are added to jest config", () => {


### PR DESCRIPTION
This accidentally slipped through in #3637

Fixes #3735

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
