### PR TITLE
feat(release): `ReleaseTrigger.workflowDispatch`

### DIFF
--- a/docs/api/release.md
+++ b/docs/api/release.md
@@ -4109,6 +4109,7 @@ and release artifact automation
 | <code><a href="#projen.release.ReleaseTrigger.continuous">continuous</a></code> | Creates a continuous release trigger. |
 | <code><a href="#projen.release.ReleaseTrigger.manual">manual</a></code> | Creates a manual release trigger. |
 | <code><a href="#projen.release.ReleaseTrigger.scheduled">scheduled</a></code> | Creates a scheduled release trigger. |
+| <code><a href="#projen.release.ReleaseTrigger.workflowDispatch">workflowDispatch</a></code> | The release can only be triggered using the GitHub UI. |
 
 ---
 
@@ -4180,12 +4181,22 @@ release options.
 
 ---
 
+##### `workflowDispatch` <a name="workflowDispatch" id="projen.release.ReleaseTrigger.workflowDispatch"></a>
+
+```typescript
+import { release } from 'projen'
+
+release.ReleaseTrigger.workflowDispatch()
+```
+
+The release can only be triggered using the GitHub UI.
+
 #### Properties <a name="Properties" id="Properties"></a>
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#projen.release.ReleaseTrigger.property.isContinuous">isContinuous</a></code> | <code>boolean</code> | Whether or not this is a continuous release. |
-| <code><a href="#projen.release.ReleaseTrigger.property.isManual">isManual</a></code> | <code>boolean</code> | Whether or not this is a manual release trigger. |
+| <code><a href="#projen.release.ReleaseTrigger.property.isManual">isManual</a></code> | <code>boolean</code> | Whether or not this is a release trigger with a manual task run in a working copy. |
 | <code><a href="#projen.release.ReleaseTrigger.property.changelogPath">changelogPath</a></code> | <code>string</code> | Project-level changelog file path. |
 | <code><a href="#projen.release.ReleaseTrigger.property.gitPushCommand">gitPushCommand</a></code> | <code>string</code> | Override git-push command used when releasing manually. |
 | <code><a href="#projen.release.ReleaseTrigger.property.paths">paths</a></code> | <code>string[]</code> | Paths for which pushes will trigger a release when `isContinuous` is `true`. |
@@ -4213,7 +4224,9 @@ public readonly isManual: boolean;
 
 - *Type:* boolean
 
-Whether or not this is a manual release trigger.
+Whether or not this is a release trigger with a manual task run in a working copy.
+
+If the `ReleaseTrigger` is a GitHub-only manual task, this will return `false`.
 
 ---
 

--- a/test/release/release-trigger.test.ts
+++ b/test/release/release-trigger.test.ts
@@ -114,3 +114,13 @@ describe("scheduled release", () => {
     expect(releaseTrigger.changelogPath).toBeUndefined();
   });
 });
+
+describe("workflowdispatch release", () => {
+  const trigger = ReleaseTrigger.workflowDispatch();
+
+  test('is not manual', () => {
+    // Well it is, but not for what this property is used for, which is to determine
+    // whether a local `yarn release` task needs to be generated.
+    expect(trigger.isManual).toEqual(false);
+  });
+});

--- a/test/release/release-trigger.test.ts
+++ b/test/release/release-trigger.test.ts
@@ -118,7 +118,7 @@ describe("scheduled release", () => {
 describe("workflowdispatch release", () => {
   const trigger = ReleaseTrigger.workflowDispatch();
 
-  test('is not manual', () => {
+  test("is not manual", () => {
     // Well it is, but not for what this property is used for, which is to determine
     // whether a local `yarn release` task needs to be generated.
     expect(trigger.isManual).toEqual(false);

--- a/test/release/release.test.ts
+++ b/test/release/release.test.ts
@@ -343,6 +343,30 @@ describe("Single Project", () => {
     });
   });
 
+  test("workflowDispatch only leads to workflow dispatch trigger", () => {
+    // GIVEN
+    const project = new TestProject();
+
+    // WHEN
+    new Release(project, {
+      task: project.buildTask,
+      versionFile: "version.json",
+      branch: "main",
+      releaseTrigger: ReleaseTrigger.workflowDispatch(),
+      publishTasks: true, // to increase coverage
+      artifactsDirectory: "dist",
+    });
+
+    // THEN
+    const outdir = synthSnapshot(project);
+    const workflow = YAML.parse(outdir[".github/workflows/release.yml"]);
+    expect(workflow).toMatchObject({
+      on: {
+        workflow_dispatch: {},
+      },
+    });
+  });
+
   test("manual release publish happens after anti-tamper check", () => {
     // GIVEN
     const project = new TestProject();


### PR DESCRIPTION
I want to be able to trigger a release only by starting a workflow on GitHub, and nothing else.

The `manual` trigger implies a task I need to run from a working copy, but I want just the scheduled job, except it runs whenever I choose and not on an actual schedule.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
