### PR TITLE
chore: bump workflow node version to 20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.0.0
+          node-version: 20.9.0
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -84,7 +84,7 @@ jobs:
           java-version: "11"
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.0.0
+          node-version: 20.9.0
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -118,7 +118,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.0.0
+          node-version: 20.9.0
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -155,7 +155,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.0.0
+          node-version: 20.9.0
       - uses: actions/setup-go@v5
         with:
           go-version: ^1.18.0
@@ -229,7 +229,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.0.0
+          node-version: 20.9.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.18.0
+          node-version: 20.0.0
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -84,7 +84,7 @@ jobs:
           java-version: "11"
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.18.0
+          node-version: 20.0.0
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -118,7 +118,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.18.0
+          node-version: 20.0.0
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -155,7 +155,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.18.0
+          node-version: 20.0.0
       - uses: actions/setup-go@v5
         with:
           go-version: ^1.18.0
@@ -229,7 +229,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.18.0
+          node-version: 20.0.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.0.0
+          node-version: 20.9.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -78,7 +78,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.0.0
+          node-version: 20.9.0
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -118,7 +118,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.0.0
+          node-version: 20.9.0
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -176,7 +176,7 @@ jobs:
           java-version: "11"
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.0.0
+          node-version: 20.9.0
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -232,7 +232,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.0.0
+          node-version: 20.9.0
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -287,7 +287,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.0.0
+          node-version: 20.9.0
       - uses: actions/setup-go@v5
         with:
           go-version: ^1.18.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.18.0
+          node-version: 20.0.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -78,7 +78,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.18.0
+          node-version: 20.0.0
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -118,7 +118,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.18.0
+          node-version: 20.0.0
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -176,7 +176,7 @@ jobs:
           java-version: "11"
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.18.0
+          node-version: 20.0.0
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -232,7 +232,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.18.0
+          node-version: 20.0.0
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -287,7 +287,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.18.0
+          node-version: 20.0.0
       - uses: actions/setup-go@v5
         with:
           go-version: ^1.18.0

--- a/.github/workflows/upgrade-bundled-main.yml
+++ b/.github/workflows/upgrade-bundled-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.18.0
+          node-version: 20.0.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.github/workflows/upgrade-bundled-main.yml
+++ b/.github/workflows/upgrade-bundled-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.0.0
+          node-version: 20.9.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.18.0
+          node-version: 20.0.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.0.0
+          node-version: 20.9.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -90,7 +90,7 @@ const project = new JsiiProject({
   projenDevDependency: false, // because I am projen
   releaseToNpm: true,
   minNodeVersion: "16.0.0", // Do not change this before a version has been EOL for a while
-  workflowNodeVersion: "18.18.0",
+  workflowNodeVersion: "20.0.0",
 
   codeCov: true,
   prettier: true,

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -90,7 +90,7 @@ const project = new JsiiProject({
   projenDevDependency: false, // because I am projen
   releaseToNpm: true,
   minNodeVersion: "16.0.0", // Do not change this before a version has been EOL for a while
-  workflowNodeVersion: "20.0.0",
+  workflowNodeVersion: "20.9.0",
 
   codeCov: true,
   prettier: true,


### PR DESCRIPTION
`lru-cache` has dropped support for Node 18, and now requires Node 20 or higher.

When `projen` creates new projects that use jest, it pulls in `lru-cache` using the following dependency path:

```
jest > @jest/core > @jest/transform > @babel/core > @babel/helper-compilation-targets > lru-cache
```

That happens to install the newest `lru-cache` version, which no longer works on Node 18, and so our tests fail.

Bump our workflow Node to 20 to at least make our PR build pass again (should we use `lts/*` to be done with this periodic breakage?)

This means that `projen new typescript-app` will no longer work on Node 18.

I don't know if this should have bearing on projen's minimum Node version; I suppose *technically* not, and people with a working `package-lock` will be unaffected... but it might be hard to explain the intricacies to users.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
