### PR TITLE
feat(gitlab): support for `default.id_token` configuration

### DIFF
--- a/docs/api/gitlab.md
+++ b/docs/api/gitlab.md
@@ -265,6 +265,7 @@ Test whether the given construct is a component.
 | <code><a href="#projen.gitlab.CiConfiguration.property.variables">variables</a></code> | <code>{[ key: string ]: string \| number \| <a href="#projen.gitlab.VariableConfig">VariableConfig</a>}</code> | Global variables that are passed to jobs. |
 | <code><a href="#projen.gitlab.CiConfiguration.property.defaultArtifacts">defaultArtifacts</a></code> | <code><a href="#projen.gitlab.Artifacts">Artifacts</a></code> | Default list of files and directories that should be attached to the job if it succeeds. |
 | <code><a href="#projen.gitlab.CiConfiguration.property.defaultCache">defaultCache</a></code> | <code><a href="#projen.gitlab.Cache">Cache</a>[]</code> | *No description.* |
+| <code><a href="#projen.gitlab.CiConfiguration.property.defaultIdTokens">defaultIdTokens</a></code> | <code>{[ key: string ]: <a href="#projen.gitlab.IDToken">IDToken</a>}</code> | Default ID tokens (JSON Web Tokens) that are used for CI/CD authentication to use globally for all jobs. |
 | <code><a href="#projen.gitlab.CiConfiguration.property.defaultImage">defaultImage</a></code> | <code><a href="#projen.gitlab.Image">Image</a></code> | Specifies the default docker image to use globally for all jobs. |
 | <code><a href="#projen.gitlab.CiConfiguration.property.defaultInterruptible">defaultInterruptible</a></code> | <code>boolean</code> | The default behavior for whether a job should be canceled when a newer pipeline starts before the job completes (Default: false). |
 | <code><a href="#projen.gitlab.CiConfiguration.property.defaultRetry">defaultRetry</a></code> | <code><a href="#projen.gitlab.Retry">Retry</a></code> | How many times a job is retried if it fails. |
@@ -434,6 +435,18 @@ public readonly defaultCache: Cache[];
 ```
 
 - *Type:* <a href="#projen.gitlab.Cache">Cache</a>[]
+
+---
+
+##### `defaultIdTokens`<sup>Optional</sup> <a name="defaultIdTokens" id="projen.gitlab.CiConfiguration.property.defaultIdTokens"></a>
+
+```typescript
+public readonly defaultIdTokens: {[ key: string ]: IDToken};
+```
+
+- *Type:* {[ key: string ]: <a href="#projen.gitlab.IDToken">IDToken</a>}
+
+Default ID tokens (JSON Web Tokens) that are used for CI/CD authentication to use globally for all jobs.
 
 ---
 
@@ -790,6 +803,7 @@ Test whether the given construct is a component.
 | <code><a href="#projen.gitlab.GitlabConfiguration.property.variables">variables</a></code> | <code>{[ key: string ]: string \| number \| <a href="#projen.gitlab.VariableConfig">VariableConfig</a>}</code> | Global variables that are passed to jobs. |
 | <code><a href="#projen.gitlab.GitlabConfiguration.property.defaultArtifacts">defaultArtifacts</a></code> | <code><a href="#projen.gitlab.Artifacts">Artifacts</a></code> | Default list of files and directories that should be attached to the job if it succeeds. |
 | <code><a href="#projen.gitlab.GitlabConfiguration.property.defaultCache">defaultCache</a></code> | <code><a href="#projen.gitlab.Cache">Cache</a>[]</code> | *No description.* |
+| <code><a href="#projen.gitlab.GitlabConfiguration.property.defaultIdTokens">defaultIdTokens</a></code> | <code>{[ key: string ]: <a href="#projen.gitlab.IDToken">IDToken</a>}</code> | Default ID tokens (JSON Web Tokens) that are used for CI/CD authentication to use globally for all jobs. |
 | <code><a href="#projen.gitlab.GitlabConfiguration.property.defaultImage">defaultImage</a></code> | <code><a href="#projen.gitlab.Image">Image</a></code> | Specifies the default docker image to use globally for all jobs. |
 | <code><a href="#projen.gitlab.GitlabConfiguration.property.defaultInterruptible">defaultInterruptible</a></code> | <code>boolean</code> | The default behavior for whether a job should be canceled when a newer pipeline starts before the job completes (Default: false). |
 | <code><a href="#projen.gitlab.GitlabConfiguration.property.defaultRetry">defaultRetry</a></code> | <code><a href="#projen.gitlab.Retry">Retry</a></code> | How many times a job is retried if it fails. |
@@ -960,6 +974,18 @@ public readonly defaultCache: Cache[];
 ```
 
 - *Type:* <a href="#projen.gitlab.Cache">Cache</a>[]
