### PR TITLE
fix(mergify): some parameters are deprecated in `pull_request_rules` and now need to be in `queue_rules`

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,17 +12,17 @@ queue_rules:
       - status-success=package-python
       - status-success=package-go
       - status-success=post-build-integ
+    merge_method: squash
+    commit_message_template: |-
+      {{ title }} (#{{ number }})
+
+      {{ body }}
 pull_request_rules:
   - name: Automatic merge on approval and successful build
     actions:
       delete_head_branch: {}
       queue:
-        method: squash
         name: default
-        commit_message_template: |-
-          {{ title }} (#{{ number }})
-
-          {{ body }}
     conditions:
       - "#approved-reviews-by>=1"
       - -label~=(do-not-merge)

--- a/docs/api/github.md
+++ b/docs/api/github.md
@@ -6588,10 +6588,23 @@ const mergifyQueue: github.MergifyQueue = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#projen.github.MergifyQueue.property.commitMessageTemplate">commitMessageTemplate</a></code> | <code>string</code> | Template to use as the commit message when using the merge or squash merge method. |
 | <code><a href="#projen.github.MergifyQueue.property.conditions">conditions</a></code> | <code>string \| <a href="#projen.github.MergifyConditionalOperator">MergifyConditionalOperator</a>[]</code> | A list of Conditions string that must match against the pull request for the pull request to be added to the queue. |
 | <code><a href="#projen.github.MergifyQueue.property.name">name</a></code> | <code>string</code> | The name of the queue. |
 | <code><a href="#projen.github.MergifyQueue.property.mergeMethod">mergeMethod</a></code> | <code>string</code> | Merge method to use. |
 | <code><a href="#projen.github.MergifyQueue.property.updateMethod">updateMethod</a></code> | <code>string</code> | Method to use to update the pull request with its base branch when the speculative check is done in-place. |
+
+---
+
+##### `commitMessageTemplate`<sup>Required</sup> <a name="commitMessageTemplate" id="projen.github.MergifyQueue.property.commitMessageTemplate"></a>
+
+```typescript
+public readonly commitMessageTemplate: string;
+```
+
+- *Type:* string
+
+Template to use as the commit message when using the merge or squash merge method.
 
 ---
 

--- a/src/github/auto-merge.ts
+++ b/src/github/auto-merge.ts
@@ -56,16 +56,7 @@ export class AutoMerge extends Component {
       delete_head_branch: {},
 
       queue: {
-        // squash all commits into a single commit when merging
-        // method: "squash",
-        method: "squash",
         name: "default",
-        // use PR title+body as the commit message
-        commit_message_template: [
-          "{{ title }} (#{{ number }})",
-          "",
-          "{{ body }}",
-        ].join("\n"),
       },
     };
 
@@ -89,6 +80,14 @@ export class AutoMerge extends Component {
       name: queueName,
       updateMethod: "merge",
       conditions: (() => this.renderConditions()) as any,
+      // squash all commits into a single commit when merging
+      mergeMethod: "squash",
+      // use PR title+body as the commit message
+      commitMessageTemplate: [
+        "{{ title }} (#{{ number }})",
+        "",
+        "{{ body }}",
+      ].join("\n"),
     });
 
     this.project.addPackageIgnore("/.mergify.yml");

--- a/src/github/mergify.ts
+++ b/src/github/mergify.ts
@@ -72,6 +72,11 @@ export interface MergifyQueue {
    * @see https://docs.mergify.com/conditions/#conditions
    */
   readonly conditions: MergifyCondition[];
+
+  /**
+   * Template to use as the commit message when using the merge or squash merge method.
+   */
+  readonly commitMessageTemplate: string;
 }
 
 export interface MergifyOptions {

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -865,17 +865,17 @@ queue_rules:
       - status-success=package-js
       - status-success=package-java
       - status-success=package-python
+    merge_method: squash
+    commit_message_template: |-
+      {{ title }} (#{{ number }})
+
+      {{ body }}
 pull_request_rules:
   - name: Automatic merge on approval and successful build
     actions:
       delete_head_branch: {}
       queue:
-        method: squash
         name: default
-        commit_message_template: |-
-          {{ title }} (#{{ number }})
-
-          {{ body }}
     conditions:
       - "#approved-reviews-by>=1"
       - -label~=(do-not-merge)
@@ -4283,17 +4283,17 @@ queue_rules:
       - "#approved-reviews-by>=1"
       - -label~=(do-not-merge)
       - status-success=build
+    merge_method: squash
+    commit_message_template: |-
+      {{ title }} (#{{ number }})
+
+      {{ body }}
 pull_request_rules:
   - name: Automatic merge on approval and successful build
     actions:
       delete_head_branch: {}
       queue:
-        method: squash
         name: default
-        commit_message_template: |-
-          {{ title }} (#{{ number }})
-
-          {{ body }}
     conditions:
       - "#approved-reviews-by>=1"
       - -label~=(do-not-merge)

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -682,17 +682,17 @@ queue_rules:
       - -label~=(do-not-merge)
       - status-success=build
       - status-success=package-js
+    merge_method: squash
+    commit_message_template: |-
+      {{ title }} (#{{ number }})
+
+      {{ body }}
 pull_request_rules:
   - name: Automatic merge on approval and successful build
     actions:
       delete_head_branch: {}
       queue:
-        method: squash
         name: default
-        commit_message_template: |-
-          {{ title }} (#{{ number }})
-
-          {{ body }}
     conditions:
       - "#approved-reviews-by>=1"
       - -label~=(do-not-merge)

--- a/test/github/__snapshots__/mergify.test.ts.snap
+++ b/test/github/__snapshots__/mergify.test.ts.snap
@@ -10,17 +10,17 @@ queue_rules:
       - "#approved-reviews-by>=1"
       - -label~=(do-not-merge)
       - status-success=build
+    merge_method: squash
+    commit_message_template: |-
+      {{ title }} (#{{ number }})
+
+      {{ body }}
 pull_request_rules:
   - name: Automatic merge on approval and successful build
     actions:
       delete_head_branch: {}
       queue:
-        method: squash
         name: default
-        commit_message_template: |-
-          {{ title }} (#{{ number }})
-
-          {{ body }}
     conditions:
       - "#approved-reviews-by>=1"
       - -label~=(do-not-merge)
@@ -38,17 +38,17 @@ queue_rules:
       - "#approved-reviews-by>=3"
       - -label~=(do-not-merge|missing-tests)
       - status-success=build
+    merge_method: squash
+    commit_message_template: |-
+      {{ title }} (#{{ number }})
+
+      {{ body }}
 pull_request_rules:
   - name: Automatic merge on approval and successful build
     actions:
       delete_head_branch: {}
       queue:
-        method: squash
         name: default
-        commit_message_template: |-
-          {{ title }} (#{{ number }})
-
-          {{ body }}
     conditions:
       - "#approved-reviews-by>=3"
       - -label~=(do-not-merge|missing-tests)

--- a/test/jsii/__snapshots__/jsii.test.ts.snap
+++ b/test/jsii/__snapshots__/jsii.test.ts.snap
@@ -682,17 +682,17 @@ queue_rules:
       - -label~=(do-not-merge)
       - status-success=build
       - status-success=package-js
+    merge_method: squash
+    commit_message_template: |-
+      {{ title }} (#{{ number }})
+
+      {{ body }}
 pull_request_rules:
   - name: Automatic merge on approval and successful build
     actions:
       delete_head_branch: {}
       queue:
-        method: squash
         name: default
-        commit_message_template: |-
-          {{ title }} (#{{ number }})
-
-          {{ body }}
     conditions:
       - "#approved-reviews-by>=1"
       - -label~=(do-not-merge)
@@ -2206,17 +2206,17 @@ queue_rules:
       - -label~=(do-not-merge)
       - status-success=build
       - status-success=package-js
+    merge_method: squash
+    commit_message_template: |-
+      {{ title }} (#{{ number }})
+
+      {{ body }}
 pull_request_rules:
   - name: Automatic merge on approval and successful build
     actions:
       delete_head_branch: {}
       queue:
-        method: squash
         name: default
-        commit_message_template: |-
-          {{ title }} (#{{ number }})
-
-          {{ body }}
     conditions:
       - "#approved-reviews-by>=1"
       - -label~=(do-not-merge)
@@ -3710,17 +3710,17 @@ queue_rules:
       - -label~=(do-not-merge)
       - status-success=build
       - status-success=package-js
+    merge_method: squash
+    commit_message_template: |-
+      {{ title }} (#{{ number }})
+
+      {{ body }}
 pull_request_rules:
   - name: Automatic merge on approval and successful build
     actions:
       delete_head_branch: {}
       queue:
-        method: squash
         name: default
-        commit_message_template: |-
-          {{ title }} (#{{ number }})
-
-          {{ body }}
     conditions:
       - "#approved-reviews-by>=1"
       - -label~=(do-not-merge)
@@ -5212,17 +5212,17 @@ queue_rules:
       - -label~=(do-not-merge)
       - status-success=build
       - status-success=package-js
+    merge_method: squash
+    commit_message_template: |-
+      {{ title }} (#{{ number }})
+
+      {{ body }}
 pull_request_rules:
   - name: Automatic merge on approval and successful build
     actions:
       delete_head_branch: {}
       queue:
-        method: squash
         name: default
-        commit_message_template: |-
-          {{ title }} (#{{ number }})
-
-          {{ body }}
     conditions:
       - "#approved-reviews-by>=1"
       - -label~=(do-not-merge)

--- a/test/typescript/__snapshots__/typescript.test.ts.snap
+++ b/test/typescript/__snapshots__/typescript.test.ts.snap
@@ -593,17 +593,17 @@ queue_rules:
       - "#approved-reviews-by>=1"
       - -label~=(do-not-merge)
       - status-success=build
+    merge_method: squash
+    commit_message_template: |-
+      {{ title }} (#{{ number }})
+
+      {{ body }}
 pull_request_rules:
   - name: Automatic merge on approval and successful build
     actions:
       delete_head_branch: {}
       queue:
-        method: squash
         name: default
-        commit_message_template: |-
-          {{ title }} (#{{ number }})
-
-          {{ body }}
     conditions:
       - "#approved-reviews-by>=1"
       - -label~=(do-not-merge)

--- a/test/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-project.test.ts.snap
@@ -365,17 +365,17 @@ queue_rules:
       - "#approved-reviews-by>=1"
       - -label~=(do-not-merge)
       - status-success=build
+    merge_method: squash
+    commit_message_template: |-
+      {{ title }} (#{{ number }})
+
+      {{ body }}
 pull_request_rules:
   - name: Automatic merge on approval and successful build
     actions:
       delete_head_branch: {}
       queue:
-        method: squash
         name: default
-        commit_message_template: |-
-          {{ title }} (#{{ number }})
-
-          {{ body }}
     conditions:
       - "#approved-reviews-by>=1"
       - -label~=(do-not-merge)

--- a/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -279,17 +279,17 @@ queue_rules:
       - "#approved-reviews-by>=1"
       - -label~=(do-not-merge)
       - status-success=build
+    merge_method: squash
+    commit_message_template: |-
+      {{ title }} (#{{ number }})
+
+      {{ body }}
 pull_request_rules:
   - name: Automatic merge on approval and successful build
     actions:
       delete_head_branch: {}
       queue:
-        method: squash
         name: default
-        commit_message_template: |-
-          {{ title }} (#{{ number }})
-
-          {{ body }}
     conditions:
       - "#approved-reviews-by>=1"
       - -label~=(do-not-merge)

--- a/test/web/__snapshots__/react-project.test.ts.snap
+++ b/test/web/__snapshots__/react-project.test.ts.snap
@@ -349,17 +349,17 @@ queue_rules:
       - "#approved-reviews-by>=1"
       - -label~=(do-not-merge)
       - status-success=build
+    merge_method: squash
+    commit_message_template: |-
+      {{ title }} (#{{ number }})
+
+      {{ body }}
 pull_request_rules:
   - name: Automatic merge on approval and successful build
     actions:
       delete_head_branch: {}
       queue:
-        method: squash
         name: default
-        commit_message_template: |-
-          {{ title }} (#{{ number }})
-
-          {{ body }}
     conditions:
       - "#approved-reviews-by>=1"
       - -label~=(do-not-merge)

--- a/test/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/react-ts-project.test.ts.snap
@@ -500,17 +500,17 @@ queue_rules:
       - "#approved-reviews-by>=1"
       - -label~=(do-not-merge)
       - status-success=build
+    merge_method: squash
+    commit_message_template: |-
+      {{ title }} (#{{ number }})
+
+      {{ body }}
 pull_request_rules:
   - name: Automatic merge on approval and successful build
     actions:
       delete_head_branch: {}
       queue:
-        method: squash
         name: default
-        commit_message_template: |-
-          {{ title }} (#{{ number }})
-
-          {{ body }}
     conditions:
       - "#approved-reviews-by>=1"
       - -label~=(do-not-merge)


### PR DESCRIPTION
To address the message from Mergify:

```
‼️ Action Required ‼️

The configuration uses the deprecated commit_message_template attribute of the queue action in one or more pull_request_rules. It must now be used under the queue_rules configuration.
A brownout is planned on September 16th, 2024.
This option will be removed on October 21st, 2024.
For more information: https://docs.mergify.com/configuration/file-format/#queue-rules

‼️ Action Required ‼️

The configuration uses the deprecated merge_method attribute of the queue action in one or more pull_request_rules. It must now be used under the queue_rules configuration.
A brownout is planned on September 16th, 2024.
This option will be removed on October 21st, 2024.
For more information: https://docs.mergify.com/configuration/file-format/#queue-rules
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
