### PR TITLE
fix(typescript): ts-jest inline compiler options type

### DIFF
--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -10493,16 +10493,16 @@ Force` ts-jest` to use its built-in defaults even if there is a `tsconfig.json` 
 ```typescript
 import { typescript } from 'projen'
 
-typescript.TsJestTsconfig.custom(config: TypescriptConfigOptions)
+typescript.TsJestTsconfig.custom(config: TypeScriptCompilerOptions)
 ```
 
 Inline compiler options.
 
-> [TypescriptConfigOptions](TypescriptConfigOptions)
+> [TypeScriptCompilerOptions](TypeScriptCompilerOptions)
 
 ###### `config`<sup>Required</sup> <a name="config" id="projen.typescript.TsJestTsconfig.custom.parameter.config"></a>
 
-- *Type:* projen.javascript.TypescriptConfigOptions
+- *Type:* projen.javascript.TypeScriptCompilerOptions
 
 ---
 

--- a/src/typescript/typescript.ts
+++ b/src/typescript/typescript.ts
@@ -144,21 +144,21 @@ export class TsJestTsconfig {
   /**
    * Inline compiler options
    *
-   * @see TypescriptConfigOptions
+   * @see TypeScriptCompilerOptions
    */
-  public static custom(config: TypescriptConfigOptions) {
+  public static custom(config: TypeScriptCompilerOptions) {
     return new TsJestTsconfig(config);
   }
 
   private constructor(
-    private readonly config: boolean | string | TypescriptConfigOptions
+    private readonly config: boolean | string | TypeScriptCompilerOptions
   ) {}
 
   /**
    * @jsii ignore
    * @internal
    */
-  public toJSON(): boolean | string | TypescriptConfigOptions {
+  public toJSON(): boolean | string | TypeScriptCompilerOptions {
     return this.config;
   }
 }

--- a/test/typescript/typescript.test.ts
+++ b/test/typescript/typescript.test.ts
@@ -409,6 +409,39 @@ describe("jestConfig", () => {
       });
     });
 
+    test("allows overriding of ts-jest compiler options inline", () => {
+      const prj = new TypeScriptProject({
+        defaultReleaseBranch: "main",
+        name: "test",
+        jestOptions: {
+          // jestVersion default is latest
+          jestConfig: {},
+        },
+        tsJestOptions: {
+          transformOptions: {
+            tsconfig: TsJestTsconfig.custom({
+              isolatedModules: true,
+            }),
+          },
+        },
+      });
+      const snapshot = synthSnapshot(prj);
+      const jestConfig = snapshot["package.json"].jest;
+      const transformConfig =
+        jestConfig.transform[
+          TypeScriptProject.DEFAULT_TS_JEST_TRANFORM_PATTERN
+        ];
+
+      expect(transformConfig).toBeDefined();
+      expect(transformConfig[0]).toStrictEqual("ts-jest");
+      expect(transformConfig[1]).toStrictEqual({
+        tsconfig: {
+          // inline compiler options without extra compilerOptions property
+          isolatedModules: true,
+        },
+      });
+    });
+
     test("sets testMatch to include src and test dirs by default", () => {
       const prj = new TypeScriptProject({
         defaultReleaseBranch: "main",


### PR DESCRIPTION
fixes #4284

As outlined in the linked issue, the inline compiler options should not be wrapped in an extra `compilerOptions` property.
See also the [ts-docs for the tsconfig option](https://kulshekhar.github.io/ts-jest/docs/getting-started/options/tsconfig/#inline-compiler-options).

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
