### PR TITLE
feat(gitlab): add path option to CiConfiguration

### DIFF
--- a/docs/api/gitlab.md
+++ b/docs/api/gitlab.md
@@ -1997,6 +1997,7 @@ const ciConfigurationOptions: gitlab.CiConfigurationOptions = { ... }
 | <code><a href="#projen.gitlab.CiConfigurationOptions.property.default">default</a></code> | <code><a href="#projen.gitlab.Default">Default</a></code> | Default settings for the CI Configuration. |
 | <code><a href="#projen.gitlab.CiConfigurationOptions.property.jobs">jobs</a></code> | <code>{[ key: string ]: <a href="#projen.gitlab.Job">Job</a>}</code> | An initial set of jobs to add to the configuration. |
 | <code><a href="#projen.gitlab.CiConfigurationOptions.property.pages">pages</a></code> | <code><a href="#projen.gitlab.Job">Job</a></code> | A special job used to upload static sites to Gitlab pages. |
+| <code><a href="#projen.gitlab.CiConfigurationOptions.property.path">path</a></code> | <code>string</code> | The path of the file to generate. |
 | <code><a href="#projen.gitlab.CiConfigurationOptions.property.stages">stages</a></code> | <code>string[]</code> | Groups jobs into stages. |
 | <code><a href="#projen.gitlab.CiConfigurationOptions.property.variables">variables</a></code> | <code>{[ key: string ]: any}</code> | Global variables that are passed to jobs. |
 | <code><a href="#projen.gitlab.CiConfigurationOptions.property.workflow">workflow</a></code> | <code><a href="#projen.gitlab.Workflow">Workflow</a></code> | Used to control pipeline behavior. |
@@ -2041,6 +2042,18 @@ A special job used to upload static sites to Gitlab pages.
 
 Requires a `public/` directory
 with `artifacts.path` pointing to it.
+
+---
+
+##### `path`<sup>Optional</sup> <a name="path" id="projen.gitlab.CiConfigurationOptions.property.path"></a>
+
+```typescript
+public readonly path: string;
+```
+
+- *Type:* string
+
+The path of the file to generate.
 
 ---
 

--- a/src/gitlab/configuration.ts
+++ b/src/gitlab/configuration.ts
@@ -48,6 +48,10 @@ export interface CiConfigurationOptions {
    * An initial set of jobs to add to the configuration.
    */
   readonly jobs?: Record<string, Job>;
+  /**
+   * The path of the file to generate.
+   */
+  readonly path?: string;
 }
 
 /**
@@ -154,10 +158,11 @@ export class CiConfiguration extends Component {
   ) {
     super(project);
     this.name = path.parse(name).name;
-    this.path =
+    const derivedPath =
       this.name === "gitlab-ci"
         ? ".gitlab-ci.yml"
         : `.gitlab/ci-templates/${name.toLocaleLowerCase()}.yml`;
+    this.path = options?.path ?? derivedPath;
     this.file = new YamlFile(this.project, this.path, {
       obj: () => this.renderCI(),
       // GitLab needs to read the file from the repository in order to work.

--- a/test/gitlab/gitlab-configuration.test.ts
+++ b/test/gitlab/gitlab-configuration.test.ts
@@ -33,3 +33,15 @@ test("main configuration inherits child configuration stages", () => {
   // THEN
   expect(c.stages).toContain("baz");
 });
+
+test("main configuration inherits child configuration services", () => {
+  // GIVEN
+  const p = new TestProject({
+    stale: true,
+  });
+
+  const c = new GitlabConfiguration(p, { path: "foo" });
+
+  // THEN
+  expect(c.path).toBe("foo");
+});


### PR DESCRIPTION
This introduces a `path` option to `GitlabConfiguration` and `NestedConfiguration`, giving users the option to produce Gitlab CI configuration and Gitlab CI templates  in the files of their choosing. This is useful for a pattern where we only want to execute a job if known input files or the job definition itself has changed, consider:

```
├── gitlab-ci.yml
├── a
│   ├── job.yml
│   └── input-a
└── b
    ├── job.yml
    └── input-b
```

```
# b.yml
a:
  script: []
  rules:
     changes: b/**/*
b:
  script: []
  rules:
     changes: b/**/*
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
