### PR TITLE
fix(github): allow setting workflow env at global scope

### DIFF
--- a/docs/api/github.md
+++ b/docs/api/github.md
@@ -2431,6 +2431,7 @@ Test whether the given construct is a component.
 | <code><a href="#projen.github.GithubWorkflow.property.name">name</a></code> | <code>string</code> | The name of the workflow. |
 | <code><a href="#projen.github.GithubWorkflow.property.projenCredentials">projenCredentials</a></code> | <code><a href="#projen.github.GithubCredentials">GithubCredentials</a></code> | GitHub API authentication method used by projen workflows. |
 | <code><a href="#projen.github.GithubWorkflow.property.concurrency">concurrency</a></code> | <code><a href="#projen.github.ConcurrencyOptions">ConcurrencyOptions</a></code> | The concurrency configuration of the workflow. |
+| <code><a href="#projen.github.GithubWorkflow.property.env">env</a></code> | <code>{[ key: string ]: string}</code> | Additional environment variables to set for the workflow. |
 | <code><a href="#projen.github.GithubWorkflow.property.file">file</a></code> | <code>projen.YamlFile</code> | The workflow YAML file. |
 | <code><a href="#projen.github.GithubWorkflow.property.runName">runName</a></code> | <code>string</code> | The name for workflow runs generated from the workflow. |
 
@@ -2498,6 +2499,18 @@ public readonly concurrency: ConcurrencyOptions;
 The concurrency configuration of the workflow.
 
 undefined means no concurrency limitations.
+
+---
+
+##### `env`<sup>Optional</sup> <a name="env" id="projen.github.GithubWorkflow.property.env"></a>
+
+```typescript
+public readonly env: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
+
+Additional environment variables to set for the workflow.
 
 ---
 
@@ -3977,6 +3990,7 @@ Test whether the given construct is a component.
 | <code><a href="#projen.github.TaskWorkflow.property.name">name</a></code> | <code>string</code> | The name of the workflow. |
 | <code><a href="#projen.github.TaskWorkflow.property.projenCredentials">projenCredentials</a></code> | <code><a href="#projen.github.GithubCredentials">GithubCredentials</a></code> | GitHub API authentication method used by projen workflows. |
 | <code><a href="#projen.github.TaskWorkflow.property.concurrency">concurrency</a></code> | <code><a href="#projen.github.ConcurrencyOptions">ConcurrencyOptions</a></code> | The concurrency configuration of the workflow. |
+| <code><a href="#projen.github.TaskWorkflow.property.env">env</a></code> | <code>{[ key: string ]: string}</code> | Additional environment variables to set for the workflow. |
 | <code><a href="#projen.github.TaskWorkflow.property.file">file</a></code> | <code>projen.YamlFile</code> | The workflow YAML file. |
 | <code><a href="#projen.github.TaskWorkflow.property.runName">runName</a></code> | <code>string</code> | The name for workflow runs generated from the workflow. |
 | <code><a href="#projen.github.TaskWorkflow.property.jobId">jobId</a></code> | <code>string</code> | *No description.* |
@@ -4046,6 +4060,18 @@ public readonly concurrency: ConcurrencyOptions;
 The concurrency configuration of the workflow.
 
 undefined means no concurrency limitations.
+
+---
+
+##### `env`<sup>Optional</sup> <a name="env" id="projen.github.TaskWorkflow.property.env"></a>
+
+```typescript
+public readonly env: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
+
+Additional environment variables to set for the workflow.
 
 ---
 
@@ -6878,6 +6904,7 @@ const githubWorkflowOptions: github.GithubWorkflowOptions = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#projen.github.GithubWorkflowOptions.property.concurrencyOptions">concurrencyOptions</a></code> | <code><a href="#projen.github.ConcurrencyOptions">ConcurrencyOptions</a></code> | Concurrency ensures that only a single job or workflow using the same concurrency group will run at a time. |
+| <code><a href="#projen.github.GithubWorkflowOptions.property.env">env</a></code> | <code>{[ key: string ]: string}</code> | Additional environment variables to set for the workflow. |
 | <code><a href="#projen.github.GithubWorkflowOptions.property.fileName">fileName</a></code> | <code>string</code> | Set a custom file name for the workflow definition file. Must include either a .yml or .yaml file extension. |
 | <code><a href="#projen.github.GithubWorkflowOptions.property.force">force</a></code> | <code>boolean</code> | Force the creation of the workflow even if `workflows` is disabled in `GitHub`. |
 | <code><a href="#projen.github.GithubWorkflowOptions.property.limitConcurrency">limitConcurrency</a></code> | <code>boolean</code> | Enable concurrency limitations. |
@@ -6898,6 +6925,19 @@ Concurrency ensures that only a single job or workflow using the same concurrenc
 Currently in beta.
 
 > [https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency)
