### PR TITLE
chore: add helper to convert arbitrary JSON to GitHub expressions

### DIFF
--- a/src/github/private/util.ts
+++ b/src/github/private/util.ts
@@ -17,3 +17,24 @@ export function ensureNotHiddenPath(value: string, name: string) {
     throw Error(`${name} cannot be a hidden path, got: ${value}`);
   }
 }
+
+/**
+ * Turn any JavaScript value into a GitHub expression
+ */
+export function toGitHubExpr(x: NonNullable<any>): string {
+  switch (typeof x) {
+    case "string":
+      return `'${x.replace(/'/g, `''`)}'`;
+    case "number":
+    case "boolean":
+      // The JSON representation of this value is also the GH representation of this value
+      return JSON.stringify(x);
+    case "object":
+      if (x === null) {
+        return "null";
+      }
+      return `fromJSON(${toGitHubExpr(JSON.stringify(x))})`;
+    default:
+      throw new Error(`Unsupported type: ${typeof x}`);
+  }
+}

--- a/test/github/expressions.test.ts
+++ b/test/github/expressions.test.ts
@@ -1,0 +1,14 @@
+import { toGitHubExpr } from "../../src/github/private/util";
+
+test.each([
+  [1, "1"],
+  [true, "true"],
+  [["a", "b"], `fromJSON('["a","b"]')`],
+  [{ a: "b" }, `fromJSON('{"a":"b"}')`],
+  [null, "null"],
+  ["asdf", "'asdf'"],
+  ["don't", "'don''t'"],
+  [["don't", "don't", "do", "it"], `fromJSON('["don''t","don''t","do","it"]')`],
+])("%p in GitHub syntax is %p", (input, expected) => {
+  expect(toGitHubExpr(input)).toEqual(expected);
+});


### PR DESCRIPTION
> This is extracted from another PR where I ended up changing the
structure so I don't need it anymore, but I think a function like this is useful in general so I want to commit it anyway.

Converting arbitrary data to GitHub Actions format reliably is not super hard but it's not extremely trivial either, especially once we get into things like quoting strings and transferring data like arrays.

This adds a helper function that takes away the guesswork and renders a GitHub Actions expression that will evaluate to the given JavaScript value.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
