### PR TITLE
feat: add pr to merge queue on `synchronize`

### DIFF
--- a/.github/workflows/auto-queue.yml
+++ b/.github/workflows/auto-queue.yml
@@ -7,6 +7,7 @@ on:
       - opened
       - reopened
       - ready_for_review
+      - synchronize
 jobs:
   enableAutoQueue:
     name: "Set AutoQueue on PR #${{ github.event.number }}"

--- a/src/github/auto-queue.ts
+++ b/src/github/auto-queue.ts
@@ -139,7 +139,7 @@ export class AutoQueue extends Component {
       // That way a user can always disable auto-queue if they want to and the workflow will
       // not automatically re-enable it, unless one of the events occurs.
       pullRequestTarget: {
-        types: ["opened", "reopened", "ready_for_review"],
+        types: ["opened", "reopened", "ready_for_review", "synchronize"],
       },
     });
     workflow.addJobs({ enableAutoQueue: autoQueueJob });

--- a/test/__snapshots__/license.test.ts.snap
+++ b/test/__snapshots__/license.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MIT with owner 1`] = `
-"Copyright (c) 2024 John Doe
+"Copyright (c) 2025 John Doe
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -47,7 +47,7 @@ SOFTWARE.
 `;
 
 exports[`MIT-0 with owner 1`] = `
-"Copyright 2024 John Doe
+"Copyright 2025 John Doe
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/test/github/__snapshots__/merge-queue.test.ts.snap
+++ b/test/github/__snapshots__/merge-queue.test.ts.snap
@@ -10,6 +10,7 @@ on:
       - opened
       - reopened
       - ready_for_review
+      - synchronize
 jobs:
   enableAutoQueue:
     name: "Set AutoQueue on PR #\${{ github.event.number }}"
@@ -36,6 +37,7 @@ on:
       - opened
       - reopened
       - ready_for_review
+      - synchronize
 jobs:
   enableAutoQueue:
     name: "Set AutoQueue on PR #\${{ github.event.number }}"


### PR DESCRIPTION
If a PR fails status checks *after* is has been added to the merge queue, github will remove it:

<img width="947" alt="image" src="https://github.com/user-attachments/assets/078bbca1-12dc-4613-b5d0-bf691d9c148a" />

It will not re-add it when you push new commits though, this doesn't seem desirable since it effectively disables the auto merge.

> Example: https://github.com/cdklabs/jsii-docgen/pull/1687

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
