### PR TITLE
feat: cdkv2 feature flags for awscdk-app-ts

### DIFF
--- a/docs/api/awscdk.md
+++ b/docs/api/awscdk.md
@@ -6701,6 +6701,7 @@ Test whether the given construct is a component.
 | <code><a href="#projen.awscdk.CdkConfig.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#projen.awscdk.CdkConfig.property.project">project</a></code> | <code>projen.Project</code> | *No description.* |
 | <code><a href="#projen.awscdk.CdkConfig.property.cdkout">cdkout</a></code> | <code>string</code> | Name of the cdk.out directory. |
+| <code><a href="#projen.awscdk.CdkConfig.property.context">context</a></code> | <code>{[ key: string ]: any}</code> | The context to write to cdk.json. |
 | <code><a href="#projen.awscdk.CdkConfig.property.exclude">exclude</a></code> | <code>string[]</code> | List of glob patterns to be excluded by CDK. |
 | <code><a href="#projen.awscdk.CdkConfig.property.include">include</a></code> | <code>string[]</code> | List of glob patterns to be included by CDK. |
 | <code><a href="#projen.awscdk.CdkConfig.property.json">json</a></code> | <code>projen.JsonFile</code> | Represents the JSON file. |
@@ -6738,6 +6739,18 @@ public readonly cdkout: string;
 - *Type:* string
 
 Name of the cdk.out directory.
+
+---
+
+##### `context`<sup>Required</sup> <a name="context" id="projen.awscdk.CdkConfig.property.context"></a>
+
+```typescript
+public readonly context: {[ key: string ]: any};
+```
+
+- *Type:* {[ key: string ]: any}
+
+The context to write to cdk.json.
 
 ---
 
@@ -13435,6 +13448,7 @@ const awsCdkJavaAppOptions: awscdk.AwsCdkJavaAppOptions = { ... }
 | <code><a href="#projen.awscdk.AwsCdkJavaAppOptions.property.sample">sample</a></code> | <code>boolean</code> | Include sample code and test if the relevant directories don't exist. |
 | <code><a href="#projen.awscdk.AwsCdkJavaAppOptions.property.sampleJavaPackage">sampleJavaPackage</a></code> | <code>string</code> | The java package to use for the code sample. |
 | <code><a href="#projen.awscdk.AwsCdkJavaAppOptions.property.buildCommand">buildCommand</a></code> | <code>string</code> | A command to execute before synthesis. |
+| <code><a href="#projen.awscdk.AwsCdkJavaAppOptions.property.cdkMajorVersion">cdkMajorVersion</a></code> | <code>number</code> | The major version of the AWS CDK (e.g. 1, 2, ...). |
 | <code><a href="#projen.awscdk.AwsCdkJavaAppOptions.property.cdkout">cdkout</a></code> | <code>string</code> | cdk.out directory. |
 | <code><a href="#projen.awscdk.AwsCdkJavaAppOptions.property.context">context</a></code> | <code>{[ key: string ]: any}</code> | Additional context to include in `cdk.json`. |
 | <code><a href="#projen.awscdk.AwsCdkJavaAppOptions.property.featureFlags">featureFlags</a></code> | <code>boolean</code> | Include all feature flags in cdk.json. |
@@ -14168,6 +14182,18 @@ code before redeployment.
 
 ---
 
