### PR TITLE
feat: add steps to a task

### DIFF
--- a/docs/api/projen.md
+++ b/docs/api/projen.md
@@ -15106,6 +15106,7 @@ new Task(name: string, props?: TaskOptions)
 | <code><a href="#projen.Task.builtin">builtin</a></code> | Execute a builtin task. |
 | <code><a href="#projen.Task.env">env</a></code> | Adds an environment variable to this task. |
 | <code><a href="#projen.Task.exec">exec</a></code> | Executes a shell command. |
+| <code><a href="#projen.Task.insertStep">insertStep</a></code> | Insert one or more steps at a given index. |
 | <code><a href="#projen.Task.lock">lock</a></code> | Forbid additional changes to this task. |
 | <code><a href="#projen.Task.prepend">prepend</a></code> | Adds a command at the beginning of the task. |
 | <code><a href="#projen.Task.prependExec">prependExec</a></code> | Adds a command at the beginning of the task. |
@@ -15209,6 +15210,33 @@ Shell command.
 - *Type:* <a href="#projen.TaskStepOptions">TaskStepOptions</a>
 
 Options.
+
+---
+
+##### `insertStep` <a name="insertStep" id="projen.Task.insertStep"></a>
+
+```typescript
+public insertStep(index: number, steps: ...TaskStep[]): void
+```
+
+Insert one or more steps at a given index.
+
+###### `index`<sup>Required</sup> <a name="index" id="projen.Task.insertStep.parameter.index"></a>
+
+- *Type:* number
+
+Steps will be inserted before this index.
+
+May be negative to
+count backwards from the end, or may be `== steps().length` to insert at the end.
+
+---
+
+###### `steps`<sup>Required</sup> <a name="steps" id="projen.Task.insertStep.parameter.steps"></a>
+
+- *Type:* ...<a href="#projen.TaskStep">TaskStep</a>[]
+
+The steps to insert.
 
 ---
 

--- a/src/task.ts
+++ b/src/task.ts
@@ -318,6 +318,30 @@ export class Task {
   }
 
   /**
+   * Insert one or more steps at a given index
+   *
+   * @param index Steps will be inserted before this index. May be negative to
+   * count backwards from the end, or may be `== steps().length` to insert at the end.
+   * @param steps The steps to insert
+   */
+  public insertStep(index: number, ...steps: TaskStep[]): void {
+    this.assertUnlocked();
+
+    if (!Array.isArray(this._steps)) {
+      this.warnForLazyValue("insert steps into");
+      return;
+    }
+
+    if (index < -this._steps.length || index > this.steps.length) {
+      throw new Error(
+        `Cannot insert steps at index ${index} for task ${this.name} because the index is out of bounds for size ${this.steps.length}`
+      );
+    }
+
+    this._steps.splice(index, 0, ...steps);
+  }
+
+  /**
    *
    * @param index The index of the step to edit
    * @param step The new step to replace the old one entirely, it is not merged with the old step

--- a/test/tasks/tasks.test.ts
+++ b/test/tasks/tasks.test.ts
@@ -316,6 +316,47 @@ test("updateStep() can be used to replace a specific step", () => {
   });
 });
 
+test.each([[2], [-2]])("insertStep(%p) can be used to insert a step at a specific location", (index) => {
+  // GIVEN
+  const p = new TestProject();
+  const t = p.addTask("my");
+  t.exec("step1");
+  t.exec("step2");
+  t.exec("step3");
+  t.exec("step4");
+
+  t.insertStep(index, { exec: 'step2.5' });
+
+  // THEN
+  expectManifest(p, {
+    tasks: {
+      my: {
+        name: "my",
+        steps: [
+          { exec: "step1" },
+          { exec: "step2" },
+          { exec: "step2.5" },
+          { exec: "step3" },
+          { exec: "step4" },
+        ],
+      },
+    },
+  });
+});
+
+test("insertStep throws if the index is out of bounds", () => {
+  // GIVEN
+  const p = new TestProject();
+  const t = p.addTask("my");
+  t.exec("step1");
+  t.exec("step2");
+  t.exec("step3");
+  t.exec("step4");
+
+  expect(() => t.insertStep(-5, { exec: 'asdf' })).toThrow(/out of bounds/);
+  expect(() => t.insertStep(5, { exec: 'asdf' })).toThrow(/out of bounds/);
+});
+
 test("removeStep() can be used to remove a specific step", () => {
   // GIVEN
   const p = new TestProject();

--- a/test/tasks/tasks.test.ts
+++ b/test/tasks/tasks.test.ts
@@ -316,33 +316,36 @@ test("updateStep() can be used to replace a specific step", () => {
   });
 });
 
-test.each([[2], [-2]])("insertStep(%p) can be used to insert a step at a specific location", (index) => {
-  // GIVEN
-  const p = new TestProject();
-  const t = p.addTask("my");
-  t.exec("step1");
-  t.exec("step2");
-  t.exec("step3");
-  t.exec("step4");
+test.each([[2], [-2]])(
+  "insertStep(%p) can be used to insert a step at a specific location",
+  (index) => {
+    // GIVEN
+    const p = new TestProject();
+    const t = p.addTask("my");
+    t.exec("step1");
+    t.exec("step2");
+    t.exec("step3");
+    t.exec("step4");
 
-  t.insertStep(index, { exec: 'step2.5' });
+    t.insertStep(index, { exec: "step2.5" });
 
-  // THEN
-  expectManifest(p, {
-    tasks: {
-      my: {
-        name: "my",
-        steps: [
-          { exec: "step1" },
-          { exec: "step2" },
-          { exec: "step2.5" },
-          { exec: "step3" },
-          { exec: "step4" },
-        ],
+    // THEN
+    expectManifest(p, {
+      tasks: {
+        my: {
+          name: "my",
+          steps: [
+            { exec: "step1" },
+            { exec: "step2" },
+            { exec: "step2.5" },
+            { exec: "step3" },
+            { exec: "step4" },
+          ],
+        },
       },
-    },
-  });
-});
+    });
+  }
+);
 
 test("insertStep throws if the index is out of bounds", () => {
   // GIVEN
@@ -353,8 +356,8 @@ test("insertStep throws if the index is out of bounds", () => {
   t.exec("step3");
   t.exec("step4");
 
-  expect(() => t.insertStep(-5, { exec: 'asdf' })).toThrow(/out of bounds/);
-  expect(() => t.insertStep(5, { exec: 'asdf' })).toThrow(/out of bounds/);
+  expect(() => t.insertStep(-5, { exec: "asdf" })).toThrow(/out of bounds/);
+  expect(() => t.insertStep(5, { exec: "asdf" })).toThrow(/out of bounds/);
 });
 
 test("removeStep() can be used to remove a specific step", () => {


### PR DESCRIPTION
We supported `updateStep()` and `removeStep()` already on Tasks, but not `insertStep()` yet. Add that as well.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
