### PR TITLE
feat(task-runtime): support bash-like quoted argument expansion in task arguments 

### DIFF
--- a/docs/api/projen.md
+++ b/docs/api/projen.md
@@ -13064,6 +13064,9 @@ Should this step receive args passed to the task.
 If `true`, args are passed through at the end of the `exec` shell command.\
 The position of the args can be changed by including the marker `$@` inside the command string.
 
+If the marker is explicitly double-quoted ("$@") arguments will be wrapped in single quotes, approximating
+the whitespace preserving behavior of bash variable expansion.
+
 If the step spawns a subtask, args are passed to the subtask.
 The subtask must define steps receiving args for this to have any effect.
 
@@ -13270,6 +13273,9 @@ Should this step receive args passed to the task.
 
 If `true`, args are passed through at the end of the `exec` shell command.\
 The position of the args can be changed by including the marker `$@` inside the command string.
+
+If the marker is explicitly double-quoted ("$@") arguments will be wrapped in single quotes, approximating
+the whitespace preserving behavior of bash variable expansion.
 
 If the step spawns a subtask, args are passed to the subtask.
 The subtask must define steps receiving args for this to have any effect.

--- a/src/task-model.ts
+++ b/src/task-model.ts
@@ -95,6 +95,9 @@ export interface TaskStepOptions {
    * If `true`, args are passed through at the end of the `exec` shell command.\
    * The position of the args can be changed by including the marker `$@` inside the command string.
    *
+   * If the marker is explicitly double-quoted ("$@") arguments will be wrapped in single quotes, approximating
+   * the whitespace preserving behavior of bash variable expansion.
+   *
    * If the step spawns a subtask, args are passed to the subtask.
    * The subtask must define steps receiving args for this to have any effect.
    *

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -122,3 +122,13 @@ test('running "projen" with task if there is no tasks.json', () => {
   };
   expect(t).toThrowError("Unknown command: build");
 });
+
+test('running "projen" with task in root of a project that receives args will respect whitespaces', () => {
+  const project = new Project({ name: "my-project" });
+  project.testTask?.exec(`touch "$@"`, { receiveArgs: true });
+  project.synth();
+
+  execProjenCLI(project.outdir, ["test", "a b", "c d"]);
+  expect(directorySnapshot(project.outdir)["a b"]).toStrictEqual("");
+  expect(directorySnapshot(project.outdir)["c d"]).toStrictEqual("");
+});


### PR DESCRIPTION
Custom task definitions do not allow for bash-style variable expansion.

For example, we have a task definition that looks like this:

```json5
{
  exec: 'prettier --write --ignore-unknown --loglevel=warn "$@"',
  receiveArgs: true,
}
```

It expects to invoke `prettier` on a series of filenames to be expanded from `"$@"`. Normally in bash, this quoted variable expansion (`"$@")` would automatically wrap whitespace containing elements in single quotes to preserve whitespace. Without this behavior, filenames including whitespace would be split and interpreted as separate filename tokens.

Currently, if we invoke `npx projen <prettier task> src/foo\ bar.txt` prettier is incorrectly invoked on `src/foo` and `bar.txt` as separate tokens because projen does not preserve whitespace in arguments.

This PR attempts to preserve whitespace in a similar fashion to bash by specifically noting the presence of `"$@"` (as opposed to `$@`) and performing a similar whitespace preserving single quotation wrap of each argument provided to the task.

I've provided an example of the behavior in a unit test. Before the change in this PR, the unit test failed as the whitespace was not being correctly preserved. It passes after the change.

For a demonstration of the behavior I am describing in bash, see the following.

```bash
$ cat script.sh
set -x
echo quoted: "$@" > /dev/null
echo unquoted: $@ > /dev/null
$ ./script.sh "a b" c\ d e f
++ echo quoted: 'a b' 'c d' e f
++ echo unquoted: a b c d e f
```

BREAKING CHANGE: Task definitions that included `"$@"` will now observe individual arguments being wrapped in single quotes, rather than the entire argstring wrapped in double quotes. This may be breaking or incompatible behavior in certain circumstances.

From my perspective, I'm not clear what use case `"<entire arg string>"` legitimately satisfies (compared to `'arg' 'arg' 'arg'`). But I'm open to hearing why this breaking change may not be desired.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
