### PR TITLE
feat(github)!: exclude hidden files from artifacts by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,7 +245,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.self_mutation.outputs.self_mutation_happened && matrix.runner.primary_build
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -261,7 +261,7 @@ jobs:
         continue-on-error: true
         if: matrix.runner.primary_build
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist

--- a/.github/workflows/upgrade-bundled-main.yml
+++ b/.github/workflows/upgrade-bundled-main.yml
@@ -34,7 +34,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -34,7 +34,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch

--- a/docs/api/build.md
+++ b/docs/api/build.md
@@ -541,8 +541,8 @@ const buildWorkflowOptions: build.BuildWorkflowOptions = { ... }
 | <code><a href="#projen.build.BuildWorkflowOptions.property.permissions">permissions</a></code> | <code>projen.github.workflows.JobPermissions</code> | Permissions granted to the build job To limit job permissions for `contents`, the desired permissions have to be explicitly set, e.g.: `{ contents: JobPermission.NONE }`. |
 | <code><a href="#projen.build.BuildWorkflowOptions.property.preBuildSteps">preBuildSteps</a></code> | <code>projen.github.workflows.JobStep[]</code> | Steps to execute before the build. |
 | <code><a href="#projen.build.BuildWorkflowOptions.property.workflowTriggers">workflowTriggers</a></code> | <code>projen.github.workflows.Triggers</code> | Build workflow triggers. |
-| <code><a href="#projen.build.BuildWorkflowOptions.property.artifactsDirectory">artifactsDirectory</a></code> | <code>string</code> | A name of a directory that includes build artifacts. |
 | <code><a href="#projen.build.BuildWorkflowOptions.property.buildTask">buildTask</a></code> | <code>projen.Task</code> | The task to execute in order to build the project. |
+| <code><a href="#projen.build.BuildWorkflowOptions.property.artifactsDirectory">artifactsDirectory</a></code> | <code>string</code> | A name of a directory that includes build artifacts. |
 | <code><a href="#projen.build.BuildWorkflowOptions.property.containerImage">containerImage</a></code> | <code>string</code> | The container image to use for builds. |
 | <code><a href="#projen.build.BuildWorkflowOptions.property.env">env</a></code> | <code>{[ key: string ]: string}</code> | Build environment variables. |
 | <code><a href="#projen.build.BuildWorkflowOptions.property.gitIdentity">gitIdentity</a></code> | <code>projen.github.GitIdentity</code> | Git identity to use for the workflow. |
@@ -605,18 +605,6 @@ Build workflow triggers.
 
 ---
 
