### PR TITLE
feat: `nextVersionCommand` can look at and modify existing bump decision

### DIFF
--- a/docs/api/awscdk.md
+++ b/docs/api/awscdk.md
@@ -11506,6 +11506,7 @@ environment:
 - Working directory: the project directory.
 - `$VERSION`: the current version. Looks like `1.2.3`.
 - `$LATEST_TAG`: the most recent tag. Looks like `prefix-v1.2.3`, or may be unset.
+- `$SUGGESTED_BUMP`: the suggested bump action based on commits. One of `major|minor|patch|none`.
 
 The command should print one of the following to `stdout`:
 
@@ -16929,6 +16930,7 @@ environment:
 - Working directory: the project directory.
 - `$VERSION`: the current version. Looks like `1.2.3`.
 - `$LATEST_TAG`: the most recent tag. Looks like `prefix-v1.2.3`, or may be unset.
+- `$SUGGESTED_BUMP`: the suggested bump action based on commits. One of `major|minor|patch|none`.
 
 The command should print one of the following to `stdout`:
 
@@ -19975,6 +19977,7 @@ environment:
 - Working directory: the project directory.
 - `$VERSION`: the current version. Looks like `1.2.3`.
 - `$LATEST_TAG`: the most recent tag. Looks like `prefix-v1.2.3`, or may be unset.
+- `$SUGGESTED_BUMP`: the suggested bump action based on commits. One of `major|minor|patch|none`.
 
 The command should print one of the following to `stdout`:
 

--- a/docs/api/cdk.md
+++ b/docs/api/cdk.md
@@ -5110,6 +5110,7 @@ environment:
 - Working directory: the project directory.
 - `$VERSION`: the current version. Looks like `1.2.3`.
 - `$LATEST_TAG`: the most recent tag. Looks like `prefix-v1.2.3`, or may be unset.
+- `$SUGGESTED_BUMP`: the suggested bump action based on commits. One of `major|minor|patch|none`.
 
 The command should print one of the following to `stdout`:
 
@@ -8403,6 +8404,7 @@ environment:
 - Working directory: the project directory.
 - `$VERSION`: the current version. Looks like `1.2.3`.
 - `$LATEST_TAG`: the most recent tag. Looks like `prefix-v1.2.3`, or may be unset.
+- `$SUGGESTED_BUMP`: the suggested bump action based on commits. One of `major|minor|patch|none`.
 
 The command should print one of the following to `stdout`:
 

--- a/docs/api/cdk8s.md
+++ b/docs/api/cdk8s.md
@@ -7843,6 +7843,7 @@ environment:
 - Working directory: the project directory.
 - `$VERSION`: the current version. Looks like `1.2.3`.
 - `$LATEST_TAG`: the most recent tag. Looks like `prefix-v1.2.3`, or may be unset.
+- `$SUGGESTED_BUMP`: the suggested bump action based on commits. One of `major|minor|patch|none`.
 
 The command should print one of the following to `stdout`:
 
@@ -10359,6 +10360,7 @@ environment:
 - Working directory: the project directory.
 - `$VERSION`: the current version. Looks like `1.2.3`.
 - `$LATEST_TAG`: the most recent tag. Looks like `prefix-v1.2.3`, or may be unset.
+- `$SUGGESTED_BUMP`: the suggested bump action based on commits. One of `major|minor|patch|none`.
 
 The command should print one of the following to `stdout`:
 

--- a/docs/api/cdktf.md
+++ b/docs/api/cdktf.md
@@ -2783,6 +2783,7 @@ environment:
 - Working directory: the project directory.
 - `$VERSION`: the current version. Looks like `1.2.3`.
 - `$LATEST_TAG`: the most recent tag. Looks like `prefix-v1.2.3`, or may be unset.
+- `$SUGGESTED_BUMP`: the suggested bump action based on commits. One of `major|minor|patch|none`.
 
 The command should print one of the following to `stdout`:
 