+##### `cdkMajorVersion`<sup>Optional</sup> <a name="cdkMajorVersion" id="projen.awscdk.AwsCdkJavaAppOptions.property.cdkMajorVersion"></a>
+
+```typescript
+public readonly cdkMajorVersion: number;
+```
+
+- *Type:* number
+
+The major version of the AWS CDK (e.g. 1, 2, ...).
+
+---
+
 ##### `cdkout`<sup>Optional</sup> <a name="cdkout" id="projen.awscdk.AwsCdkJavaAppOptions.property.cdkout"></a>
 
 ```typescript
@@ -14563,6 +14589,7 @@ const awsCdkPythonAppOptions: awscdk.AwsCdkPythonAppOptions = { ... }
 | <code><a href="#projen.awscdk.AwsCdkPythonAppOptions.property.venv">venv</a></code> | <code>boolean</code> | Use venv to manage a virtual environment for installing dependencies inside. |
 | <code><a href="#projen.awscdk.AwsCdkPythonAppOptions.property.venvOptions">venvOptions</a></code> | <code>projen.python.VenvOptions</code> | Venv options. |
 | <code><a href="#projen.awscdk.AwsCdkPythonAppOptions.property.buildCommand">buildCommand</a></code> | <code>string</code> | A command to execute before synthesis. |
+| <code><a href="#projen.awscdk.AwsCdkPythonAppOptions.property.cdkMajorVersion">cdkMajorVersion</a></code> | <code>number</code> | The major version of the AWS CDK (e.g. 1, 2, ...). |
 | <code><a href="#projen.awscdk.AwsCdkPythonAppOptions.property.cdkout">cdkout</a></code> | <code>string</code> | cdk.out directory. |
 | <code><a href="#projen.awscdk.AwsCdkPythonAppOptions.property.context">context</a></code> | <code>{[ key: string ]: any}</code> | Additional context to include in `cdk.json`. |
 | <code><a href="#projen.awscdk.AwsCdkPythonAppOptions.property.featureFlags">featureFlags</a></code> | <code>boolean</code> | Include all feature flags in cdk.json. |
@@ -15410,6 +15437,18 @@ code before redeployment.
 
 ---
 
+##### `cdkMajorVersion`<sup>Optional</sup> <a name="cdkMajorVersion" id="projen.awscdk.AwsCdkPythonAppOptions.property.cdkMajorVersion"></a>
+
+```typescript
+public readonly cdkMajorVersion: number;
+```
+
+- *Type:* number
+
+The major version of the AWS CDK (e.g. 1, 2, ...).
+
+---
+
 ##### `cdkout`<sup>Optional</sup> <a name="cdkout" id="projen.awscdk.AwsCdkPythonAppOptions.property.cdkout"></a>
 
 ```typescript
@@ -15821,6 +15860,7 @@ const awsCdkTypeScriptAppOptions: awscdk.AwsCdkTypeScriptAppOptions = { ... }
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.tsJestOptions">tsJestOptions</a></code> | <code>projen.typescript.TsJestOptions</code> | Options for ts-jest. |
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.typescriptVersion">typescriptVersion</a></code> | <code>string</code> | TypeScript version to use. |
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.buildCommand">buildCommand</a></code> | <code>string</code> | A command to execute before synthesis. |
+| <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.cdkMajorVersion">cdkMajorVersion</a></code> | <code>number</code> | The major version of the AWS CDK (e.g. 1, 2, ...). |
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.cdkout">cdkout</a></code> | <code>string</code> | cdk.out directory. |
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.context">context</a></code> | <code>{[ key: string ]: any}</code> | Additional context to include in `cdk.json`. |
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.featureFlags">featureFlags</a></code> | <code>boolean</code> | Include all feature flags in cdk.json. |
@@ -17999,6 +18039,18 @@ code before redeployment.
 
 ---
 
