### PR TITLE
feat(bump-task): allow forcing a version suffix

### DIFF
--- a/src/release/bump-version.task.ts
+++ b/src/release/bump-version.task.ts
@@ -32,6 +32,7 @@ const versionrcOptions = process.env.VERSIONRCOPTIONS;
 const releasableCommits = process.env.RELEASABLE_COMMITS;
 const bumpPackage = process.env.BUMP_PACKAGE;
 const nextVersionCommand = process.env.NEXT_VERSION_COMMAND;
+const forceSuffix = process.env.FORCE_VERSION_SUFFIX;
 
 if (!versionFile) {
   throw new Error("OUTFILE is required");
@@ -75,6 +76,7 @@ const opts: BumpOptions = {
   releasableCommits,
   bumpPackage,
   nextVersionCommand: nextVersionCommand ? nextVersionCommand : undefined,
+  forceSuffix: forceSuffix ? forceSuffix : undefined,
 };
 logging.debug(opts);
 

--- a/src/release/bump-version.ts
+++ b/src/release/bump-version.ts
@@ -323,12 +323,14 @@ export async function bump(cwd: string, options: BumpOptions) {
   if (options.forceSuffix) {
     let suffix = options.forceSuffix;
     if (!suffix.match(/^-/)) suffix = `-${suffix}`;
-    if (!suffix.match(/\d$/)) suffix += '.0';
+    if (!suffix.match(/\d$/)) suffix += ".0";
     newVersion = `${newVersion}${suffix}`;
     updatedVersionFile.contents.version = newVersion;
 
-    const updatedContents = JSON.stringify(updatedVersionFile.contents, undefined, 2) + (updatedVersionFile.newline ? '\n' : '');
-    await fs.writeFile(versionFile, updatedContents, 'utf-8');
+    const updatedContents =
+      JSON.stringify(updatedVersionFile.contents, undefined, 2) +
+      (updatedVersionFile.newline ? "\n" : "");
+    await fs.writeFile(versionFile, updatedContents, "utf-8");
   }
 
   await fs.writeFile(bumpFile, newVersion);

--- a/test/version.test.ts
+++ b/test/version.test.ts
@@ -137,7 +137,7 @@ describe("bump task", () => {
         workdir: project.outdir,
         env: {
           ...process.env,
-          FORCE_VERSION_SUFFIX: 'test.0',
+          FORCE_VERSION_SUFFIX: "test.0",
         },
         commits: [
           { message: "chore(release): v0.1.0", tag: "v0.1.0" },
@@ -205,7 +205,7 @@ describe("bump task", () => {
 function testBumpTask(
   opts: {
     workdir?: string;
-    env?: Record<string, string>,
+    env?: Record<string, string>;
     commits?: { message: string; tag?: string; path?: string }[];
   } = {}
 ) {


### PR DESCRIPTION
The `yarn bump` task allows forcing a suffix by setting an environment variable. This will be used to force a unique local version for testing by appending `test.0` to all versions before building.

It makes sure that candidate packages have a realistic but definitely unique version during integration tests.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