--- a/docs/api/javascript.md
+++ b/docs/api/javascript.md
@@ -9437,6 +9437,7 @@ environment:
 - Working directory: the project directory.
 - `$VERSION`: the current version. Looks like `1.2.3`.
 - `$LATEST_TAG`: the most recent tag. Looks like `prefix-v1.2.3`, or may be unset.
+- `$SUGGESTED_BUMP`: the suggested bump action based on commits. One of `major|minor|patch|none`.
 
 The command should print one of the following to `stdout`:
 

--- a/docs/api/projen.md
+++ b/docs/api/projen.md
@@ -13706,6 +13706,7 @@ environment:
 - Working directory: the project directory.
 - `$VERSION`: the current version. Looks like `1.2.3`.
 - `$LATEST_TAG`: the most recent tag. Looks like `prefix-v1.2.3`, or may be unset.
+- `$SUGGESTED_BUMP`: the suggested bump action based on commits. One of `major|minor|patch|none`.
 
 The command should print one of the following to `stdout`:
 

--- a/docs/api/release.md
+++ b/docs/api/release.md
@@ -3255,6 +3255,7 @@ environment:
 - Working directory: the project directory.
 - `$VERSION`: the current version. Looks like `1.2.3`.
 - `$LATEST_TAG`: the most recent tag. Looks like `prefix-v1.2.3`, or may be unset.
+- `$SUGGESTED_BUMP`: the suggested bump action based on commits. One of `major|minor|patch|none`.
 
 The command should print one of the following to `stdout`:
 
@@ -3769,6 +3770,7 @@ environment:
 - Working directory: the project directory.
 - `$VERSION`: the current version. Looks like `1.2.3`.
 - `$LATEST_TAG`: the most recent tag. Looks like `prefix-v1.2.3`, or may be unset.
+- `$SUGGESTED_BUMP`: the suggested bump action based on commits. One of `major|minor|patch|none`.
 
 The command should print one of the following to `stdout`:
 

--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -6733,6 +6733,7 @@ environment:
 - Working directory: the project directory.
 - `$VERSION`: the current version. Looks like `1.2.3`.
 - `$LATEST_TAG`: the most recent tag. Looks like `prefix-v1.2.3`, or may be unset.
+- `$SUGGESTED_BUMP`: the suggested bump action based on commits. One of `major|minor|patch|none`.
 
 The command should print one of the following to `stdout`:
 
@@ -9172,6 +9173,7 @@ environment:
 - Working directory: the project directory.
 - `$VERSION`: the current version. Looks like `1.2.3`.
 - `$LATEST_TAG`: the most recent tag. Looks like `prefix-v1.2.3`, or may be unset.
+- `$SUGGESTED_BUMP`: the suggested bump action based on commits. One of `major|minor|patch|none`.
 
 The command should print one of the following to `stdout`:
 

--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -7806,6 +7806,7 @@ environment:
 - Working directory: the project directory.
 - `$VERSION`: the current version. Looks like `1.2.3`.
 - `$LATEST_TAG`: the most recent tag. Looks like `prefix-v1.2.3`, or may be unset.
+- `$SUGGESTED_BUMP`: the suggested bump action based on commits. One of `major|minor|patch|none`.
 
 The command should print one of the following to `stdout`:
 
@@ -9921,6 +9922,7 @@ environment:
 - Working directory: the project directory.
 - `$VERSION`: the current version. Looks like `1.2.3`.
 - `$LATEST_TAG`: the most recent tag. Looks like `prefix-v1.2.3`, or may be unset.
+- `$SUGGESTED_BUMP`: the suggested bump action based on commits. One of `major|minor|patch|none`.
 
 The command should print one of the following to `stdout`:
 
@@ -12332,6 +12334,7 @@ environment:
 - Working directory: the project directory.
 - `$VERSION`: the current version. Looks like `1.2.3`.
 - `$LATEST_TAG`: the most recent tag. Looks like `prefix-v1.2.3`, or may be unset.
+- `$SUGGESTED_BUMP`: the suggested bump action based on commits. One of `major|minor|patch|none`.
 
 The command should print one of the following to `stdout`:
 
