### PR TITLE
feat(python): trusted publishing to PyPI

### DIFF
--- a/docs/api/cdk.md
+++ b/docs/api/cdk.md
@@ -9870,6 +9870,7 @@ const jsiiPythonTarget: cdk.JsiiPythonTarget = { ... }
 | <code><a href="#projen.cdk.JsiiPythonTarget.property.prePublishSteps">prePublishSteps</a></code> | <code>projen.github.workflows.JobStep[]</code> | Steps to execute before executing the publishing command. These can be used to prepare the artifact for publishing if needed. |
 | <code><a href="#projen.cdk.JsiiPythonTarget.property.publishTools">publishTools</a></code> | <code>projen.github.workflows.Tools</code> | Additional tools to install in the publishing job. |
 | <code><a href="#projen.cdk.JsiiPythonTarget.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.release.CodeArtifactOptions</code> | Options for publishing to AWS CodeArtifact. |
+| <code><a href="#projen.cdk.JsiiPythonTarget.property.trustedPublishing">trustedPublishing</a></code> | <code>boolean</code> | Use PyPI trusted publishing instead of tokens or username & password. |
 | <code><a href="#projen.cdk.JsiiPythonTarget.property.twinePasswordSecret">twinePasswordSecret</a></code> | <code>string</code> | The GitHub secret which contains PyPI password. |
 | <code><a href="#projen.cdk.JsiiPythonTarget.property.twineRegistryUrl">twineRegistryUrl</a></code> | <code>string</code> | The registry url to use when releasing packages. |
 | <code><a href="#projen.cdk.JsiiPythonTarget.property.twineUsernameSecret">twineUsernameSecret</a></code> | <code>string</code> | The GitHub secret which contains PyPI user name. |
@@ -9954,6 +9955,22 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 - *Default:* undefined
 
 Options for publishing to AWS CodeArtifact.
