### PR TITLE
feat(eslint): expose underlying config file as public property

### DIFF
--- a/docs/api/javascript.md
+++ b/docs/api/javascript.md
@@ -524,6 +524,7 @@ Returns the singleton Eslint component of a project or undefined if there is non
 | <code><a href="#projen.javascript.Eslint.property.project">project</a></code> | <code>projen.Project</code> | *No description.* |
 | <code><a href="#projen.javascript.Eslint.property.config">config</a></code> | <code>any</code> | Direct access to the eslint configuration (escape hatch). |
 | <code><a href="#projen.javascript.Eslint.property.eslintTask">eslintTask</a></code> | <code>projen.Task</code> | eslint task. |
+| <code><a href="#projen.javascript.Eslint.property.file">file</a></code> | <code>projen.ObjectFile</code> | The underlying config file. |
 | <code><a href="#projen.javascript.Eslint.property.ignorePatterns">ignorePatterns</a></code> | <code>string[]</code> | File patterns that should not be linted. |
 | <code><a href="#projen.javascript.Eslint.property.lintPatterns">lintPatterns</a></code> | <code>string[]</code> | Returns an immutable copy of the lintPatterns being used by this eslint configuration. |
 | <code><a href="#projen.javascript.Eslint.property.overrides">overrides</a></code> | <code><a href="#projen.javascript.EslintOverride">EslintOverride</a>[]</code> | eslint overrides. |
@@ -574,6 +575,18 @@ public readonly eslintTask: Task;
 - *Type:* projen.Task
 
 eslint task.
+
+---
+
+##### `file`<sup>Required</sup> <a name="file" id="projen.javascript.Eslint.property.file"></a>
+
+```typescript
+public readonly file: ObjectFile;
+```
+
+- *Type:* projen.ObjectFile
+
+The underlying config file.
 
 ---
 

--- a/src/javascript/eslint.ts
+++ b/src/javascript/eslint.ts
@@ -1,11 +1,13 @@
-import { Project, TaskStepOptions } from "..";
 import { Prettier } from "./prettier";
 import { DEFAULT_PROJEN_RC_JS_FILENAME } from "../common";
 import { ICompareString } from "../compare";
 import { Component } from "../component";
 import { NodeProject } from "../javascript";
 import { JsonFile } from "../json";
+import { ObjectFile } from "../object-file";
+import { Project } from "../project";
 import { Task } from "../task";
+import { TaskStepOptions } from "../task-model";
 import { YamlFile } from "../yaml";
 
 export interface EslintOptions {
@@ -161,6 +163,11 @@ export class Eslint extends Component {
     const isEslint = (c: Component): c is Eslint => c instanceof Eslint;
     return project.components.find(isEslint);
   }
+
+  /**
+   * The underlying config file
+   */
+  public readonly file: ObjectFile;
 
   /**
    * eslint rules.
@@ -452,12 +459,12 @@ export class Eslint extends Component {
     };
 
     if (options.yaml) {
-      new YamlFile(project, ".eslintrc.yml", {
+      this.file = new YamlFile(project, ".eslintrc.yml", {
         obj: this.config,
         marker: true,
       });
     } else {
-      new JsonFile(project, ".eslintrc.json", {
+      this.file = new JsonFile(project, ".eslintrc.json", {
         obj: this.config,
         // https://eslint.org/docs/latest/user-guide/configuring/configuration-files#comments-in-configuration-files
         marker: true,

--- a/test/javascript/eslint.test.ts
+++ b/test/javascript/eslint.test.ts
@@ -19,6 +19,26 @@ test.each([
   execProjenCLI(project.outdir, ["eslint"]);
 });
 
+test("can acceess file", () => {
+  // GIVEN
+  const project = new NodeProject({
+    name: "test",
+    defaultReleaseBranch: "master",
+  });
+
+  const eslint = new Eslint(project, {
+    dirs: ["mysrc"],
+    lintProjenRc: false,
+  });
+
+  // WHEN
+  eslint.file.addOverride("env.foo", "bar");
+
+  // THEN
+  const output = synthSnapshot(project)[".eslintrc.json"];
+  expect(output.env).toHaveProperty("foo", "bar");
+});
+
 describe("prettier", () => {
   test("snapshot", () => {
     // GIVEN


### PR DESCRIPTION
This PR exposes the underlying config file of the Eslint component as a public property, allowing direct manipulation of the eslint configuration file.

The change:
- Adds a new `file` property to the Eslint class that provides access to the underlying ObjectFile
- Updates API documentation to reflect this new property
- Adds a test to verify the functionality works as expected

This enhancement makes it easier to customize eslint configuration through direct file manipulation when needed.

---

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.*