### PR TITLE
feat(pnpm)!: update pnpm version to 10

### DIFF
--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -681,7 +681,7 @@ export class NodePackage extends Component {
     // node version
     this.minNodeVersion = options.minNodeVersion;
     this.maxNodeVersion = options.maxNodeVersion;
-    this.pnpmVersion = options.pnpmVersion ?? "9";
+    this.pnpmVersion = options.pnpmVersion ?? "10";
     this.bunVersion = options.bunVersion ?? "latest";
     this.addNodeEngine();
 

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -3955,7 +3955,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: "9"
+          version: "10"
       - name: Install dependencies
         run: pnpm i --no-frozen-lockfile
       - name: build
@@ -4076,7 +4076,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: "9"
+          version: "10"
       - name: Install dependencies
         run: pnpm i --frozen-lockfile
       - name: release
@@ -4151,7 +4151,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: "9"
+          version: "10"
       - name: Install dependencies
         run: pnpm i --frozen-lockfile
       - name: Upgrade dependencies


### PR DESCRIPTION
BREAKING CHANGE: Upgrades the default pnpm version to v10. To keep using the previous version, set `pnpmVersion: '9'`.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
