### PR TITLE
feat(gitlab): add name to gitlab workflow

### DIFF
--- a/docs/api/gitlab.md
+++ b/docs/api/gitlab.md
@@ -4353,7 +4353,20 @@ const workflow: gitlab.Workflow = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#projen.gitlab.Workflow.property.name">name</a></code> | <code>string</code> | You can use name to define a name for pipelines. |
 | <code><a href="#projen.gitlab.Workflow.property.rules">rules</a></code> | <code><a href="#projen.gitlab.WorkflowRule">WorkflowRule</a>[]</code> | Used to control whether or not a whole pipeline is created. |
+
+---
+
+##### `name`<sup>Optional</sup> <a name="name" id="projen.gitlab.Workflow.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* string
+
+You can use name to define a name for pipelines.
 
 ---
 

--- a/src/gitlab/configuration-model.ts
+++ b/src/gitlab/configuration-model.ts
@@ -631,6 +631,8 @@ export interface VariableConfig {
  * @see https://docs.gitlab.com/ee/ci/yaml/#workflow
  */
 export interface Workflow {
+  /** You can use name to define a name for pipelines. */
+  readonly name?: string;
   /** Used to control whether or not a whole pipeline is created. */
   readonly rules?: WorkflowRule[];
 }


### PR DESCRIPTION
Fixes #3894 

Adds missing "name" property from GitLab workflow configuration

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