-##### `artifactsDirectory`<sup>Required</sup> <a name="artifactsDirectory" id="projen.build.BuildWorkflowOptions.property.artifactsDirectory"></a>
-
-```typescript
-public readonly artifactsDirectory: string;
-```
-
-- *Type:* string
-
-A name of a directory that includes build artifacts.
-
----
-
 ##### `buildTask`<sup>Required</sup> <a name="buildTask" id="projen.build.BuildWorkflowOptions.property.buildTask"></a>
 
 ```typescript
@@ -626,6 +614,19 @@ public readonly buildTask: Task;
 - *Type:* projen.Task
 
 The task to execute in order to build the project.
+
+---
+
+##### `artifactsDirectory`<sup>Optional</sup> <a name="artifactsDirectory" id="projen.build.BuildWorkflowOptions.property.artifactsDirectory"></a>
+
+```typescript
+public readonly artifactsDirectory: string;
+```
+
+- *Type:* string
+- *Default:* "dist"
+
+A name of a directory that includes build artifacts.
 
 ---
 

--- a/docs/api/github.md
+++ b/docs/api/github.md
@@ -8404,6 +8404,7 @@ const uploadArtifactWith: github.UploadArtifactWith = { ... }
 | <code><a href="#projen.github.UploadArtifactWith.property.path">path</a></code> | <code>string</code> | A file, directory or wildcard pattern that describes what to upload. |
 | <code><a href="#projen.github.UploadArtifactWith.property.compressionLevel">compressionLevel</a></code> | <code>number</code> | The level of compression for Zlib to be applied to the artifact archive. |
 | <code><a href="#projen.github.UploadArtifactWith.property.ifNoFilesFound">ifNoFilesFound</a></code> | <code>string</code> | The desired behavior if no files are found using the provided path. |
+| <code><a href="#projen.github.UploadArtifactWith.property.includeHiddenFiles">includeHiddenFiles</a></code> | <code>boolean</code> | Whether to include hidden files in the provided path in the artifact. |
 | <code><a href="#projen.github.UploadArtifactWith.property.name">name</a></code> | <code>string</code> | Name of the artifact to upload. |
 | <code><a href="#projen.github.UploadArtifactWith.property.overwrite">overwrite</a></code> | <code>boolean</code> | Whether action should overwrite an existing artifact with the same name (should one exist). |
 | <code><a href="#projen.github.UploadArtifactWith.property.retentionDays">retentionDays</a></code> | <code>number</code> | Duration after which artifact will expire in days. 0 means using default repository retention. |
@@ -8453,6 +8454,21 @@ Available Options:
   warn: Output a warning but do not fail the action
   error: Fail the action with an error message
   ignore: Do not output any warnings or errors, the action does not fail
+
+---
+
+##### `includeHiddenFiles`<sup>Optional</sup> <a name="includeHiddenFiles" id="projen.github.UploadArtifactWith.property.includeHiddenFiles"></a>
+
+```typescript
+public readonly includeHiddenFiles: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Whether to include hidden files in the provided path in the artifact.
+
+The file contents of any hidden files in the path should be validated before enabled this to avoid uploading sensitive information.
 
 ---
 

--- a/src/build/private/consts.ts
+++ b/src/build/private/consts.ts
@@ -8,3 +8,4 @@ export const IS_FORK =
   "github.event.pull_request.head.repo.full_name != github.repository";
 export const NOT_FORK = `!(${IS_FORK})`;
 export const SELF_MUTATION_CONDITION = `needs.${BUILD_JOBID}.outputs.${SELF_MUTATION_HAPPENED_OUTPUT}`;
+export const DEFAULT_ARTIFACTS_DIRECTORY = "dist";

--- a/src/github/private/util.ts
+++ b/src/github/private/util.ts
@@ -1,0 +1,19 @@
+export function secretToString(secretName: string): string {
+  return `\${{ secrets.${secretName} }}`;
+}
+
+export function context(value: string) {
+  return `\${{ ${value} }}`;
+}
+
+// Checks if part of the file path is hidden
+export function isHiddenPath(path: string) {
+  return /(^|\/)\.[^\/\.]/g.test(path);
+}
+
+// Helper to assert a path is not hidden
+export function ensureNotHiddenPath(value: string, name: string) {
+  if (isHiddenPath(value)) {
+    throw Error(`${name} cannot be a hidden path, got: ${value}`);
+  }
+}