+
+---
+
+##### `defaultIdTokens`<sup>Optional</sup> <a name="defaultIdTokens" id="projen.gitlab.GitlabConfiguration.property.defaultIdTokens"></a>
+
+```typescript
+public readonly defaultIdTokens: {[ key: string ]: IDToken};
+```
+
+- *Type:* {[ key: string ]: <a href="#projen.gitlab.IDToken">IDToken</a>}
+
+Default ID tokens (JSON Web Tokens) that are used for CI/CD authentication to use globally for all jobs.
 
 ---
 
@@ -1321,6 +1347,7 @@ Test whether the given construct is a component.
 | <code><a href="#projen.gitlab.NestedConfiguration.property.variables">variables</a></code> | <code>{[ key: string ]: string \| number \| <a href="#projen.gitlab.VariableConfig">VariableConfig</a>}</code> | Global variables that are passed to jobs. |
 | <code><a href="#projen.gitlab.NestedConfiguration.property.defaultArtifacts">defaultArtifacts</a></code> | <code><a href="#projen.gitlab.Artifacts">Artifacts</a></code> | Default list of files and directories that should be attached to the job if it succeeds. |
 | <code><a href="#projen.gitlab.NestedConfiguration.property.defaultCache">defaultCache</a></code> | <code><a href="#projen.gitlab.Cache">Cache</a>[]</code> | *No description.* |
+| <code><a href="#projen.gitlab.NestedConfiguration.property.defaultIdTokens">defaultIdTokens</a></code> | <code>{[ key: string ]: <a href="#projen.gitlab.IDToken">IDToken</a>}</code> | Default ID tokens (JSON Web Tokens) that are used for CI/CD authentication to use globally for all jobs. |
 | <code><a href="#projen.gitlab.NestedConfiguration.property.defaultImage">defaultImage</a></code> | <code><a href="#projen.gitlab.Image">Image</a></code> | Specifies the default docker image to use globally for all jobs. |
 | <code><a href="#projen.gitlab.NestedConfiguration.property.defaultInterruptible">defaultInterruptible</a></code> | <code>boolean</code> | The default behavior for whether a job should be canceled when a newer pipeline starts before the job completes (Default: false). |
 | <code><a href="#projen.gitlab.NestedConfiguration.property.defaultRetry">defaultRetry</a></code> | <code><a href="#projen.gitlab.Retry">Retry</a></code> | How many times a job is retried if it fails. |
@@ -1491,6 +1518,18 @@ public readonly defaultCache: Cache[];
 ```
 
 - *Type:* <a href="#projen.gitlab.Cache">Cache</a>[]
+
+---
+
+##### `defaultIdTokens`<sup>Optional</sup> <a name="defaultIdTokens" id="projen.gitlab.NestedConfiguration.property.defaultIdTokens"></a>
+
+```typescript
+public readonly defaultIdTokens: {[ key: string ]: IDToken};
+```
+
+- *Type:* {[ key: string ]: <a href="#projen.gitlab.IDToken">IDToken</a>}
+
+Default ID tokens (JSON Web Tokens) that are used for CI/CD authentication to use globally for all jobs.
 
 ---
 
@@ -2113,6 +2152,7 @@ const default: gitlab.Default = { ... }
 | <code><a href="#projen.gitlab.Default.property.artifacts">artifacts</a></code> | <code><a href="#projen.gitlab.Artifacts">Artifacts</a></code> | *No description.* |
 | <code><a href="#projen.gitlab.Default.property.beforeScript">beforeScript</a></code> | <code>string[]</code> | *No description.* |
 | <code><a href="#projen.gitlab.Default.property.cache">cache</a></code> | <code><a href="#projen.gitlab.Cache">Cache</a>[]</code> | *No description.* |
+| <code><a href="#projen.gitlab.Default.property.idTokens">idTokens</a></code> | <code>{[ key: string ]: <a href="#projen.gitlab.IDToken">IDToken</a>}</code> | Specifies the default ID tokens (JSON Web Tokens) that are used for CI/CD authentication to use globally for all jobs. |
 | <code><a href="#projen.gitlab.Default.property.image">image</a></code> | <code><a href="#projen.gitlab.Image">Image</a></code> | *No description.* |
 | <code><a href="#projen.gitlab.Default.property.interruptible">interruptible</a></code> | <code>boolean</code> | *No description.* |
 | <code><a href="#projen.gitlab.Default.property.retry">retry</a></code> | <code><a href="#projen.gitlab.Retry">Retry</a></code> | *No description.* |
@@ -2159,6 +2199,18 @@ public readonly cache: Cache[];
 ```
 
 - *Type:* <a href="#projen.gitlab.Cache">Cache</a>[]
