### PR TITLE
fix(release): Version class breaks with projects other than Node

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -2,6 +2,7 @@ import { posix } from "path";
 import { IConstruct } from "constructs";
 import { Component } from "./component";
 import { Dependencies, DependencyType } from "./dependencies";
+import { NodePackage } from "./javascript/node-package";
 import { Task } from "./task";
 
 /**
@@ -107,16 +108,21 @@ export class Version extends Component {
     this.releaseTagFileName = "releasetag.txt";
     this.bumpPackage = options.bumpPackage ?? COMMIT_AND_TAG_VERSION_DEFAULT;
 
-    const { name: bumpName, version: bumpVersion } =
-      Dependencies.parseDependency(this.bumpPackage);
-    if (
-      !this.project.deps.isDependencySatisfied(
-        bumpName,
-        DependencyType.BUILD,
-        bumpVersion ?? "*"
-      )
-    ) {
-      this.project.deps.addDependency(this.bumpPackage, DependencyType.BUILD);
+    // This component is language independent.
+    // However, when in the Node.js ecosystem, we can improve the experience by adding a dev dependency on the bump package.
+    const node = NodePackage.of(this.project);
+    if (node) {
+      const { name: bumpName, version: bumpVersion } =
+        Dependencies.parseDependency(this.bumpPackage);
+      if (
+        !node.project.deps.isDependencySatisfied(
+          bumpName,
+          DependencyType.BUILD,
+          bumpVersion ?? "*"
+        )
+      ) {
+        node.project.deps.addDependency(this.bumpPackage, DependencyType.BUILD);
+      }
     }
 
     const versionInputFile = options.versionInputFile;

--- a/test/util.ts
+++ b/test/util.ts
@@ -4,7 +4,10 @@ import * as os from "os";
 import * as path from "path";
 import { Project } from "../src";
 import { installPackage } from "../src/cli/util";
-import { GitHubProject, GitHubProjectOptions } from "../src/github";
+import {
+  GitHubProject,
+  GitHubProjectOptions,
+} from "../src/github/github-project";
 import * as logging from "../src/logging";
 import { Task } from "../src/task";
 import { exec } from "../src/util";


### PR DESCRIPTION
Fixes #3806

The PR https://github.com/projen/projen/pull/3801 modified the `Version` class by moving the addition of the version bump dependency from `NodeProject` to `Version`. While this makes sense intuitively, the `Version` class was previously written in a way that could be run against any project type provided the running environment had npx installed

The fix is to only add the `bumpPackage` dependency when we have a `NodePackage` available. Also adds a test and comment so this should not regress again in future.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
