### PR TITLE
fix(bump): exclamation operator `!` is not recognized when running bump on windows

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -40,7 +40,7 @@
           "builtin": "release/bump-version"
         }
       ],
-      "condition": "git log HEAD --exit-code --oneline --grep \"chore(release):\""
+      "condition": "git log --oneline -1 | grep -qv \"chore(release):\""
     },
     "bundle:task-runner": {
       "name": "bundle:task-runner",

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -40,7 +40,7 @@
           "builtin": "release/bump-version"
         }
       ],
-      "condition": "(git log --oneline -1 | grep -q \"chore(release):\") && exit 1 || exit 0"
+      "condition": "git log HEAD --exit-code --oneline --grep \"chore(release):\""
     },
     "bundle:task-runner": {
       "name": "bundle:task-runner",

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -40,7 +40,7 @@
           "builtin": "release/bump-version"
         }
       ],
-      "condition": "! git log --oneline -1 | grep -q \"chore(release):\""
+      "condition": "(git log --oneline -1 | grep -q \"chore(release):\") && exit 1 || exit 0"
     },
     "bundle:task-runner": {
       "name": "bundle:task-runner",

--- a/src/release/publisher.ts
+++ b/src/release/publisher.ts
@@ -15,6 +15,7 @@ import {
 import { defaultNpmToken } from "../javascript/node-package";
 import { Project } from "../project";
 import { GroupRunnerOptions, filteredRunsOnOptions } from "../runner-options";
+import { CHANGES_SINCE_LAST_RELEASE } from "../version";
 
 const PUBLIB_VERSION = "latest";
 const GITHUB_PACKAGES_REGISTRY = "npm.pkg.github.com";
@@ -261,7 +262,7 @@ export class Publisher extends Component {
         PROJECT_CHANGELOG_FILE: projectChangelogFile ?? "",
         VERSION_FILE: versionFile,
       },
-      condition: '! git log --oneline -1 | grep -q "chore(release):"',
+      condition: CHANGES_SINCE_LAST_RELEASE,
     });
     if (projectChangelogFile) {
       publishTask.builtin("release/update-changelog");

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,6 +3,12 @@ import { Component } from "./component";
 import { Project } from "./project";
 import { Task } from "./task";
 
+// this command determines if there were any changes since the last release
+// (the top-most commit is not a bump). it is used as a condition for both
+// the `bump` and the `release` tasks.
+export const CHANGES_SINCE_LAST_RELEASE =
+  '(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0';
+
 /**
  * Options for `Version`.
  */
@@ -69,12 +75,6 @@ export class Version extends Component {
 
     const versionInputFile = options.versionInputFile;
 
-    // this command determines if there were any changes since the last release
-    // (the top-most commit is not a bump). it is used as a condition for both
-    // the `bump` and the `release` tasks.
-    const changesSinceLastRelease =
-      '! git log --oneline -1 | grep -q "chore(release):"';
-
     const changelogFile = posix.join(
       options.artifactsDirectory,
       this.changelogFileName
@@ -105,7 +105,7 @@ export class Version extends Component {
     this.bumpTask = project.addTask("bump", {
       description:
         "Bumps version based on latest git tag and generates a changelog entry",
-      condition: changesSinceLastRelease,
+      condition: CHANGES_SINCE_LAST_RELEASE,
       env: { ...commonEnv },
     });
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -9,9 +9,11 @@ import { Task } from "./task";
  *
  * Explanation:
  *  - log commits                                               | git log
- *  - looks only at the most recent commit                      | -1
  *  - limit log output to a single line per commit              | --oneline
- *  - filter commits using simple grep using our search string  | --grep "chore(release):"
+ *  - looks only at the most recent commit                      | -1
+ *  - silent grep output                                        | grep -q
+ *  - exits with code 0 if a match is found                     | grep -q "chore(release):"
+ *  - exits with code 1 if a match is found (reverse-match)     | grep -qv "chore(release):"
  */
 export const CHANGES_SINCE_LAST_RELEASE =
   'git log --oneline -1 | grep -qv "chore(release):"';

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,11 +3,19 @@ import { Component } from "./component";
 import { Project } from "./project";
 import { Task } from "./task";
 
-// this command determines if there were any changes since the last release
-// (the top-most commit is not a bump). it is used as a condition for both
-// the `bump` and the `release` tasks.
+/**
+ * This command determines if there were any changes since the last release in a cross-platform compatible way.
+ * It is used as a condition for both the `bump` and the `release` tasks.
+ *
+ * Explanation:
+ *  - log commits                                               | git log
+ *  - looks only at the most recent commit                      | HEAD
+ *  - returns exit code 1 if any commits are found, 0 otherwise | --exit-code
+ *  - limit log output to a single line per commit              | --oneline
+ *  - filter commits using simple grep using our search string  | --grep "chore(release):"
+ */
 export const CHANGES_SINCE_LAST_RELEASE =
-  '(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0';
+  'git log HEAD --exit-code --oneline --grep "chore(release):"';
 
 /**
  * Options for `Version`.

--- a/src/version.ts
+++ b/src/version.ts
@@ -9,13 +9,12 @@ import { Task } from "./task";
  *
  * Explanation:
  *  - log commits                                               | git log
- *  - looks only at the most recent commit                      | HEAD
- *  - returns exit code 1 if any commits are found, 0 otherwise | --exit-code
+ *  - looks only at the most recent commit                      | -1
  *  - limit log output to a single line per commit              | --oneline
  *  - filter commits using simple grep using our search string  | --grep "chore(release):"
  */
 export const CHANGES_SINCE_LAST_RELEASE =
-  'git log HEAD --exit-code --oneline --grep "chore(release):"';
+  'git log --oneline -1 | grep -qv "chore(release):"';
 
 /**
  * Options for `Version`.

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -927,7 +927,7 @@ tsconfig.tsbuildinfo
           "builtin": "release/bump-version"
         }
       ],
-      "condition": "! git log --oneline -1 | grep -q \\"chore(release):\\""
+      "condition": "(git log --oneline -1 | grep -q \\"chore(release):\\") && exit 1 || exit 0"
     },
     "clobber": {
       "name": "clobber",
@@ -4324,7 +4324,7 @@ resolution-mode=highest
           "builtin": "release/bump-version"
         }
       ],
-      "condition": "! git log --oneline -1 | grep -q \\"chore(release):\\""
+      "condition": "(git log --oneline -1 | grep -q \\"chore(release):\\") && exit 1 || exit 0"
     },
     "clobber": {
       "name": "clobber",

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -927,7 +927,7 @@ tsconfig.tsbuildinfo
           "builtin": "release/bump-version"
         }
       ],
-      "condition": "git log HEAD --exit-code --oneline --grep \\"chore(release):\\""
+      "condition": "git log --oneline -1 | grep -qv \\"chore(release):\\""
     },
     "clobber": {
       "name": "clobber",
@@ -4324,7 +4324,7 @@ resolution-mode=highest
           "builtin": "release/bump-version"
         }
       ],
-      "condition": "git log HEAD --exit-code --oneline --grep \\"chore(release):\\""
+      "condition": "git log --oneline -1 | grep -qv \\"chore(release):\\""
     },
     "clobber": {
       "name": "clobber",

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -927,7 +927,7 @@ tsconfig.tsbuildinfo
           "builtin": "release/bump-version"
         }
       ],
-      "condition": "(git log --oneline -1 | grep -q \\"chore(release):\\") && exit 1 || exit 0"
+      "condition": "git log HEAD --exit-code --oneline --grep \\"chore(release):\\""
     },
     "clobber": {
       "name": "clobber",
@@ -4324,7 +4324,7 @@ resolution-mode=highest
           "builtin": "release/bump-version"
         }
       ],
-      "condition": "(git log --oneline -1 | grep -q \\"chore(release):\\") && exit 1 || exit 0"
+      "condition": "git log HEAD --exit-code --oneline --grep \\"chore(release):\\""
     },
     "clobber": {
       "name": "clobber",

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -863,7 +863,7 @@ tsconfig.tsbuildinfo
         ],
       },
       "bump": {
-        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
+        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -863,7 +863,7 @@ tsconfig.tsbuildinfo
         ],
       },
       "bump": {
-        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
+        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -863,7 +863,7 @@ tsconfig.tsbuildinfo
         ],
       },
       "bump": {
-        "condition": "! git log --oneline -1 | grep -q "chore(release):"",
+        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",

--- a/test/jsii/__snapshots__/jsii.test.ts.snap
+++ b/test/jsii/__snapshots__/jsii.test.ts.snap
@@ -863,7 +863,7 @@ tsconfig.tsbuildinfo
         ],
       },
       "bump": {
-        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
+        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -2354,7 +2354,7 @@ tsconfig.tsbuildinfo
         ],
       },
       "bump": {
-        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
+        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -3852,7 +3852,7 @@ tsconfig.tsbuildinfo
         ],
       },
       "bump": {
-        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
+        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -5329,7 +5329,7 @@ tsconfig.tsbuildinfo
         ],
       },
       "bump": {
-        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
+        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",

--- a/test/jsii/__snapshots__/jsii.test.ts.snap
+++ b/test/jsii/__snapshots__/jsii.test.ts.snap
@@ -863,7 +863,7 @@ tsconfig.tsbuildinfo
         ],
       },
       "bump": {
-        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
+        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -2354,7 +2354,7 @@ tsconfig.tsbuildinfo
         ],
       },
       "bump": {
-        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
+        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -3852,7 +3852,7 @@ tsconfig.tsbuildinfo
         ],
       },
       "bump": {
-        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
+        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -5329,7 +5329,7 @@ tsconfig.tsbuildinfo
         ],
       },
       "bump": {
-        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
+        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",

--- a/test/jsii/__snapshots__/jsii.test.ts.snap
+++ b/test/jsii/__snapshots__/jsii.test.ts.snap
@@ -863,7 +863,7 @@ tsconfig.tsbuildinfo
         ],
       },
       "bump": {
-        "condition": "! git log --oneline -1 | grep -q "chore(release):"",
+        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -2354,7 +2354,7 @@ tsconfig.tsbuildinfo
         ],
       },
       "bump": {
-        "condition": "! git log --oneline -1 | grep -q "chore(release):"",
+        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -3852,7 +3852,7 @@ tsconfig.tsbuildinfo
         ],
       },
       "bump": {
-        "condition": "! git log --oneline -1 | grep -q "chore(release):"",
+        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -5329,7 +5329,7 @@ tsconfig.tsbuildinfo
         ],
       },
       "bump": {
-        "condition": "! git log --oneline -1 | grep -q "chore(release):"",
+        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",

--- a/test/release/__snapshots__/release.test.ts.snap
+++ b/test/release/__snapshots__/release.test.ts.snap
@@ -230,7 +230,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
+        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -613,7 +613,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
+        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -1003,7 +1003,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
+        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -1350,7 +1350,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
+        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -1815,7 +1815,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
+        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -2332,7 +2332,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
+        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -2694,7 +2694,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
+        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -3203,7 +3203,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
+        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -3484,7 +3484,7 @@ exports[`Single Project majorVersion can be 0 2`] = `
       ],
     },
     "bump": {
-      "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
+      "condition": "git log --oneline -1 | grep -qv "chore(release):"",
       "description": "Bumps version based on latest git tag and generates a changelog entry",
       "env": {
         "BUMPFILE": "dist/version.txt",
@@ -3627,7 +3627,7 @@ exports[`Single Project minMajorVersion can be 1 1`] = `
       ],
     },
     "bump": {
-      "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
+      "condition": "git log --oneline -1 | grep -qv "chore(release):"",
       "description": "Bumps version based on latest git tag and generates a changelog entry",
       "env": {
         "BUMPFILE": "dist/version.txt",
@@ -3910,7 +3910,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
+        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -4136,7 +4136,7 @@ exports[`Single Project prerelease can be specified per branch 3`] = `
       ],
     },
     "bump": {
-      "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
+      "condition": "git log --oneline -1 | grep -qv "chore(release):"",
       "description": "Bumps version based on latest git tag and generates a changelog entry",
       "env": {
         "BUMPFILE": "dist/version.txt",
@@ -4544,7 +4544,7 @@ exports[`Single Project publisher (defaults) 2`] = `
       ],
     },
     "bump": {
-      "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
+      "condition": "git log --oneline -1 | grep -qv "chore(release):"",
       "description": "Bumps version based on latest git tag and generates a changelog entry",
       "env": {
         "BUMPFILE": "dist/version.txt",
@@ -4993,7 +4993,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
+        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -5482,7 +5482,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
+        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -5852,7 +5852,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
+        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -6137,7 +6137,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
+        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",

--- a/test/release/__snapshots__/release.test.ts.snap
+++ b/test/release/__snapshots__/release.test.ts.snap
@@ -230,7 +230,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "! git log --oneline -1 | grep -q "chore(release):"",
+        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -613,7 +613,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "! git log --oneline -1 | grep -q "chore(release):"",
+        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -1003,7 +1003,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "! git log --oneline -1 | grep -q "chore(release):"",
+        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -1350,7 +1350,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "! git log --oneline -1 | grep -q "chore(release):"",
+        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -1815,7 +1815,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "! git log --oneline -1 | grep -q "chore(release):"",
+        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -2332,7 +2332,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "! git log --oneline -1 | grep -q "chore(release):"",
+        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -2694,7 +2694,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "! git log --oneline -1 | grep -q "chore(release):"",
+        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -3203,7 +3203,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "! git log --oneline -1 | grep -q "chore(release):"",
+        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -3484,7 +3484,7 @@ exports[`Single Project majorVersion can be 0 2`] = `
       ],
     },
     "bump": {
-      "condition": "! git log --oneline -1 | grep -q "chore(release):"",
+      "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
       "description": "Bumps version based on latest git tag and generates a changelog entry",
       "env": {
         "BUMPFILE": "dist/version.txt",
@@ -3627,7 +3627,7 @@ exports[`Single Project minMajorVersion can be 1 1`] = `
       ],
     },
     "bump": {
-      "condition": "! git log --oneline -1 | grep -q "chore(release):"",
+      "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
       "description": "Bumps version based on latest git tag and generates a changelog entry",
       "env": {
         "BUMPFILE": "dist/version.txt",
@@ -3910,7 +3910,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "! git log --oneline -1 | grep -q "chore(release):"",
+        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -4136,7 +4136,7 @@ exports[`Single Project prerelease can be specified per branch 3`] = `
       ],
     },
     "bump": {
-      "condition": "! git log --oneline -1 | grep -q "chore(release):"",
+      "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
       "description": "Bumps version based on latest git tag and generates a changelog entry",
       "env": {
         "BUMPFILE": "dist/version.txt",
@@ -4544,7 +4544,7 @@ exports[`Single Project publisher (defaults) 2`] = `
       ],
     },
     "bump": {
-      "condition": "! git log --oneline -1 | grep -q "chore(release):"",
+      "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
       "description": "Bumps version based on latest git tag and generates a changelog entry",
       "env": {
         "BUMPFILE": "dist/version.txt",
@@ -4993,7 +4993,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "! git log --oneline -1 | grep -q "chore(release):"",
+        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -5482,7 +5482,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "! git log --oneline -1 | grep -q "chore(release):"",
+        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -5852,7 +5852,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "! git log --oneline -1 | grep -q "chore(release):"",
+        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -6137,7 +6137,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "! git log --oneline -1 | grep -q "chore(release):"",
+        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",

--- a/test/release/__snapshots__/release.test.ts.snap
+++ b/test/release/__snapshots__/release.test.ts.snap
@@ -230,7 +230,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
+        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -613,7 +613,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
+        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -1003,7 +1003,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
+        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -1350,7 +1350,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
+        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -1815,7 +1815,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
+        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -2332,7 +2332,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
+        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -2694,7 +2694,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
+        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -3203,7 +3203,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
+        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -3484,7 +3484,7 @@ exports[`Single Project majorVersion can be 0 2`] = `
       ],
     },
     "bump": {
-      "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
+      "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
       "description": "Bumps version based on latest git tag and generates a changelog entry",
       "env": {
         "BUMPFILE": "dist/version.txt",
@@ -3627,7 +3627,7 @@ exports[`Single Project minMajorVersion can be 1 1`] = `
       ],
     },
     "bump": {
-      "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
+      "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
       "description": "Bumps version based on latest git tag and generates a changelog entry",
       "env": {
         "BUMPFILE": "dist/version.txt",
@@ -3910,7 +3910,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
+        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -4136,7 +4136,7 @@ exports[`Single Project prerelease can be specified per branch 3`] = `
       ],
     },
     "bump": {
-      "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
+      "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
       "description": "Bumps version based on latest git tag and generates a changelog entry",
       "env": {
         "BUMPFILE": "dist/version.txt",
@@ -4544,7 +4544,7 @@ exports[`Single Project publisher (defaults) 2`] = `
       ],
     },
     "bump": {
-      "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
+      "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
       "description": "Bumps version based on latest git tag and generates a changelog entry",
       "env": {
         "BUMPFILE": "dist/version.txt",
@@ -4993,7 +4993,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
+        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -5482,7 +5482,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
+        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -5852,7 +5852,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
+        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -6137,7 +6137,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
+        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",

--- a/test/release/bump.test.ts
+++ b/test/release/bump.test.ts
@@ -511,26 +511,6 @@ describe("Releasable Commits Configurations", () => {
     });
     expect(result.version).toEqual("1.3.0");
   });
-
-  test("will not bump if last commit was a release", async () => {
-    const result = await testBump({
-      commits: [
-        { message: "docs: update Readme" },
-        { message: "chore(release): 1.2.0", tag: "v1.2.0" },
-      ],
-    });
-    expect(result.version).toEqual("1.2.0");
-  });
-
-  test("will bump if last commit was not a release", async () => {
-    const result = await testBump({
-      commits: [
-        { message: "chore(release): 1.2.0", tag: "v1.2.0" },
-        { message: "docs: update Readme" },
-      ],
-    });
-    expect(result.version).toEqual("1.2.1");
-  });
 });
 
 //----------------------------------------------------------------------------------------------------------------------------------
@@ -557,7 +537,7 @@ describe("newline at the end of version file", () => {
 
       // Commit files so the bump will work
       execSync("git add .", { cwd: projectdir });
-      execSync('git commit -m"chore: init"', { cwd: projectdir });
+      execSync('git commit -m "chore: init"', { cwd: projectdir });
 
       // Bump the version
       execProjenCLI(projectdir, ["bump"]);

--- a/test/release/bump.test.ts
+++ b/test/release/bump.test.ts
@@ -515,10 +515,18 @@ describe("Releasable Commits Configurations", () => {
   test("will not bump if last commit was a release", async () => {
     const result = await testBump({
       commits: [
-        { message: "first version", tag: "v1.1.0" },
-        { message: "second version", tag: "v1.2.0" },
         { message: "docs: update Readme" },
-        { message: "chore(release): no more bugs" },
+        { message: "chore(release): 1.2.0", tag: "v1.2.0" },
+      ],
+    });
+    expect(result.version).toEqual("1.2.0");
+  });
+
+  test("will bump if last commit was not a release", async () => {
+    const result = await testBump({
+      commits: [
+        { message: "chore(release): 1.2.0", tag: "v1.2.0" },
+        { message: "docs: update Readme" },
       ],
     });
     expect(result.version).toEqual("1.2.1");

--- a/test/release/bump.test.ts
+++ b/test/release/bump.test.ts
@@ -511,6 +511,18 @@ describe("Releasable Commits Configurations", () => {
     });
     expect(result.version).toEqual("1.3.0");
   });
+
+  test("will not bump if last commit was a release", async () => {
+    const result = await testBump({
+      commits: [
+        { message: "first version", tag: "v1.1.0" },
+        { message: "second version", tag: "v1.2.0" },
+        { message: "docs: update Readme" },
+        { message: "chore(release): no more bugs" },
+      ],
+    });
+    expect(result.version).toEqual("1.2.1");
+  });
 });
 
 //----------------------------------------------------------------------------------------------------------------------------------

--- a/test/typescript/__snapshots__/typescript.test.ts.snap
+++ b/test/typescript/__snapshots__/typescript.test.ts.snap
@@ -750,7 +750,7 @@ tsconfig.tsbuildinfo
         ],
       },
       "bump": {
-        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
+        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",

--- a/test/typescript/__snapshots__/typescript.test.ts.snap
+++ b/test/typescript/__snapshots__/typescript.test.ts.snap
@@ -750,7 +750,7 @@ tsconfig.tsbuildinfo
         ],
       },
       "bump": {
-        "condition": "! git log --oneline -1 | grep -q "chore(release):"",
+        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",

--- a/test/typescript/__snapshots__/typescript.test.ts.snap
+++ b/test/typescript/__snapshots__/typescript.test.ts.snap
@@ -750,7 +750,7 @@ tsconfig.tsbuildinfo
         ],
       },
       "bump": {
-        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
+        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",

--- a/test/version.test.ts
+++ b/test/version.test.ts
@@ -1,4 +1,8 @@
-import { TestProject } from "./util";
+import { execSync } from "child_process";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { dirname, join } from "path";
+import { execProjenCLI, TestProject, withProjectDir } from "./util";
 import { Version } from "../src/version";
 
 describe("Version", () => {
@@ -19,3 +23,112 @@ describe("Version", () => {
     expect(version.unbumpTask.envVars.STEP_NAME).toEqual("unbump");
   });
 });
+
+describe("bump task", () => {
+  test("will bump if last commit is not a tag", async () => {
+    withProjectDir((projectdir) => {
+      const project = new TestProject({
+        outdir: projectdir,
+      });
+      new Version(project, {
+        versionInputFile: "package.json",
+        artifactsDirectory: "dist",
+      });
+
+      project.synth();
+
+      const result = testBumpTask({
+        workdir: project.outdir,
+        commits: [
+          { message: "chore(release): v0.1.0", tag: "v0.1.0" },
+          { message: "new change" },
+        ],
+      });
+
+      expect(result.version).toEqual("0.1.1");
+    });
+  });
+
+  test("will not bump if last commit is a tag", async () => {
+    withProjectDir((projectdir) => {
+      const project = new TestProject({
+        outdir: projectdir,
+      });
+      new Version(project, {
+        versionInputFile: "package.json",
+        artifactsDirectory: "dist",
+      });
+
+      project.synth();
+
+      // Bump the first time to generate the initial version
+      let result = testBumpTask({
+        workdir: project.outdir,
+        commits: [
+          { message: "chore(release): v0.1.0", tag: "v0.1.0" },
+          { message: "new change" },
+        ],
+      });
+
+      // Bump again to see if the version is the same
+      result = testBumpTask({
+        workdir: project.outdir,
+      });
+
+      expect(result.version).toEqual("0.1.1");
+    });
+  });
+});
+
+function testBumpTask(
+  opts: {
+    workdir?: string;
+    commits?: { message: string; tag?: string; path?: string }[];
+  } = {}
+) {
+  const workdir = opts.workdir ?? mkdtempSync(join(tmpdir(), "bump-test-"));
+
+  const git = (cmd: string) =>
+    execSync(`git ${cmd}`, {
+      cwd: workdir,
+      stdio: "inherit",
+      // let's try to catch hanging processes sooner than later
+      timeout: 10_000,
+    });
+
+  // Initialize a git repository
+  git("init -b main");
+  git('config user.email "you@example.com"');
+  git('config user.name "Your Name"');
+  git("config commit.gpgsign false");
+  git("config tag.gpgsign false");
+
+  const commit = (message: string, path: string = "dummy.txt") => {
+    const filePath = join(workdir, path);
+    mkdirSync(dirname(filePath), { recursive: true });
+    writeFileSync(filePath, message);
+    git("add .");
+    git(`commit -F "${filePath}"`);
+  };
+
+  commit("initial commit");
+
+  for (const c of opts.commits ?? []) {
+    commit(c.message, c.path);
+    if (c.tag) {
+      git(`tag ${c.tag}`);
+    }
+  }
+
+  // Bump the version
+  execProjenCLI(workdir, ["bump"]);
+
+  return {
+    version: JSON.parse(readFileSync(join(workdir, "package.json"), "utf-8"))
+      .version,
+    changelog: readFileSync(join(workdir, "dist/changelog.md"), "utf8"),
+    bumpfile: readFileSync(join(workdir, "dist/version.txt"), "utf8"),
+    tag: readFileSync(join(workdir, "dist/releasetag.txt"), "utf8"),
+    workdir,
+  };
+}

--- a/test/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-project.test.ts.snap
@@ -483,7 +483,7 @@ permissions-backup.acl
         ],
       },
       "bump": {
-        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
+        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",

--- a/test/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-project.test.ts.snap
@@ -483,7 +483,7 @@ permissions-backup.acl
         ],
       },
       "bump": {
-        "condition": "! git log --oneline -1 | grep -q "chore(release):"",
+        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",

--- a/test/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-project.test.ts.snap
@@ -483,7 +483,7 @@ permissions-backup.acl
         ],
       },
       "bump": {
-        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
+        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",

--- a/test/web/__snapshots__/react-project.test.ts.snap
+++ b/test/web/__snapshots__/react-project.test.ts.snap
@@ -468,7 +468,7 @@ permissions-backup.acl
         ],
       },
       "bump": {
-        "condition": "! git log --oneline -1 | grep -q "chore(release):"",
+        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",

--- a/test/web/__snapshots__/react-project.test.ts.snap
+++ b/test/web/__snapshots__/react-project.test.ts.snap
@@ -468,7 +468,7 @@ permissions-backup.acl
         ],
       },
       "bump": {
-        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
+        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",

--- a/test/web/__snapshots__/react-project.test.ts.snap
+++ b/test/web/__snapshots__/react-project.test.ts.snap
@@ -468,7 +468,7 @@ permissions-backup.acl
         ],
       },
       "bump": {
-        "condition": "(git log --oneline -1 | grep -q "chore(release):") && exit 1 || exit 0",
+        "condition": "git log HEAD --exit-code --oneline --grep "chore(release):"",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",


### PR DESCRIPTION
Fixes https://github.com/projen/projen/issues/2427

The `!` mark is used in bash because is interpreted by the `test` command. Because `test` doesn't exist in Windows cmd, then running the bump task fails. It turns out that `grep` has a flag `-v` to invert the match and works both in bash and cmd, and it solved the problem. Refactored the `publishTask.condition` to use the same expression. Added a test to check the correct handling of a release commit with message `chore(release):`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