@@ -14615,6 +14618,7 @@ environment:
 - Working directory: the project directory.
 - `$VERSION`: the current version. Looks like `1.2.3`.
 - `$LATEST_TAG`: the most recent tag. Looks like `prefix-v1.2.3`, or may be unset.
+- `$SUGGESTED_BUMP`: the suggested bump action based on commits. One of `major|minor|patch|none`.
 
 The command should print one of the following to `stdout`:
 

--- a/docs/quick-starts/typescript/hello-world/index.md
+++ b/docs/quick-starts/typescript/hello-world/index.md
@@ -113,5 +113,5 @@ const project = new typescript.TypeScriptProject({
 As described in the section above, Projen recommends that you list your dependencies
 only by module name and have Projen install the latest version of the package. A
 consequence of this recommendation is that when migrating, you may unknowingly update
-your dependencies to incompatible versions. You can always provide specific semvar
+your dependencies to incompatible versions. You can always provide specific semver
 requirements (e.g. `express@2.1.0`) if necessary.

--- a/src/release/bump-type.ts
+++ b/src/release/bump-type.ts
@@ -1,0 +1,92 @@
+import { inc, parse, ReleaseType } from "semver";
+
+export type BumpType =
+  | RelativeBumpType
+  | { bump: "absolute"; absolute: string };
+
+export type RelativeBumpType =
+  | { bump: "none" }
+  | { bump: "relative"; relative: ReleaseType };
+
+/**
+ * Reverse engineer the bump type from two version
+ *
+ * We have to do this because `commit-and-tag-version` will not just tell
+ * us the type of bump it performed, it only prints the new version.
+ */
+export function relativeBumpType(v0: string, v1: string): RelativeBumpType {
+  const s0 = parse(v0);
+  if (!s0) {
+    throw new Error(`Not a parseable version: ${v0}`);
+  }
+  const s1 = parse(v1);
+  if (!s1) {
+    throw new Error(`Not a parseable version: ${v1}`);
+  }
+
+  // Discards the build qualifier (`+12345`)
+  if (s0.version === s1.version) {
+    return { bump: "none" };
+  }
+
+  if (s0.major !== s1.major) {
+    return { bump: "relative", relative: "minor" };
+  }
+  if (s0.minor !== s1.minor) {
+    return { bump: "relative", relative: "minor" };
+  }
+  if (s0.patch !== s1.patch) {
+    return { bump: "relative", relative: "patch" };
+  }
+  return { bump: "relative", relative: "prerelease" };
+}
+
+export function renderBumpType(bumpType: BumpType) {
+  switch (bumpType.bump) {
+    case "none":
+      return "none";
+    case "relative":
+      return bumpType.relative;
+    case "absolute":
+      return bumpType.absolute;
+  }
+}
+
+export function performBump(baseVersion: string, bumpType: BumpType): string {
+  switch (bumpType.bump) {
+    case "none":
+      return baseVersion;
+    case "absolute":
+      return bumpType.absolute;
+    case "relative":
+      const inced = inc(baseVersion, bumpType.relative);
+      if (!inced) {
+        throw new Error(
+          `Could not bump version: ${baseVersion}, type ${bumpType.relative}`
+        );
+      }
+      return inced.toString();
+  }
+}
+
+export function parseBumpType(x: string): BumpType {
+  if (x === "none") {
+    return { bump: "none" };
+  }
+  if (isReleaseType(x)) {
+    return { bump: "relative", relative: x };
+  }
+  if (isFullVersionString(x)) {
+    return { bump: "absolute", absolute: x };
+  }
+  throw new Error(`Invalid version: ${x}`);
+}
+
+export function isReleaseType(v: string): v is ReleaseType {
+  // We are not recognizing all of them yet. That's fine for now.
+  return !!v.match(/^(major|minor|patch|prerelease)$/);
+}
+
+function isFullVersionString(nextVersion: string) {
+  return nextVersion.match(/^\d+\.\d+\.\d+(-[^\s]+)?$/);
+}

--- a/src/release/bump-type.ts
+++ b/src/release/bump-type.ts
@@ -1,3 +1,8 @@
+/**
+ * Symbolic representations of version bumps
+ *
+ * There are 3 types of bumps: no bump, a relative bump (increasing one component) or an absolute bump (a specific new version)
+ */
 import { inc, parse } from "semver";
 
 export type BumpType =
@@ -41,6 +46,9 @@ export function relativeBumpType(v0: string, v1: string): RelativeBumpType {
   return { bump: "relative", relative: "patch" };
 }
 
+/**
+ * Bump type to string
+ */
 export function renderBumpType(bumpType: BumpType) {
   switch (bumpType.bump) {
     case "none":
@@ -52,6 +60,25 @@ export function renderBumpType(bumpType: BumpType) {
   }
 }
 
+/**
+ * String to bump type
+ */
+export function parseBumpType(x: string): BumpType {
+  if (x === "none") {
+    return { bump: "none" };
+  }
+  if (isMajorMinorPatch(x)) {
+    return { bump: "relative", relative: x };
+  }
+  if (isFullVersionString(x)) {
+    return { bump: "absolute", absolute: x };
+  }
+  throw new Error(`Invalid version: ${x}`);
+}
+
+/**
+ * Perform the given bump on the given version, returning the new version
+ */
 export function performBump(baseVersion: string, bumpType: BumpType): string {
   switch (bumpType.bump) {
     case "none":
@@ -69,21 +96,7 @@ export function performBump(baseVersion: string, bumpType: BumpType): string {
   }
 }
 
-export function parseBumpType(x: string): BumpType {
-  if (x === "none") {
-    return { bump: "none" };
-  }
-  if (isMajorMinorPatch(x)) {
-    return { bump: "relative", relative: x };
-  }
-  if (isFullVersionString(x)) {
-    return { bump: "absolute", absolute: x };
-  }
-  throw new Error(`Invalid version: ${x}`);
-}
-
 export function isMajorMinorPatch(v: string): v is MajorMinorPatch {
-  // We are not recognizing all of them yet. That's fine for now.
   return !!v.match(/^(major|minor|patch)$/);
 }
 

--- a/src/release/bump-type.ts
+++ b/src/release/bump-type.ts
@@ -1,4 +1,4 @@
-import { inc, parse, ReleaseType } from "semver";
+import { inc, parse } from "semver";
 
 export type BumpType =
   | RelativeBumpType
@@ -6,7 +6,10 @@ export type BumpType =
 
 export type RelativeBumpType =
   | { bump: "none" }
-  | { bump: "relative"; relative: ReleaseType };
+  | { bump: "relative"; relative: MajorMinorPatch };
+
+// The only relative types that CATV supports
+export type MajorMinorPatch = "major" | "minor" | "patch";
 
 /**
  * Reverse engineer the bump type from two version
@@ -30,15 +33,12 @@ export function relativeBumpType(v0: string, v1: string): RelativeBumpType {
   }
 
   if (s0.major !== s1.major) {
-    return { bump: "relative", relative: "minor" };
+    return { bump: "relative", relative: "major" };
   }
   if (s0.minor !== s1.minor) {
     return { bump: "relative", relative: "minor" };
   }
-  if (s0.patch !== s1.patch) {
-    return { bump: "relative", relative: "patch" };
-  }
-  return { bump: "relative", relative: "prerelease" };
+  return { bump: "relative", relative: "patch" };
 }
 
 export function renderBumpType(bumpType: BumpType) {
@@ -73,7 +73,7 @@ export function parseBumpType(x: string): BumpType {
   if (x === "none") {
     return { bump: "none" };
   }
-  if (isReleaseType(x)) {
+  if (isMajorMinorPatch(x)) {
     return { bump: "relative", relative: x };
   }
   if (isFullVersionString(x)) {
@@ -82,9 +82,9 @@ export function parseBumpType(x: string): BumpType {
   throw new Error(`Invalid version: ${x}`);
 }
 
-export function isReleaseType(v: string): v is ReleaseType {
+export function isMajorMinorPatch(v: string): v is MajorMinorPatch {
   // We are not recognizing all of them yet. That's fine for now.
-  return !!v.match(/^(major|minor|patch|prerelease)$/);
+  return !!v.match(/^(major|minor|patch)$/);
 }
 
 function isFullVersionString(nextVersion: string) {

--- a/src/release/bump-version.ts
+++ b/src/release/bump-version.ts
@@ -3,7 +3,7 @@ import { dirname, join } from "path";
 import { Config } from "conventional-changelog-config-spec";
 import { compare } from "semver";
 import * as logging from "../logging";
-import { exec, execCapture, execOrUndefined } from "../util";
+import { execCapture, execOrUndefined } from "../util";
 import { ReleasableCommits } from "../version";
 import {
   BumpType,

--- a/src/release/bump-version.ts
+++ b/src/release/bump-version.ts
@@ -224,7 +224,7 @@ export async function bump(cwd: string, options: BumpOptions) {
       : { bump: "none" };
 
   if (options.nextVersionCommand) {
-    logging.debug(`Proposed bump type: ${bumpType}`);
+    logging.debug(`Proposed bump type: ${renderBumpType(bumpType)}`);
     const nextVersion = execCapture(options.nextVersionCommand, {
       cwd,
       modEnv: {
@@ -239,7 +239,9 @@ export async function bump(cwd: string, options: BumpOptions) {
     if (nextVersion) {
       try {
         bumpType = parseBumpType(nextVersion);
-        logging.info(`nextVersionCommand selects bump type: ${bumpType}`);
+        logging.info(
+          `nextVersionCommand selects bump type: ${renderBumpType(bumpType)}`
+        );
       } catch (e) {
         throw new Error(
           `nextVersionCommand "${options.nextVersionCommand}" returned invalid output: ${e}`
@@ -247,7 +249,7 @@ export async function bump(cwd: string, options: BumpOptions) {
       }
     }
   } else {
-    logging.info(`bump type: ${bumpType}`);
+    logging.info(`bump type: ${renderBumpType(bumpType)}`);
   }
 
   // Respect minMajorVersion to correct the result of the nextVersionCommand

--- a/src/release/commit-tag-version.ts
+++ b/src/release/commit-tag-version.ts
@@ -1,0 +1,143 @@
+/**
+ * Library to invoke commit-and-tag-version
+ */
+import { promises as fs } from "fs";
+import * as path from "node:path";
+import { Config } from "conventional-changelog-config-spec";
+import * as logging from "../logging";
+import { exec, execCapture } from "../util";
+
+export interface CommitAndTagOptions {
+  readonly isFirstRelease?: boolean;
+  readonly tagPrefix?: string;
+  readonly versionFile: string;
+  readonly changelogFile?: string;
+  readonly prerelease?: string;
+  readonly configOptions?: Config;
+}
+
+export interface InvokeOptions {
+  readonly releaseAs?: string;
+  readonly dryRun?: boolean;
+  readonly skipBump?: boolean;
+  readonly skipChangelog?: boolean;
+  readonly capture?: boolean;
+  readonly noColors?: boolean;
+}
+
+export class CommitAndTagVersion {
+  constructor(
+    private readonly packageSpec: string,
+    private readonly cwd: string,
+    private readonly options: CommitAndTagOptions
+  ) {}
+
+  /**
+   * Invoke the `commit-and-tag` package
+   */
+  public async invoke<A extends InvokeOptions>(
+    options: A
+  ): Promise<A extends { capture: true } ? string : void> {
+    const catvConfig: CommitAndTagConfig = {
+      packageFiles: [
+        {
+          filename: this.options.versionFile,
+          type: "json",
+        },
+      ],
+      bumpFiles: [
+        {
+          filename: this.options.versionFile,
+          type: "json",
+        },
+      ],
+      commitAll: false,
+      infile: this.options.changelogFile,
+      prerelease: this.options.prerelease,
+      header: "",
+      skip: {
+        commit: true,
+        tag: true,
+        bump: options.skipBump,
+        changelog: options.skipChangelog,
+      },
+      firstRelease: this.options.isFirstRelease,
+      tagPrefix: this.options.tagPrefix
+        ? `${this.options.tagPrefix}v`
+        : undefined,
+      releaseAs: options.releaseAs,
+      dryRun: options.dryRun,
+      ...this.options.configOptions,
+    };
+    logging.debug(`.versionrc.json: ${JSON.stringify(catvConfig)}`);
+
+    // Generate a temporary config file, then execute the package and remove the
+    // config file again.
+    const rcfile = path.join(this.cwd, ".versionrc.json");
+    await fs.writeFile(rcfile, JSON.stringify(catvConfig, undefined, 2));
+    try {
+      const commandline = `npx ${this.packageSpec} ${
+        options.noColors ? "--no-colors" : ""
+      }`;
+
+      let ret: any;
+      if (options.capture) {
+        ret = execCapture(commandline, {
+          cwd: this.cwd,
+        }).toString();
+      } else {
+        ret = exec(commandline, { cwd: this.cwd });
+      }
+      return ret;
+    } finally {
+      await fs.unlink(rcfile);
+    }
+  }
+
+  /**
+   * Invoke CATV and return the version it would have bumped to
+   *
+   * CATV will always at least perform a patch bump, even if there aren't any
+   * commits to look at.
+   *
+   * We have to do this by parsing the output string, which is pretty bad
+   * but I don't see that we have another way.
+   */
+  public async dryRun(): Promise<string> {
+    const output = await this.invoke({
+      capture: true,
+      dryRun: true,
+      skipChangelog: true,
+      noColors: true,
+    });
+    const re = /bumping version.*from ([0-9a-z.+-]+) to ([0-9a-z.+-]+)/im;
+    const m = re.exec(output);
+    if (!m) {
+      throw new Error(`Could not match ${re} in ${output}`);
+    }
+
+    return m[2];
+  }
+}
+
+/**
+ * Modeling the CATV config file
+ */
+interface CommitAndTagConfig extends Config {
+  packageFiles?: Array<{ filename: string; type: string }>;
+  bumpFiles?: Array<{ filename: string; type: string }>;
+  commitAll?: boolean;
+  infile?: string;
+  prerelease?: string;
+  skip?: {
+    commit?: boolean;
+    tag?: boolean;
+    bump?: boolean;
+    changelog?: boolean;
+  };
+  firstRelease?: boolean;
+  tagPrefix?: string;
+  releaseAs?: string;
+  dryRun?: boolean;
+  path?: string;
+}

--- a/src/release/release.ts
+++ b/src/release/release.ts
@@ -258,6 +258,7 @@ export interface ReleaseProjectOptions {
    * - Working directory: the project directory.
    * - `$VERSION`: the current version. Looks like `1.2.3`.
    * - `$LATEST_TAG`: the most recent tag. Looks like `prefix-v1.2.3`, or may be unset.
+   * - `$SUGGESTED_BUMP`: the suggested bump action based on commits. One of `major|minor|patch|none`.
    *
    * The command should print one of the following to `stdout`:
    *

--- a/src/version.ts
+++ b/src/version.ts
@@ -79,6 +79,7 @@ export interface VersionOptions {
    * - Working directory: the project directory.
    * - `$VERSION`: the current version. Looks like `1.2.3`.
    * - `$LATEST_TAG`: the most recent tag. Looks like `prefix-v1.2.3`, or may be unset.
+   * - `$SUGGESTED_BUMP`: the suggested bump action based on commits. One of `major|minor|patch|none`.
    *
    * The command should print one of the following to `stdout`:
    *

--- a/test/version.test.ts
+++ b/test/version.test.ts
@@ -153,7 +153,7 @@ describe("bump task", () => {
       new Version(project, {
         versionInputFile: "package.json",
         artifactsDirectory: "dist",
-        nextVersionCommand: "[[ $SUGGESTED_BUMP = patch ]] || exit 1", // Suggestion must be 'patch' or we fail
+        nextVersionCommand: "[ $SUGGESTED_BUMP = patch ] || exit 1", // Suggestion must be 'patch' or we fail
       });
 
       project.synth();

--- a/test/version.test.ts
+++ b/test/version.test.ts
@@ -145,6 +145,31 @@ describe("bump task", () => {
     });
   });
 
+  test("shell command can see proposed version", async () => {
+    withProjectDir((projectdir) => {
+      const project = new TestProject({
+        outdir: projectdir,
+      });
+      new Version(project, {
+        versionInputFile: "package.json",
+        artifactsDirectory: "dist",
+        nextVersionCommand: "[[ $SUGGESTED_BUMP = patch ]] || exit 1", // Suggestion must be 'patch' or we fail
+      });
+
+      project.synth();
+
+      const result = testBumpTask({
+        workdir: project.outdir,
+        commits: [
+          { message: "chore(release): v0.1.0", tag: "v0.1.0" },
+          { message: "fix: new change" }, // Leads to a patch
+        ],
+      });
+
+      expect(result.version).toEqual("0.1.1");
+    });
+  });
+
   test("if there are 0 commits but the version script outputs a version, bump anyway", async () => {
     withProjectDir((projectdir) => {
       const project = new TestProject({

--- a/test/version.test.ts
+++ b/test/version.test.ts
@@ -153,7 +153,7 @@ describe("bump task", () => {
       new Version(project, {
         versionInputFile: "package.json",
         artifactsDirectory: "dist",
-        nextVersionCommand: "[ $SUGGESTED_BUMP = patch ] || exit 1", // Suggestion must be 'patch' or we fail
+        nextVersionCommand: "bash -c '[ $SUGGESTED_BUMP = patch ] || exit 1'", // Suggestion must be 'patch' or we fail
       });
 
       project.synth();


### PR DESCRIPTION
Previously, when `nextVersionCommand` was specified it would need to entirely determine the bump decision, or it was not specified and the bump decision was fully left to `commit-and-tag-version`.

If we want to use `nextVersionCommand` to do "the default action but occasionally something else", it now need to do a bunch of work itself, like determining what "the default action even is", i.e., it would need to duplicate or invoke CATV.

# Why does nextVersionCommand even exist?

This is a place for user code to affect the versioning decision. For example, in monorepos we would use this to copy the version of other packages, or for workflows that test installation we would inject fake version numbers here, or we would force major version bumps when certain files have changed, or copy the version number from a data file. There are numerous non-standard versioning decisions that we can't all add properties with predefined functionality for; instead, we want to leave up the user to specify with some code of their own.

Ideally this would have been a pure TypeScript function, but this code runs in a subprocess of a subprocess, so it's not trivial to invoke an anonymous function defined in `.projenrc.ts`. Instead, we make users supply a shell command that they can use to slot in arbitrary logic into the versioning workflow.

# Old workflow

In the current workflow, most of the work is outsourced to `commit-and-tag-version`. CATV does:

- Determine current version (from package.json)
- Determine change commits (from tag and git history)
- Update package.json
- Generate changelog

When we introduced `nextVersionCommand` we added it fully before CATV (because that was simpler 😝), so it can force certain types of behaviors in certain cases. What it *can't* do in this design, is look at the "current decision" and potentially modify it. 

So for example, it *can't* look at the current decision and leave it unchanged, but downgrade `major` to `minor` (leaving `patch` unchanged). The only thing it can do is "always force `minor`" or "always force `patch`" (or it would need to look at commit history itself, predict whether CATV would have done a `major`, and output `minor` in that case).

The current workflow looks like this:

```
                                                                   
                          Start                                    
                                                                   
                            │                                      
                            ├────────────────┐   (current version) 
                            │                │                     
                            │                ▼                     
                            │     ┌────────────────────┐           
                            │     │                    │           
                            │     │ nextVersionCommand │           
                            │     │                    │           
 (commit history)           │     └────────────────────┘           
                            │                │                     
         │                  │                │  (maybe version or  
         └──────────────┐   │   ┌────────────┘      bump type)     
                        │   │   │                                  
                        ▼   ▼   ▼                                  
               ┌─────────────────────────┐                         
               │                         │                         
               │ commit-and-tag-version  │                         
               │                         │                         
               └─────────────────────────┘                         
                            │                                      
                            │                                      
                            ▼                                      
                                                                   
                      (package.json                                
                        changelog)                                 
```

# New design

A better design is the following:

1. Determine the proposed new version number (or alternatively, bump type)
2. Use any kind of logic to inspect and modify that decision. Right now this mostly means the user-pluggable `nextVersionCommand`, but any additional kind of properties for built-in functionality (like the one suggested by @iliapolo, `autoRestrictToVersion: true`) would also slot in here. They would need to inspect the current decision and modify it if it turns out to be the wrong one.
3. Finally use CATV to apply the version number decided in (2): update `package.json` and generate the changelog.

```                                                                          
                                      Start                                    
                                                                               
                                        │                                      
                                        │                                      
                                        ▼                                      
                      ┌───────────────────────────────────┐                    
                      │                                   │                    
 (commit history) ───▶│ commit-and-tag-version --dry-run  │                    
                      │                                   │                    
         │            └───────────────────────────────────┘                    
         │                              │                    (current version, 
         │                              ├────────────────┐     suggested bump  
         │                              │                │         type)       
         │                              │                ▼                     
         │                              │     ┌────────────────────┐           
         │                              │     │                    │           
         │                              │     │ nextVersionCommand │           
         │                              │     │                    │           
         │                              │     └────────────────────┘           
         │                              │                │                     
         │                              │                │                     
         │                              │                │                     
         │                              ├────────────────┘                     
         │                              │    (suggested or                     
         │                              │  updated bump type                   
         │                              │     or version)                      
         │                              ▼                                      
         │           ┌─────────────────────────────────────┐                   
         │           │                                     │                   
         └──────────▶│ commit-and-tag-version --release-as │                   
                     │                                     │                   
                     └─────────────────────────────────────┘                   
                                        │                                      
                                        │                                      
                                        │                                      
                                        ▼                                      
                                 (package.json                                 
                                   changelog)                                  
```

# Changes in this PR

In this PR, change the process to be the following:

- `commit-and-tag-version` determines the bump type (using its `--dry-run` feature)
- We then pass the decision into `nextVersionCommand` via a new environment variable named `$SUGGESTED_BUMP`.
- The script is free to return a new bump type, or return nothing. If nothing is returned, the `$SUGGESTED_BUMP` type is still used (this will lead to the same behavior as before this change, where the new version is fully determined by CATV). The script can also return `none` to suppress the version update.
- Finally the selected bump type is applied. 

This gives the script the ability to reuse decisions made by `commit-and-tag-version`, while remaining backwards compatible. Any other version restriction logic that we would like to defunctionalize would slot into the same place as `nextVersionCommand`.

As part of changing the flow there are 2 changes that make this PR look intimidating:

- The introduction of a class `CommitAndTagVersion`: we used to have a couple of functions lying around to write a CATV config and invoke it, I've moved those to a class in a new file. We used to have a mix of config file settings and command-line flags; everything is now passed via the config file. We used to always use `npx` to run CATV (in a temporary directory, so that would always do an install from NPM), right now if the user  doesn't override the CATV package we try to find it in our `devDependencies` and invoke it from there to save time. 
- The introduction of some data structures to talk about and reason about "bump types". We distinguish 3 bump types: `none`, `relative` (a major/minor/patch bump), and `absolute` (just a target version number), some functions convert between data and strings, and some functions to convert between absolute and relative bumps.
  - CATV `--dry-run` only outputs the target version but that's annoying for the user script to reason about so we convert it back to a relative bump. For example, CATV will say `updated version from 2.3.4 to 3.0.0`, and we turn that into `SUGGESTED_BUMP_TYPE: major` so that the script has an easy way to say "I don't like major version bumps". Otherwise this conversion logic would have to be done inside the script, and we want to make that as convenient as possible.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
