### PR TITLE
chore(docs): Synatx Error in building-your-own docs 

### DIFF
--- a/docs/concepts/projects/building-your-own.md
+++ b/docs/concepts/projects/building-your-own.md
@@ -236,7 +236,6 @@ Let's add a few:
 
 ```typescript
 export class MyMicroserviceProject extends TypeScriptProject {
-  export class MyMicroserviceProject extends TypeScriptProject {
   constructor(options: MyMicroserviceProjectOptions) {
     super({
       ...options,


### PR DESCRIPTION
Fixes #

[building-your-own docs](https://projen.io/docs/concepts/projects/building-your-own/#adding-a-pr-template-component)

In the **PR template component** example, there is duplicate export class. 
```ts
export class MyMicroserviceProject extends TypeScriptProject {
```
This line is written twice. I removed one.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
