### PR TITLE
chore(typescript): align default ES version to `cdk init`

### DIFF
--- a/src/typescript/typescript.ts
+++ b/src/typescript/typescript.ts
@@ -461,7 +461,7 @@ export class TypeScriptProject extends NodeProject {
       experimentalDecorators: true,
       inlineSourceMap: true,
       inlineSources: true,
-      lib: ["es2019"],
+      lib: ["es2020"],
       module: "CommonJS",
       noEmitOnError: false,
       noFallthroughCasesInSwitch: true,
@@ -475,7 +475,7 @@ export class TypeScriptProject extends NodeProject {
       strictNullChecks: true,
       strictPropertyInitialization: true,
       stripInternal: true,
-      target: "ES2019",
+      target: "ES2020",
     };
 
     if (options.disableTsconfigDev && options.disableTsconfig) {

--- a/test/javascript/jest.test.ts
+++ b/test/javascript/jest.test.ts
@@ -12,7 +12,7 @@ const compilerOptionDefaults = {
   experimentalDecorators: true,
   inlineSourceMap: true,
   inlineSources: true,
-  lib: ["es2019"],
+  lib: ["es2020"],
   module: "CommonJS",
   noEmitOnError: false,
   noFallthroughCasesInSwitch: true,
@@ -26,7 +26,7 @@ const compilerOptionDefaults = {
   strictNullChecks: true,
   strictPropertyInitialization: true,
   stripInternal: true,
-  target: "ES2019",
+  target: "ES2020",
 };
 
 test("Node Project Jest Defaults Configured", () => {


### PR DESCRIPTION
Current `tsconfig.json` file generated by `cdk init`:

```json
{
  "compilerOptions": {
    "target": "ES2020",
    "module": "commonjs",
    "lib": [
      "es2020",
      "dom"
    ],
    "declaration": true,
    "strict": true,
    "noImplicitAny": true,
    "strictNullChecks": true,
    "noImplicitThis": true,
    "alwaysStrict": true,
    "noUnusedLocals": false,
    "noUnusedParameters": false,
    "noImplicitReturns": true,
    "noFallthroughCasesInSwitch": false,
    "inlineSourceMap": true,
    "inlineSources": true,
    "experimentalDecorators": true,
    "strictPropertyInitialization": false,
    "typeRoots": [
      "./node_modules/@types"
    ]
  },
  "exclude": [
    "node_modules",
    "cdk.out"
  ]
}

```