### PR TITLE
fix(typescript): `minNodeVersion` doesn't update `@types/node` when it's just a major version number

### DIFF
--- a/src/typescript/typescript.ts
+++ b/src/typescript/typescript.ts
@@ -616,7 +616,7 @@ export class TypeScriptProject extends NodeProject {
       return;
     }
 
-    const minNodeParsed = semver.parse(minNodeVersion);
+    const minNodeParsed = semver.min(minNodeVersion);
     if (minNodeParsed) {
       return this.addDevDeps(`${name}@^${minNodeParsed.major}`);
     }

--- a/src/typescript/typescript.ts
+++ b/src/typescript/typescript.ts
@@ -616,9 +616,11 @@ export class TypeScriptProject extends NodeProject {
       return;
     }
 
-    const minNodeParsed = semver.min(minNodeVersion);
-    if (minNodeParsed) {
-      return this.addDevDeps(`${name}@^${minNodeParsed.major}`);
+    if (minNodeVersion) {
+      const minNodeParsed = semver.minVersion(minNodeVersion);
+      if (minNodeParsed) {
+        return this.addDevDeps(`${name}@^${minNodeParsed.major}`);
+      }
     }
 
     // coerce version, since the ts version likely something like ~5.3.0

--- a/test/typescript/typescript.test.ts
+++ b/test/typescript/typescript.test.ts
@@ -625,6 +625,25 @@ describe("tsconfigDev", () => {
     );
   });
 
+  test.each([
+    ["20", "^20"],
+    ["18.3", "^18"],
+    ["20.13.1", "^20"],
+    ["22.0.0", "^22"],
+    ["16.0.0", "^16"],
+  ])("minNodeVersion %s sets @types/node version to %s", (minNodeVersion: string, typesVersion: string) => {
+    const project = new TypeScriptAppProject({
+      name: "test",
+      projenrcTs: true,
+      defaultReleaseBranch: "main",
+      typescriptVersion: "~5.4.0",
+      minNodeVersion
+    });
+
+    const packageJson = synthSnapshot(project)["package.json"];
+    expect(packageJson.devDependencies["@types/node"]).toBe(typesVersion);
+  });
+
   test("@types/node version will match the typescriptVersion", () => {
     const project = new TypeScriptAppProject({
       name: "test",

--- a/test/typescript/typescript.test.ts
+++ b/test/typescript/typescript.test.ts
@@ -631,18 +631,21 @@ describe("tsconfigDev", () => {
     ["20.13.1", "^20"],
     ["22.0.0", "^22"],
     ["16.0.0", "^16"],
-  ])("minNodeVersion: %s sets @types/node version to %s", (minNodeVersion: string, typesVersion: string) => {
-    const project = new TypeScriptAppProject({
-      name: "test",
-      projenrcTs: true,
-      defaultReleaseBranch: "main",
-      typescriptVersion: "~5.4.0",
-      minNodeVersion
-    });
+  ])(
+    "minNodeVersion: %s sets @types/node version to %s",
+    (minNodeVersion: string, typesVersion: string) => {
+      const project = new TypeScriptAppProject({
+        name: "test",
+        projenrcTs: true,
+        defaultReleaseBranch: "main",
+        typescriptVersion: "~5.4.0",
+        minNodeVersion,
+      });
 
-    const packageJson = synthSnapshot(project)["package.json"];
-    expect(packageJson.devDependencies["@types/node"]).toBe(typesVersion);
-  });
+      const packageJson = synthSnapshot(project)["package.json"];
+      expect(packageJson.devDependencies["@types/node"]).toBe(typesVersion);
+    }
+  );
 
   test("@types/node version will match the typescriptVersion", () => {
     const project = new TypeScriptAppProject({

--- a/test/typescript/typescript.test.ts
+++ b/test/typescript/typescript.test.ts
@@ -631,7 +631,7 @@ describe("tsconfigDev", () => {
     ["20.13.1", "^20"],
     ["22.0.0", "^22"],
     ["16.0.0", "^16"],
-  ])("minNodeVersion %s sets @types/node version to %s", (minNodeVersion: string, typesVersion: string) => {
+  ])("minNodeVersion: %s sets @types/node version to %s", (minNodeVersion: string, typesVersion: string) => {
     const project = new TypeScriptAppProject({
       name: "test",
       projenrcTs: true,


### PR DESCRIPTION
Fixes #3962

`minNodeVersion` is supposed to define the version of `@types/node` that is installed. However when `minNodeVersion` is set to just a major version, e.g. `20` than this failed because `semver.parse("20")` fails.

Instead we use `semver.minVersion(minNodeVersion)` which makes sense because we definitely want the minimal version here.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
