### PR TITLE
chore: fix tests by dropping jsii support

### DIFF
--- a/test/jsii/jsii.test.ts
+++ b/test/jsii/jsii.test.ts
@@ -116,7 +116,7 @@ describe("JsiiProject with jsiiVersion: '*'", () => {
 });
 
 // matrix test
-describe.each([["~5.4.0"], ["~5.5.0"], ["~5.6.0"]])(
+describe.each([["~5.5.0"], ["~5.6.0"], ["~5.7.0"], ["~5.8.0"]])(
   "JsiiProject with jsiiVersion: '%s'",
   (jsiiVersion) => {
     describe.each([


### PR DESCRIPTION
The combination of `jsii-rosetta` 5.4 and `jsii-pacmak` >= 1.110 does not install anymore (since packmak requires >= 5.5)

Remove the 5.4 line from our tests (because they fail) and add 5.7 and 5.8.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
