### PR TITLE
fix: bundledDependencies are silently ignored by NPM

### DIFF
--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -1257,7 +1257,7 @@ export class NodePackage extends Component {
           // `dependencies` and `dependencies` only.
           if (depDecls.some((d) => d.type === DependencyType.BUILD)) {
             throw new Error(
-              `unable to bundle "${name}": it cannot appear as a devDependency (certain versions of NPM will silently fail to bundle it if it is)`
+              `unable to bundle "${name}": it cannot appear as a devDependency (only prod dependencies are bundled, and any dependency appearing as a devDependency is considered to be not a prod dependency)`
             );
           }
 

--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -1245,13 +1245,19 @@ export class NodePackage extends Component {
         case DependencyType.BUNDLED:
           bundledDependencies.push(name);
 
-          if (
-            this.project.deps.all.find(
-              (d) => d.name === name && d.type === DependencyType.PEER
-            )
-          ) {
+          const depDecls = this.project.deps.all.filter((d) => d.name === name);
+          if (depDecls.some((d) => d.type === DependencyType.PEER)) {
             throw new Error(
-              `unable to bundle "${name}". it cannot appear as a peer dependency`
+              `unable to bundle "${name}". it cannot appear as a peer dependency (bundled would always take precedence over peer)`
+            );
+          }
+
+          // I've observed that at least npm 10.8.2 will silently fail to bundle
+          // a dependency if it is [also] part of `devDependencies`. It must exist in
+          // `dependencies` and `dependencies` only.
+          if (depDecls.some((d) => d.type === DependencyType.BUILD)) {
+            throw new Error(
+              `unable to bundle "${name}": it cannot appear as a devDependency (certain versions of NPM will silently fail to bundle it if it is)`
             );
           }
 

--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -1248,7 +1248,7 @@ export class NodePackage extends Component {
           const depDecls = this.project.deps.all.filter((d) => d.name === name);
           if (depDecls.some((d) => d.type === DependencyType.PEER)) {
             throw new Error(
-              `unable to bundle "${name}". it cannot appear as a peer dependency (bundled would always take precedence over peer)`
+              `unable to bundle "${name}": it cannot appear as a peer dependency (bundled would always take precedence over peer)`
             );
           }
 

--- a/test/javascript/node-package.test.ts
+++ b/test/javascript/node-package.test.ts
@@ -389,6 +389,18 @@ test("devDependencies are not pinned by peerDependencies if pinnedDevDependency 
   expect(pkgFile.devDependencies).toBeUndefined();
 });
 
+test("bundled dependencies may not occur as peerDependencies", () => {
+  const project = new Project({ name: "test" });
+  new NodePackage(project, {
+    peerDeps: ["my-package"],
+    bundledDeps: ["my-package"],
+  });
+
+  expect(() => project.synth()).toThrow(
+    /unable to bundle "my-package": it cannot appear as a peer dependency/
+  );
+});
+
 test("bundled dependencies may not occur as devDependencies", () => {
   const project = new Project({ name: "test" });
   new NodePackage(project, {

--- a/test/javascript/node-package.test.ts
+++ b/test/javascript/node-package.test.ts
@@ -389,6 +389,18 @@ test("devDependencies are not pinned by peerDependencies if pinnedDevDependency 
   expect(pkgFile.devDependencies).toBeUndefined();
 });
 
+test("bundled dependencies may not occur as devDependencies", () => {
+  const project = new Project({ name: "test" });
+  new NodePackage(project, {
+    devDeps: ["my-package"],
+    bundledDeps: ["my-package"],
+  });
+
+  expect(() => project.synth()).toThrow(
+    /unable to bundle "my-package": it cannot appear as a devDependency/
+  );
+});
+
 test("file path dependencies are respected", () => {
   // Post-synth dependency version resolution uses installed package from node_modules folder
   // Mock install command to add this folder with a fixed dependency version,


### PR DESCRIPTION
Certain versions of npm (at least my tested version, `10.8.2`) silently refuse to bundle a dependency if it doesn't occur in `dependencies`, and `dependencies` only. Specifically, if it also occurs in `devDependencies`, `npm pack` will just silently not bundle the directory.

Add a check for that to prevent users from falling into this trap.

Also add a clarification on the `peerDependencies` check. It makes sense, but it took me longer than should be necessary to understand, and I like the computer to explain things to my peanut-sized brain 😉.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