+##### `cdkMajorVersion`<sup>Optional</sup> <a name="cdkMajorVersion" id="projen.awscdk.AwsCdkTypeScriptAppOptions.property.cdkMajorVersion"></a>
+
+```typescript
+public readonly cdkMajorVersion: number;
+```
+
+- *Type:* number
+
+The major version of the AWS CDK (e.g. 1, 2, ...).
+
+---
+
 ##### `cdkout`<sup>Optional</sup> <a name="cdkout" id="projen.awscdk.AwsCdkTypeScriptAppOptions.property.cdkout"></a>
 
 ```typescript
@@ -18339,6 +18391,7 @@ const cdkConfigCommonOptions: awscdk.CdkConfigCommonOptions = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#projen.awscdk.CdkConfigCommonOptions.property.buildCommand">buildCommand</a></code> | <code>string</code> | A command to execute before synthesis. |
+| <code><a href="#projen.awscdk.CdkConfigCommonOptions.property.cdkMajorVersion">cdkMajorVersion</a></code> | <code>number</code> | The major version of the AWS CDK (e.g. 1, 2, ...). |
 | <code><a href="#projen.awscdk.CdkConfigCommonOptions.property.cdkout">cdkout</a></code> | <code>string</code> | cdk.out directory. |
 | <code><a href="#projen.awscdk.CdkConfigCommonOptions.property.context">context</a></code> | <code>{[ key: string ]: any}</code> | Additional context to include in `cdk.json`. |
 | <code><a href="#projen.awscdk.CdkConfigCommonOptions.property.featureFlags">featureFlags</a></code> | <code>boolean</code> | Include all feature flags in cdk.json. |
@@ -18362,6 +18415,18 @@ A command to execute before synthesis.
 This command will be called when
 running `cdk synth` or when `cdk watch` identifies a change in your source
 code before redeployment.
+
+---
+
+##### `cdkMajorVersion`<sup>Optional</sup> <a name="cdkMajorVersion" id="projen.awscdk.CdkConfigCommonOptions.property.cdkMajorVersion"></a>
+
+```typescript
+public readonly cdkMajorVersion: number;
+```
+
+- *Type:* number
+
+The major version of the AWS CDK (e.g. 1, 2, ...).
 
 ---
 
@@ -18460,6 +18525,7 @@ const cdkConfigOptions: awscdk.CdkConfigOptions = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#projen.awscdk.CdkConfigOptions.property.buildCommand">buildCommand</a></code> | <code>string</code> | A command to execute before synthesis. |
+| <code><a href="#projen.awscdk.CdkConfigOptions.property.cdkMajorVersion">cdkMajorVersion</a></code> | <code>number</code> | The major version of the AWS CDK (e.g. 1, 2, ...). |
 | <code><a href="#projen.awscdk.CdkConfigOptions.property.cdkout">cdkout</a></code> | <code>string</code> | cdk.out directory. |
 | <code><a href="#projen.awscdk.CdkConfigOptions.property.context">context</a></code> | <code>{[ key: string ]: any}</code> | Additional context to include in `cdk.json`. |
 | <code><a href="#projen.awscdk.CdkConfigOptions.property.featureFlags">featureFlags</a></code> | <code>boolean</code> | Include all feature flags in cdk.json. |
@@ -18484,6 +18550,18 @@ A command to execute before synthesis.
 This command will be called when
 running `cdk synth` or when `cdk watch` identifies a change in your source
 code before redeployment.
+
+---
+
+##### `cdkMajorVersion`<sup>Optional</sup> <a name="cdkMajorVersion" id="projen.awscdk.CdkConfigOptions.property.cdkMajorVersion"></a>
+
+```typescript
+public readonly cdkMajorVersion: number;
+```
+
+- *Type:* number
+
+The major version of the AWS CDK (e.g. 1, 2, ...).
 
 ---
 

--- a/src/awscdk/awscdk-app-ts.ts
+++ b/src/awscdk/awscdk-app-ts.ts
@@ -1,5 +1,9 @@
 import * as fs from "fs";
 import * as path from "path";
+import { Component } from "../component";
+import { DependencyType } from "../dependencies";
+import { NodePackageManager, RunBundleTask } from "../javascript";
+import { TypeScriptAppProject, TypeScriptProjectOptions } from "../typescript";
 import { AutoDiscover } from "./auto-discover";
 import { AwsCdkDeps, AwsCdkDepsCommonOptions } from "./awscdk-deps";
 import { AwsCdkDepsJs } from "./awscdk-deps-js";
@@ -7,10 +11,6 @@ import { CdkConfig, CdkConfigCommonOptions } from "./cdk-config";
 import { CdkTasks } from "./cdk-tasks";
 import { IntegRunner } from "./integ-runner";
 import { LambdaFunctionCommonOptions } from "./lambda-function";
-import { Component } from "../component";
-import { DependencyType } from "../dependencies";
-import { NodePackageManager, RunBundleTask } from "../javascript";
-import { TypeScriptAppProject, TypeScriptProjectOptions } from "../typescript";
 
 export interface AwsCdkTypeScriptAppOptions
   extends TypeScriptProjectOptions,
@@ -144,7 +144,8 @@ export class AwsCdkTypeScriptApp extends TypeScriptAppProject {
     }
 
     this.cdkConfig = new CdkConfig(this, {
-      featureFlags: this.cdkDeps.cdkMajorVersion < 2,
+      // featureFlags: this.cdkDeps.cdkMajorVersion < 2,
+      cdkMajorVersion: this.cdkDeps.cdkMajorVersion,
       buildCommand: this.runTaskCommand(this.bundler.bundleTask),
       watchIncludes: [`${this.srcdir}/**/*.ts`, `${this.testdir}/**/*.ts`],
       watchExcludes: [

--- a/src/awscdk/internal.ts
+++ b/src/awscdk/internal.ts
@@ -1,4 +1,4 @@
-import { sep, posix } from "path";
+import { posix, sep } from "path";
 
 /**
  * Feature flags as of v1.130.0
@@ -18,6 +18,89 @@ export const FEATURE_FLAGS = [
   "@aws-cdk/aws-lambda:recognizeVersionProps",
   "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021",
 ];
+
+/**
+ * Feature flags as of v2.190.0
+ */
+export const FEATURE_FLAGS_V2 = {
+  "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+  "@aws-cdk/core:checkSecretUsage": true,
+  "@aws-cdk/core:target-partitions": ["aws", "aws-cn"],
+  "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+  "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+  "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+  "@aws-cdk/aws-iam:minimizePolicies": true,
+  "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+  "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+  "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+  "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+  "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+  "@aws-cdk/core:enablePartitionLiterals": true,
+  "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
+  "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
+  "@aws-cdk/aws-iam:importedRoleStackSafeDefaultPolicyName": true,
+  "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
+  "@aws-cdk/aws-route53-patters:useCertificate": true,
+  "@aws-cdk/customresources:installLatestAwsSdkDefault": false,
+  "@aws-cdk/aws-rds:databaseProxyUniqueResourceName": true,
+  "@aws-cdk/aws-codedeploy:removeAlarmsFromDeploymentGroup": true,
+  "@aws-cdk/aws-apigateway:authorizerChangeDeploymentLogicalId": true,
+  "@aws-cdk/aws-ec2:launchTemplateDefaultUserData": true,
+  "@aws-cdk/aws-secretsmanager:useAttachedSecretResourcePolicyForSecretTargetAttachments":
+    true,
+  "@aws-cdk/aws-redshift:columnId": true,
+  "@aws-cdk/aws-stepfunctions-tasks:enableEmrServicePolicyV2": true,
+  "@aws-cdk/aws-ec2:restrictDefaultSecurityGroup": true,
+  "@aws-cdk/aws-apigateway:requestValidatorUniqueId": true,
+  "@aws-cdk/aws-kms:aliasNameRef": true,
+  "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true,
+  "@aws-cdk/core:includePrefixInUniqueNameGeneration": true,
+  "@aws-cdk/aws-efs:denyAnonymousAccess": true,
+  "@aws-cdk/aws-opensearchservice:enableOpensearchMultiAzWithStandby": true,
+  "@aws-cdk/aws-lambda-nodejs:useLatestRuntimeVersion": true,
+  "@aws-cdk/aws-efs:mountTargetOrderInsensitiveLogicalId": true,
+  "@aws-cdk/aws-rds:auroraClusterChangeScopeOfInstanceParameterGroupWithEachParameters":
+    true,
+  "@aws-cdk/aws-appsync:useArnForSourceApiAssociationIdentifier": true,
+  "@aws-cdk/aws-rds:preventRenderingDeprecatedCredentials": true,
+  "@aws-cdk/aws-codepipeline-actions:useNewDefaultBranchForCodeCommitSource":
+    true,
+  "@aws-cdk/aws-cloudwatch-actions:changeLambdaPermissionLogicalIdForLambdaAction":
+    true,
+  "@aws-cdk/aws-codepipeline:crossAccountKeysDefaultValueToFalse": true,
+  "@aws-cdk/aws-codepipeline:defaultPipelineTypeToV2": true,
+  "@aws-cdk/aws-kms:reduceCrossAccountRegionPolicyScope": true,
+  "@aws-cdk/aws-eks:nodegroupNameAttribute": true,
+  "@aws-cdk/aws-ec2:ebsDefaultGp3Volume": true,
+  "@aws-cdk/aws-ecs:removeDefaultDeploymentAlarm": true,
+  "@aws-cdk/custom-resources:logApiResponseDataPropertyTrueDefault": false,
+  "@aws-cdk/aws-s3:keepNotificationInImportedBucket": false,
+  "@aws-cdk/aws-ecs:enableImdsBlockingDeprecatedFeature": false,
+  "@aws-cdk/aws-ecs:disableEcsImdsBlocking": true,
+  "@aws-cdk/aws-ecs:reduceEc2FargateCloudWatchPermissions": true,
+  "@aws-cdk/aws-dynamodb:resourcePolicyPerReplica": true,
+  "@aws-cdk/aws-ec2:ec2SumTImeoutEnabled": true,
+  "@aws-cdk/aws-appsync:appSyncGraphQLAPIScopeLambdaPermission": true,
+  "@aws-cdk/aws-rds:setCorrectValueForDatabaseInstanceReadReplicaInstanceResourceId":
+    true,
+  "@aws-cdk/core:cfnIncludeRejectComplexResourceUpdateCreatePolicyIntrinsics":
+    true,
+  "@aws-cdk/aws-lambda-nodejs:sdkV3ExcludeSmithyPackages": true,
+  "@aws-cdk/aws-stepfunctions-tasks:fixRunEcsTaskPolicy": true,
+  "@aws-cdk/aws-ec2:bastionHostUseAmazonLinux2023ByDefault": true,
+  "@aws-cdk/aws-route53-targets:userPoolDomainNameMethodWithoutCustomResource":
+    true,
+  "@aws-cdk/aws-elasticloadbalancingV2:albDualstackWithoutPublicIpv4SecurityGroupRulesDefault":
+    true,
+  "@aws-cdk/aws-iam:oidcRejectUnauthorizedConnections": true,
+  "@aws-cdk/core:enableAdditionalMetadataCollection": true,
+  "@aws-cdk/aws-lambda:createNewPoliciesWithAddToRolePolicy": false,
+  "@aws-cdk/aws-s3:setUniqueReplicationRoleName": true,
+  "@aws-cdk/aws-events:requireEventBusPolicySid": true,
+  "@aws-cdk/core:aspectPrioritiesMutating": true,
+  "@aws-cdk/aws-dynamodb:retainTableReplica": true,
+  "@aws-cdk/aws-stepfunctions:useDistributedMapResultWriterV2": true,
+};
 
 /**
  * Suffix for AWS Lambda handlers.

--- a/test/__snapshots__/inventory.test.ts.snap
+++ b/test/__snapshots__/inventory.test.ts.snap
@@ -190,6 +190,22 @@ exports[`inventory 1`] = `
         "switch": "cdk-dependencies-as-deps",
       },
       {
+        "docs": "The major version of the AWS CDK (e.g. 1, 2, ...).",
+        "featured": false,
+        "fullType": {
+          "primitive": "number",
+        },
+        "jsonLike": true,
+        "name": "cdkMajorVersion",
+        "optional": true,
+        "parent": "CdkConfigCommonOptions",
+        "path": [
+          "cdkMajorVersion",
+        ],
+        "simpleType": "number",
+        "switch": "cdk-major-version",
+      },
+      {
         "default": ""cdk.out"",
         "docs": "cdk.out directory.",
         "featured": false,
@@ -1395,6 +1411,22 @@ exports[`inventory 1`] = `
         ],
         "simpleType": "boolean",
         "switch": "cdk-dependencies-as-deps",
+      },
+      {
+        "docs": "The major version of the AWS CDK (e.g. 1, 2, ...).",
+        "featured": false,
+        "fullType": {
+          "primitive": "number",
+        },
+        "jsonLike": true,
+        "name": "cdkMajorVersion",
+        "optional": true,
+        "parent": "CdkConfigCommonOptions",
+        "path": [
+          "cdkMajorVersion",
+        ],
+        "simpleType": "number",
+        "switch": "cdk-major-version",
       },
       {
         "default": ""cdk.out"",
@@ -3076,6 +3108,22 @@ exports[`inventory 1`] = `
         ],
         "simpleType": "boolean",
         "switch": "cdk-dependencies-as-deps",