+
+---
+
+##### `idTokens`<sup>Optional</sup> <a name="idTokens" id="projen.gitlab.Default.property.idTokens"></a>
+
+```typescript
+public readonly idTokens: {[ key: string ]: IDToken};
+```
+
+- *Type:* {[ key: string ]: <a href="#projen.gitlab.IDToken">IDToken</a>}
+
+Specifies the default ID tokens (JSON Web Tokens) that are used for CI/CD authentication to use globally for all jobs.
 
 ---
 

--- a/src/gitlab/configuration-model.ts
+++ b/src/gitlab/configuration-model.ts
@@ -76,6 +76,8 @@ export interface Default {
   readonly beforeScript?: string[];
   /* A list of cache definitions (max. 4) with the files and directories to cache between jobs. You can only use paths that are in the local working copy. */
   readonly cache?: Cache[];
+  /** Specifies the default ID tokens (JSON Web Tokens) that are used for CI/CD authentication to use globally for all jobs. */
+  readonly idTokens?: Record<string, IDToken>;
   /* Specifies the default docker image to use globally for all jobs. */
   readonly image?: Image;
   /* If a job should be canceled when a newer pipeline starts before the job completes (Default: false).*/

--- a/src/gitlab/configuration.ts
+++ b/src/gitlab/configuration.ts
@@ -4,6 +4,7 @@ import {
   Artifacts,
   Cache,
   Default,
+  IDToken,
   Image,
   Include,
   Job,
@@ -112,6 +113,10 @@ export class CiConfiguration extends Component {
    */
   readonly defaultTimeout?: string;
   /**
+   * Default ID tokens (JSON Web Tokens) that are used for CI/CD authentication to use globally for all jobs.
+   */
+  readonly defaultIdTokens?: Record<string, IDToken>;
+  /**
    * Can be `Include` or `Include[]`. Each `Include` will be a string, or an
    * object with properties for the method if including external YAML file. The external
    * content will be fetched, included and evaluated along the `.gitlab-ci.yml`.
@@ -165,6 +170,7 @@ export class CiConfiguration extends Component {
       defaults.beforeScript &&
         this.defaultBeforeScript.push(...defaults.beforeScript);
       defaults.cache && this.addDefaultCaches(defaults.cache);
+      this.defaultIdTokens = defaults.idTokens;
       this.defaultImage = defaults.image;
       this.defaultInterruptible = defaults.interruptible;
       this.defaultRetry = defaults.retry;
@@ -373,6 +379,7 @@ export class CiConfiguration extends Component {
           ? this.defaultBeforeScript
           : undefined,
       cache: this.defaultCache,
+      idTokens: this.defaultIdTokens,
       image: this.defaultImage,
       interruptible: this.defaultInterruptible,
       retry: this.defaultRetry,

--- a/test/gitlab/configuration.test.ts
+++ b/test/gitlab/configuration.test.ts
@@ -324,6 +324,24 @@ test("adds correct entries for fallback-keys caching", () => {
   expect(snapshot[".gitlab/ci-templates/foo.yml"]).toMatchSnapshot();
 });
 
+test("add default tokens to all jobs", () => {
+  // GIVEN
+  const p = new TestProject();
+  new CiConfiguration(p, "foo", {
+    default: {
+      idTokens: { TEST_ID_TOKEN: { aud: "https://test.service.com" } },
+    },
+    jobs: {
+      build: {},
+    },
+  });
+  // THEN
+  expect(
+    YAML.parse(synthSnapshot(p)[".gitlab/ci-templates/foo.yml"]).default
+      .id_tokens
+  ).toStrictEqual({ TEST_ID_TOKEN: { aud: "https://test.service.com" } });
+});
+
 test("does not snake job names", () => {
   // GIVEN
   const p = new TestProject({


### PR DESCRIPTION
Adds the missing default configuration option for `id_tokens` as documented in [Gitlab docs](https://docs.gitlab.com/ee/ci/yaml/#default).


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