+
+---
+
+##### `trustedPublishing`<sup>Optional</sup> <a name="trustedPublishing" id="projen.cdk.JsiiPythonTarget.property.trustedPublishing"></a>
+
+```typescript
+public readonly trustedPublishing: boolean;
+```
+
+- *Type:* boolean
+
+Use PyPI trusted publishing instead of tokens or username & password.
+
+Needs to be setup in PyPI.
+
+> [https://docs.pypi.org/trusted-publishers/adding-a-publisher/](https://docs.pypi.org/trusted-publishers/adding-a-publisher/)
 
 ---
 

--- a/docs/api/release.md
+++ b/docs/api/release.md
@@ -2296,6 +2296,7 @@ const jsiiReleasePyPi: release.JsiiReleasePyPi = { ... }
 | <code><a href="#projen.release.JsiiReleasePyPi.property.prePublishSteps">prePublishSteps</a></code> | <code>projen.github.workflows.JobStep[]</code> | Steps to execute before executing the publishing command. These can be used to prepare the artifact for publishing if needed. |
 | <code><a href="#projen.release.JsiiReleasePyPi.property.publishTools">publishTools</a></code> | <code>projen.github.workflows.Tools</code> | Additional tools to install in the publishing job. |
 | <code><a href="#projen.release.JsiiReleasePyPi.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code><a href="#projen.release.CodeArtifactOptions">CodeArtifactOptions</a></code> | Options for publishing to AWS CodeArtifact. |
+| <code><a href="#projen.release.JsiiReleasePyPi.property.trustedPublishing">trustedPublishing</a></code> | <code>boolean</code> | Use PyPI trusted publishing instead of tokens or username & password. |
 | <code><a href="#projen.release.JsiiReleasePyPi.property.twinePasswordSecret">twinePasswordSecret</a></code> | <code>string</code> | The GitHub secret which contains PyPI password. |
 | <code><a href="#projen.release.JsiiReleasePyPi.property.twineRegistryUrl">twineRegistryUrl</a></code> | <code>string</code> | The registry url to use when releasing packages. |
 | <code><a href="#projen.release.JsiiReleasePyPi.property.twineUsernameSecret">twineUsernameSecret</a></code> | <code>string</code> | The GitHub secret which contains PyPI user name. |
@@ -2388,6 +2389,24 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 - *Default:* undefined
 
 Options for publishing to AWS CodeArtifact.
+
+---
+
+##### ~~`trustedPublishing`~~<sup>Optional</sup> <a name="trustedPublishing" id="projen.release.JsiiReleasePyPi.property.trustedPublishing"></a>
+
+- *Deprecated:* Use `PyPiPublishOptions` instead.
+
+```typescript
+public readonly trustedPublishing: boolean;
+```
+
+- *Type:* boolean
+
+Use PyPI trusted publishing instead of tokens or username & password.
+
+Needs to be setup in PyPI.
+
+> [https://docs.pypi.org/trusted-publishers/adding-a-publisher/](https://docs.pypi.org/trusted-publishers/adding-a-publisher/)
 
 ---
 
@@ -3263,6 +3282,7 @@ const pyPiPublishOptions: release.PyPiPublishOptions = { ... }
 | <code><a href="#projen.release.PyPiPublishOptions.property.prePublishSteps">prePublishSteps</a></code> | <code>projen.github.workflows.JobStep[]</code> | Steps to execute before executing the publishing command. These can be used to prepare the artifact for publishing if needed. |
 | <code><a href="#projen.release.PyPiPublishOptions.property.publishTools">publishTools</a></code> | <code>projen.github.workflows.Tools</code> | Additional tools to install in the publishing job. |
 | <code><a href="#projen.release.PyPiPublishOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code><a href="#projen.release.CodeArtifactOptions">CodeArtifactOptions</a></code> | Options for publishing to AWS CodeArtifact. |
+| <code><a href="#projen.release.PyPiPublishOptions.property.trustedPublishing">trustedPublishing</a></code> | <code>boolean</code> | Use PyPI trusted publishing instead of tokens or username & password. |
 | <code><a href="#projen.release.PyPiPublishOptions.property.twinePasswordSecret">twinePasswordSecret</a></code> | <code>string</code> | The GitHub secret which contains PyPI password. |
 | <code><a href="#projen.release.PyPiPublishOptions.property.twineRegistryUrl">twineRegistryUrl</a></code> | <code>string</code> | The registry url to use when releasing packages. |
 | <code><a href="#projen.release.PyPiPublishOptions.property.twineUsernameSecret">twineUsernameSecret</a></code> | <code>string</code> | The GitHub secret which contains PyPI user name. |
@@ -3345,6 +3365,22 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 - *Default:* undefined
 
 Options for publishing to AWS CodeArtifact.
+
+---
+
+##### `trustedPublishing`<sup>Optional</sup> <a name="trustedPublishing" id="projen.release.PyPiPublishOptions.property.trustedPublishing"></a>
+
+```typescript
+public readonly trustedPublishing: boolean;
+```
+
+- *Type:* boolean
+
+Use PyPI trusted publishing instead of tokens or username & password.
+
+Needs to be setup in PyPI.
+
+> [https://docs.pypi.org/trusted-publishers/adding-a-publisher/](https://docs.pypi.org/trusted-publishers/adding-a-publisher/)
 
 ---
 

--- a/docs/publishing/releases-and-versioning.md
+++ b/docs/publishing/releases-and-versioning.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # Releases and Versioning

--- a/docs/publishing/trusted-publishing.md
+++ b/docs/publishing/trusted-publishing.md
@@ -1,0 +1,92 @@
+---
+sidebar_position: 3
+---
+
+# Trusted Publishers
+
+Trusted Publishers is a modern authentication method that helps you publish packages more securely by eliminating the need for long-lived API tokens.
+Instead of managing sensitive credentials, it uses OpenID Connect (OIDC) to generate short-lived tokens from your CI system (like GitHub Actions or GitLab Pipelines).
+This means less security risk and easier maintenance, as you don't need to regularly rotate or protect long-lived tokens.
+Trusted Publishers ensures packages come from specific CI systems or build pipelines, reducing the risk of token theft and unauthorized publications.
+
+## How Trusted Publishers Work
+
+Trusted Publishers leverage OpenID Connect (OIDC) to establish trust between your CI/CD system and package repositories:
+
+1. **Identity Provider**: Your CI system (GitHub Actions) acts as an OIDC identity provider
+2. **Token Exchange**: The CI system generates a short-lived OIDC token containing metadata about the workflow
+3. **Verification**: The package repository verifies the token and checks it against configured trusted publishers
+4. **API Token**: If verification succeeds, the repository issues a temporary API token for publishing
+
+This eliminates the need to store long-lived secrets in your repository.
+
+## Supported Package Repositories
+
+Projen currently supports trusted publishing for:
+
+- **PyPI** - Python Package Index
+<!-- - **npm** (with provenance) - Node.js packages with provenance statements -->
+
+## PyPI Trusted Publishing
+
+### Setup
+
+To enable PyPI trusted publishing in your projen project:
+
+```typescript
+const project = new PythonProject({
+  // ... other options
+  publishToPypi: {
+    trustedPublishing: true,
+  },
+});
+```
+
+### PyPI Configuration
+
+Before using trusted publishing, you must configure your PyPI project:
+
+1. **Go to PyPI**: Navigate to your project's settings on [PyPI](https://pypi.org)
+2. **Add Publisher**: Under "Publishing", click "Add a new publisher"
+3. **Configure GitHub Actions**:
+   - **Owner**: Your GitHub username or organization
+   - **Repository name**: Your repository name
+   - **Workflow name**: `release.yml` (or your release workflow filename)
+   - **Environment name**: Leave empty unless using GitHub environments
+
+Or follow the [official PyPI documentation](https://docs.pypi.org/trusted-publishers/adding-a-publisher/).
+
+### How It Works
+
+When publishing with trusted publishing enabled:
+
+1. GitHub Actions generates an OIDC token containing workflow metadata
+2. The publishing job exchanges this token for a PyPI API token
+3. The temporary API token is used to publish your package
+4. No long-lived secrets are stored in your repository
+
+## Migration Guide
+
+### From Token-Based to Trusted Publishing
+
+1. **Update your projen configuration**:
+
+   ```typescript
+   publishToPypi: {
+     trustedPublishing: true,
+     // Remove twinePasswordSecret if present
+   }
+   ```
+
+2. **Configure PyPI trusted publisher** (see PyPI Configuration above)
+
+3. **Remove secrets from GitHub**:
+   - You can safely remove `TWINE_PASSWORD` and `TWINE_USERNAME` secrets
+   - Keep them temporarily during transition for rollback capability
+
+4. **Test the setup**:
+   - Create a test release to verify trusted publishing works
+   - Monitor the workflow logs for successful token minting
+
+5. **Clean up**:
+   - Delete old API tokens in PyPI once you are confident with the new setup


### PR DESCRIPTION
This PR adds support for publishing to PyPI with Trusted Publishers. Trusted Publishing is a standard to authenticate with package repositories using OIDC and short-lived identity tokens. This method can be used in automated environments and eliminates the need to use manually generated API tokens.

PyPI docs: https://docs.pypi.org/trusted-publishers/
OSSF Standard: https://repos.openssf.org/trusted-publishers-for-all-package-repositories

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