--- a/src/github/task-workflow-job.ts
+++ b/src/github/task-workflow-job.ts
@@ -15,6 +15,7 @@ import {
 import { Component } from "../component";
 import { GroupRunnerOptions, filteredRunsOnOptions } from "../runner-options";
 import { Task } from "../task";
+import { ensureNotHiddenPath } from "./private/util";
 
 /**
  * Options to create the Job associated with a TaskWorkflow.
@@ -164,6 +165,7 @@ export class TaskWorkflowJob extends Component {
     const gitIdentity = options.gitIdentity ?? DEFAULT_GITHUB_ACTIONS_USER;
 
     if (options.artifactsDirectory) {
+      ensureNotHiddenPath(options.artifactsDirectory, "artifactsDirectory");
       postBuildSteps.push(
         WorkflowSteps.uploadArtifact({
           // Setting to always will ensure that this step will run even if

--- a/src/github/util.ts
+++ b/src/github/util.ts
@@ -1,3 +1,0 @@
-export function secretToString(secretName: string): string {
-  return `\${{ secrets.${secretName} }}`;
-}

--- a/src/github/workflow-actions.ts
+++ b/src/github/workflow-actions.ts
@@ -1,16 +1,8 @@
 import { GitIdentity, GithubCredentials } from ".";
 import { DEFAULT_GITHUB_ACTIONS_USER } from "./constants";
+import { context, isHiddenPath } from "./private/util";
 import { CheckoutWith, WorkflowSteps } from "./workflow-steps";
 import { JobStep } from "./workflows-model";
-
-function context(value: string) {
-  return `\${{ ${value} }}`;
-}
-
-// Checks if part of the file path is hidden
-function isHiddenPath(path: string) {
-  return /(^|\/)\.[^\/\.]/g.test(path);
-}
 
 const REPO = context("github.repository");
 const RUN_ID = context("github.run_id");

--- a/src/github/workflow-actions.ts
+++ b/src/github/workflow-actions.ts
@@ -7,6 +7,11 @@ function context(value: string) {
   return `\${{ ${value} }}`;
 }
 
+// Checks if part of the file path is hidden
+function isHiddenPath(path: string) {
+  return /(^|\/)\.[^\/\.]/g.test(path);
+}
+
 const REPO = context("github.repository");
 const RUN_ID = context("github.run_id");
 const SERVER_URL = context("github.server_url");
@@ -49,6 +54,7 @@ export class WorkflowActions {
         with: {
           name: GIT_PATCH_FILE,
           path: GIT_PATCH_FILE,
+          includeHiddenFiles: isHiddenPath(GIT_PATCH_FILE) ? true : undefined,
         },
       }),
     ];

--- a/src/github/workflow-steps.ts
+++ b/src/github/workflow-steps.ts
@@ -101,6 +101,7 @@ export class WorkflowSteps {
         "if-no-files-found": options?.with?.ifNoFilesFound,
         "retention-days": options?.with?.retentionDays,
         "compression-level": options?.with?.compressionLevel,
+        "include-hidden-files": options?.with?.includeHiddenFiles,
       });
 
     return {
@@ -108,7 +109,7 @@ export class WorkflowSteps {
         ...options,
         name: options.name ?? "Upload artifact",
       }),
-      uses: "actions/upload-artifact@v4.3.6",
+      uses: "actions/upload-artifact@v4.4.0",
       with: uploadArtifactWith,
     };
   }
@@ -271,6 +272,15 @@ export interface UploadArtifactWith {
    * @default true
    */
   readonly overwrite?: boolean;
+
+  /**
+   * Whether to include hidden files in the provided path in the artifact
+   *
+   * The file contents of any hidden files in the path should be validated before enabled this to avoid uploading sensitive information.
+   *
+   * @default false
+   */
+  readonly includeHiddenFiles?: boolean;
 }
 
 export interface UploadArtifactOptions extends JobStepConfiguration {

--- a/src/javascript/node-project.ts
+++ b/src/javascript/node-project.ts
@@ -11,6 +11,7 @@ import {
 } from "./node-package";
 import { Projenrc, ProjenrcOptions } from "./projenrc";
 import { BuildWorkflow, BuildWorkflowCommonOptions } from "../build";
+import { DEFAULT_ARTIFACTS_DIRECTORY } from "../build/private/consts";
 import { PROJEN_DIR } from "../common";
 import { DependencyType } from "../dependencies";
 import {
@@ -22,7 +23,7 @@ import {
   GitIdentity,
 } from "../github";
 import { DEFAULT_GITHUB_ACTIONS_USER } from "../github/constants";
-import { secretToString } from "../github/util";
+import { ensureNotHiddenPath, secretToString } from "../github/private/util";
 import {
   JobPermission,
   JobPermissions,
@@ -510,7 +511,9 @@ export class NodeProject extends GitHubProject {
     this.workflowGitIdentity =
       options.workflowGitIdentity ?? DEFAULT_GITHUB_ACTIONS_USER;
     this.workflowPackageCache = options.workflowPackageCache ?? false;
-    this.artifactsDirectory = options.artifactsDirectory ?? "dist";
+    this.artifactsDirectory =
+      options.artifactsDirectory ?? DEFAULT_ARTIFACTS_DIRECTORY;
+    ensureNotHiddenPath(this.artifactsDirectory, "artifactsDirectory");
     const normalizedArtifactsDirectory = normalizePersistedPath(
       this.artifactsDirectory
     );

--- a/src/release/release.ts
+++ b/src/release/release.ts
@@ -2,6 +2,7 @@ import * as path from "path";
 import { IConstruct } from "constructs";
 import { Publisher } from "./publisher";
 import { ReleaseTrigger } from "./release-trigger";
+import { DEFAULT_ARTIFACTS_DIRECTORY } from "../build/private/consts";
 import { Component } from "../component";
 import {
   GitHub,
@@ -13,6 +14,7 @@ import {
   BUILD_ARTIFACT_NAME,
   PERMISSION_BACKUP_FILE,
 } from "../github/constants";
+import { ensureNotHiddenPath } from "../github/private/util";
 import {
   Job,
   JobPermission,
@@ -358,7 +360,9 @@ export class Release extends Component {
     this.buildTask = options.task;
     this.preBuildSteps = options.releaseWorkflowSetupSteps ?? [];
     this.postBuildSteps = options.postBuildSteps ?? [];
-    this.artifactsDirectory = options.artifactsDirectory ?? "dist";
+    this.artifactsDirectory =
+      options.artifactsDirectory ?? DEFAULT_ARTIFACTS_DIRECTORY;
+    ensureNotHiddenPath(this.artifactsDirectory, "artifactsDirectory");
     this.versionFile = options.versionFile;
     this.releaseTrigger = options.releaseTrigger ?? ReleaseTrigger.continuous();
     this.containerImage = options.workflowContainerImage;

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -296,7 +296,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.self_mutation.outputs.self_mutation_happened
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -311,7 +311,7 @@ jobs:
         run: cd dist && getfacl -R . > permissions-backup.acl
         continue-on-error: true
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -535,7 +535,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -733,7 +733,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -1890,7 +1890,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -3093,7 +3093,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -3972,7 +3972,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.self_mutation.outputs.self_mutation_happened
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -4096,7 +4096,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -4163,7 +4163,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch

--- a/test/awscdk/__snapshots__/awscdk-construct.test.ts.snap
+++ b/test/awscdk/__snapshots__/awscdk-construct.test.ts.snap
@@ -46,7 +46,7 @@ git diff --staged --patch --exit-code > repo.patch || echo "self_mutation_happen
     {
       "if": "steps.self_mutation.outputs.self_mutation_happened",
       "name": "Upload patch",
-      "uses": "actions/upload-artifact@v4.3.6",
+      "uses": "actions/upload-artifact@v4.4.0",
       "with": {
         "name": "repo.patch",
         "overwrite": true,
@@ -67,7 +67,7 @@ exit 1",
     },
     {
       "name": "Upload artifact",
-      "uses": "actions/upload-artifact@v4.3.6",
+      "uses": "actions/upload-artifact@v4.4.0",
       "with": {
         "name": "build-artifact",
         "overwrite": true,
@@ -124,7 +124,7 @@ git diff --staged --patch --exit-code > repo.patch || echo "self_mutation_happen
     {
       "if": "steps.self_mutation.outputs.self_mutation_happened",
       "name": "Upload patch",
-      "uses": "actions/upload-artifact@v4.3.6",
+      "uses": "actions/upload-artifact@v4.4.0",
       "with": {
         "name": "repo.patch",
         "overwrite": true,
@@ -145,7 +145,7 @@ exit 1",
     },
     {
       "name": "Upload artifact",
-      "uses": "actions/upload-artifact@v4.3.6",
+      "uses": "actions/upload-artifact@v4.4.0",
       "with": {
         "name": "build-artifact",
         "overwrite": true,
@@ -202,7 +202,7 @@ git diff --staged --patch --exit-code > repo.patch || echo "self_mutation_happen
     {
       "if": "steps.self_mutation.outputs.self_mutation_happened",
       "name": "Upload patch",
-      "uses": "actions/upload-artifact@v4.3.6",
+      "uses": "actions/upload-artifact@v4.4.0",
       "with": {
         "name": "repo.patch",
         "overwrite": true,
@@ -223,7 +223,7 @@ exit 1",
     },
     {
       "name": "Upload artifact",
-      "uses": "actions/upload-artifact@v4.3.6",
+      "uses": "actions/upload-artifact@v4.4.0",
       "with": {
         "name": "build-artifact",
         "overwrite": true,

--- a/test/build/__snapshots__/build-workflow.test.ts.snap
+++ b/test/build/__snapshots__/build-workflow.test.ts.snap
@@ -32,7 +32,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.self_mutation.outputs.self_mutation_happened
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -109,7 +109,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.self_mutation.outputs.self_mutation_happened
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -189,7 +189,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.self_mutation.outputs.self_mutation_happened
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -290,7 +290,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.self_mutation.outputs.self_mutation_happened
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -305,7 +305,7 @@ jobs:
         run: cd dist && getfacl -R . > permissions-backup.acl
         continue-on-error: true
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -452,7 +452,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -558,7 +558,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -2337,7 +2337,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -2507,7 +2507,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -2675,7 +2675,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -2841,7 +2841,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist

--- a/test/github/__snapshots__/task-workflow.test.ts.snap
+++ b/test/github/__snapshots__/task-workflow.test.ts.snap
@@ -43,7 +43,7 @@ jobs:
         run: projen gh-workflow-test
       - name: Upload artifact
         if: always()
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: ./artifacts/
           path: ./artifacts/

--- a/test/javascript/__snapshots__/node-project.test.ts.snap
+++ b/test/javascript/__snapshots__/node-project.test.ts.snap
@@ -95,7 +95,7 @@ git diff --staged --patch --exit-code > repo.patch || echo "self_mutation_happen
   {
     "if": "steps.self_mutation.outputs.self_mutation_happened",
     "name": "Upload patch",
-    "uses": "actions/upload-artifact@v4.3.6",
+    "uses": "actions/upload-artifact@v4.4.0",
     "with": {
       "name": "repo.patch",
       "overwrite": true,
@@ -173,7 +173,7 @@ git diff --staged --patch --exit-code > repo.patch || echo "self_mutation_happen
   {
     "if": "steps.self_mutation.outputs.self_mutation_happened",
     "name": "Upload patch",
-    "uses": "actions/upload-artifact@v4.3.6",
+    "uses": "actions/upload-artifact@v4.4.0",
     "with": {
       "name": "repo.patch",
       "overwrite": true,
@@ -359,7 +359,7 @@ git diff --staged --patch --exit-code > repo.patch || echo "self_mutation_happen
   {
     "if": "steps.self_mutation.outputs.self_mutation_happened",
     "name": "Upload patch",
-    "uses": "actions/upload-artifact@v4.3.6",
+    "uses": "actions/upload-artifact@v4.4.0",
     "with": {
       "name": "repo.patch",
       "overwrite": true,

--- a/test/javascript/__snapshots__/upgrade-dependencies.test.ts.snap
+++ b/test/javascript/__snapshots__/upgrade-dependencies.test.ts.snap
@@ -33,7 +33,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -125,7 +125,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -217,7 +217,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -309,7 +309,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -401,7 +401,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -493,7 +493,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -585,7 +585,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -677,7 +677,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -769,7 +769,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -861,7 +861,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -953,7 +953,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -1043,7 +1043,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -1135,7 +1135,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -1233,7 +1233,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch

--- a/test/javascript/node-project.test.ts
+++ b/test/javascript/node-project.test.ts
@@ -3,7 +3,7 @@ import { Component } from "../../src";
 import { PROJEN_MARKER } from "../../src/common";
 import { DependencyType } from "../../src/dependencies";
 import { GithubCredentials } from "../../src/github";
-import { secretToString } from "../../src/github/util";
+import { secretToString } from "../../src/github/private/util";
 import { JobPermission } from "../../src/github/workflows-model";
 import {
   CodeArtifactAuthProvider,

--- a/test/jsii/__snapshots__/jsii.test.ts.snap
+++ b/test/jsii/__snapshots__/jsii.test.ts.snap
@@ -290,7 +290,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.self_mutation.outputs.self_mutation_happened
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -305,7 +305,7 @@ jobs:
         run: cd dist && getfacl -R . > permissions-backup.acl
         continue-on-error: true
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -452,7 +452,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -558,7 +558,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -1810,7 +1810,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.self_mutation.outputs.self_mutation_happened
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -1825,7 +1825,7 @@ jobs:
         run: cd dist && getfacl -R . > permissions-backup.acl
         continue-on-error: true
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -1972,7 +1972,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -2078,7 +2078,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -3312,7 +3312,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.self_mutation.outputs.self_mutation_happened
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -3327,7 +3327,7 @@ jobs:
         run: cd dist && getfacl -R . > permissions-backup.acl
         continue-on-error: true
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -3474,7 +3474,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -3580,7 +3580,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -4810,7 +4810,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.self_mutation.outputs.self_mutation_happened
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -4825,7 +4825,7 @@ jobs:
         run: cd dist && getfacl -R . > permissions-backup.acl
         continue-on-error: true
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -4972,7 +4972,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -5078,7 +5078,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch

--- a/test/release/__snapshots__/release.test.ts.snap
+++ b/test/release/__snapshots__/release.test.ts.snap
@@ -88,7 +88,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -474,7 +474,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -860,7 +860,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -1249,7 +1249,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -1588,7 +1588,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -1665,7 +1665,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -1742,7 +1742,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -2090,7 +2090,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -2230,7 +2230,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -2629,7 +2629,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -2877,7 +2877,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -3054,7 +3054,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -3446,7 +3446,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -3857,7 +3857,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -4103,7 +4103,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -4373,7 +4373,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -4868,7 +4868,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -4945,7 +4945,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -5281,7 +5281,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -5358,7 +5358,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -5435,7 +5435,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -5812,7 +5812,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -6100,7 +6100,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -6351,7 +6351,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: packages/subproject/dist

--- a/test/typescript/__snapshots__/typescript.test.ts.snap
+++ b/test/typescript/__snapshots__/typescript.test.ts.snap
@@ -290,7 +290,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.self_mutation.outputs.self_mutation_happened
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -410,7 +410,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -473,7 +473,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch

--- a/test/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-project.test.ts.snap
@@ -61,7 +61,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.self_mutation.outputs.self_mutation_happened
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -185,7 +185,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -252,7 +252,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch

--- a/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -62,7 +62,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.self_mutation.outputs.self_mutation_happened
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -168,7 +168,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch

--- a/test/web/__snapshots__/react-project.test.ts.snap
+++ b/test/web/__snapshots__/react-project.test.ts.snap
@@ -55,7 +55,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.self_mutation.outputs.self_mutation_happened
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -175,7 +175,7 @@ jobs:
         continue-on-error: true
       - name: Upload artifact
         if: \${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: build-artifact
           path: dist
@@ -238,7 +238,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch

--- a/test/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/react-ts-project.test.ts.snap
@@ -288,7 +288,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.self_mutation.outputs.self_mutation_happened
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch
@@ -390,7 +390,7 @@ jobs:
         working-directory: ./
       - name: Upload patch
         if: steps.create_patch.outputs.patch_created
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: repo.patch
           path: repo.patch


### PR DESCRIPTION
Previously `WorkflowSteps.uploadArtifact()` would upload hidden files. However this is not advisable as hidden files might contain sensitive information. Recently the upstream GitHub Action `actions/upload-artifact` has addressed this behavior (see https://github.com/projen/projen/pull/3822). 

This change brings the projen helper and all usage inline.

BREAKING CHANGE: In GitHub Actions Workflows, hidden files are not uploaded as part of artifacts anymore. If you are using only standard projen configurations, this change will not affect you. If you have previously relied on uploading hidden files as part of artifacts, we strongly recommend adjusting the workflow. Alternatively, setting `WorkflowSteps.uploadArtifact({ with: { includeHiddenFiles: true } })` will restore the previous behavior.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
