### PR TITLE
fix(bump): output of nextVersionCommand is ignored if there are 0 new commits

### DIFF
--- a/src/release/bump-version.ts
+++ b/src/release/bump-version.ts
@@ -241,7 +241,10 @@ export async function bump(cwd: string, options: BumpOptions) {
       // Calculate the next version
       if (isReleaseType(nextVersion)) {
         releaseAs = inc(latestVersion, nextVersion)?.toString();
-      } else if (isFullVersionString(nextVersion) && nextVersion !== latestVersion) {
+      } else if (
+        isFullVersionString(nextVersion) &&
+        nextVersion !== latestVersion
+      ) {
         releaseAs = nextVersion;
       } else {
         throw new Error(

--- a/test/version.test.ts
+++ b/test/version.test.ts
@@ -145,6 +145,33 @@ describe("bump task", () => {
     });
   });
 
+  test("if there are 0 commits but the version script outputs a version, bump anyway", async () => {
+    withProjectDir((projectdir) => {
+      const project = new TestProject({
+        outdir: projectdir,
+      });
+      new Version(project, {
+        versionInputFile: "package.json",
+        artifactsDirectory: "dist",
+        nextVersionCommand: "echo 9.9.9",
+      });
+
+      project.synth();
+
+      // Run with no new commits since last release
+      const result = testBumpTask({
+        workdir: project.outdir,
+        commits: [
+          // projen will fully skip the 'bump' task if the most recent commit contains the text "chore(release):",
+          // so name this commit something else.
+          { message: "release: v0.1.0", tag: "v0.1.0" },
+        ],
+      });
+
+      expect(result.version).toEqual("9.9.9");
+    });
+  });
+
   test("throws an error if the bump command output is not valid", async () => {
     withProjectDir((projectdir) => {
       const project = new TestProject({


### PR DESCRIPTION
The `nextVersionCommand` script should have full control over whether a version bump gets executed or not, but currently there is logic that decides that if there are 0 commits since the last tag, the bump will always be skipped.

Change that to take the output of the `nextVersionCommand` script into account.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
