### PR TITLE
feat(vscode): scaffold .vscode/mcp.json for MCP polyglot projects

### DIFF
--- a/projenrc/index.ts
+++ b/projenrc/index.ts
@@ -6,6 +6,7 @@ import {
   UpgradeDependencies,
   UpgradeDependenciesSchedule,
 } from "../src/javascript";
+import { VsCodeMcpConfig } from "./vscode/mcp-config";
 
 export * from "./windows-build";
 
@@ -261,6 +262,11 @@ export function setupVscode(project: NodeProject) {
     skipFiles: ["<node_internals>/**"],
     program: "${workspaceFolder}/lib/cli/index.js",
     outFiles: ["${workspaceFolder}/lib/**/*.js"],
+  });
+
+  // Scaffold .vscode/mcp.json with a default structure
+  new VsCodeMcpConfig(project, {
+    // Add default MCP config properties here if needed
   });
 }
 

--- a/src/vscode/index.ts
+++ b/src/vscode/index.ts
@@ -3,3 +3,4 @@ export * from "./extensions";
 export * from "./launch-config";
 export * from "./settings";
 export * from "./vscode";
+export * from "./mcp";

--- a/src/vscode/mcp-config.ts
+++ b/src/vscode/mcp-config.ts
@@ -1,0 +1,29 @@
+import { Component } from "../component";
+import { JsonFile } from "../json";
+import { Project } from "../project";
+
+/**
+ * VS Code MCP configuration file generator
+ */
+export class VsCodeMcpConfig extends Component {
+  private readonly content: any;
+  public readonly file: JsonFile;
+
+  constructor(project: Project, content: any = {}) {
+    super(project);
+    this.content = content;
+    this.file = new JsonFile(project, ".vscode/mcp.json", {
+      omitEmpty: false,
+      obj: this.content,
+    });
+  }
+
+  /**
+   * Adds or updates a property in the mcp.json file
+   * @param key The property key
+   * @param value The property value
+   */
+  public setProperty(key: string, value: unknown) {
+    this.content[key] = value;
+  }
+}

--- a/src/vscode/mcp.ts
+++ b/src/vscode/mcp.ts
@@ -1,0 +1,18 @@
+import { Component } from "../component";
+import { JsonFile } from "../json";
+import { VsCode } from "./vscode";
+
+export interface VsCodeMcpConfigOptions {
+  readonly obj: any; // The contents of mcp.json
+}
+
+export class VsCodeMcpConfig extends Component {
+  public readonly file: JsonFile;
+
+  constructor(vscode: VsCode, options: VsCodeMcpConfigOptions) {
+    super(vscode.project);
+    this.file = new JsonFile(vscode.project, ".vscode/mcp.json", {
+      obj: options.obj,
+    });
+  }
+}

--- a/src/vscode/vscode.ts
+++ b/src/vscode/vscode.ts
@@ -3,11 +3,13 @@ import { VsCodeLaunchConfig } from "./launch-config";
 import { VsCodeSettings } from "./settings";
 import { Component } from "../component";
 import { Project } from "../project";
+import { VsCodeMcpConfig } from "./mcp";
 
 export class VsCode extends Component {
   private _launchConfig?: VsCodeLaunchConfig;
   private _settings?: VsCodeSettings;
   private _extensions?: VsCodeRecommendedExtensions;
+  private _mcpConfig?: VsCodeMcpConfig;
 
   constructor(project: Project) {
     super(project);
@@ -35,5 +37,13 @@ export class VsCode extends Component {
     }
 
     return this._extensions;
+  }
+
+  public get mcpConfig() {
+    if (!this._mcpConfig) {
+      // Default to empty object, user can override after instantiation
+      this._mcpConfig = new VsCodeMcpConfig(this, { obj: {} });
+    }
+    return this._mcpConfig;
   }
 }


### PR DESCRIPTION
Introduce a new configuration class for generating the `.vscode/mcp.json` file, enabling easier management of MCP settings in polyglot projects. This change includes the setup of a default structure for the configuration file.

I have read the [Contributor Statement](https://github.com/projen/projen/blob/main/CONTRIBUTING.md#contributor-statement) and agree to its terms.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.