### PR TITLE
chore: move CI workloads to D: drive on windows build to improve performance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -231,8 +231,10 @@ jobs:
         with:
           node-version: 20.9.0
       - if: runner.os == 'Windows'
-        name: Set yarn cache-folder
-        run: yarn config set cache-folder D:\a\_temp\yarn
+        name: Windows performance improvements
+        run: |-
+          yarn config set cache-folder D:\a\_temp\yarn
+          echo "TEMP=D:\a\_temp" >> $env:GITHUB_ENV
       - name: Install dependencies
         run: yarn install --check-files
       - name: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -230,6 +230,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.9.0
+      - if: runner.os == 'Windows'
+        name: Set yarn cache-folder
+        run: yarn config set cache-folder D:\a\_temp\yarn
       - name: Install dependencies
         run: yarn install --check-files
       - name: build

--- a/projenrc/windows-build.ts
+++ b/projenrc/windows-build.ts
@@ -81,6 +81,15 @@ export class WindowsBuild extends Component {
       ...onlyPrimaryStepsPatches
     );
 
+    // speed up windows build
+    buildWorkflowFile?.patch(
+      JsonPatch.add(buildJobPath("/steps/2"), {
+        if: "runner.os == 'Windows'",
+        name: "Set yarn cache-folder",
+        run: "yarn config set cache-folder D:\\a\\_temp\\yarn",
+      })
+    );
+
     // Add the join target job for branch protection
     buildWorkflowFile?.patch(
       // Rename old workflow

--- a/projenrc/windows-build.ts
+++ b/projenrc/windows-build.ts
@@ -85,8 +85,11 @@ export class WindowsBuild extends Component {
     buildWorkflowFile?.patch(
       JsonPatch.add(buildJobPath("/steps/2"), {
         if: "runner.os == 'Windows'",
-        name: "Set yarn cache-folder",
-        run: "yarn config set cache-folder D:\\a\\_temp\\yarn",
+        name: "Windows performance improvements",
+        run: [
+          "yarn config set cache-folder D:\\a\\_temp\\yarn", // move the yarn cache to D:
+          `echo "TEMP=D:\\a\\_temp" >> $env:GITHUB_ENV`, // move the tmp dir used for projen test projects to D:
+        ].join("\n"),
       })
     );
 


### PR DESCRIPTION
Build times on Windows have crept up to about an hour and roughly 5x slower compared to the Ubuntu build. There is literature [1] that windows build on GitHub have bad I/O performance and that the D: drive should be faster. 

This change moves the temp directory and the yarn cache to the D: drive. Overall this reduces the build time by 40 min down to 17 min (compared to 11 min on Ubuntu). So much better!


[1] https://chadgolden.com/blog/github-actions-hosted-windows-runners-slower-than-expected-ci-and-you

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
