### PR TITLE
fix(eslint): make lint vs formatting rules consistent with official eslint definition

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,9 +44,12 @@
     "!projenrc/**/*.ts"
   ],
   "rules": {
-    "@typescript-eslint/no-require-imports": [
-      "error"
+    "curly": [
+      "error",
+      "multi-line",
+      "consistent"
     ],
+    "@typescript-eslint/no-require-imports": "error",
     "import/no-extraneous-dependencies": [
       "error",
       {
@@ -82,27 +85,12 @@
     "no-shadow": [
       "off"
     ],
-    "@typescript-eslint/no-shadow": [
-      "error"
-    ],
-    "key-spacing": [
-      "error"
-    ],
-    "no-multiple-empty-lines": [
-      "error"
-    ],
-    "@typescript-eslint/no-floating-promises": [
-      "error"
-    ],
+    "@typescript-eslint/no-shadow": "error",
+    "@typescript-eslint/no-floating-promises": "error",
     "no-return-await": [
       "off"
     ],
-    "@typescript-eslint/return-await": [
-      "error"
-    ],
-    "no-trailing-spaces": [
-      "error"
-    ],
+    "@typescript-eslint/return-await": "error",
     "dot-notation": [
       "error"
     ],

--- a/docs/api/javascript.md
+++ b/docs/api/javascript.md
@@ -527,7 +527,7 @@ Returns the singleton Eslint component of a project or undefined if there is non
 | <code><a href="#projen.javascript.Eslint.property.ignorePatterns">ignorePatterns</a></code> | <code>string[]</code> | File patterns that should not be linted. |
 | <code><a href="#projen.javascript.Eslint.property.lintPatterns">lintPatterns</a></code> | <code>string[]</code> | Returns an immutable copy of the lintPatterns being used by this eslint configuration. |
 | <code><a href="#projen.javascript.Eslint.property.overrides">overrides</a></code> | <code><a href="#projen.javascript.EslintOverride">EslintOverride</a>[]</code> | eslint overrides. |
-| <code><a href="#projen.javascript.Eslint.property.rules">rules</a></code> | <code>{[ key: string ]: any[]}</code> | eslint rules. |
+| <code><a href="#projen.javascript.Eslint.property.rules">rules</a></code> | <code>{[ key: string ]: any}</code> | eslint rules. |
 
 ---
 
@@ -616,10 +616,10 @@ eslint overrides.
 ##### `rules`<sup>Required</sup> <a name="rules" id="projen.javascript.Eslint.property.rules"></a>
 
 ```typescript
-public readonly rules: {[ key: string ]: any[]};
+public readonly rules: {[ key: string ]: any};
 ```
 
-- *Type:* {[ key: string ]: any[]}
+- *Type:* {[ key: string ]: any}
 
 eslint rules.
 

--- a/src/_resolve.ts
+++ b/src/_resolve.ts
@@ -23,10 +23,11 @@ export function resolve(value: any, options: ResolveOptions = {}): any {
   // as they are missing a `toJSON` implementation.
   switch (true) {
     case types.isRegExp(value):
-      if (value.flags)
+      if (value.flags) {
         throw new Error(
           "RegExp with flags should be explicitly converted to a string"
         );
+      }
       return value.source;
 
     case types.isSet(value):

--- a/src/javascript/eslint.ts
+++ b/src/javascript/eslint.ts
@@ -165,7 +165,7 @@ export class Eslint extends Component {
   /**
    * eslint rules.
    */
-  public readonly rules: { [rule: string]: any[] };
+  public readonly rules: { [rule: string]: any };
 
   /**
    * eslint overrides.
@@ -253,35 +253,34 @@ export class Eslint extends Component {
     project.npmignore?.exclude("/.eslintrc.json");
 
     this._formattingRules = {
-      // @see https://github.com/typescript-eslint/typescript-eslint/issues/8072
-      indent: ["off"],
-      "@stylistic/indent": ["error", 2],
-
       // Style
-      quotes: ["error", "single", { avoidEscape: true }],
-      "comma-dangle": ["error", "always-multiline"], // ensures clean diffs, see https://medium.com/@nikgraf/why-you-should-enforce-dangling-commas-for-multiline-statements-d034c98e36f8
-      "comma-spacing": ["error", { before: false, after: true }], // space after, no space before
-      "no-multi-spaces": ["error", { ignoreEOLComments: false }], // no multi spaces
-      "array-bracket-spacing": ["error", "never"], // [1, 2, 3]
-      "array-bracket-newline": ["error", "consistent"], // enforce consistent line breaks between brackets
-      "object-curly-spacing": ["error", "always"], // { key: 'value' }
-      "object-curly-newline": ["error", { multiline: true, consistent: true }], // enforce consistent line breaks between braces
-      "object-property-newline": [
+      "@stylistic/indent": ["error", 2],
+      "@stylistic/quotes": ["error", "single", { avoidEscape: true }],
+      "@stylistic/comma-dangle": ["error", "always-multiline"], // ensures clean diffs, see https://medium.com/@nikgraf/why-you-should-enforce-dangling-commas-for-multiline-statements-d034c98e36f8
+      "@stylistic/comma-spacing": ["error", { before: false, after: true }], // space after, no space before
+      "@stylistic/no-multi-spaces": ["error", { ignoreEOLComments: false }], // no multi spaces
+      "@stylistic/array-bracket-spacing": ["error", "never"], // [1, 2, 3]
+      "@stylistic/array-bracket-newline": ["error", "consistent"], // enforce consistent line breaks between brackets
+      "@stylistic/object-curly-spacing": ["error", "always"], // { key: 'value' }
+      "@stylistic/object-curly-newline": [
+        "error",
+        { multiline: true, consistent: true },
+      ], // enforce consistent line breaks between braces
+      "@stylistic/object-property-newline": [
         "error",
         { allowAllPropertiesOnSameLine: true },
       ], // enforce "same line" or "multiple line" on object properties
-      "keyword-spacing": ["error"], // require a space before & after keywords
-      "brace-style": ["error", "1tbs", { allowSingleLine: true }], // enforce one true brace style
-      "space-before-blocks": ["error"], // require space before blocks
-      curly: ["error", "multi-line", "consistent"], // require curly braces for multiline control statements
+      "@stylistic/keyword-spacing": ["error"], // require a space before & after keywords
+      "@stylistic/brace-style": ["error", "1tbs", { allowSingleLine: true }], // enforce one true brace style
+      "@stylistic/space-before-blocks": ["error"], // require space before blocks
       // @see https://github.com/typescript-eslint/typescript-eslint/issues/8072
       "@stylistic/member-delimiter-style": ["error"],
 
       // Require semicolons
-      semi: ["error", "always"],
+      "@stylistic/semi": ["error", "always"],
 
       // Max line lengths
-      "max-len": [
+      "@stylistic/max-len": [
         "error",
         {
           code: 150,
@@ -294,12 +293,24 @@ export class Eslint extends Component {
       ],
 
       // Don't unnecessarily quote properties
-      "quote-props": ["error", "consistent-as-needed"],
+      "@stylistic/quote-props": ["error", "consistent-as-needed"],
+
+      // Required spacing in property declarations (copied from TSLint, defaults are good)
+      "@stylistic/key-spacing": ["error"],
+
+      // No multiple empty lines
+      "@stylistic/no-multiple-empty-lines": ["error"],
+
+      // Useless diff results
+      "@stylistic/no-trailing-spaces": ["error"],
     };
 
     this.rules = {
+      // require curly braces for multiline control statements
+      curly: ["error", "multi-line", "consistent"],
+
       // Require use of the `import { foo } from 'bar';` form instead of `import foo = require('bar');`
-      "@typescript-eslint/no-require-imports": ["error"],
+      "@typescript-eslint/no-require-imports": "error",
 
       // Require all imported dependencies are actually declared in package.json
       "import/no-extraneous-dependencies": [
@@ -329,24 +340,14 @@ export class Eslint extends Component {
 
       // Cannot shadow names
       "no-shadow": ["off"],
-      "@typescript-eslint/no-shadow": ["error"],
-
-      // Required spacing in property declarations (copied from TSLint, defaults are good)
-      "key-spacing": ["error"],
-
-      // No multiple empty lines
-      "no-multiple-empty-lines": ["error"],
-
+      "@typescript-eslint/no-shadow": "error",
       // One of the easiest mistakes to make
-      "@typescript-eslint/no-floating-promises": ["error"],
+      "@typescript-eslint/no-floating-promises": "error",
 
       // Make sure that inside try/catch blocks, promises are 'return await'ed
       // (must disable the base rule as it can report incorrect errors)
       "no-return-await": ["off"],
-      "@typescript-eslint/return-await": ["error"],
-
-      // Useless diff results
-      "no-trailing-spaces": ["error"],
+      "@typescript-eslint/return-await": "error",
 
       // Must use foo.bar instead of foo['bar'] if possible
       "dot-notation": ["error"],

--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -1127,8 +1127,9 @@ export class NodePackage extends Component {
             `CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${domain} --region ${region} --domain-owner ${accountId} --query authorizationToken --output text)`,
             `npm config set //${registry}:_authToken=$CODEARTIFACT_AUTH_TOKEN`,
           ];
-          if (!this.minNodeVersion || semver.major(this.minNodeVersion) <= 16)
+          if (!this.minNodeVersion || semver.major(this.minNodeVersion) <= 16) {
             commands.push(`npm config set //${registry}:always-auth=true`);
+          }
           return {
             exec: commands.join("; "),
           };

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -47,88 +47,80 @@ exports[`cdk-watchful 1`] = `
     "!.projenrc.js"
   ],
   "rules": {
-    "indent": [
-      "off"
-    ],
     "@stylistic/indent": [
       "error",
       2
     ],
-    "quotes": [
+    "@stylistic/quotes": [
       "error",
       "single",
       {
         "avoidEscape": true
       }
     ],
-    "comma-dangle": [
+    "@stylistic/comma-dangle": [
       "error",
       "always-multiline"
     ],
-    "comma-spacing": [
+    "@stylistic/comma-spacing": [
       "error",
       {
         "before": false,
         "after": true
       }
     ],
-    "no-multi-spaces": [
+    "@stylistic/no-multi-spaces": [
       "error",
       {
         "ignoreEOLComments": false
       }
     ],
-    "array-bracket-spacing": [
+    "@stylistic/array-bracket-spacing": [
       "error",
       "never"
     ],
-    "array-bracket-newline": [
+    "@stylistic/array-bracket-newline": [
       "error",
       "consistent"
     ],
-    "object-curly-spacing": [
+    "@stylistic/object-curly-spacing": [
       "error",
       "always"
     ],
-    "object-curly-newline": [
+    "@stylistic/object-curly-newline": [
       "error",
       {
         "multiline": true,
         "consistent": true
       }
     ],
-    "object-property-newline": [
+    "@stylistic/object-property-newline": [
       "error",
       {
         "allowAllPropertiesOnSameLine": true
       }
     ],
-    "keyword-spacing": [
+    "@stylistic/keyword-spacing": [
       "error"
     ],
-    "brace-style": [
+    "@stylistic/brace-style": [
       "error",
       "1tbs",
       {
         "allowSingleLine": true
       }
     ],
-    "space-before-blocks": [
+    "@stylistic/space-before-blocks": [
       "error"
-    ],
-    "curly": [
-      "error",
-      "multi-line",
-      "consistent"
     ],
     "@stylistic/member-delimiter-style": [
       "error"
     ],
-    "semi": [
+    "@stylistic/semi": [
       "error",
       "always"
     ],
-    "max-len": [
+    "@stylistic/max-len": [
       "error",
       {
         "code": 150,
@@ -139,13 +131,25 @@ exports[`cdk-watchful 1`] = `
         "ignoreRegExpLiterals": true
       }
     ],
-    "quote-props": [
+    "@stylistic/quote-props": [
       "error",
       "consistent-as-needed"
     ],
-    "@typescript-eslint/no-require-imports": [
+    "@stylistic/key-spacing": [
       "error"
     ],
+    "@stylistic/no-multiple-empty-lines": [
+      "error"
+    ],
+    "@stylistic/no-trailing-spaces": [
+      "error"
+    ],
+    "curly": [
+      "error",
+      "multi-line",
+      "consistent"
+    ],
+    "@typescript-eslint/no-require-imports": "error",
     "import/no-extraneous-dependencies": [
       "error",
       {
@@ -179,27 +183,12 @@ exports[`cdk-watchful 1`] = `
     "no-shadow": [
       "off"
     ],
-    "@typescript-eslint/no-shadow": [
-      "error"
-    ],
-    "key-spacing": [
-      "error"
-    ],
-    "no-multiple-empty-lines": [
-      "error"
-    ],
-    "@typescript-eslint/no-floating-promises": [
-      "error"
-    ],
+    "@typescript-eslint/no-shadow": "error",
+    "@typescript-eslint/no-floating-promises": "error",
     "no-return-await": [
       "off"
     ],
-    "@typescript-eslint/return-await": [
-      "error"
-    ],
-    "no-trailing-spaces": [
-      "error"
-    ],
+    "@typescript-eslint/return-await": "error",
     "dot-notation": [
       "error"
     ],
@@ -1630,88 +1619,80 @@ exports[`cdk8s 1`] = `
     "!.projenrc.js"
   ],
   "rules": {
-    "indent": [
-      "off"
-    ],
     "@stylistic/indent": [
       "error",
       2
     ],
-    "quotes": [
+    "@stylistic/quotes": [
       "error",
       "single",
       {
         "avoidEscape": true
       }
     ],
-    "comma-dangle": [
+    "@stylistic/comma-dangle": [
       "error",
       "always-multiline"
     ],
-    "comma-spacing": [
+    "@stylistic/comma-spacing": [
       "error",
       {
         "before": false,
         "after": true
       }
     ],
-    "no-multi-spaces": [
+    "@stylistic/no-multi-spaces": [
       "error",
       {
         "ignoreEOLComments": false
       }
     ],
-    "array-bracket-spacing": [
+    "@stylistic/array-bracket-spacing": [
       "error",
       "never"
     ],
-    "array-bracket-newline": [
+    "@stylistic/array-bracket-newline": [
       "error",
       "consistent"
     ],
-    "object-curly-spacing": [
+    "@stylistic/object-curly-spacing": [
       "error",
       "always"
     ],
-    "object-curly-newline": [
+    "@stylistic/object-curly-newline": [
       "error",
       {
         "multiline": true,
         "consistent": true
       }
     ],
-    "object-property-newline": [
+    "@stylistic/object-property-newline": [
       "error",
       {
         "allowAllPropertiesOnSameLine": true
       }
     ],
-    "keyword-spacing": [
+    "@stylistic/keyword-spacing": [
       "error"
     ],
-    "brace-style": [
+    "@stylistic/brace-style": [
       "error",
       "1tbs",
       {
         "allowSingleLine": true
       }
     ],
-    "space-before-blocks": [
+    "@stylistic/space-before-blocks": [
       "error"
-    ],
-    "curly": [
-      "error",
-      "multi-line",
-      "consistent"
     ],
     "@stylistic/member-delimiter-style": [
       "error"
     ],
-    "semi": [
+    "@stylistic/semi": [
       "error",
       "always"
     ],
-    "max-len": [
+    "@stylistic/max-len": [
       "error",
       {
         "code": 150,
@@ -1722,13 +1703,25 @@ exports[`cdk8s 1`] = `
         "ignoreRegExpLiterals": true
       }
     ],
-    "quote-props": [
+    "@stylistic/quote-props": [
       "error",
       "consistent-as-needed"
     ],
-    "@typescript-eslint/no-require-imports": [
+    "@stylistic/key-spacing": [
       "error"
     ],
+    "@stylistic/no-multiple-empty-lines": [
+      "error"
+    ],
+    "@stylistic/no-trailing-spaces": [
+      "error"
+    ],
+    "curly": [
+      "error",
+      "multi-line",
+      "consistent"
+    ],
+    "@typescript-eslint/no-require-imports": "error",
     "import/no-extraneous-dependencies": [
       "error",
       {
@@ -1762,27 +1755,12 @@ exports[`cdk8s 1`] = `
     "no-shadow": [
       "off"
     ],
-    "@typescript-eslint/no-shadow": [
-      "error"
-    ],
-    "key-spacing": [
-      "error"
-    ],
-    "no-multiple-empty-lines": [
-      "error"
-    ],
-    "@typescript-eslint/no-floating-promises": [
-      "error"
-    ],
+    "@typescript-eslint/no-shadow": "error",
+    "@typescript-eslint/no-floating-promises": "error",
     "no-return-await": [
       "off"
     ],
-    "@typescript-eslint/return-await": [
-      "error"
-    ],
-    "no-trailing-spaces": [
-      "error"
-    ],
+    "@typescript-eslint/return-await": "error",
     "dot-notation": [
       "error"
     ],
@@ -2839,88 +2817,80 @@ exports[`cdk8s-cli 1`] = `
     "!.projenrc.js"
   ],
   "rules": {
-    "indent": [
-      "off"
-    ],
     "@stylistic/indent": [
       "error",
       2
     ],
-    "quotes": [
+    "@stylistic/quotes": [
       "error",
       "single",
       {
         "avoidEscape": true
       }
     ],
-    "comma-dangle": [
+    "@stylistic/comma-dangle": [
       "error",
       "always-multiline"
     ],
-    "comma-spacing": [
+    "@stylistic/comma-spacing": [
       "error",
       {
         "before": false,
         "after": true
       }
     ],
-    "no-multi-spaces": [
+    "@stylistic/no-multi-spaces": [
       "error",
       {
         "ignoreEOLComments": false
       }
     ],
-    "array-bracket-spacing": [
+    "@stylistic/array-bracket-spacing": [
       "error",
       "never"
     ],
-    "array-bracket-newline": [
+    "@stylistic/array-bracket-newline": [
       "error",
       "consistent"
     ],
-    "object-curly-spacing": [
+    "@stylistic/object-curly-spacing": [
       "error",
       "always"
     ],
-    "object-curly-newline": [
+    "@stylistic/object-curly-newline": [
       "error",
       {
         "multiline": true,
         "consistent": true
       }
     ],
-    "object-property-newline": [
+    "@stylistic/object-property-newline": [
       "error",
       {
         "allowAllPropertiesOnSameLine": true
       }
     ],
-    "keyword-spacing": [
+    "@stylistic/keyword-spacing": [
       "error"
     ],
-    "brace-style": [
+    "@stylistic/brace-style": [
       "error",
       "1tbs",
       {
         "allowSingleLine": true
       }
     ],
-    "space-before-blocks": [
+    "@stylistic/space-before-blocks": [
       "error"
-    ],
-    "curly": [
-      "error",
-      "multi-line",
-      "consistent"
     ],
     "@stylistic/member-delimiter-style": [
       "error"
     ],
-    "semi": [
+    "@stylistic/semi": [
       "error",
       "always"
     ],
-    "max-len": [
+    "@stylistic/max-len": [
       "error",
       {
         "code": 150,
@@ -2931,13 +2901,25 @@ exports[`cdk8s-cli 1`] = `
         "ignoreRegExpLiterals": true
       }
     ],
-    "quote-props": [
+    "@stylistic/quote-props": [
       "error",
       "consistent-as-needed"
     ],
-    "@typescript-eslint/no-require-imports": [
+    "@stylistic/key-spacing": [
       "error"
     ],
+    "@stylistic/no-multiple-empty-lines": [
+      "error"
+    ],
+    "@stylistic/no-trailing-spaces": [
+      "error"
+    ],
+    "curly": [
+      "error",
+      "multi-line",
+      "consistent"
+    ],
+    "@typescript-eslint/no-require-imports": "error",
     "import/no-extraneous-dependencies": [
       "error",
       {
@@ -2971,27 +2953,12 @@ exports[`cdk8s-cli 1`] = `
     "no-shadow": [
       "off"
     ],
-    "@typescript-eslint/no-shadow": [
-      "error"
-    ],
-    "key-spacing": [
-      "error"
-    ],
-    "no-multiple-empty-lines": [
-      "error"
-    ],
-    "@typescript-eslint/no-floating-promises": [
-      "error"
-    ],
+    "@typescript-eslint/no-shadow": "error",
+    "@typescript-eslint/no-floating-promises": "error",
     "no-return-await": [
       "off"
     ],
-    "@typescript-eslint/return-await": [
-      "error"
-    ],
-    "no-trailing-spaces": [
-      "error"
-    ],
+    "@typescript-eslint/return-await": "error",
     "dot-notation": [
       "error"
     ],

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -42,11 +42,101 @@ exports[`JsiiProject with default settings synthesizes 1`] = `
     ],
     "root": true,
     "rules": {
+      "@stylistic/array-bracket-newline": [
+        "error",
+        "consistent",
+      ],
+      "@stylistic/array-bracket-spacing": [
+        "error",
+        "never",
+      ],
+      "@stylistic/brace-style": [
+        "error",
+        "1tbs",
+        {
+          "allowSingleLine": true,
+        },
+      ],
+      "@stylistic/comma-dangle": [
+        "error",
+        "always-multiline",
+      ],
+      "@stylistic/comma-spacing": [
+        "error",
+        {
+          "after": true,
+          "before": false,
+        },
+      ],
       "@stylistic/indent": [
         "error",
         2,
       ],
+      "@stylistic/key-spacing": [
+        "error",
+      ],
+      "@stylistic/keyword-spacing": [
+        "error",
+      ],
+      "@stylistic/max-len": [
+        "error",
+        {
+          "code": 150,
+          "ignoreComments": true,
+          "ignoreRegExpLiterals": true,
+          "ignoreStrings": true,
+          "ignoreTemplateLiterals": true,
+          "ignoreUrls": true,
+        },
+      ],
       "@stylistic/member-delimiter-style": [
+        "error",
+      ],
+      "@stylistic/no-multi-spaces": [
+        "error",
+        {
+          "ignoreEOLComments": false,
+        },
+      ],
+      "@stylistic/no-multiple-empty-lines": [
+        "error",
+      ],
+      "@stylistic/no-trailing-spaces": [
+        "error",
+      ],
+      "@stylistic/object-curly-newline": [
+        "error",
+        {
+          "consistent": true,
+          "multiline": true,
+        },
+      ],
+      "@stylistic/object-curly-spacing": [
+        "error",
+        "always",
+      ],
+      "@stylistic/object-property-newline": [
+        "error",
+        {
+          "allowAllPropertiesOnSameLine": true,
+        },
+      ],
+      "@stylistic/quote-props": [
+        "error",
+        "consistent-as-needed",
+      ],
+      "@stylistic/quotes": [
+        "error",
+        "single",
+        {
+          "avoidEscape": true,
+        },
+      ],
+      "@stylistic/semi": [
+        "error",
+        "always",
+      ],
+      "@stylistic/space-before-blocks": [
         "error",
       ],
       "@typescript-eslint/member-ordering": [
@@ -65,44 +155,10 @@ exports[`JsiiProject with default settings synthesizes 1`] = `
           ],
         },
       ],
-      "@typescript-eslint/no-floating-promises": [
-        "error",
-      ],
-      "@typescript-eslint/no-require-imports": [
-        "error",
-      ],
-      "@typescript-eslint/no-shadow": [
-        "error",
-      ],
-      "@typescript-eslint/return-await": [
-        "error",
-      ],
-      "array-bracket-newline": [
-        "error",
-        "consistent",
-      ],
-      "array-bracket-spacing": [
-        "error",
-        "never",
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true,
-        },
-      ],
-      "comma-dangle": [
-        "error",
-        "always-multiline",
-      ],
-      "comma-spacing": [
-        "error",
-        {
-          "after": true,
-          "before": false,
-        },
-      ],
+      "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/no-require-imports": "error",
+      "@typescript-eslint/no-shadow": "error",
+      "@typescript-eslint/return-await": "error",
       "curly": [
         "error",
         "multi-line",
@@ -141,36 +197,7 @@ exports[`JsiiProject with default settings synthesizes 1`] = `
           ],
         },
       ],
-      "indent": [
-        "off",
-      ],
-      "key-spacing": [
-        "error",
-      ],
-      "keyword-spacing": [
-        "error",
-      ],
-      "max-len": [
-        "error",
-        {
-          "code": 150,
-          "ignoreComments": true,
-          "ignoreRegExpLiterals": true,
-          "ignoreStrings": true,
-          "ignoreTemplateLiterals": true,
-          "ignoreUrls": true,
-        },
-      ],
       "no-bitwise": [
-        "error",
-      ],
-      "no-multi-spaces": [
-        "error",
-        {
-          "ignoreEOLComments": false,
-        },
-      ],
-      "no-multiple-empty-lines": [
         "error",
       ],
       "no-return-await": [
@@ -178,44 +205,6 @@ exports[`JsiiProject with default settings synthesizes 1`] = `
       ],
       "no-shadow": [
         "off",
-      ],
-      "no-trailing-spaces": [
-        "error",
-      ],
-      "object-curly-newline": [
-        "error",
-        {
-          "consistent": true,
-          "multiline": true,
-        },
-      ],
-      "object-curly-spacing": [
-        "error",
-        "always",
-      ],
-      "object-property-newline": [
-        "error",
-        {
-          "allowAllPropertiesOnSameLine": true,
-        },
-      ],
-      "quote-props": [
-        "error",
-        "consistent-as-needed",
-      ],
-      "quotes": [
-        "error",
-        "single",
-        {
-          "avoidEscape": true,
-        },
-      ],
-      "semi": [
-        "error",
-        "always",
-      ],
-      "space-before-blocks": [
-        "error",
       ],
     },
     "settings": {

--- a/test/javascript/__snapshots__/eslint.test.ts.snap
+++ b/test/javascript/__snapshots__/eslint.test.ts.snap
@@ -41,11 +41,101 @@ exports[`eslint settings devdirs 1`] = `
   ],
   "root": true,
   "rules": {
+    "@stylistic/array-bracket-newline": [
+      "error",
+      "consistent",
+    ],
+    "@stylistic/array-bracket-spacing": [
+      "error",
+      "never",
+    ],
+    "@stylistic/brace-style": [
+      "error",
+      "1tbs",
+      {
+        "allowSingleLine": true,
+      },
+    ],
+    "@stylistic/comma-dangle": [
+      "error",
+      "always-multiline",
+    ],
+    "@stylistic/comma-spacing": [
+      "error",
+      {
+        "after": true,
+        "before": false,
+      },
+    ],
     "@stylistic/indent": [
       "error",
       2,
     ],
+    "@stylistic/key-spacing": [
+      "error",
+    ],
+    "@stylistic/keyword-spacing": [
+      "error",
+    ],
+    "@stylistic/max-len": [
+      "error",
+      {
+        "code": 150,
+        "ignoreComments": true,
+        "ignoreRegExpLiterals": true,
+        "ignoreStrings": true,
+        "ignoreTemplateLiterals": true,
+        "ignoreUrls": true,
+      },
+    ],
     "@stylistic/member-delimiter-style": [
+      "error",
+    ],
+    "@stylistic/no-multi-spaces": [
+      "error",
+      {
+        "ignoreEOLComments": false,
+      },
+    ],
+    "@stylistic/no-multiple-empty-lines": [
+      "error",
+    ],
+    "@stylistic/no-trailing-spaces": [
+      "error",
+    ],
+    "@stylistic/object-curly-newline": [
+      "error",
+      {
+        "consistent": true,
+        "multiline": true,
+      },
+    ],
+    "@stylistic/object-curly-spacing": [
+      "error",
+      "always",
+    ],
+    "@stylistic/object-property-newline": [
+      "error",
+      {
+        "allowAllPropertiesOnSameLine": true,
+      },
+    ],
+    "@stylistic/quote-props": [
+      "error",
+      "consistent-as-needed",
+    ],
+    "@stylistic/quotes": [
+      "error",
+      "single",
+      {
+        "avoidEscape": true,
+      },
+    ],
+    "@stylistic/semi": [
+      "error",
+      "always",
+    ],
+    "@stylistic/space-before-blocks": [
       "error",
     ],
     "@typescript-eslint/member-ordering": [
@@ -64,44 +154,10 @@ exports[`eslint settings devdirs 1`] = `
         ],
       },
     ],
-    "@typescript-eslint/no-floating-promises": [
-      "error",
-    ],
-    "@typescript-eslint/no-require-imports": [
-      "error",
-    ],
-    "@typescript-eslint/no-shadow": [
-      "error",
-    ],
-    "@typescript-eslint/return-await": [
-      "error",
-    ],
-    "array-bracket-newline": [
-      "error",
-      "consistent",
-    ],
-    "array-bracket-spacing": [
-      "error",
-      "never",
-    ],
-    "brace-style": [
-      "error",
-      "1tbs",
-      {
-        "allowSingleLine": true,
-      },
-    ],
-    "comma-dangle": [
-      "error",
-      "always-multiline",
-    ],
-    "comma-spacing": [
-      "error",
-      {
-        "after": true,
-        "before": false,
-      },
-    ],
+    "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-require-imports": "error",
+    "@typescript-eslint/no-shadow": "error",
+    "@typescript-eslint/return-await": "error",
     "curly": [
       "error",
       "multi-line",
@@ -140,36 +196,7 @@ exports[`eslint settings devdirs 1`] = `
         ],
       },
     ],
-    "indent": [
-      "off",
-    ],
-    "key-spacing": [
-      "error",
-    ],
-    "keyword-spacing": [
-      "error",
-    ],
-    "max-len": [
-      "error",
-      {
-        "code": 150,
-        "ignoreComments": true,
-        "ignoreRegExpLiterals": true,
-        "ignoreStrings": true,
-        "ignoreTemplateLiterals": true,
-        "ignoreUrls": true,
-      },
-    ],
     "no-bitwise": [
-      "error",
-    ],
-    "no-multi-spaces": [
-      "error",
-      {
-        "ignoreEOLComments": false,
-      },
-    ],
-    "no-multiple-empty-lines": [
       "error",
     ],
     "no-return-await": [
@@ -177,44 +204,6 @@ exports[`eslint settings devdirs 1`] = `
     ],
     "no-shadow": [
       "off",
-    ],
-    "no-trailing-spaces": [
-      "error",
-    ],
-    "object-curly-newline": [
-      "error",
-      {
-        "consistent": true,
-        "multiline": true,
-      },
-    ],
-    "object-curly-spacing": [
-      "error",
-      "always",
-    ],
-    "object-property-newline": [
-      "error",
-      {
-        "allowAllPropertiesOnSameLine": true,
-      },
-    ],
-    "quote-props": [
-      "error",
-      "consistent-as-needed",
-    ],
-    "quotes": [
-      "error",
-      "single",
-      {
-        "avoidEscape": true,
-      },
-    ],
-    "semi": [
-      "error",
-      "always",
-    ],
-    "space-before-blocks": [
-      "error",
     ],
   },
   "settings": {
@@ -292,17 +281,14 @@ exports[`prettier snapshot 1`] = `
         ],
       },
     ],
-    "@typescript-eslint/no-floating-promises": [
+    "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-require-imports": "error",
+    "@typescript-eslint/no-shadow": "error",
+    "@typescript-eslint/return-await": "error",
+    "curly": [
       "error",
-    ],
-    "@typescript-eslint/no-require-imports": [
-      "error",
-    ],
-    "@typescript-eslint/no-shadow": [
-      "error",
-    ],
-    "@typescript-eslint/return-await": [
-      "error",
+      "multi-line",
+      "consistent",
     ],
     "dot-notation": [
       "error",
@@ -334,13 +320,7 @@ exports[`prettier snapshot 1`] = `
         ],
       },
     ],
-    "key-spacing": [
-      "error",
-    ],
     "no-bitwise": [
-      "error",
-    ],
-    "no-multiple-empty-lines": [
       "error",
     ],
     "no-return-await": [
@@ -348,9 +328,6 @@ exports[`prettier snapshot 1`] = `
     ],
     "no-shadow": [
       "off",
-    ],
-    "no-trailing-spaces": [
-      "error",
     ],
   },
   "settings": {

--- a/test/jsii/__snapshots__/jsii.test.ts.snap
+++ b/test/jsii/__snapshots__/jsii.test.ts.snap
@@ -42,11 +42,101 @@ exports[`JsiiProject with default settings synthesizes 1`] = `
     ],
     "root": true,
     "rules": {
+      "@stylistic/array-bracket-newline": [
+        "error",
+        "consistent",
+      ],
+      "@stylistic/array-bracket-spacing": [
+        "error",
+        "never",
+      ],
+      "@stylistic/brace-style": [
+        "error",
+        "1tbs",
+        {
+          "allowSingleLine": true,
+        },
+      ],
+      "@stylistic/comma-dangle": [
+        "error",
+        "always-multiline",
+      ],
+      "@stylistic/comma-spacing": [
+        "error",
+        {
+          "after": true,
+          "before": false,
+        },
+      ],
       "@stylistic/indent": [
         "error",
         2,
       ],
+      "@stylistic/key-spacing": [
+        "error",
+      ],
+      "@stylistic/keyword-spacing": [
+        "error",
+      ],
+      "@stylistic/max-len": [
+        "error",
+        {
+          "code": 150,
+          "ignoreComments": true,
+          "ignoreRegExpLiterals": true,
+          "ignoreStrings": true,
+          "ignoreTemplateLiterals": true,
+          "ignoreUrls": true,
+        },
+      ],
       "@stylistic/member-delimiter-style": [
+        "error",
+      ],
+      "@stylistic/no-multi-spaces": [
+        "error",
+        {
+          "ignoreEOLComments": false,
+        },
+      ],
+      "@stylistic/no-multiple-empty-lines": [
+        "error",
+      ],
+      "@stylistic/no-trailing-spaces": [
+        "error",
+      ],
+      "@stylistic/object-curly-newline": [
+        "error",
+        {
+          "consistent": true,
+          "multiline": true,
+        },
+      ],
+      "@stylistic/object-curly-spacing": [
+        "error",
+        "always",
+      ],
+      "@stylistic/object-property-newline": [
+        "error",
+        {
+          "allowAllPropertiesOnSameLine": true,
+        },
+      ],
+      "@stylistic/quote-props": [
+        "error",
+        "consistent-as-needed",
+      ],
+      "@stylistic/quotes": [
+        "error",
+        "single",
+        {
+          "avoidEscape": true,
+        },
+      ],
+      "@stylistic/semi": [
+        "error",
+        "always",
+      ],
+      "@stylistic/space-before-blocks": [
         "error",
       ],
       "@typescript-eslint/member-ordering": [
@@ -65,44 +155,10 @@ exports[`JsiiProject with default settings synthesizes 1`] = `
           ],
         },
       ],
-      "@typescript-eslint/no-floating-promises": [
-        "error",
-      ],
-      "@typescript-eslint/no-require-imports": [
-        "error",
-      ],
-      "@typescript-eslint/no-shadow": [
-        "error",
-      ],
-      "@typescript-eslint/return-await": [
-        "error",
-      ],
-      "array-bracket-newline": [
-        "error",
-        "consistent",
-      ],
-      "array-bracket-spacing": [
-        "error",
-        "never",
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true,
-        },
-      ],
-      "comma-dangle": [
-        "error",
-        "always-multiline",
-      ],
-      "comma-spacing": [
-        "error",
-        {
-          "after": true,
-          "before": false,
-        },
-      ],
+      "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/no-require-imports": "error",
+      "@typescript-eslint/no-shadow": "error",
+      "@typescript-eslint/return-await": "error",
       "curly": [
         "error",
         "multi-line",
@@ -141,36 +197,7 @@ exports[`JsiiProject with default settings synthesizes 1`] = `
           ],
         },
       ],
-      "indent": [
-        "off",
-      ],
-      "key-spacing": [
-        "error",
-      ],
-      "keyword-spacing": [
-        "error",
-      ],
-      "max-len": [
-        "error",
-        {
-          "code": 150,
-          "ignoreComments": true,
-          "ignoreRegExpLiterals": true,
-          "ignoreStrings": true,
-          "ignoreTemplateLiterals": true,
-          "ignoreUrls": true,
-        },
-      ],
       "no-bitwise": [
-        "error",
-      ],
-      "no-multi-spaces": [
-        "error",
-        {
-          "ignoreEOLComments": false,
-        },
-      ],
-      "no-multiple-empty-lines": [
         "error",
       ],
       "no-return-await": [
@@ -178,44 +205,6 @@ exports[`JsiiProject with default settings synthesizes 1`] = `
       ],
       "no-shadow": [
         "off",
-      ],
-      "no-trailing-spaces": [
-        "error",
-      ],
-      "object-curly-newline": [
-        "error",
-        {
-          "consistent": true,
-          "multiline": true,
-        },
-      ],
-      "object-curly-spacing": [
-        "error",
-        "always",
-      ],
-      "object-property-newline": [
-        "error",
-        {
-          "allowAllPropertiesOnSameLine": true,
-        },
-      ],
-      "quote-props": [
-        "error",
-        "consistent-as-needed",
-      ],
-      "quotes": [
-        "error",
-        "single",
-        {
-          "avoidEscape": true,
-        },
-      ],
-      "semi": [
-        "error",
-        "always",
-      ],
-      "space-before-blocks": [
-        "error",
       ],
     },
     "settings": {
@@ -1560,11 +1549,101 @@ exports[`JsiiProject with jsiiVersion: '*' synthesizes 1`] = `
     ],
     "root": true,
     "rules": {
+      "@stylistic/array-bracket-newline": [
+        "error",
+        "consistent",
+      ],
+      "@stylistic/array-bracket-spacing": [
+        "error",
+        "never",
+      ],
+      "@stylistic/brace-style": [
+        "error",
+        "1tbs",
+        {
+          "allowSingleLine": true,
+        },
+      ],
+      "@stylistic/comma-dangle": [
+        "error",
+        "always-multiline",
+      ],
+      "@stylistic/comma-spacing": [
+        "error",
+        {
+          "after": true,
+          "before": false,
+        },
+      ],
       "@stylistic/indent": [
         "error",
         2,
       ],
+      "@stylistic/key-spacing": [
+        "error",
+      ],
+      "@stylistic/keyword-spacing": [
+        "error",
+      ],
+      "@stylistic/max-len": [
+        "error",
+        {
+          "code": 150,
+          "ignoreComments": true,
+          "ignoreRegExpLiterals": true,
+          "ignoreStrings": true,
+          "ignoreTemplateLiterals": true,
+          "ignoreUrls": true,
+        },
+      ],
       "@stylistic/member-delimiter-style": [
+        "error",
+      ],
+      "@stylistic/no-multi-spaces": [
+        "error",
+        {
+          "ignoreEOLComments": false,
+        },
+      ],
+      "@stylistic/no-multiple-empty-lines": [
+        "error",
+      ],
+      "@stylistic/no-trailing-spaces": [
+        "error",
+      ],
+      "@stylistic/object-curly-newline": [
+        "error",
+        {
+          "consistent": true,
+          "multiline": true,
+        },
+      ],
+      "@stylistic/object-curly-spacing": [
+        "error",
+        "always",
+      ],
+      "@stylistic/object-property-newline": [
+        "error",
+        {
+          "allowAllPropertiesOnSameLine": true,
+        },
+      ],
+      "@stylistic/quote-props": [
+        "error",
+        "consistent-as-needed",
+      ],
+      "@stylistic/quotes": [
+        "error",
+        "single",
+        {
+          "avoidEscape": true,
+        },
+      ],
+      "@stylistic/semi": [
+        "error",
+        "always",
+      ],
+      "@stylistic/space-before-blocks": [
         "error",
       ],
       "@typescript-eslint/member-ordering": [
@@ -1583,44 +1662,10 @@ exports[`JsiiProject with jsiiVersion: '*' synthesizes 1`] = `
           ],
         },
       ],
-      "@typescript-eslint/no-floating-promises": [
-        "error",
-      ],
-      "@typescript-eslint/no-require-imports": [
-        "error",
-      ],
-      "@typescript-eslint/no-shadow": [
-        "error",
-      ],
-      "@typescript-eslint/return-await": [
-        "error",
-      ],
-      "array-bracket-newline": [
-        "error",
-        "consistent",
-      ],
-      "array-bracket-spacing": [
-        "error",
-        "never",
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true,
-        },
-      ],
-      "comma-dangle": [
-        "error",
-        "always-multiline",
-      ],
-      "comma-spacing": [
-        "error",
-        {
-          "after": true,
-          "before": false,
-        },
-      ],
+      "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/no-require-imports": "error",
+      "@typescript-eslint/no-shadow": "error",
+      "@typescript-eslint/return-await": "error",
       "curly": [
         "error",
         "multi-line",
@@ -1659,36 +1704,7 @@ exports[`JsiiProject with jsiiVersion: '*' synthesizes 1`] = `
           ],
         },
       ],
-      "indent": [
-        "off",
-      ],
-      "key-spacing": [
-        "error",
-      ],
-      "keyword-spacing": [
-        "error",
-      ],
-      "max-len": [
-        "error",
-        {
-          "code": 150,
-          "ignoreComments": true,
-          "ignoreRegExpLiterals": true,
-          "ignoreStrings": true,
-          "ignoreTemplateLiterals": true,
-          "ignoreUrls": true,
-        },
-      ],
       "no-bitwise": [
-        "error",
-      ],
-      "no-multi-spaces": [
-        "error",
-        {
-          "ignoreEOLComments": false,
-        },
-      ],
-      "no-multiple-empty-lines": [
         "error",
       ],
       "no-return-await": [
@@ -1696,44 +1712,6 @@ exports[`JsiiProject with jsiiVersion: '*' synthesizes 1`] = `
       ],
       "no-shadow": [
         "off",
-      ],
-      "no-trailing-spaces": [
-        "error",
-      ],
-      "object-curly-newline": [
-        "error",
-        {
-          "consistent": true,
-          "multiline": true,
-        },
-      ],
-      "object-curly-spacing": [
-        "error",
-        "always",
-      ],
-      "object-property-newline": [
-        "error",
-        {
-          "allowAllPropertiesOnSameLine": true,
-        },
-      ],
-      "quote-props": [
-        "error",
-        "consistent-as-needed",
-      ],
-      "quotes": [
-        "error",
-        "single",
-        {
-          "avoidEscape": true,
-        },
-      ],
-      "semi": [
-        "error",
-        "always",
-      ],
-      "space-before-blocks": [
-        "error",
       ],
     },
     "settings": {
@@ -3076,11 +3054,101 @@ exports[`JsiiProject with modern jsiiVersion synthesizes 1`] = `
     ],
     "root": true,
     "rules": {
+      "@stylistic/array-bracket-newline": [
+        "error",
+        "consistent",
+      ],
+      "@stylistic/array-bracket-spacing": [
+        "error",
+        "never",
+      ],
+      "@stylistic/brace-style": [
+        "error",
+        "1tbs",
+        {
+          "allowSingleLine": true,
+        },
+      ],
+      "@stylistic/comma-dangle": [
+        "error",
+        "always-multiline",
+      ],
+      "@stylistic/comma-spacing": [
+        "error",
+        {
+          "after": true,
+          "before": false,
+        },
+      ],
       "@stylistic/indent": [
         "error",
         2,
       ],
+      "@stylistic/key-spacing": [
+        "error",
+      ],
+      "@stylistic/keyword-spacing": [
+        "error",
+      ],
+      "@stylistic/max-len": [
+        "error",
+        {
+          "code": 150,
+          "ignoreComments": true,
+          "ignoreRegExpLiterals": true,
+          "ignoreStrings": true,
+          "ignoreTemplateLiterals": true,
+          "ignoreUrls": true,
+        },
+      ],
       "@stylistic/member-delimiter-style": [
+        "error",
+      ],
+      "@stylistic/no-multi-spaces": [
+        "error",
+        {
+          "ignoreEOLComments": false,
+        },
+      ],
+      "@stylistic/no-multiple-empty-lines": [
+        "error",
+      ],
+      "@stylistic/no-trailing-spaces": [
+        "error",
+      ],
+      "@stylistic/object-curly-newline": [
+        "error",
+        {
+          "consistent": true,
+          "multiline": true,
+        },
+      ],
+      "@stylistic/object-curly-spacing": [
+        "error",
+        "always",
+      ],
+      "@stylistic/object-property-newline": [
+        "error",
+        {
+          "allowAllPropertiesOnSameLine": true,
+        },
+      ],
+      "@stylistic/quote-props": [
+        "error",
+        "consistent-as-needed",
+      ],
+      "@stylistic/quotes": [
+        "error",
+        "single",
+        {
+          "avoidEscape": true,
+        },
+      ],
+      "@stylistic/semi": [
+        "error",
+        "always",
+      ],
+      "@stylistic/space-before-blocks": [
         "error",
       ],
       "@typescript-eslint/member-ordering": [
@@ -3099,44 +3167,10 @@ exports[`JsiiProject with modern jsiiVersion synthesizes 1`] = `
           ],
         },
       ],
-      "@typescript-eslint/no-floating-promises": [
-        "error",
-      ],
-      "@typescript-eslint/no-require-imports": [
-        "error",
-      ],
-      "@typescript-eslint/no-shadow": [
-        "error",
-      ],
-      "@typescript-eslint/return-await": [
-        "error",
-      ],
-      "array-bracket-newline": [
-        "error",
-        "consistent",
-      ],
-      "array-bracket-spacing": [
-        "error",
-        "never",
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true,
-        },
-      ],
-      "comma-dangle": [
-        "error",
-        "always-multiline",
-      ],
-      "comma-spacing": [
-        "error",
-        {
-          "after": true,
-          "before": false,
-        },
-      ],
+      "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/no-require-imports": "error",
+      "@typescript-eslint/no-shadow": "error",
+      "@typescript-eslint/return-await": "error",
       "curly": [
         "error",
         "multi-line",
@@ -3175,36 +3209,7 @@ exports[`JsiiProject with modern jsiiVersion synthesizes 1`] = `
           ],
         },
       ],
-      "indent": [
-        "off",
-      ],
-      "key-spacing": [
-        "error",
-      ],
-      "keyword-spacing": [
-        "error",
-      ],
-      "max-len": [
-        "error",
-        {
-          "code": 150,
-          "ignoreComments": true,
-          "ignoreRegExpLiterals": true,
-          "ignoreStrings": true,
-          "ignoreTemplateLiterals": true,
-          "ignoreUrls": true,
-        },
-      ],
       "no-bitwise": [
-        "error",
-      ],
-      "no-multi-spaces": [
-        "error",
-        {
-          "ignoreEOLComments": false,
-        },
-      ],
-      "no-multiple-empty-lines": [
         "error",
       ],
       "no-return-await": [
@@ -3212,44 +3217,6 @@ exports[`JsiiProject with modern jsiiVersion synthesizes 1`] = `
       ],
       "no-shadow": [
         "off",
-      ],
-      "no-trailing-spaces": [
-        "error",
-      ],
-      "object-curly-newline": [
-        "error",
-        {
-          "consistent": true,
-          "multiline": true,
-        },
-      ],
-      "object-curly-spacing": [
-        "error",
-        "always",
-      ],
-      "object-property-newline": [
-        "error",
-        {
-          "allowAllPropertiesOnSameLine": true,
-        },
-      ],
-      "quote-props": [
-        "error",
-        "consistent-as-needed",
-      ],
-      "quotes": [
-        "error",
-        "single",
-        {
-          "avoidEscape": true,
-        },
-      ],
-      "semi": [
-        "error",
-        "always",
-      ],
-      "space-before-blocks": [
-        "error",
       ],
     },
     "settings": {

--- a/test/typescript/__snapshots__/typescript.test.ts.snap
+++ b/test/typescript/__snapshots__/typescript.test.ts.snap
@@ -42,11 +42,101 @@ exports[`TypeScriptProject with default settings synthesizes 1`] = `
     ],
     "root": true,
     "rules": {
+      "@stylistic/array-bracket-newline": [
+        "error",
+        "consistent",
+      ],
+      "@stylistic/array-bracket-spacing": [
+        "error",
+        "never",
+      ],
+      "@stylistic/brace-style": [
+        "error",
+        "1tbs",
+        {
+          "allowSingleLine": true,
+        },
+      ],
+      "@stylistic/comma-dangle": [
+        "error",
+        "always-multiline",
+      ],
+      "@stylistic/comma-spacing": [
+        "error",
+        {
+          "after": true,
+          "before": false,
+        },
+      ],
       "@stylistic/indent": [
         "error",
         2,
       ],
+      "@stylistic/key-spacing": [
+        "error",
+      ],
+      "@stylistic/keyword-spacing": [
+        "error",
+      ],
+      "@stylistic/max-len": [
+        "error",
+        {
+          "code": 150,
+          "ignoreComments": true,
+          "ignoreRegExpLiterals": true,
+          "ignoreStrings": true,
+          "ignoreTemplateLiterals": true,
+          "ignoreUrls": true,
+        },
+      ],
       "@stylistic/member-delimiter-style": [
+        "error",
+      ],
+      "@stylistic/no-multi-spaces": [
+        "error",
+        {
+          "ignoreEOLComments": false,
+        },
+      ],
+      "@stylistic/no-multiple-empty-lines": [
+        "error",
+      ],
+      "@stylistic/no-trailing-spaces": [
+        "error",
+      ],
+      "@stylistic/object-curly-newline": [
+        "error",
+        {
+          "consistent": true,
+          "multiline": true,
+        },
+      ],
+      "@stylistic/object-curly-spacing": [
+        "error",
+        "always",
+      ],
+      "@stylistic/object-property-newline": [
+        "error",
+        {
+          "allowAllPropertiesOnSameLine": true,
+        },
+      ],
+      "@stylistic/quote-props": [
+        "error",
+        "consistent-as-needed",
+      ],
+      "@stylistic/quotes": [
+        "error",
+        "single",
+        {
+          "avoidEscape": true,
+        },
+      ],
+      "@stylistic/semi": [
+        "error",
+        "always",
+      ],
+      "@stylistic/space-before-blocks": [
         "error",
       ],
       "@typescript-eslint/member-ordering": [
@@ -65,44 +155,10 @@ exports[`TypeScriptProject with default settings synthesizes 1`] = `
           ],
         },
       ],
-      "@typescript-eslint/no-floating-promises": [
-        "error",
-      ],
-      "@typescript-eslint/no-require-imports": [
-        "error",
-      ],
-      "@typescript-eslint/no-shadow": [
-        "error",
-      ],
-      "@typescript-eslint/return-await": [
-        "error",
-      ],
-      "array-bracket-newline": [
-        "error",
-        "consistent",
-      ],
-      "array-bracket-spacing": [
-        "error",
-        "never",
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true,
-        },
-      ],
-      "comma-dangle": [
-        "error",
-        "always-multiline",
-      ],
-      "comma-spacing": [
-        "error",
-        {
-          "after": true,
-          "before": false,
-        },
-      ],
+      "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/no-require-imports": "error",
+      "@typescript-eslint/no-shadow": "error",
+      "@typescript-eslint/return-await": "error",
       "curly": [
         "error",
         "multi-line",
@@ -141,36 +197,7 @@ exports[`TypeScriptProject with default settings synthesizes 1`] = `
           ],
         },
       ],
-      "indent": [
-        "off",
-      ],
-      "key-spacing": [
-        "error",
-      ],
-      "keyword-spacing": [
-        "error",
-      ],
-      "max-len": [
-        "error",
-        {
-          "code": 150,
-          "ignoreComments": true,
-          "ignoreRegExpLiterals": true,
-          "ignoreStrings": true,
-          "ignoreTemplateLiterals": true,
-          "ignoreUrls": true,
-        },
-      ],
       "no-bitwise": [
-        "error",
-      ],
-      "no-multi-spaces": [
-        "error",
-        {
-          "ignoreEOLComments": false,
-        },
-      ],
-      "no-multiple-empty-lines": [
         "error",
       ],
       "no-return-await": [
@@ -178,44 +205,6 @@ exports[`TypeScriptProject with default settings synthesizes 1`] = `
       ],
       "no-shadow": [
         "off",
-      ],
-      "no-trailing-spaces": [
-        "error",
-      ],
-      "object-curly-newline": [
-        "error",
-        {
-          "consistent": true,
-          "multiline": true,
-        },
-      ],
-      "object-curly-spacing": [
-        "error",
-        "always",
-      ],
-      "object-property-newline": [
-        "error",
-        {
-          "allowAllPropertiesOnSameLine": true,
-        },
-      ],
-      "quote-props": [
-        "error",
-        "consistent-as-needed",
-      ],
-      "quotes": [
-        "error",
-        "single",
-        {
-          "avoidEscape": true,
-        },
-      ],
-      "semi": [
-        "error",
-        "always",
-      ],
-      "space-before-blocks": [
-        "error",
       ],
     },
     "settings": {

--- a/test/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/react-ts-project.test.ts.snap
@@ -42,11 +42,101 @@ exports[`defaults 1`] = `
     ],
     "root": true,
     "rules": {
+      "@stylistic/array-bracket-newline": [
+        "error",
+        "consistent",
+      ],
+      "@stylistic/array-bracket-spacing": [
+        "error",
+        "never",
+      ],
+      "@stylistic/brace-style": [
+        "error",
+        "1tbs",
+        {
+          "allowSingleLine": true,
+        },
+      ],
+      "@stylistic/comma-dangle": [
+        "error",
+        "always-multiline",
+      ],
+      "@stylistic/comma-spacing": [
+        "error",
+        {
+          "after": true,
+          "before": false,
+        },
+      ],
       "@stylistic/indent": [
         "error",
         2,
       ],
+      "@stylistic/key-spacing": [
+        "error",
+      ],
+      "@stylistic/keyword-spacing": [
+        "error",
+      ],
+      "@stylistic/max-len": [
+        "error",
+        {
+          "code": 150,
+          "ignoreComments": true,
+          "ignoreRegExpLiterals": true,
+          "ignoreStrings": true,
+          "ignoreTemplateLiterals": true,
+          "ignoreUrls": true,
+        },
+      ],
       "@stylistic/member-delimiter-style": [
+        "error",
+      ],
+      "@stylistic/no-multi-spaces": [
+        "error",
+        {
+          "ignoreEOLComments": false,
+        },
+      ],
+      "@stylistic/no-multiple-empty-lines": [
+        "error",
+      ],
+      "@stylistic/no-trailing-spaces": [
+        "error",
+      ],
+      "@stylistic/object-curly-newline": [
+        "error",
+        {
+          "consistent": true,
+          "multiline": true,
+        },
+      ],
+      "@stylistic/object-curly-spacing": [
+        "error",
+        "always",
+      ],
+      "@stylistic/object-property-newline": [
+        "error",
+        {
+          "allowAllPropertiesOnSameLine": true,
+        },
+      ],
+      "@stylistic/quote-props": [
+        "error",
+        "consistent-as-needed",
+      ],
+      "@stylistic/quotes": [
+        "error",
+        "single",
+        {
+          "avoidEscape": true,
+        },
+      ],
+      "@stylistic/semi": [
+        "error",
+        "always",
+      ],
+      "@stylistic/space-before-blocks": [
         "error",
       ],
       "@typescript-eslint/member-ordering": [
@@ -65,44 +155,10 @@ exports[`defaults 1`] = `
           ],
         },
       ],
-      "@typescript-eslint/no-floating-promises": [
-        "error",
-      ],
-      "@typescript-eslint/no-require-imports": [
-        "error",
-      ],
-      "@typescript-eslint/no-shadow": [
-        "error",
-      ],
-      "@typescript-eslint/return-await": [
-        "error",
-      ],
-      "array-bracket-newline": [
-        "error",
-        "consistent",
-      ],
-      "array-bracket-spacing": [
-        "error",
-        "never",
-      ],
-      "brace-style": [
-        "error",
-        "1tbs",
-        {
-          "allowSingleLine": true,
-        },
-      ],
-      "comma-dangle": [
-        "error",
-        "always-multiline",
-      ],
-      "comma-spacing": [
-        "error",
-        {
-          "after": true,
-          "before": false,
-        },
-      ],
+      "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/no-require-imports": "error",
+      "@typescript-eslint/no-shadow": "error",
+      "@typescript-eslint/return-await": "error",
       "curly": [
         "error",
         "multi-line",
@@ -141,36 +197,7 @@ exports[`defaults 1`] = `
           ],
         },
       ],
-      "indent": [
-        "off",
-      ],
-      "key-spacing": [
-        "error",
-      ],
-      "keyword-spacing": [
-        "error",
-      ],
-      "max-len": [
-        "error",
-        {
-          "code": 150,
-          "ignoreComments": true,
-          "ignoreRegExpLiterals": true,
-          "ignoreStrings": true,
-          "ignoreTemplateLiterals": true,
-          "ignoreUrls": true,
-        },
-      ],
       "no-bitwise": [
-        "error",
-      ],
-      "no-multi-spaces": [
-        "error",
-        {
-          "ignoreEOLComments": false,
-        },
-      ],
-      "no-multiple-empty-lines": [
         "error",
       ],
       "no-return-await": [
@@ -178,44 +205,6 @@ exports[`defaults 1`] = `
       ],
       "no-shadow": [
         "off",
-      ],
-      "no-trailing-spaces": [
-        "error",
-      ],
-      "object-curly-newline": [
-        "error",
-        {
-          "consistent": true,
-          "multiline": true,
-        },
-      ],
-      "object-curly-spacing": [
-        "error",
-        "always",
-      ],
-      "object-property-newline": [
-        "error",
-        {
-          "allowAllPropertiesOnSameLine": true,
-        },
-      ],
-      "quote-props": [
-        "error",
-        "consistent-as-needed",
-      ],
-      "quotes": [
-        "error",
-        "single",
-        {
-          "avoidEscape": true,
-        },
-      ],
-      "semi": [
-        "error",
-        "always",
-      ],
-      "space-before-blocks": [
-        "error",
       ],
     },
     "settings": {


### PR DESCRIPTION
With eslint v8 all "formatting" rules have been deprecated and moved into a separate plugin called `@stylistic`. In future all formatting rules will be removed from eslint. Some rules have been removed already and in projen we moved them over to use the `@stylistic` version. However not all rules have been updated and as it turns out projen's and eslint's definition on what is formatting did not fully align. The PR also upgrades `@stylistic/eslint-plugin` to v3.

In this change projen is adopting eslint's definition of what a "formatting" rule is. As a consequence, it moves a number of rules to formatting and vice versa. All formatting rules now use the `@stylistic` version. Notably, any configurations using prettier do not get any formatting rules (as they are delegated to prettier), but will receive the other rules.

Finally this PR contains fixes to use non-array rule definitions where preferred. This is based of validation warnings provided from the VSCode eslint plugin.

**The following rules have changed their classification:**

- the `curly` rule is no longer classified as a formatting rule, consequently it is now also applied to configurations using prettier
- the `key-spacing` rule is now classified as a formatting rule (using `@stylistic/key-spacing`), prettier covers this natively and the removal has no effect on configurations using prettier
- the `max-len` rule is now classified as a formatting rule (using `@stylistic/max-len`), prettier covers this natively and the removal has no effect on configurations using prettier
- the `no-multiple-empty-lines` rule is now classified as a formatting rule (using `@stylistic/no-multiple-empty-lines`), prettier covers this natively and the removal has no effect on configurations using prettier
- the `no-trailing-spaces` rule is now classified as a formatting rule (using `@stylistic/no-trailing-spaces`), prettier covers this natively and the removal has no effect on configurations using prettier
- the `semi` rule is now classified as a formatting rule (using `@stylistic/semi`), prettier covers this natively and the removal has no effect on configurations using prettier
- the `indent` formatting rule has been removed in favor of the already added `@stylistic/indent` rule, this was previously turned off to not interfere with the `@stylistic` version but did not have an effect anymore

**The following rules have not changed their classification, but now use the `@stylistic` version:**
(The change is always `<rule>` -> `@stylistic/<rule>`)

```
quotes
comma-dangle
comma-spacing
no-multi-spaces
array-bracket-spacing
array-bracket-newline
object-curly-spacing
object-curly-newline
object-property-newline
keyword-spacing
brace-style
space-before-blocks
quote-props
```

BREAKING CHANGE: Eslint rules have been migrated to use the `@stylistic` version and some rules have been re-categorized to formatting and vice versa. Your rule overrides could be effected and need updating. Please see the PR for more details.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