+      },
+      {
+        "docs": "The major version of the AWS CDK (e.g. 1, 2, ...).",
+        "featured": false,
+        "fullType": {
+          "primitive": "number",
+        },
+        "jsonLike": true,
+        "name": "cdkMajorVersion",
+        "optional": true,
+        "parent": "CdkConfigCommonOptions",
+        "path": [
+          "cdkMajorVersion",
+        ],
+        "simpleType": "number",
+        "switch": "cdk-major-version",
       },
       {
         "default": ""cdk.out"",

--- a/test/awscdk/awscdk-app.test.ts
+++ b/test/awscdk/awscdk-app.test.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
 import { AwsCdkTypeScriptApp, LambdaRuntime } from "../../src/awscdk";
+import { FEATURE_FLAGS, FEATURE_FLAGS_V2 } from "../../src/awscdk/internal";
 import { NodePackageManager } from "../../src/javascript";
 import { mkdtemp, SynthOutput, synthSnapshot } from "../util";
 
@@ -307,8 +308,10 @@ describe("CDK v2", () => {
       "import { App, Stack, StackProps } from 'aws-cdk-lib'"
     );
   });
-  it("has an empty context", () => {
-    expect(snapshot["cdk.json"].context).toBeUndefined();
+  it("has v2 feature flags in context", () => {
+    expect(snapshot["cdk.json"].context).toEqual(
+      expect.objectContaining(FEATURE_FLAGS_V2)
+    );
   });
 });
 
