### PR TITLE
fix: use npx instead of yarn exec for ts-node in AWS CDK TypeScript apps

### DIFF
--- a/src/awscdk/awscdk-app-ts.ts
+++ b/src/awscdk/awscdk-app-ts.ts
@@ -234,9 +234,9 @@ export class AwsCdkTypeScriptApp extends TypeScriptAppProject {
       case NodePackageManager.YARN:
       case NodePackageManager.YARN_BERRY:
       case NodePackageManager.YARN2:
-        // https://classic.yarnpkg.com/lang/en/docs/cli/exec/
-        // https://yarnpkg.com/cli/exec
-        return `yarn exec ${tsNodeApp}`;
+        // use npx with yarn due to reported issues
+        // @see https://github.com/projen/projen/issues/4180
+        return `npx ${tsNodeApp}`;
       default:
         return `npx ${tsNodeApp}`;
     }

--- a/test/awscdk/awscdk-app.test.ts
+++ b/test/awscdk/awscdk-app.test.ts
@@ -64,7 +64,7 @@ describe("cdk.json", () => {
     });
     const files = synthSnapshot(project);
     expect(files["cdk.json"].app).toStrictEqual(
-      "yarn exec ts-node -P tsconfig.json --prefer-ts-exts src/main.ts"
+      "npx ts-node -P tsconfig.json --prefer-ts-exts src/main.ts"
     );
   });
 
@@ -77,7 +77,7 @@ describe("cdk.json", () => {
     });
     const files = synthSnapshot(project);
     expect(files["cdk.json"].app).toStrictEqual(
-      "yarn exec ts-node -P tsconfig.json --prefer-ts-exts src/main.ts"
+      "npx ts-node -P tsconfig.json --prefer-ts-exts src/main.ts"
     );
   });
 
@@ -89,7 +89,7 @@ describe("cdk.json", () => {
     });
     const files = synthSnapshot(project);
     expect(files["cdk.json"].app).toStrictEqual(
-      "yarn exec ts-node -P tsconfig.json --prefer-ts-exts src/main.ts"
+      "npx ts-node -P tsconfig.json --prefer-ts-exts src/main.ts"
     );
   });
 
@@ -102,7 +102,7 @@ describe("cdk.json", () => {
     });
     const files = synthSnapshot(project);
     expect(files["cdk.json"].app).toStrictEqual(
-      "yarn exec ts-node -P tsconfig.json --prefer-ts-exts src/my-app.ts"
+      "npx ts-node -P tsconfig.json --prefer-ts-exts src/my-app.ts"
     );
   });
 


### PR DESCRIPTION
## Description

This PR changes the AWS CDK TypeScript app to use `npx` instead of `yarn exec` for running ts-node, even when using Yarn as the package manager.

Fixes #4180

## Changes

- Modified `src/awscdk/awscdk-app-ts.ts` to use `npx` instead of `yarn exec` for ts-node
- Updated corresponding tests in `test/awscdk/awscdk-app.test.ts`

## Motivation

There have been reported issues with `yarn exec` when running ts-node in AWS CDK TypeScript apps. Using `npx` provides a more consistent experience across different package managers. Although we cannot reproduce the reported issues, reverting back to how this was for the last >5 years seems like a reasonable option. Users can still define a custom app command of their choice. 


---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._