### PR TITLE
fix(typescript): add node10 to moduleResolution enum

### DIFF
--- a/docs/api/javascript.md
+++ b/docs/api/javascript.md
@@ -14984,6 +14984,7 @@ Determines how modules get resolved.
 | --- | --- |
 | <code><a href="#projen.javascript.TypeScriptModuleResolution.CLASSIC">CLASSIC</a></code> | TypeScript's former default resolution strategy. |
 | <code><a href="#projen.javascript.TypeScriptModuleResolution.NODE">NODE</a></code> | Resolution strategy which attempts to mimic the Node.js module resolution strategy at runtime. |
+| <code><a href="#projen.javascript.TypeScriptModuleResolution.NODE10">NODE10</a></code> | `--moduleResolution node` was renamed to `node10` (keeping `node` as an alias for backward compatibility) in TypeScript 5.0. It reflects the CommonJS module resolution algorithm as it existed in Node.js versions earlier than v12. It should no longer be used. |
 | <code><a href="#projen.javascript.TypeScriptModuleResolution.NODE16">NODE16</a></code> | Node.js’ ECMAScript Module Support from TypeScript 4.7 onwards. |
 | <code><a href="#projen.javascript.TypeScriptModuleResolution.NODE_NEXT">NODE_NEXT</a></code> | Node.js’ ECMAScript Module Support from TypeScript 4.7 onwards. |
 | <code><a href="#projen.javascript.TypeScriptModuleResolution.BUNDLER">BUNDLER</a></code> | Resolution strategy which attempts to mimic resolution patterns of modern bundlers; |
@@ -15004,6 +15005,15 @@ TypeScript's former default resolution strategy.
 Resolution strategy which attempts to mimic the Node.js module resolution strategy at runtime.
 
 > [https://www.typescriptlang.org/docs/handbook/module-resolution.html#node](https://www.typescriptlang.org/docs/handbook/module-resolution.html#node)
+
+---
+
+
+##### `NODE10` <a name="NODE10" id="projen.javascript.TypeScriptModuleResolution.NODE10"></a>
+
+`--moduleResolution node` was renamed to `node10` (keeping `node` as an alias for backward compatibility) in TypeScript 5.0. It reflects the CommonJS module resolution algorithm as it existed in Node.js versions earlier than v12. It should no longer be used.
+
+> [https://www.typescriptlang.org/docs/handbook/modules/reference.html#node10-formerly-known-as-node](https://www.typescriptlang.org/docs/handbook/modules/reference.html#node10-formerly-known-as-node)
 
 ---
 

--- a/src/javascript/typescript-config.ts
+++ b/src/javascript/typescript-config.ts
@@ -64,6 +64,16 @@ export enum TypeScriptModuleResolution {
   NODE = "node",
 
   /**
+   * `--moduleResolution node` was renamed to `node10`
+   * (keeping `node` as an alias for backward compatibility) in TypeScript 5.0.
+   * It reflects the CommonJS module resolution algorithm as it existed in Node.js versions
+   * earlier than v12. It should no longer be used.
+   *
+   * @see https://www.typescriptlang.org/docs/handbook/modules/reference.html#node10-formerly-known-as-node
+   */
+  NODE10 = "node10",
+
+  /**
    * Node.js’ ECMAScript Module Support from TypeScript 4.7 onwards
    *
    * @see https://www.typescriptlang.org/tsconfig#moduleResolution


### PR DESCRIPTION
I noticed that `TypescriptConfig` component is missing quite a few number of options from tsconfig. If I were to add them to the component should I use the descriptions from https://www.typescriptlang.org/tsconfig/ page or https://json.schemastore.org/tsconfig?

I couldn't run `npx projen build` locally as `package` task is failing due to some missing dependencies.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
