### PR TITLE
fix: `Jest` component cannot be created as a child of non-project

### DIFF
--- a/src/component.ts
+++ b/src/component.ts
@@ -34,7 +34,7 @@ export class Component extends Construct {
     this.node.addMetadata("type", "component");
     this.node.addMetadata("construct", new.target.name);
 
-    this.project = findClosestProject(scope);
+    this.project = findClosestProject(scope, new.target.name);
   }
 
   /**

--- a/src/file.ts
+++ b/src/file.ts
@@ -97,7 +97,7 @@ export abstract class FileBase extends Component {
     filePath: string,
     options: FileBaseOptions = {}
   ) {
-    const project = findClosestProject(scope);
+    const project = findClosestProject(scope, new.target.name);
     const root = project.root;
     const normalizedPath = path.normalize(filePath);
     const projectPath = normalizePersistedPath(normalizedPath);

--- a/src/javascript/jest.ts
+++ b/src/javascript/jest.ts
@@ -1,9 +1,11 @@
 import * as path from "path";
+import { IConstruct } from "constructs";
 import { Component } from "../component";
 import { NodeProject } from "../javascript";
 import { JsonFile } from "../json";
 import { Project } from "../project";
 import { normalizePersistedPath } from "../util";
+import { closestProjectMustBe } from "../util/constructs";
 
 const DEFAULT_TEST_REPORTS_DIR = "test-reports";
 
@@ -675,6 +677,9 @@ export class Jest extends Component {
     const isJest = (c: Component): c is Jest => c instanceof Jest;
     return project.components.find(isJest);
   }
+
+  public readonly project: NodeProject;
+
   /**
    * Escape hatch.
    */
@@ -703,8 +708,9 @@ export class Jest extends Component {
   private readonly passWithNoTests: boolean;
   private _snapshotResolver: string | undefined;
 
-  constructor(project: NodeProject, options: JestOptions = {}) {
-    super(project);
+  constructor(scope: IConstruct, options: JestOptions = {}) {
+    super(scope);
+    this.project = closestProjectMustBe(scope, NodeProject, new.target.name);
 
     // hard deprecation
     if ((options as any).typescriptConfig) {
@@ -714,9 +720,9 @@ export class Jest extends Component {
     }
 
     // Jest snapshot files are generated files!
-    project.root.annotateGenerated("*.snap");
+    this.project.root.annotateGenerated("*.snap");
     this.jestVersion = options.jestVersion ? `@${options.jestVersion}` : "";
-    project.addDevDeps(`jest${this.jestVersion}`);
+    this.project.addDevDeps(`jest${this.jestVersion}`);
 
     // use native v8 coverage collection as default
     // https://jestjs.io/docs/en/cli#--coverageproviderprovider
@@ -784,14 +790,14 @@ export class Jest extends Component {
         new JestReporter("jest-junit", { outputDirectory: reportsDir })
       );
 
-      project.addDevDeps("jest-junit@^16");
+      this.project.addDevDeps("jest-junit@^16");
 
-      project.gitignore.exclude(
+      this.project.gitignore.exclude(
         "# jest-junit artifacts",
         `/${reportsDir}/`,
         "junit.xml"
       );
-      project.npmignore?.exclude(
+      this.project.npmignore?.exclude(
         "# jest-junit artifacts",
         `/${reportsDir}/`,
         "junit.xml"
@@ -813,17 +819,17 @@ export class Jest extends Component {
     this.configureTestCommand(options.updateSnapshot ?? UpdateSnapshot.ALWAYS);
 
     if (options.configFilePath) {
-      this.file = new JsonFile(project, options.configFilePath, {
+      this.file = new JsonFile(this.project, options.configFilePath, {
         obj: this.config,
       });
-      project.npmignore?.addPatterns(`/${this.file.path}`);
+      this.project.npmignore?.addPatterns(`/${this.file.path}`);
     } else {
-      project.addFields({ jest: this.config });
+      this.project.addFields({ jest: this.config });
     }
 
     const coverageDirectoryPath = path.posix.join("/", coverageDirectory, "/");
-    project.npmignore?.exclude(coverageDirectoryPath);
-    project.gitignore.exclude(coverageDirectoryPath);
+    this.project.npmignore?.exclude(coverageDirectoryPath);
+    this.project.gitignore.exclude(coverageDirectoryPath);
 
     if (options.coverageText ?? true) {
       this.coverageReporters.push("text");

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -34,7 +34,7 @@ export class Logger extends Component {
   private readonly usePrefix: boolean;
 
   constructor(scope: IConstruct, options: LoggerOptions = {}) {
-    const project = findClosestProject(scope);
+    const project = findClosestProject(scope, new.target.name);
     super(scope, `${new.target.name}#${project.name}`);
 
     // if we are running inside a test, default to no logs

--- a/src/project.ts
+++ b/src/project.ts
@@ -172,7 +172,7 @@ export class Project extends Construct {
    * @throws when no project is found in the path to the root
    */
   public static of(construct: IConstruct): Project {
-    return findClosestProject(construct);
+    return findClosestProject(construct, this.name);
   }
 
   /**

--- a/test/util/constructs.test.ts
+++ b/test/util/constructs.test.ts
@@ -1,0 +1,45 @@
+import { Construct } from "constructs";
+import { NodeProject } from "../../src/javascript";
+import { Project } from "../../src/project";
+import { closestProjectMustBe } from "../../src/util/constructs";
+
+describe("closestProjectMustBeA", () => {
+  test("finds the closest NodeProject", () => {
+    // GIVEN
+    const project = new NodeProject({
+      name: "test",
+      defaultReleaseBranch: "main",
+    });
+    const child = new Construct(project, "child");
+
+    // WHEN
+    const found = closestProjectMustBe(child, NodeProject, "TestComponent");
+
+    // THEN
+    expect(found).toBe(project);
+  });
+
+  test("throws if the closest project is not a NodeProject", () => {
+    // GIVEN
+    const project = new Project({
+      name: "test",
+    });
+    const child = new Construct(project, "child");
+
+    // WHEN/THEN
+    expect(() =>
+      closestProjectMustBe(child, NodeProject, "TestComponent")
+    ).toThrow(/must be created within a NodeProject, but found: Project/);
+  });
+
+  test("throws if there is no Project at all", () => {
+    // GIVEN
+    const root = new Construct(undefined as any, "root");
+    const child = new Construct(root, "child");
+
+    // WHEN/THEN
+    expect(() =>
+      closestProjectMustBe(child, NodeProject, "TestComponent")
+    ).toThrow(/must be created within a NodeProject, but no Project was found/);
+  });
+});


### PR DESCRIPTION
The fix is just a proxy to introduce a new helper function `closestProjectMustBe`.

The helper allows components to easily ensure they are created within a project of a certain type and correctly declare the types of its enclosing project. This approach more flexible than requiring a specific project type inside the class constructor, since the component can now be created nested inside an abstraction. If a project of the required type is not found, an error is thrown.

An implementing component would use this like so:

```ts
export class MyComponent extends Component {
  public readonly project: NodeProject;
  constructor(scope: IConstruct, options: JestOptions = {}) {
    super(scope);
    this.project = closestProjectMustBe(scope, NodeProject, new.target.name);
  }
}
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
