### PR TITLE
fix(typescript): can't release when package is disabled

### DIFF
--- a/src/javascript/node-project.ts
+++ b/src/javascript/node-project.ts
@@ -834,7 +834,13 @@ export class NodeProject extends GitHubProject {
     // add a bundler component - this enables things like Lambda bundling and in the future web bundling.
     this.bundler = new Bundler(this, options.bundlerOptions);
 
-    if (options.package ?? true) {
+    const shouldPackage = options.package ?? true;
+    if (release && !shouldPackage) {
+      this.logger.warn(
+        "When `release` is enabled, `package` must also be enabled as it is required by release. Force enabling `package`."
+      );
+    }
+    if (release || shouldPackage) {
       this.packageTask.exec(`mkdir -p ${this.artifactsJavascriptDirectory}`);
 
       const pkgMgr =

--- a/src/typescript/typescript.ts
+++ b/src/typescript/typescript.ts
@@ -794,11 +794,14 @@ class SampleCode extends Component {
  */
 export class TypeScriptAppProject extends TypeScriptProject {
   constructor(options: TypeScriptProjectOptions) {
+    // Releasing and packaging are coupled. If one is disabled, disable the other by default.
+    const shouldRelease = options.release ?? options.releaseWorkflow ?? false;
+
     super({
+      release: shouldRelease,
+      package: shouldRelease,
       allowLibraryDependencies: false,
-      releaseWorkflow: false,
       entrypoint: "", // "main" is not needed in typescript apps
-      package: false,
       ...options,
     });
   }

--- a/test/cdk8s/cdk8s-app-project-ts.test.ts
+++ b/test/cdk8s/cdk8s-app-project-ts.test.ts
@@ -178,7 +178,7 @@ test("upgrade task ignores pinned versions", () => {
     cdk8sVersionPinning: true,
     cdk8sCliVersionPinning: true,
     cdk8sPlusVersionPinning: true,
-    releaseWorkflow: true,
+    release: true,
     constructsVersion: "3.3.75",
   });
   const tasks = synthSnapshot(project)[TaskRuntime.MANIFEST_FILE].tasks;

--- a/test/typescript/typescript.test.ts
+++ b/test/typescript/typescript.test.ts
@@ -6,6 +6,7 @@ import { Transform } from "../../src/javascript";
 import {
   mergeTsconfigOptions,
   TsJestTsconfig,
+  TypeScriptAppProject,
   TypeScriptProject,
 } from "../../src/typescript";
 import { execProjenCLI, synthSnapshot, withProjectDir } from "../util";
@@ -589,6 +590,35 @@ describe("tsconfigDev", () => {
         })
     ).toThrow(
       "Cannot specify both 'disableTsconfigDev' and 'disableTsconfig' fields."
+    );
+  });
+
+  test("TypeScriptAppProject enables packaging when release is enabled", () => {
+    const project = new TypeScriptAppProject({
+      name: "test",
+      projenrcTs: true,
+      defaultReleaseBranch: "main",
+      release: true,
+    });
+    project.synth();
+
+    expect(project.packageTask.steps.length).not.toBe(0);
+  });
+
+  test("TypeScriptProject force enables packaging when release is enabled", () => {
+    const loggerWarnSpy = jest.spyOn(Logger.prototype, "warn");
+    const project = new TypeScriptAppProject({
+      name: "test",
+      projenrcTs: true,
+      defaultReleaseBranch: "main",
+      release: true,
+      package: false,
+    });
+    project.synth();
+
+    expect(project.packageTask.steps.length).not.toBe(0);
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      expect.stringMatching("Force enabling `package`")
     );
   });
 });


### PR DESCRIPTION
Fixes #3846

The `Release` component of `NodeProject` requires the packaging task to be available and functioning. Previously it was possible to configure the project so that `release: true` and `package: false`, causing a failure during the release. This was most prominent in the `TypeScriptAppProject`, which is an opinionated TypeScript project type that basically indicates that the package should not be published. Because it has both `release` and `package` disabled by default, it's easy to just enable releases but not packaging.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