+
+---
+
+##### `env`<sup>Optional</sup> <a name="env" id="projen.github.GithubWorkflowOptions.property.env"></a>
+
+```typescript
+public readonly env: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
+- *Default:* no additional environment variables
+
+Additional environment variables to set for the workflow.
 
 ---
 

--- a/src/github/workflows.ts
+++ b/src/github/workflows.ts
@@ -71,6 +71,13 @@ export interface GithubWorkflowOptions {
    * @default - a path-safe version of the workflow name plus the .yml file ending, e.g. build.yml
    */
   readonly fileName?: string;
+
+  /**
+   * Additional environment variables to set for the workflow.
+   *
+   * @default - no additional environment variables
+   */
+  readonly env?: Record<string, string>;
 }
 
 /**
@@ -102,6 +109,11 @@ export class GithubWorkflow extends Component {
    * GitHub API authentication method used by projen workflows.
    */
   public readonly projenCredentials: GithubCredentials;
+
+  /**
+   * Additional environment variables to set for the workflow.
+   */
+  public readonly env?: Record<string, string>;
 
   /**
    * The name for workflow runs generated from the workflow. GitHub displays the
@@ -149,6 +161,8 @@ export class GithubWorkflow extends Component {
       : undefined;
     this.projenCredentials = github.projenCredentials;
     this.actions = github.actions;
+
+    this.env = options.env;
 
     const workflowsEnabled = github.workflowsEnabled || options.force;
 
@@ -278,6 +292,7 @@ export class GithubWorkflow extends Component {
             "cancel-in-progress": this.concurrency.cancelInProgress,
           }
         : undefined,
+      env: this.env,
       jobs: renderJobs(this.jobs, this.actions),
     };
   }

--- a/src/github/workflows.ts
+++ b/src/github/workflows.ts
@@ -61,6 +61,13 @@ export interface GithubWorkflowOptions {
   readonly concurrencyOptions?: ConcurrencyOptions;
 
   /**
+   * Additional environment variables to set for the workflow.
+   *
+   * @default - no additional environment variables
+   */
+  readonly env?: Record<string, string>;
+
+  /**
    * Set a custom file name for the workflow definition file. Must include either a .yml or .yaml file extension.
    *
    * Use this option to set a file name for the workflow file, that is different than the display name.
@@ -71,13 +78,6 @@ export interface GithubWorkflowOptions {
    * @default - a path-safe version of the workflow name plus the .yml file ending, e.g. build.yml
    */
   readonly fileName?: string;
-
-  /**
-   * Additional environment variables to set for the workflow.
-   *
-   * @default - no additional environment variables
-   */
-  readonly env?: Record<string, string>;
 }
 
 /**
@@ -101,6 +101,11 @@ export class GithubWorkflow extends Component {
   public readonly concurrency?: ConcurrencyOptions;
 
   /**
+   * Additional environment variables to set for the workflow.
+   */
+  public readonly env?: Record<string, string>;
+
+  /**
    * The workflow YAML file. May not exist if `workflowsEnabled` is false on `GitHub`.
    */
   public readonly file: YamlFile | undefined;
@@ -109,11 +114,6 @@ export class GithubWorkflow extends Component {
    * GitHub API authentication method used by projen workflows.
    */
   public readonly projenCredentials: GithubCredentials;
-
-  /**
-   * Additional environment variables to set for the workflow.
-   */
-  public readonly env?: Record<string, string>;
 
   /**
    * The name for workflow runs generated from the workflow. GitHub displays the

--- a/test/github/github-workflow.test.ts
+++ b/test/github/github-workflow.test.ts
@@ -6,6 +6,36 @@ import { synthSnapshot, TestProject } from "../util";
 describe("github-workflow", () => {
   const workflowName = "test-workflow";
 
+  test("env is not set by default", () => {
+    const project = new TestProject();
+
+    new GithubWorkflow(project.github!, workflowName);
+
+    const snapshot = synthSnapshot(project);
+
+    const workflow = YAML.parse(
+      snapshot[`.github/workflows/${workflowName}.yml`]
+    );
+
+    expect(workflow.env).toBeUndefined();
+  });
+
+  test("env can be set at workflow level", () => {
+    const project = new TestProject();
+
+    new GithubWorkflow(project.github!, workflowName, { env: { FOO: "bar" } });
+
+    const snapshot = synthSnapshot(project);
+
+    const workflow = YAML.parse(
+      snapshot[`.github/workflows/${workflowName}.yml`]
+    );
+
+    console.log(JSON.stringify(workflow, null, 2));
+
+    expect(workflow.env).toEqual({ FOO: "bar" });
+  });
+
   test("concurrency is not set by default", () => {
     const project = new TestProject();
 


### PR DESCRIPTION
Fixes #4135 

It is currently not possible to set `env` for GithubWorkflows at a global scope, other than:
```
const workflow = new GithubWorkflow(project.github!, 'test-workflow')
workflow.file?.patch(
    JsonPatch.add('/env', {
        FOO: 'bar',
    })
);
```

This PR makes it possible to pass the `env` object as an option at initialization, to set it on workflow level, which is useful for environment variables that are applicable to all jobs. e.g. `NODE_VERSION`
```
new GithubWorkflow(project.github!, 'test-workflow', { env: { FOO: "bar" } });
``` 
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