@@ -333,6 +336,9 @@ describe("CDK v1", () => {
     expect(snapshot["package.json"].dependencies).toMatchObject({
       constructs: "^3.2.27",
     });
+  });
+  it("has v1 feature flags in context", () => {
+    expect(Object.keys(snapshot["cdk.json"].context)).toEqual(FEATURE_FLAGS);
   });
 });
 

--- a/test/awscdk/cdk-config.test.ts
+++ b/test/awscdk/cdk-config.test.ts
@@ -1,4 +1,5 @@
 import { CdkConfig } from "../../src/awscdk/cdk-config";
+import { FEATURE_FLAGS, FEATURE_FLAGS_V2 } from "../../src/awscdk/internal";
 import { TestProject } from "../util";
 
 describe("context values", () => {
@@ -90,5 +91,25 @@ describe("excludes", () => {
     config.addExcludes(...newExcludes);
 
     expect(config.exclude).toEqual(newExcludes);
+  });
+});
+
+describe("feature flags", () => {
+  test("should be set for cdk v1", () => {
+    const config = new CdkConfig(new TestProject(), {
+      app: "test feature flags",
+      cdkMajorVersion: 1,
+    });
+
+    expect(Object.keys(config.context)).toEqual(FEATURE_FLAGS);
+  });
+
+  test("should be set for cdk v2", () => {
+    const config = new CdkConfig(new TestProject(), {
+      app: "test feature flags",
+      cdkMajorVersion: 2,
+    });
+
+    expect(config.context).toEqual(expect.objectContaining(FEATURE_FLAGS_V2));
   });
 });


### PR DESCRIPTION
Fixes # https://github.com/projen/projen/issues/4199

For awscdk-app-ts, this will try to read the recommended-feature-flags.json from the node_modules. 
If it cannot be read/parsed, it will fall back to a default list of feature flags for CDKv2

The defaults are set to CDKv1 so it should be backwards compatible with all existing projects


Something I'm not sure of:  if this changes existing project's their context (add feature flags), can we introduce breaking changes that way?

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
