### PR TITLE
fix(javascript): remove requiredEnv and dot-exclusion from codeartifact login task

### DIFF
--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -1114,7 +1114,6 @@ export class NodePackage extends Component {
     }
 
     this.project.addTask("ca:login", {
-      requiredEnv: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
       steps: [
         { exec: "which aws" }, // check that AWS CLI is installed
         ...this.scopedPackagesOptions.map((scopedPackagesOption) => {

--- a/src/javascript/util.ts
+++ b/src/javascript/util.ts
@@ -37,7 +37,7 @@ export function renderBundleName(entrypoint: string) {
  * Regex for AWS CodeArtifact registry
  */
 export const codeArtifactRegex =
-  /^https:\/\/(?<registry>(?<domain>[^\.]+)-(?<accountId>\d{12})\.d\.codeartifact\.(?<region>[^\.]+).*\.amazonaws\.com\/.*\/(?<repository>[^\/.]+)\/)/;
+  /^https:\/\/(?<registry>(?<domain>[^\.]+)-(?<accountId>\d{12})\.d\.codeartifact\.(?<region>[^\.]+).*\.amazonaws\.com\/.*\/(?<repository>[^\/]+)\/)/;
 
 /**
  * gets AWS details from the Code Artifact registry URL

--- a/test/javascript/node-project.test.ts
+++ b/test/javascript/node-project.test.ts
@@ -1715,7 +1715,6 @@ describe("scoped private packages", () => {
     const tasks = output[TaskRuntime.MANIFEST_FILE].tasks;
     expect(tasks["ca:login"]).toEqual({
       name: "ca:login",
-      requiredEnv: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
       steps: [
         {
           exec: "which aws",
@@ -1742,7 +1741,6 @@ describe("scoped private packages", () => {
     const tasks = output[TaskRuntime.MANIFEST_FILE].tasks;
     expect(tasks["ca:login"]).toEqual({
       name: "ca:login",
-      requiredEnv: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
       steps: [
         {
           exec: "which aws",
@@ -1779,7 +1777,6 @@ describe("scoped private packages", () => {
     const tasks = output[TaskRuntime.MANIFEST_FILE].tasks;
     expect(tasks["ca:login"]).toEqual({
       name: "ca:login",
-      requiredEnv: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
       steps: [
         {
           exec: "which aws",

--- a/test/javascript/util.test.ts
+++ b/test/javascript/util.test.ts
@@ -9,6 +9,7 @@ import {
   tryResolveModuleManifest,
   tryResolveDependencyVersion,
   installedVersionProbablyMatches,
+  extractCodeArtifactDetails,
 } from "../../src/javascript/util";
 import { mkdtemp } from "../util";
 
@@ -144,3 +145,46 @@ test.each([
     expect(installedVersionProbablyMatches(requested, check)).toEqual(expected);
   }
 );
+
+test.each([
+  [
+    "https://foobar-123456789013.d.codeartifact.xx-region-1.amazonaws.com/npm/MyRepo/",
+    {
+      accountId: "123456789013",
+      domain: "foobar",
+      region: "xx-region-1",
+      registry:
+        "foobar-123456789013.d.codeartifact.xx-region-1.amazonaws.com/npm/MyRepo/",
+      repository: "MyRepo",
+    },
+  ],
+
+  [
+    "https://foobar-123456789013.d.codeartifact.xx-region-1.amazonaws.com/npm/MyRepo.With.Dots/",
+    {
+      accountId: "123456789013",
+      domain: "foobar",
+      region: "xx-region-1",
+      registry:
+        "foobar-123456789013.d.codeartifact.xx-region-1.amazonaws.com/npm/MyRepo.With.Dots/",
+      repository: "MyRepo.With.Dots",
+    },
+  ],
+])("extractCodeArtifactDetails(%p) should work", (url, retVal) => {
+  expect(extractCodeArtifactDetails(url)).toEqual(retVal);
+});
+
+test.each([
+  [
+    "https://foobar-123456789013.d.codeartifact.xx-region-1.amazonaws.com/npm/MyRepo",
+  ],
+  ["https://foobar-123456789013.d.codeartifact.xx-region-1.amazonaws.com/npm"],
+  [
+    "https://123456789013.d.codeartifact.xx-region-1.amazonaws.com/npm/MyRepo//",
+  ],
+  ["https://123456789013.d.codeartifact.xx-region-1.amazonaws.com/npm/MyRepo"],
+])("extractCodeArtifactDetails(%p) should throw an exception", (url) => {
+  expect(() => {
+    extractCodeArtifactDetails(url);
+  }).toThrow(/Could not get CodeArtifact details from npm Registry/);
+});


### PR DESCRIPTION
This PR has two changes that I think are important to improving the usability of the `yarn run ca:login` task.

#### Remove the `requiredEnv` settings

Requiring that the `ca:login` task sees a `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` variable means that the task does not work for local developers who use other methods to log in to AWS. This breaks if you are running in a Kubernetes Pod that is using web identity access files. This breaks if you are operating using AWS SSO logins. This breaks if you simply have your credentials hard-coded in your AWS config file.

I propose removing this requirement because it's just too explicit.

#### Remove `.` exclusion from `codeArtifactRegex`

We have hundreds of CodeArtifact repositories that use a `.` in their name - ie `"myrepo.git"`.. it's completely valid to have a `.` in the name of a CodeArtifact repository, yet the `codeArtifactRegex` was excluding that and then failing to match. I am removing the `.` because it is valid in the naming patterns for codeartifact. I have tested this change locally and it works great.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
