### PR TITLE
fix: projen dev dependency on `constructs` cannot be overridden

### DIFF
--- a/docs/api/projen.md
+++ b/docs/api/projen.md
@@ -227,7 +227,7 @@ The parent project.
 | <code><a href="#projen.Dependencies.synthesize">synthesize</a></code> | Synthesizes files to the project output directory. |
 | <code><a href="#projen.Dependencies.addDependency">addDependency</a></code> | Adds a dependency to this project. |
 | <code><a href="#projen.Dependencies.getDependency">getDependency</a></code> | Returns a dependency by name. |
-| <code><a href="#projen.Dependencies.isDependencySatisfied">isDependencySatisfied</a></code> | Checks if a dependency requirement is already satisfied by an existing dependency. |
+| <code><a href="#projen.Dependencies.isDependencySatisfied">isDependencySatisfied</a></code> | Checks if an existing dependency satisfies a dependency requirement. |
 | <code><a href="#projen.Dependencies.removeDependency">removeDependency</a></code> | Removes a dependency. |
 | <code><a href="#projen.Dependencies.tryGetDependency">tryGetDependency</a></code> | Returns a dependency by name. |
 
@@ -333,7 +333,7 @@ single type, this argument can be omitted.
 public isDependencySatisfied(name: string, type: DependencyType, expectedRange: string): boolean
 ```
 
-Checks if a dependency requirement is already satisfied by an existing dependency.
+Checks if an existing dependency satisfies a dependency requirement.
 
 ###### `name`<sup>Required</sup> <a name="name" id="projen.Dependencies.isDependencySatisfied.parameter.name"></a>
 

--- a/docs/api/projen.md
+++ b/docs/api/projen.md
@@ -227,6 +227,7 @@ The parent project.
 | <code><a href="#projen.Dependencies.synthesize">synthesize</a></code> | Synthesizes files to the project output directory. |
 | <code><a href="#projen.Dependencies.addDependency">addDependency</a></code> | Adds a dependency to this project. |
 | <code><a href="#projen.Dependencies.getDependency">getDependency</a></code> | Returns a dependency by name. |
+| <code><a href="#projen.Dependencies.isDependencySatisfied">isDependencySatisfied</a></code> | Checks if a dependency requirement is already satisfied by an existing dependency. |
 | <code><a href="#projen.Dependencies.removeDependency">removeDependency</a></code> | Removes a dependency. |
 | <code><a href="#projen.Dependencies.tryGetDependency">tryGetDependency</a></code> | Returns a dependency by name. |
 
@@ -323,6 +324,38 @@ The dependency type.
 
 If this dependency is defined only for a
 single type, this argument can be omitted.
+
+---
+
+##### `isDependencySatisfied` <a name="isDependencySatisfied" id="projen.Dependencies.isDependencySatisfied"></a>
+
+```typescript
+public isDependencySatisfied(name: string, type: DependencyType, expectedRange: string): boolean
+```
+
+Checks if a dependency requirement is already satisfied by an existing dependency.
+
+###### `name`<sup>Required</sup> <a name="name" id="projen.Dependencies.isDependencySatisfied.parameter.name"></a>
+
+- *Type:* string
+
+The name of the dependency to check (without the version).
+
+---
+
+###### `type`<sup>Required</sup> <a name="type" id="projen.Dependencies.isDependencySatisfied.parameter.type"></a>
+
+- *Type:* <a href="#projen.DependencyType">DependencyType</a>
+
+The dependency type.
+
+---
+
+###### `expectedRange`<sup>Required</sup> <a name="expectedRange" id="projen.Dependencies.isDependencySatisfied.parameter.expectedRange"></a>
+
+- *Type:* string
+
+The version constraint to check (e.g. `^3.4.0`). The constraint of the dependency must be a subset of the expected range to satisfy the requirements.
 
 ---
 

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -1,4 +1,5 @@
 import * as path from "path";
+import * as semver from "semver";
 import { PROJEN_DIR } from "./common";
 import { Component } from "./component";
 import { JsonFile } from "./json";
@@ -171,6 +172,24 @@ export class Dependencies extends Component {
     }
 
     this._deps.splice(removeIndex, 1);
+  }
+
+  /**
+   * Checks if a dependency requirement is already satisfied by an existing dependency.
+   * @param name The name of the dependency to check (without the version).
+   * @param type The dependency type. This is only required if there the dependency is defined for multiple types.
+   * @param expectedRange The version constraint to check (e.g. `^3.4.0`).
+   * The constraint of the dependency must be a subset of the expected range to satisfy the requirements.
+   * @returns `true` if the dependency exists and its version satisfies the provided constraint. `false` otherwise.
+   * Notably returns `false` if a dependency exists, but has no version.
+   */
+  public isDependencySatisfied(
+    name: string,
+    type: DependencyType | undefined,
+    expectedRange: string
+  ): boolean {
+    const dep = this.tryGetDependency(name, type);
+    return dep?.version != null && semver.subset(dep.version, expectedRange);
   }
 
   private tryGetDependencyIndex(name: string, type?: DependencyType): number {

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -177,7 +177,7 @@ export class Dependencies extends Component {
   /**
    * Checks if a dependency requirement is already satisfied by an existing dependency.
    * @param name The name of the dependency to check (without the version).
-   * @param type The dependency type. This is only required if there the dependency is defined for multiple types.
+   * @param type The dependency type.
    * @param expectedRange The version constraint to check (e.g. `^3.4.0`).
    * The constraint of the dependency must be a subset of the expected range to satisfy the requirements.
    * @returns `true` if the dependency exists and its version satisfies the provided constraint. `false` otherwise.
@@ -185,7 +185,7 @@ export class Dependencies extends Component {
    */
   public isDependencySatisfied(
     name: string,
-    type: DependencyType | undefined,
+    type: DependencyType,
     expectedRange: string
   ): boolean {
     const dep = this.tryGetDependency(name, type);

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -175,7 +175,7 @@ export class Dependencies extends Component {
   }
 
   /**
-   * Checks if a dependency requirement is already satisfied by an existing dependency.
+   * Checks if an existing dependency satisfies a dependency requirement.
    * @param name The name of the dependency to check (without the version).
    * @param type The dependency type.
    * @param expectedRange The version constraint to check (e.g. `^3.4.0`).

--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -1177,9 +1177,14 @@ export class NodePackage extends Component {
       )) {
         let req = dep.name;
 
-        // skip if we already have a runtime dependency on this peer
+        // Skip if we already have a runtime dependency on this peer and no build dependency yet.
+        // If there is a build dep already, we need to override its version.
         if (
-          this.project.deps.tryGetDependency(dep.name, DependencyType.RUNTIME)
+          this.project.deps.tryGetDependency(
+            dep.name,
+            DependencyType.RUNTIME
+          ) &&
+          !this.project.deps.tryGetDependency(dep.name, DependencyType.BUILD)
         ) {
           continue;
         }

--- a/src/javascript/node-project.ts
+++ b/src/javascript/node-project.ts
@@ -12,6 +12,7 @@ import {
 import { Projenrc, ProjenrcOptions } from "./projenrc";
 import { BuildWorkflow, BuildWorkflowCommonOptions } from "../build";
 import { PROJEN_DIR } from "../common";
+import { DependencyType } from "../dependencies";
 import {
   AutoMerge,
   DependabotOptions,
@@ -594,7 +595,16 @@ export class NodeProject extends GitHubProject {
     if (projen && !this.ejected) {
       const postfix = options.projenVersion ? `@${options.projenVersion}` : "";
       this.addDevDeps(`projen${postfix}`);
-      this.addDevDeps(`constructs@^10.0.0`);
+
+      if (
+        !this.deps.isDependencySatisfied(
+          "constructs",
+          DependencyType.BUILD,
+          "^10.0.0"
+        )
+      ) {
+        this.addDevDeps(`constructs@^10.0.0`);
+      }
     }
 
     if (!options.defaultReleaseBranch) {

--- a/test/cdktf/cdktf-construct.test.ts
+++ b/test/cdktf/cdktf-construct.test.ts
@@ -5,7 +5,7 @@ import {
 import { NpmAccess } from "../../src/javascript";
 import { synthSnapshot } from "../util";
 
-describe("constructs dependency selection", () => {
+describe("cdktf dependency selection", () => {
   test("user-selected", () => {
     // GIVEN
     const project = new TestProject({ cdktfVersion: "0.99" });
@@ -18,7 +18,9 @@ describe("constructs dependency selection", () => {
     expect(snapshot["package.json"]?.devDependencies?.cdktf).toBe("0.99.0");
     expect(snapshot["package.json"]?.dependencies?.cdktf).toBeUndefined();
   });
+});
 
+describe("constructs dependency selection", () => {
   test("user-selected constructs version", () => {
     // GIVEN
     const project = new TestProject({
@@ -37,6 +39,27 @@ describe("constructs dependency selection", () => {
       "10.0.1"
     );
     expect(snapshot["package.json"]?.dependencies?.constructs).toBeUndefined();
+  });
+
+  test("user-selected constructs version and installed as dependency", () => {
+    // GIVEN
+    const project = new TestProject({
+      cdktfVersion: "0.99",
+      constructsVersion: "10.3.0",
+      deps: ["constructs@10.3.0"],
+    });
+
+    // WHEN
+    const snapshot = synthSnapshot(project);
+
+    // THEN
+    expect(snapshot["package.json"]?.peerDependencies?.constructs).toBe(
+      "10.3.0"
+    );
+    expect(snapshot["package.json"]?.devDependencies?.constructs).toBe(
+      "10.3.0"
+    );
+    expect(snapshot["package.json"]?.dependencies?.constructs).toBe("10.3.0");
   });
 });
 

--- a/test/javascript/node-project.test.ts
+++ b/test/javascript/node-project.test.ts
@@ -197,6 +197,17 @@ describe("deps", () => {
     });
     expect(pkgjson.bundledDependencies).toStrictEqual(["bar", "foo", "hey"]);
   });
+
+  test("can override projen devDep on constructs", () => {
+    // GIVEN
+    const project = new TestNodeProject({
+      devDeps: ["constructs@^10.3.0"],
+    });
+
+    // THEN
+    const pkgjson = packageJson(project);
+    expect(pkgjson.devDependencies.constructs).toStrictEqual("^10.3.0");
+  });
 });
 
 describe("deps upgrade", () => {


### PR DESCRIPTION
Fixes #3776

Resolves two separate but related issues with dependency handling.

1. peer dependencies have a check to not a build dependency if a runtime dependency already exists
  This check made the assumption that no build dependency would exists if a runtime dependency exists.
  However when dealing with project inheritance, this can actually happen quite easily.
  First fix is to make that check more robust and have peer deps override an existing build dep.
2. projen indiscriminately adds build dependency on `constructs@^10.0.0`.
  This is fine, but fails when a project needs to constraint their usage of constructs to e.g. `^10.3.0`. 
  The fix is to add a check if there already is a dependency on constructs that fulfills this requirement.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
