### PR TITLE
fix(github): normalize paths in annotateGenerated method

### DIFF
--- a/src/github/github-project.ts
+++ b/src/github/github-project.ts
@@ -8,6 +8,7 @@ import { Clobber } from "../clobber";
 import { Gitpod } from "../gitpod";
 import { Project, ProjectOptions, ProjectType } from "../project";
 import { SampleReadme, SampleReadmeProps } from "../readme";
+import { normalizePersistedPath } from "../util";
 import { DevContainer, VsCode } from "../vscode";
 
 /**
@@ -246,6 +247,9 @@ export class GitHubProject extends Project {
    * @see https://github.com/github/linguist/blob/master/docs/overrides.md
    */
   public annotateGenerated(glob: string): void {
-    this.gitattributes.addAttributes(glob, "linguist-generated");
+    this.gitattributes.addAttributes(
+      normalizePersistedPath(glob),
+      "linguist-generated"
+    );
   }
 }

--- a/test/gitattributes.test.ts
+++ b/test/gitattributes.test.ts
@@ -115,3 +115,14 @@ describe("GitAttributesFile", () => {
     expect(project.gitattributes.endOfLine).toBe(EndOfLine.LF);
   });
 });
+
+describe("annotateGenerated", () => {
+  test("uses normalized paths", () => {
+    const project = new TestProject();
+    project.annotateGenerated("\\some\\windows\\like\\path");
+
+    const lines = synthSnapshot(project)[".gitattributes"].split("\n");
+
+    expect(lines).toContain("/some/windows/like/path linguist-generated");
+  });
+});


### PR DESCRIPTION
This PR fixes an issue where Windows-style paths passed to the `annotateGenerated` method were not being properly normalized before being added to the .gitattributes file.

## Changes
- Updated `GitHubProject.annotateGenerated()` to use `normalizePersistedPath()` for path normalization
- Added test case to verify Windows-style paths are converted to Unix-style paths

## Testing
- Added unit test that verifies Windows-style paths (with backslashes) are properly converted to Unix-style paths (with forward slashes) in the .gitattributes file

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.