### PR TITLE
fix(awscdk): use npx for ts-node execution with pnpm

### DIFF
--- a/src/awscdk/awscdk-app-ts.ts
+++ b/src/awscdk/awscdk-app-ts.ts
@@ -228,13 +228,11 @@ export class AwsCdkTypeScriptApp extends TypeScriptAppProject {
         // bun can run ts files directly
         return `bun run${bunTsConfig} ${bunEntrypoint}`;
       case NodePackageManager.PNPM:
-        // https://pnpm.io/cli/exec
-        return `pnpm exec ${tsNodeApp}`;
       case NodePackageManager.YARN_CLASSIC:
       case NodePackageManager.YARN:
       case NodePackageManager.YARN_BERRY:
       case NodePackageManager.YARN2:
-        // use npx with yarn due to reported issues
+        // use npx with also for yarn & pnpm due to reported issues
         // @see https://github.com/projen/projen/issues/4180
         return `npx ${tsNodeApp}`;
       default:

--- a/test/awscdk/awscdk-app.test.ts
+++ b/test/awscdk/awscdk-app.test.ts
@@ -38,7 +38,7 @@ describe("cdk.json", () => {
     });
     const files = synthSnapshot(project);
     expect(files["cdk.json"].app).toStrictEqual(
-      "pnpm exec ts-node -P tsconfig.json --prefer-ts-exts src/main.ts"
+      "npx ts-node -P tsconfig.json --prefer-ts-exts src/main.ts"
     );
   });
 


### PR DESCRIPTION
Similar to yarn, use npx instead of pnpm exec for ts-node execution to ensure consistent behavior and address potential issues. Relates to #4180.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
