### PR TITLE
fix(bump): log more information during the bumping process

### DIFF
--- a/docs/api/projen.md
+++ b/docs/api/projen.md
@@ -14786,6 +14786,10 @@ result of a new project creation (and take additional steps accordingly)
 
 Find commits that should be considered releasable to decide if a release is required.
 
+This setting only controls whether a release is triggered, yes or no. The
+paths used here are independent of the code that controls what commits are inspected
+to determine the version number.
+
 
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 

--- a/src/release/bump-version.ts
+++ b/src/release/bump-version.ts
@@ -223,8 +223,8 @@ export async function bump(cwd: string, options: BumpOptions) {
       ? relativeBumpType(latestVersion, await catv.dryRun())
       : { bump: "none" };
 
+  logging.info(`Bump from commits: ${renderBumpType(bumpType)}`);
   if (options.nextVersionCommand) {
-    logging.debug(`Proposed bump type: ${renderBumpType(bumpType)}`);
     const nextVersion = execCapture(options.nextVersionCommand, {
       cwd,
       modEnv: {
@@ -240,7 +240,7 @@ export async function bump(cwd: string, options: BumpOptions) {
       try {
         bumpType = parseBumpType(nextVersion);
         logging.info(
-          `nextVersionCommand selects bump type: ${renderBumpType(bumpType)}`
+          `Bump from nextVersionCommand: ${renderBumpType(bumpType)}`
         );
       } catch (e) {
         throw new Error(
@@ -248,8 +248,6 @@ export async function bump(cwd: string, options: BumpOptions) {
         );
       }
     }
-  } else {
-    logging.info(`bump type: ${renderBumpType(bumpType)}`);
   }
 
   // Respect minMajorVersion to correct the result of the nextVersionCommand
@@ -317,6 +315,7 @@ function hasNewInterestingCommits(options: {
   const findCommits = (
     options.releasableCommits ?? ReleasableCommits.everyCommit().cmd
   ).replace("$LATEST_TAG", options.latestTag);
+
   const commitsSinceLastTag = execOrUndefined(findCommits, {
     cwd: options.cwd,
   })?.split("\n");

--- a/src/util.ts
+++ b/src/util.ts
@@ -26,7 +26,8 @@ export function exec(
     stdio?: child_process.StdioOptions;
   }
 ): void {
-  logging.debug(command);
+  logging.debug(`${command} (cwd: ${options.cwd})`);
+
   child_process.execSync(command, {
     stdio: options.stdio || ["inherit", 2, "pipe"], // "pipe" for STDERR means it appears in exceptions
     maxBuffer: MAX_BUFFER,
@@ -42,7 +43,8 @@ export function execCapture(
   command: string,
   options: { cwd: string; modEnv?: Record<string, string> }
 ) {
-  logging.debug(command);
+  logging.debug(`${command} (cwd: ${options.cwd})`);
+
   return child_process.execSync(command, {
     stdio: ["inherit", "pipe", "pipe"], // "pipe" for STDERR means it appears in exceptions
     maxBuffer: MAX_BUFFER,
@@ -61,6 +63,8 @@ export function execOrUndefined(
   command: string,
   options: { cwd: string }
 ): string | undefined {
+  logging.debug(`${command} (cwd: ${options.cwd})`);
+
   try {
     const value = child_process
       .execSync(command, {

--- a/src/version.ts
+++ b/src/version.ts
@@ -293,6 +293,10 @@ export interface VersionBranchOptions {
 
 /**
  * Find commits that should be considered releasable to decide if a release is required.
+ *
+ * This setting only controls whether a release is triggered, yes or no. The
+ * paths used here are independent of the code that controls what commits are inspected
+ * to determine the version number.
  */
 export class ReleasableCommits {
   /**

--- a/test/python/poetry.test.ts
+++ b/test/python/poetry.test.ts
@@ -237,7 +237,9 @@ test("poetry environment is setup with pythonExec", () => {
   }
 
   // THEN
-  expect(debug).toBeCalledWith("poetry env use python-exec-test-path");
+  expect(debug).toBeCalledWith(
+    expect.stringContaining("poetry env use python-exec-test-path")
+  );
 
   // AFTER
   debug.mockRestore();


### PR DESCRIPTION
We are seeing some weird behavior around considering commits with breaking changes in a monorepo context as part of the wrong package. The logging of the bump task isn't up to snuff to debug this issue. Add more logging to try to figure out what's going on.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
