### PR TITLE
chore(docs): fix wrong tsconfig property name in typescript quick-start

### DIFF
--- a/docs/quick-starts/typescript/hello-world/index.md
+++ b/docs/quick-starts/typescript/hello-world/index.md
@@ -98,7 +98,7 @@ repository:
 const { typescript } = require('projen');
 const project = new typescript.TypeScriptProject({
   ...
-  tsConfig: {
+  tsconfig: {
     compilerOptions: {
       rootDir: '.',
       outDir: '.',

--- a/docs/quick-starts/typescript/hello-world/index.md
+++ b/docs/quick-starts/typescript/hello-world/index.md
@@ -89,7 +89,7 @@ time to fully migrate to the expected project structure so that you can take ful
 advantage of Projen management on your repository.
 
 However, you can also configure your `.projenrc.js` file to reflect your current
-project structure. A `TypeScriptProject` exposes all options in a `tsConfig` file
+project structure. A `TypeScriptProject` exposes all options in a `tsconfig` file
 so you can manually set the structure you want. Here is an example for specifying a
 structure where the TypeScript compiler finds all TypeScript files recursively in your
 repository:


### PR DESCRIPTION
typo in code example for `tsconfig`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
