### PR TITLE
feat(circleci): support `circleciIpRanges` in CircleCI Job

### DIFF
--- a/docs/api/circleci.md
+++ b/docs/api/circleci.md
@@ -567,6 +567,7 @@ const job: circleci.Job = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#projen.circleci.Job.property.identifier">identifier</a></code> | <code>string</code> | name of dynamic key *. |
+| <code><a href="#projen.circleci.Job.property.circleciIpRanges">circleciIpRanges</a></code> | <code>boolean</code> | Enables jobs to go through a set of well-defined IP address ranges. |
 | <code><a href="#projen.circleci.Job.property.docker">docker</a></code> | <code><a href="#projen.circleci.Docker">Docker</a>[]</code> | *No description.* |
 | <code><a href="#projen.circleci.Job.property.environment">environment</a></code> | <code>{[ key: string ]: string \| number \| boolean}</code> | A map of environment variable names and values. |
 | <code><a href="#projen.circleci.Job.property.machine">machine</a></code> | <code><a href="#projen.circleci.Machine">Machine</a></code> | *No description.* |
@@ -589,6 +590,18 @@ public readonly identifier: string;
 - *Type:* string
 
 name of dynamic key *.
+
+---
+
+##### `circleciIpRanges`<sup>Optional</sup> <a name="circleciIpRanges" id="projen.circleci.Job.property.circleciIpRanges"></a>
+
+```typescript
+public readonly circleciIpRanges: boolean;
+```
+
+- *Type:* boolean
+
+Enables jobs to go through a set of well-defined IP address ranges.
 
 ---
 

--- a/src/circleci/circleci.ts
+++ b/src/circleci/circleci.ts
@@ -196,6 +196,7 @@ export class Circleci extends Component {
       "resourceClass",
       "dockerLayerCaching",
       "noOutputTimeout",
+      "circleciIpRanges",
     ];
     return snakeCaseKeys(input, true, snakeCaseKeyWords);
   };

--- a/src/circleci/model.ts
+++ b/src/circleci/model.ts
@@ -192,6 +192,8 @@ export interface Job {
   readonly environment?: Record<string, string | number | boolean>;
   /** {@link ResourceClass} */
   readonly resourceClass?: ResourceClass | string;
+  /** Enables jobs to go through a set of well-defined IP address ranges */
+  readonly circleciIpRanges?: boolean;
 }
 
 /**

--- a/test/circleci/__snapshots__/circleci.test.ts.snap
+++ b/test/circleci/__snapshots__/circleci.test.ts.snap
@@ -48,6 +48,7 @@ jobs:
         description: job1Param description
         type: string
         default: job1Param default
+    circleci_ip_ranges: true
 workflows:
   workflow1:
     when:

--- a/test/circleci/circleci.test.ts
+++ b/test/circleci/circleci.test.ts
@@ -48,6 +48,7 @@ test("full spec of api should be provided", () => {
             default: "job1Param default",
           },
         },
+        circleciIpRanges: true,
       },
     ],
     workflows: [
@@ -114,6 +115,7 @@ test("full spec of api should be provided", () => {
   const customJob = yaml.jobs["custom-job-1"];
   expect(customJob.docker[0].image).toEqual("golang:alpine");
   expect(customJob.machine.image).toEqual("node:alpine");
+  expect(customJob.circleci_ip_ranges).toEqual(true);
   expect(customJob.steps).toHaveLength(2);
   expect(customJob.steps).toContain("checkout");
   expect(customJob).toEqual(


### PR DESCRIPTION
Support the circleci_ip_ranges property from the CircleCI config reference

https://circleci.com/docs/configuration-reference/#circleciipranges

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
