### PR TITLE
fix(github)!: auto-queued pull requests are not getting merged

### DIFF
--- a/.github/workflows/auto-queue.yml
+++ b/.github/workflows/auto-queue.yml
@@ -17,6 +17,6 @@ jobs:
     steps:
       - uses: peter-evans/enable-pull-request-automerge@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           pull-request-number: ${{ github.event.number }}
           merge-method: squash

--- a/docs/api/github.md
+++ b/docs/api/github.md
@@ -4672,8 +4672,8 @@ const autoQueueOptions: github.AutoQueueOptions = { ... }
 | <code><a href="#projen.github.AutoQueueOptions.property.allowedUsernames">allowedUsernames</a></code> | <code>string[]</code> | Only pull requests authored by these Github usernames will have auto-queue enabled. |
 | <code><a href="#projen.github.AutoQueueOptions.property.labels">labels</a></code> | <code>string[]</code> | Only pull requests with one of this labels will have auto-queue enabled. |
 | <code><a href="#projen.github.AutoQueueOptions.property.mergeMethod">mergeMethod</a></code> | <code><a href="#projen.github.MergeMethod">MergeMethod</a></code> | The method used to add the PR to the merge queue Any branch protection rules must allow this merge method. |
+| <code><a href="#projen.github.AutoQueueOptions.property.projenCredentials">projenCredentials</a></code> | <code><a href="#projen.github.GithubCredentials">GithubCredentials</a></code> | Choose a method for authenticating with GitHub to enable auto-queue on pull requests. |
 | <code><a href="#projen.github.AutoQueueOptions.property.runsOn">runsOn</a></code> | <code>string[]</code> | Github Runner selection labels. |
-| <code><a href="#projen.github.AutoQueueOptions.property.secret">secret</a></code> | <code>string</code> | A GitHub secret name which contains a GitHub Access Token with write permissions for the `pull_request` scope. |
 
 ---
 
@@ -4716,6 +4716,25 @@ The method used to add the PR to the merge queue Any branch protection rules mus
 
 ---
 
+##### `projenCredentials`<sup>Optional</sup> <a name="projenCredentials" id="projen.github.AutoQueueOptions.property.projenCredentials"></a>
+
+```typescript
+public readonly projenCredentials: GithubCredentials;
+```
+
+- *Type:* <a href="#projen.github.GithubCredentials">GithubCredentials</a>
+- *Default:* uses credentials from the GitHub component
+
+Choose a method for authenticating with GitHub to enable auto-queue on pull requests.
+
+The workflow cannot use a default github token. Queuing a PR
+with the default token will not trigger any merge queue workflows,
+which results in the PR just not getting merged at all.
+
+> [https://projen.io/docs/integrations/github/](https://projen.io/docs/integrations/github/)
+
+---
+
 ##### `runsOn`<sup>Optional</sup> <a name="runsOn" id="projen.github.AutoQueueOptions.property.runsOn"></a>
 
 ```typescript
@@ -4726,21 +4745,6 @@ public readonly runsOn: string[];
 - *Default:* ["ubuntu-latest"]
 
 Github Runner selection labels.
-
----
-
-##### `secret`<sup>Optional</sup> <a name="secret" id="projen.github.AutoQueueOptions.property.secret"></a>
-
-```typescript
-public readonly secret: string;
-```
-
-- *Type:* string
-- *Default:* "GITHUB_TOKEN"
-
-A GitHub secret name which contains a GitHub Access Token with write permissions for the `pull_request` scope.
-
-This token is used to enable auto-queue on pull requests.
 
 ---
 

--- a/test/github/__snapshots__/merge-queue.test.ts.snap
+++ b/test/github/__snapshots__/merge-queue.test.ts.snap
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: peter-evans/enable-pull-request-automerge@v3
         with:
-          token: \${{ secrets.GITHUB_TOKEN }}
+          token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           pull-request-number: \${{ github.event.number }}
           merge-method: squash
 "

--- a/test/github/merge-queue.test.ts
+++ b/test/github/merge-queue.test.ts
@@ -1,3 +1,4 @@
+import { GithubCredentials } from "../../src/github";
 import { MergeMethod } from "../../src/github/auto-queue";
 import { NodeProject } from "../../src/javascript";
 import { synthSnapshot, TestProject } from "../util";
@@ -54,7 +55,9 @@ describe("merge-queue", () => {
             labels: ["abc"],
             mergeMethod: MergeMethod.MERGE,
             runsOn: ["gpu"],
-            secret: "shh",
+            projenCredentials: GithubCredentials.fromPersonalAccessToken({
+              secret: "shh",
+            }),
           },
         },
       },


### PR DESCRIPTION
The AutoQueue workflow cannot use a default github token, because queuing a PR with the default token will not trigger any merge queue workflows. Which just means the PR will not be merged at all.

BREAKING CHANGE: `AutoQueueOptions` now takes an optional `projenCredentials` option instead of the `secret` option. Use `GithubCredentials.fromPersonalAccessToken({ secret: 'MY_SECRET' })` to provide a custom secret name.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
