### PR TITLE
feat(release): add Poetry release automation support

### DIFF
--- a/src/release/commit-tag-version.ts
+++ b/src/release/commit-tag-version.ts
@@ -56,17 +56,22 @@ export class CommitAndTagVersion {
   public async invoke<A extends InvokeOptions>(
     options: A
   ): Promise<A extends { capture: true } ? string : void> {
+    // JSON files need explicit type, others are auto-detected by commit-and-tag-version
+    const fileType = this.options.versionFile.endsWith(".json")
+      ? "json"
+      : undefined;
+
     const catvConfig: CommitAndTagConfig = {
       packageFiles: [
         {
           filename: this.options.versionFile,
-          type: "json",
+          ...(fileType && { type: fileType }),
         },
       ],
       bumpFiles: [
         {
           filename: this.options.versionFile,
-          type: "json",
+          ...(fileType && { type: fileType }),
         },
       ],
       commitAll: false,
@@ -166,8 +171,8 @@ export class CommitAndTagVersion {
  * Modeling the CATV config file
  */
 interface CommitAndTagConfig extends Config {
-  packageFiles?: Array<{ filename: string; type: string }>;
-  bumpFiles?: Array<{ filename: string; type: string }>;
+  packageFiles?: Array<{ filename: string; type?: string }>;
+  bumpFiles?: Array<{ filename: string; type?: string }>;
   commitAll?: boolean;
   infile?: string;
   prerelease?: string;

--- a/src/release/reset-version.task.ts
+++ b/src/release/reset-version.task.ts
@@ -1,7 +1,8 @@
 // a builtin task that sets the "version" field of the file
 // specified in OUTFILE to "0.0.0"
 
-import { existsSync, readFileSync, writeFileSync } from "fs";
+import { existsSync } from "fs";
+import { createVersionHandler } from "./version-handlers";
 
 const outfile = process.env.OUTFILE;
 if (!outfile) {
@@ -12,6 +13,5 @@ if (!existsSync(outfile)) {
   process.exit(0); // nothing to do
 }
 
-const content = JSON.parse(readFileSync(outfile, "utf8"));
-content.version = "0.0.0";
-writeFileSync(outfile, JSON.stringify(content, undefined, 2) + "\n");
+const handler = createVersionHandler(outfile!);
+handler.writeVersion("0.0.0");

--- a/src/release/version-handlers.ts
+++ b/src/release/version-handlers.ts
@@ -1,0 +1,132 @@
+import { readFileSync, writeFileSync, existsSync } from "fs";
+
+/**
+ * Interface for handling different types of version files
+ */
+export interface IVersionFileHandler {
+  /** Read version from the file */
+  readVersion(): string;
+
+  /** Write version to the file, preserving formatting */
+  writeVersion(version: string): void;
+}
+
+/**
+ * Handler for JSON-based version files (package.json, version.json, etc.)
+ * Implementation mirrors commit-and-tag-version's JSON updater:
+ * https://github.com/absolute-version/commit-and-tag-version/blob/master/lib/updaters/types/json.js
+ */
+export class JsonVersionHandler implements IVersionFileHandler {
+  constructor(private filePath: string) {}
+
+  readVersion(): string {
+    if (!existsSync(this.filePath)) {
+      throw new Error(`Version file does not exist: ${this.filePath}`);
+    }
+
+    const contents = readFileSync(this.filePath, "utf-8");
+    const json = JSON.parse(contents);
+    if (!json.version) {
+      throw new Error(`No version found in ${this.filePath}`);
+    }
+    return json.version;
+  }
+
+  writeVersion(version: string): void {
+    if (!existsSync(this.filePath)) {
+      // Create a minimal JSON file if it doesn't exist
+      const json = { version };
+      writeFileSync(this.filePath, JSON.stringify(json, undefined, 2) + "\n");
+      return;
+    }
+
+    const contents = readFileSync(this.filePath, "utf-8");
+    const json = JSON.parse(contents);
+
+    // Detect original formatting
+    const indent = this.detectIndent(contents);
+    const newline = contents.includes("\r\n") ? "\r\n" : "\n";
+    const hasTrailingNewline =
+      contents.endsWith("\n") || contents.endsWith("\r\n");
+
+    // Update version
+    json.version = version;
+
+    // Handle package-lock.json v2 format (like commit-and-tag-version does)
+    if (json.packages && json.packages[""]) {
+      json.packages[""].version = version;
+    }
+
+    const output =
+      JSON.stringify(json, undefined, indent) +
+      (hasTrailingNewline ? newline : "");
+    writeFileSync(this.filePath, output);
+  }
+
+  private detectIndent(contents: string): string | number {
+    const match = contents.match(/^(\s+)/m);
+    if (match) {
+      const indent = match[1];
+      // If it's all spaces, return the number of spaces
+      if (indent.indexOf("\t") === -1) {
+        return indent.length;
+      }
+      // If it contains tabs, return the actual string
+      return indent;
+    }
+    // Default to 2 spaces if no indentation detected
+    return 2;
+  }
+}
+
+/**
+ * Handler for Python version files (pyproject.toml, setup.py)
+ * Implementation mirrors commit-and-tag-version's Python updater:
+ * https://github.com/absolute-version/commit-and-tag-version/blob/master/lib/updaters/types/python.js
+ */
+export class PythonVersionHandler implements IVersionFileHandler {
+  constructor(private filePath: string) {}
+
+  readVersion(): string {
+    if (!existsSync(this.filePath)) {
+      throw new Error(`Python version file does not exist: ${this.filePath}`);
+    }
+
+    const content = readFileSync(this.filePath, "utf-8");
+
+    // Use the same regex pattern as commit-and-tag-version
+    const versionMatch = content.match(/version["' ]*=[ ]*["'](.*)['"]/i);
+    if (!versionMatch) {
+      throw new Error(`No version found in ${this.filePath}`);
+    }
+    return versionMatch[1];
+  }
+
+  writeVersion(version: string): void {
+    if (!existsSync(this.filePath)) {
+      throw new Error(`Python version file does not exist: ${this.filePath}`);
+    }
+
+    const content = readFileSync(this.filePath, "utf-8");
+
+    // Replace version using the same regex pattern as commit-and-tag-version
+    const updatedContent = content.replace(
+      /version["' ]*=[ ]*["'](.*)["']/i,
+      `version = "${version}"`
+    );
+
+    writeFileSync(this.filePath, updatedContent);
+  }
+}
+
+/**
+ * Factory function to create the appropriate version handler for a given file path
+ */
+export function createVersionHandler(filePath: string): IVersionFileHandler {
+  if (filePath.endsWith("pyproject.toml") || filePath.endsWith("setup.py")) {
+    return new PythonVersionHandler(filePath);
+  }
+
+  // Default to JSON for backward compatibility
+  return new JsonVersionHandler(filePath);
+}

--- a/test/python/__snapshots__/poetry.test.ts.snap
+++ b/test/python/__snapshots__/poetry.test.ts.snap
@@ -5,7 +5,7 @@ exports[`poetry correctly handles dependencies with toml inline tables should ma
 
 [tool.poetry]
 name = "test-python-project"
-version = "0.1.0"
+version = "0.0.0"
 description = "a short project description"
 license = "Apache-2.0"
 authors = [ "First Last <email@example.com>" ]
@@ -219,7 +219,6 @@ cython_debug/
       ".projen/files.json",
       ".projen/tasks.json",
       "poetry.toml",
-      "pyproject.toml",
     ],
   },
   ".projen/tasks.json": {
@@ -352,7 +351,7 @@ url = "https://test.pypi.org/legacy/"
 
 [tool.poetry]
 name = "test-python-project"
-version = "0.1.0"
+version = "0.0.0"
 description = "a short project description"
 license = "Apache-2.0"
 authors = [ "First Last <email@example.com>" ]

--- a/test/python/poetry.test.ts
+++ b/test/python/poetry.test.ts
@@ -262,7 +262,7 @@ test("generates correct pyproject.toml content", () => {
     tool: {
       poetry: {
         name: "test-python-project",
-        version: "0.1.0",
+        version: "0.0.0",
         description: "A short project description",
         license: "Apache-2.0",
         authors: ["First Last <email@example.com>"],

--- a/test/release/commit-tag-version.test.ts
+++ b/test/release/commit-tag-version.test.ts
@@ -1,0 +1,100 @@
+import { promises as fs, mkdtempSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { CommitAndTagVersion } from "../../src/release/commit-tag-version";
+import * as util from "../../src/util";
+
+describe("CommitAndTagVersion", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "catv-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true });
+  });
+
+  test("creates config without type property for auto-detection", async () => {
+    const catv = new CommitAndTagVersion(undefined, tempDir, {
+      versionFile: "package.json",
+    });
+
+    // Test that invoke creates a config file without type property
+    const mockExec = jest.fn();
+    const execSpy = jest.spyOn(util, "exec").mockImplementation(mockExec);
+
+    try {
+      await catv.invoke({ dryRun: true });
+    } catch {
+      // Expected to fail since we mocked exec, but config file should be created
+    }
+
+    // Read the generated config file
+    const rcfile = join(tempDir, ".versionrc.json");
+    const configExists = await fs
+      .stat(rcfile)
+      .then(() => true)
+      .catch(() => false);
+
+    if (configExists) {
+      const config = JSON.parse(await fs.readFile(rcfile, "utf-8"));
+
+      // Check that type property is not present, allowing auto-detection
+      expect(config.packageFiles[0]).toEqual({
+        filename: "package.json",
+      });
+      expect(config.bumpFiles[0]).toEqual({
+        filename: "package.json",
+      });
+      expect(config.packageFiles[0].type).toBeUndefined();
+      expect(config.bumpFiles[0].type).toBeUndefined();
+    }
+
+    // Restore original exec
+    execSpy.mockRestore();
+  });
+
+  test("handles pyproject.toml files without type specification", async () => {
+    const catv = new CommitAndTagVersion(undefined, tempDir, {
+      versionFile: "pyproject.toml",
+    });
+
+    // Test that invoke creates a config file without type property for TOML files
+    const mockExec = jest.fn();
+    const execSpy = jest.spyOn(util, "exec").mockImplementation(mockExec);
+
+    try {
+      await catv.invoke({ dryRun: true });
+    } catch {
+      // Expected to fail since we mocked exec
+    }
+
+    const rcfile = join(tempDir, ".versionrc.json");
+    const configExists = await fs
+      .stat(rcfile)
+      .then(() => true)
+      .catch(() => false);
+
+    if (configExists) {
+      const config = JSON.parse(await fs.readFile(rcfile, "utf-8"));
+
+      expect(config.packageFiles[0]).toEqual({
+        filename: "pyproject.toml",
+      });
+      expect(config.bumpFiles[0]).toEqual({
+        filename: "pyproject.toml",
+      });
+    }
+
+    execSpy.mockRestore();
+  });
+
+  test("maintains backward compatibility with version.json", () => {
+    const catv = new CommitAndTagVersion(undefined, tempDir, {
+      versionFile: "version.json",
+    });
+
+    expect(catv).toBeInstanceOf(CommitAndTagVersion);
+  });
+});

--- a/test/release/version-handlers.test.ts
+++ b/test/release/version-handlers.test.ts
@@ -1,0 +1,173 @@
+import { promises as fs, mkdtempSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  JsonVersionHandler,
+  PythonVersionHandler,
+  createVersionHandler,
+} from "../../src/release/version-handlers";
+
+describe("JsonVersionHandler", () => {
+  let tempDir: string;
+  let versionFile: string;
+  let handler: JsonVersionHandler;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "json-version-test-"));
+    versionFile = join(tempDir, "package.json");
+    handler = new JsonVersionHandler(versionFile);
+  });
+
+  afterEach(async () => {
+    await fs.rmdir(tempDir, { recursive: true });
+  });
+
+  test("reads version from package.json", async () => {
+    const packageContent = {
+      name: "test-package",
+      version: "1.2.3",
+      description: "Test package",
+    };
+    await fs.writeFile(versionFile, JSON.stringify(packageContent, null, 2));
+
+    const version = await handler.readVersion();
+    expect(version).toBe("1.2.3");
+  });
+
+  test("writes version to package.json preserving formatting", async () => {
+    const packageContent = {
+      name: "test-package",
+      version: "1.0.0",
+      description: "Test package",
+    };
+    await fs.writeFile(
+      versionFile,
+      JSON.stringify(packageContent, null, 2) + "\n"
+    );
+
+    await handler.writeVersion("2.0.0");
+
+    const updatedContent = await fs.readFile(versionFile, "utf-8");
+    const parsed = JSON.parse(updatedContent);
+
+    expect(parsed.version).toBe("2.0.0");
+    expect(parsed.name).toBe("test-package");
+    expect(parsed.description).toBe("Test package");
+    expect(updatedContent.endsWith("\n")).toBe(true);
+  });
+
+  test("returns undefined for non-existent file", async () => {
+    const version = await handler.readVersion();
+    expect(version).toBeUndefined();
+  });
+
+  test("creates new file when writing version to non-existent file", async () => {
+    await handler.writeVersion("1.0.0");
+
+    const content = await fs.readFile(versionFile, "utf-8");
+    const parsed = JSON.parse(content);
+    expect(parsed.version).toBe("1.0.0");
+  });
+});
+
+describe("PythonVersionHandler", () => {
+  let tempDir: string;
+  let versionFile: string;
+  let handler: PythonVersionHandler;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "python-version-test-"));
+    versionFile = join(tempDir, "pyproject.toml");
+    handler = new PythonVersionHandler(versionFile);
+  });
+
+  afterEach(async () => {
+    await fs.rmdir(tempDir, { recursive: true });
+  });
+
+  test("reads version from pyproject.toml", async () => {
+    const tomlContent = `[tool.poetry]
+name = "test-package"
+version = "1.2.3"
+description = "Test package"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+`;
+    await fs.writeFile(versionFile, tomlContent);
+
+    const version = await handler.readVersion();
+    expect(version).toBe("1.2.3");
+  });
+
+  test("writes version to pyproject.toml preserving structure", async () => {
+    const tomlContent = `[tool.poetry]
+name = "test-package"
+version = "1.0.0"
+description = "Test package"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+`;
+    await fs.writeFile(versionFile, tomlContent);
+
+    await handler.writeVersion("2.0.0");
+
+    const updatedContent = await fs.readFile(versionFile, "utf-8");
+    expect(updatedContent).toContain('version = "2.0.0"');
+    expect(updatedContent).toContain('name = "test-package"');
+    expect(updatedContent).toContain("[build-system]");
+  });
+
+  test("handles setup.py files", async () => {
+    const setupPyFile = join(tempDir, "setup.py");
+    const setupPyHandler = new PythonVersionHandler(setupPyFile);
+
+    const setupContent = `from setuptools import setup
+
+setup(
+    name="test-package",
+    version="1.2.3",
+    description="Test package",
+)
+`;
+    await fs.writeFile(setupPyFile, setupContent);
+
+    const version = await setupPyHandler.readVersion();
+    expect(version).toBe("1.2.3");
+  });
+
+  test("returns undefined for non-existent file", async () => {
+    const version = await handler.readVersion();
+    expect(version).toBeUndefined();
+  });
+});
+
+describe("createVersionHandler", () => {
+  test("returns PythonVersionHandler for pyproject.toml", () => {
+    const handler = createVersionHandler("pyproject.toml");
+    expect(handler).toBeInstanceOf(PythonVersionHandler);
+  });
+
+  test("returns PythonVersionHandler for setup.py", () => {
+    const handler = createVersionHandler("setup.py");
+    expect(handler).toBeInstanceOf(PythonVersionHandler);
+  });
+
+  test("returns JsonVersionHandler for package.json", () => {
+    const handler = createVersionHandler("package.json");
+    expect(handler).toBeInstanceOf(JsonVersionHandler);
+  });
+
+  test("returns JsonVersionHandler for version.json", () => {
+    const handler = createVersionHandler("version.json");
+    expect(handler).toBeInstanceOf(JsonVersionHandler);
+  });
+
+  test("defaults to JsonVersionHandler for unknown file types", () => {
+    const handler = createVersionHandler("unknown.txt");
+    expect(handler).toBeInstanceOf(JsonVersionHandler);
+  });
+});


### PR DESCRIPTION
- Add version file handlers for JSON and Python (pyproject.toml, setup.py)
- Update CommitAndTagVersion with intelligent file type detection
- Enable Poetry projects to use projen's release automation
- Maintain full backward compatibility for existing projects

🤖 Generated with [Claude Code](https://claude.ai/code)

Implements #4227 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
