### PR TITLE
chore(github): default value for `mergeQueue` is incorrectly documented as `true`

### DIFF
--- a/docs/api/github.md
+++ b/docs/api/github.md
@@ -6249,7 +6249,7 @@ public readonly mergeQueue: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* true
+- *Default:* false
 
 Whether a merge queue should be used on this repository to merge pull requests.
 

--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -32,7 +32,7 @@ export interface GitHubOptions {
    * Whether a merge queue should be used on this repository to merge pull requests.
    * Requires additional configuration of the repositories branch protection rules.
    *
-   * @default true
+   * @default false
    */
   readonly mergeQueue?: boolean;
 


### PR DESCRIPTION
This causes confusion for users.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
