### PR TITLE
feat(release): Trusted Publishers for PyPI & npmjs.com

### DIFF
--- a/docs/api/awscdk.md
+++ b/docs/api/awscdk.md
@@ -10330,6 +10330,7 @@ const awsCdkConstructLibraryOptions: awscdk.AwsCdkConstructLibraryOptions = { ..
 | <code><a href="#projen.awscdk.AwsCdkConstructLibraryOptions.property.npmRegistry">npmRegistry</a></code> | <code>string</code> | The host name of the npm registry to publish to. |
 | <code><a href="#projen.awscdk.AwsCdkConstructLibraryOptions.property.npmRegistryUrl">npmRegistryUrl</a></code> | <code>string</code> | The base URL of the npm package registry. |
 | <code><a href="#projen.awscdk.AwsCdkConstructLibraryOptions.property.npmTokenSecret">npmTokenSecret</a></code> | <code>string</code> | GitHub secret which contains the NPM token to use when publishing packages. |
+| <code><a href="#projen.awscdk.AwsCdkConstructLibraryOptions.property.npmTrustedPublishing">npmTrustedPublishing</a></code> | <code>boolean</code> | Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work. |
 | <code><a href="#projen.awscdk.AwsCdkConstructLibraryOptions.property.packageManager">packageManager</a></code> | <code>projen.javascript.NodePackageManager</code> | The Node Package Manager used to execute scripts. |
 | <code><a href="#projen.awscdk.AwsCdkConstructLibraryOptions.property.packageName">packageName</a></code> | <code>string</code> | The "name" in package.json. |
 | <code><a href="#projen.awscdk.AwsCdkConstructLibraryOptions.property.peerDependencyOptions">peerDependencyOptions</a></code> | <code>projen.javascript.PeerDependencyOptions</code> | Options for `peerDeps`. |
@@ -11300,6 +11301,19 @@ public readonly npmTokenSecret: string;
 - *Default:* "NPM_TOKEN"
 
 GitHub secret which contains the NPM token to use when publishing packages.
+
+---
+
+##### `npmTrustedPublishing`<sup>Optional</sup> <a name="npmTrustedPublishing" id="projen.awscdk.AwsCdkConstructLibraryOptions.property.npmTrustedPublishing"></a>
+
+```typescript
+public readonly npmTrustedPublishing: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.
 
 ---
 
@@ -15811,6 +15825,7 @@ const awsCdkTypeScriptAppOptions: awscdk.AwsCdkTypeScriptAppOptions = { ... }
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.npmRegistry">npmRegistry</a></code> | <code>string</code> | The host name of the npm registry to publish to. |
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.npmRegistryUrl">npmRegistryUrl</a></code> | <code>string</code> | The base URL of the npm package registry. |
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.npmTokenSecret">npmTokenSecret</a></code> | <code>string</code> | GitHub secret which contains the NPM token to use when publishing packages. |
+| <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.npmTrustedPublishing">npmTrustedPublishing</a></code> | <code>boolean</code> | Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work. |
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.packageManager">packageManager</a></code> | <code>projen.javascript.NodePackageManager</code> | The Node Package Manager used to execute scripts. |
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.packageName">packageName</a></code> | <code>string</code> | The "name" in package.json. |
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.peerDependencyOptions">peerDependencyOptions</a></code> | <code>projen.javascript.PeerDependencyOptions</code> | Options for `peerDeps`. |
@@ -16773,6 +16788,19 @@ public readonly npmTokenSecret: string;
 - *Default:* "NPM_TOKEN"
 
 GitHub secret which contains the NPM token to use when publishing packages.
+
+---
+
+##### `npmTrustedPublishing`<sup>Optional</sup> <a name="npmTrustedPublishing" id="projen.awscdk.AwsCdkTypeScriptAppOptions.property.npmTrustedPublishing"></a>
+
+```typescript
+public readonly npmTrustedPublishing: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.
 
 ---
 
@@ -18778,6 +18806,7 @@ const constructLibraryAwsOptions: awscdk.ConstructLibraryAwsOptions = { ... }
 | <code><a href="#projen.awscdk.ConstructLibraryAwsOptions.property.npmRegistry">npmRegistry</a></code> | <code>string</code> | The host name of the npm registry to publish to. |
 | <code><a href="#projen.awscdk.ConstructLibraryAwsOptions.property.npmRegistryUrl">npmRegistryUrl</a></code> | <code>string</code> | The base URL of the npm package registry. |
 | <code><a href="#projen.awscdk.ConstructLibraryAwsOptions.property.npmTokenSecret">npmTokenSecret</a></code> | <code>string</code> | GitHub secret which contains the NPM token to use when publishing packages. |
+| <code><a href="#projen.awscdk.ConstructLibraryAwsOptions.property.npmTrustedPublishing">npmTrustedPublishing</a></code> | <code>boolean</code> | Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work. |
 | <code><a href="#projen.awscdk.ConstructLibraryAwsOptions.property.packageManager">packageManager</a></code> | <code>projen.javascript.NodePackageManager</code> | The Node Package Manager used to execute scripts. |
 | <code><a href="#projen.awscdk.ConstructLibraryAwsOptions.property.packageName">packageName</a></code> | <code>string</code> | The "name" in package.json. |
 | <code><a href="#projen.awscdk.ConstructLibraryAwsOptions.property.peerDependencyOptions">peerDependencyOptions</a></code> | <code>projen.javascript.PeerDependencyOptions</code> | Options for `peerDeps`. |
@@ -19850,6 +19879,21 @@ public readonly npmTokenSecret: string;
 - *Default:* "NPM_TOKEN"
 
 GitHub secret which contains the NPM token to use when publishing packages.
+
+---
+
+##### ~~`npmTrustedPublishing`~~<sup>Optional</sup> <a name="npmTrustedPublishing" id="projen.awscdk.ConstructLibraryAwsOptions.property.npmTrustedPublishing"></a>
+
+- *Deprecated:* use `AwsCdkConstructLibraryOptions`
+
+```typescript
+public readonly npmTrustedPublishing: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.
 
 ---
 

--- a/docs/api/cdk.md
+++ b/docs/api/cdk.md
@@ -3936,6 +3936,7 @@ const constructLibraryOptions: cdk.ConstructLibraryOptions = { ... }
 | <code><a href="#projen.cdk.ConstructLibraryOptions.property.npmRegistry">npmRegistry</a></code> | <code>string</code> | The host name of the npm registry to publish to. |
 | <code><a href="#projen.cdk.ConstructLibraryOptions.property.npmRegistryUrl">npmRegistryUrl</a></code> | <code>string</code> | The base URL of the npm package registry. |
 | <code><a href="#projen.cdk.ConstructLibraryOptions.property.npmTokenSecret">npmTokenSecret</a></code> | <code>string</code> | GitHub secret which contains the NPM token to use when publishing packages. |
+| <code><a href="#projen.cdk.ConstructLibraryOptions.property.npmTrustedPublishing">npmTrustedPublishing</a></code> | <code>boolean</code> | Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work. |
 | <code><a href="#projen.cdk.ConstructLibraryOptions.property.packageManager">packageManager</a></code> | <code>projen.javascript.NodePackageManager</code> | The Node Package Manager used to execute scripts. |
 | <code><a href="#projen.cdk.ConstructLibraryOptions.property.packageName">packageName</a></code> | <code>string</code> | The "name" in package.json. |
 | <code><a href="#projen.cdk.ConstructLibraryOptions.property.peerDependencyOptions">peerDependencyOptions</a></code> | <code>projen.javascript.PeerDependencyOptions</code> | Options for `peerDeps`. |
@@ -4891,6 +4892,19 @@ public readonly npmTokenSecret: string;
 - *Default:* "NPM_TOKEN"
 
 GitHub secret which contains the NPM token to use when publishing packages.
+
+---
+
+##### `npmTrustedPublishing`<sup>Optional</sup> <a name="npmTrustedPublishing" id="projen.cdk.ConstructLibraryOptions.property.npmTrustedPublishing"></a>
+
+```typescript
+public readonly npmTrustedPublishing: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.
 
 ---
 
@@ -7338,6 +7352,7 @@ const jsiiProjectOptions: cdk.JsiiProjectOptions = { ... }
 | <code><a href="#projen.cdk.JsiiProjectOptions.property.npmRegistry">npmRegistry</a></code> | <code>string</code> | The host name of the npm registry to publish to. |
 | <code><a href="#projen.cdk.JsiiProjectOptions.property.npmRegistryUrl">npmRegistryUrl</a></code> | <code>string</code> | The base URL of the npm package registry. |
 | <code><a href="#projen.cdk.JsiiProjectOptions.property.npmTokenSecret">npmTokenSecret</a></code> | <code>string</code> | GitHub secret which contains the NPM token to use when publishing packages. |
+| <code><a href="#projen.cdk.JsiiProjectOptions.property.npmTrustedPublishing">npmTrustedPublishing</a></code> | <code>boolean</code> | Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work. |
 | <code><a href="#projen.cdk.JsiiProjectOptions.property.packageManager">packageManager</a></code> | <code>projen.javascript.NodePackageManager</code> | The Node Package Manager used to execute scripts. |
 | <code><a href="#projen.cdk.JsiiProjectOptions.property.packageName">packageName</a></code> | <code>string</code> | The "name" in package.json. |
 | <code><a href="#projen.cdk.JsiiProjectOptions.property.peerDependencyOptions">peerDependencyOptions</a></code> | <code>projen.javascript.PeerDependencyOptions</code> | Options for `peerDeps`. |
@@ -8292,6 +8307,19 @@ public readonly npmTokenSecret: string;
 - *Default:* "NPM_TOKEN"
 
 GitHub secret which contains the NPM token to use when publishing packages.
+
+---
+
+##### `npmTrustedPublishing`<sup>Optional</sup> <a name="npmTrustedPublishing" id="projen.cdk.JsiiProjectOptions.property.npmTrustedPublishing"></a>
+
+```typescript
+public readonly npmTrustedPublishing: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.
 
 ---
 
@@ -9869,7 +9897,9 @@ const jsiiPythonTarget: cdk.JsiiPythonTarget = { ... }
 | <code><a href="#projen.cdk.JsiiPythonTarget.property.postPublishSteps">postPublishSteps</a></code> | <code>projen.github.workflows.JobStep[]</code> | Steps to execute after executing the publishing command. |
 | <code><a href="#projen.cdk.JsiiPythonTarget.property.prePublishSteps">prePublishSteps</a></code> | <code>projen.github.workflows.JobStep[]</code> | Steps to execute before executing the publishing command. These can be used to prepare the artifact for publishing if needed. |
 | <code><a href="#projen.cdk.JsiiPythonTarget.property.publishTools">publishTools</a></code> | <code>projen.github.workflows.Tools</code> | Additional tools to install in the publishing job. |
+| <code><a href="#projen.cdk.JsiiPythonTarget.property.attestations">attestations</a></code> | <code>boolean</code> | Generate and publish cryptographic attestations for files uploaded to PyPI. |
 | <code><a href="#projen.cdk.JsiiPythonTarget.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.release.CodeArtifactOptions</code> | Options for publishing to AWS CodeArtifact. |
+| <code><a href="#projen.cdk.JsiiPythonTarget.property.trustedPublishing">trustedPublishing</a></code> | <code>boolean</code> | Use PyPI trusted publishing instead of tokens or username & password. |
 | <code><a href="#projen.cdk.JsiiPythonTarget.property.twinePasswordSecret">twinePasswordSecret</a></code> | <code>string</code> | The GitHub secret which contains PyPI password. |
 | <code><a href="#projen.cdk.JsiiPythonTarget.property.twineRegistryUrl">twineRegistryUrl</a></code> | <code>string</code> | The registry url to use when releasing packages. |
 | <code><a href="#projen.cdk.JsiiPythonTarget.property.twineUsernameSecret">twineUsernameSecret</a></code> | <code>string</code> | The GitHub secret which contains PyPI user name. |
@@ -9944,6 +9974,24 @@ Additional tools to install in the publishing job.
 
 ---
 
+##### `attestations`<sup>Optional</sup> <a name="attestations" id="projen.cdk.JsiiPythonTarget.property.attestations"></a>
+
+```typescript
+public readonly attestations: boolean;
+```
+
+- *Type:* boolean
+- *Default:* enabled when using trusted publishing, otherwise not applicable
+
+Generate and publish cryptographic attestations for files uploaded to PyPI.
+
+Attestations provide package provenance and integrity an can be viewed on PyPI.
+They are only available when using a Trusted Publisher for publishing.
+
+> [https://docs.pypi.org/attestations/producing-attestations/](https://docs.pypi.org/attestations/producing-attestations/)
+
+---
+
 ##### `codeArtifactOptions`<sup>Optional</sup> <a name="codeArtifactOptions" id="projen.cdk.JsiiPythonTarget.property.codeArtifactOptions"></a>
 
 ```typescript
@@ -9954,6 +10002,22 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 - *Default:* undefined
 
 Options for publishing to AWS CodeArtifact.
+
+---
+
+##### `trustedPublishing`<sup>Optional</sup> <a name="trustedPublishing" id="projen.cdk.JsiiPythonTarget.property.trustedPublishing"></a>
+
+```typescript
+public readonly trustedPublishing: boolean;
+```
+
+- *Type:* boolean
+
+Use PyPI trusted publishing instead of tokens or username & password.
+
+Needs to be setup in PyPI.
+
+> [https://docs.pypi.org/trusted-publishers/adding-a-publisher/](https://docs.pypi.org/trusted-publishers/adding-a-publisher/)
 
 ---
 

--- a/docs/api/cdk8s.md
+++ b/docs/api/cdk8s.md
@@ -6672,6 +6672,7 @@ const cdk8sTypeScriptAppOptions: cdk8s.Cdk8sTypeScriptAppOptions = { ... }
 | <code><a href="#projen.cdk8s.Cdk8sTypeScriptAppOptions.property.npmRegistry">npmRegistry</a></code> | <code>string</code> | The host name of the npm registry to publish to. |
 | <code><a href="#projen.cdk8s.Cdk8sTypeScriptAppOptions.property.npmRegistryUrl">npmRegistryUrl</a></code> | <code>string</code> | The base URL of the npm package registry. |
 | <code><a href="#projen.cdk8s.Cdk8sTypeScriptAppOptions.property.npmTokenSecret">npmTokenSecret</a></code> | <code>string</code> | GitHub secret which contains the NPM token to use when publishing packages. |
+| <code><a href="#projen.cdk8s.Cdk8sTypeScriptAppOptions.property.npmTrustedPublishing">npmTrustedPublishing</a></code> | <code>boolean</code> | Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work. |
 | <code><a href="#projen.cdk8s.Cdk8sTypeScriptAppOptions.property.packageManager">packageManager</a></code> | <code>projen.javascript.NodePackageManager</code> | The Node Package Manager used to execute scripts. |
 | <code><a href="#projen.cdk8s.Cdk8sTypeScriptAppOptions.property.packageName">packageName</a></code> | <code>string</code> | The "name" in package.json. |
 | <code><a href="#projen.cdk8s.Cdk8sTypeScriptAppOptions.property.peerDependencyOptions">peerDependencyOptions</a></code> | <code>projen.javascript.PeerDependencyOptions</code> | Options for `peerDeps`. |
@@ -7624,6 +7625,19 @@ public readonly npmTokenSecret: string;
 - *Default:* "NPM_TOKEN"
 
 GitHub secret which contains the NPM token to use when publishing packages.
+
+---
+
+##### `npmTrustedPublishing`<sup>Optional</sup> <a name="npmTrustedPublishing" id="projen.cdk8s.Cdk8sTypeScriptAppOptions.property.npmTrustedPublishing"></a>
+
+```typescript
+public readonly npmTrustedPublishing: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.
 
 ---
 
@@ -9228,6 +9242,7 @@ const constructLibraryCdk8sOptions: cdk8s.ConstructLibraryCdk8sOptions = { ... }
 | <code><a href="#projen.cdk8s.ConstructLibraryCdk8sOptions.property.npmRegistry">npmRegistry</a></code> | <code>string</code> | The host name of the npm registry to publish to. |
 | <code><a href="#projen.cdk8s.ConstructLibraryCdk8sOptions.property.npmRegistryUrl">npmRegistryUrl</a></code> | <code>string</code> | The base URL of the npm package registry. |
 | <code><a href="#projen.cdk8s.ConstructLibraryCdk8sOptions.property.npmTokenSecret">npmTokenSecret</a></code> | <code>string</code> | GitHub secret which contains the NPM token to use when publishing packages. |
+| <code><a href="#projen.cdk8s.ConstructLibraryCdk8sOptions.property.npmTrustedPublishing">npmTrustedPublishing</a></code> | <code>boolean</code> | Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work. |
 | <code><a href="#projen.cdk8s.ConstructLibraryCdk8sOptions.property.packageManager">packageManager</a></code> | <code>projen.javascript.NodePackageManager</code> | The Node Package Manager used to execute scripts. |
 | <code><a href="#projen.cdk8s.ConstructLibraryCdk8sOptions.property.packageName">packageName</a></code> | <code>string</code> | The "name" in package.json. |
 | <code><a href="#projen.cdk8s.ConstructLibraryCdk8sOptions.property.peerDependencyOptions">peerDependencyOptions</a></code> | <code>projen.javascript.PeerDependencyOptions</code> | Options for `peerDeps`. |
@@ -10189,6 +10204,19 @@ public readonly npmTokenSecret: string;
 - *Default:* "NPM_TOKEN"
 
 GitHub secret which contains the NPM token to use when publishing packages.
+
+---
+
+##### `npmTrustedPublishing`<sup>Optional</sup> <a name="npmTrustedPublishing" id="projen.cdk8s.ConstructLibraryCdk8sOptions.property.npmTrustedPublishing"></a>
+
+```typescript
+public readonly npmTrustedPublishing: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.
 
 ---
 

--- a/docs/api/cdktf.md
+++ b/docs/api/cdktf.md
@@ -1596,6 +1596,7 @@ const constructLibraryCdktfOptions: cdktf.ConstructLibraryCdktfOptions = { ... }
 | <code><a href="#projen.cdktf.ConstructLibraryCdktfOptions.property.npmRegistry">npmRegistry</a></code> | <code>string</code> | The host name of the npm registry to publish to. |
 | <code><a href="#projen.cdktf.ConstructLibraryCdktfOptions.property.npmRegistryUrl">npmRegistryUrl</a></code> | <code>string</code> | The base URL of the npm package registry. |
 | <code><a href="#projen.cdktf.ConstructLibraryCdktfOptions.property.npmTokenSecret">npmTokenSecret</a></code> | <code>string</code> | GitHub secret which contains the NPM token to use when publishing packages. |
+| <code><a href="#projen.cdktf.ConstructLibraryCdktfOptions.property.npmTrustedPublishing">npmTrustedPublishing</a></code> | <code>boolean</code> | Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work. |
 | <code><a href="#projen.cdktf.ConstructLibraryCdktfOptions.property.packageManager">packageManager</a></code> | <code>projen.javascript.NodePackageManager</code> | The Node Package Manager used to execute scripts. |
 | <code><a href="#projen.cdktf.ConstructLibraryCdktfOptions.property.packageName">packageName</a></code> | <code>string</code> | The "name" in package.json. |
 | <code><a href="#projen.cdktf.ConstructLibraryCdktfOptions.property.peerDependencyOptions">peerDependencyOptions</a></code> | <code>projen.javascript.PeerDependencyOptions</code> | Options for `peerDeps`. |
@@ -2553,6 +2554,19 @@ public readonly npmTokenSecret: string;
 - *Default:* "NPM_TOKEN"
 
 GitHub secret which contains the NPM token to use when publishing packages.
+
+---
+
+##### `npmTrustedPublishing`<sup>Optional</sup> <a name="npmTrustedPublishing" id="projen.cdktf.ConstructLibraryCdktfOptions.property.npmTrustedPublishing"></a>
+
+```typescript
+public readonly npmTrustedPublishing: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.
 
 ---
 

--- a/docs/api/javascript.md
+++ b/docs/api/javascript.md
@@ -7981,6 +7981,7 @@ const nodePackageOptions: javascript.NodePackageOptions = { ... }
 | <code><a href="#projen.javascript.NodePackageOptions.property.npmRegistry">npmRegistry</a></code> | <code>string</code> | The host name of the npm registry to publish to. |
 | <code><a href="#projen.javascript.NodePackageOptions.property.npmRegistryUrl">npmRegistryUrl</a></code> | <code>string</code> | The base URL of the npm package registry. |
 | <code><a href="#projen.javascript.NodePackageOptions.property.npmTokenSecret">npmTokenSecret</a></code> | <code>string</code> | GitHub secret which contains the NPM token to use when publishing packages. |
+| <code><a href="#projen.javascript.NodePackageOptions.property.npmTrustedPublishing">npmTrustedPublishing</a></code> | <code>boolean</code> | Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work. |
 | <code><a href="#projen.javascript.NodePackageOptions.property.packageManager">packageManager</a></code> | <code><a href="#projen.javascript.NodePackageManager">NodePackageManager</a></code> | The Node Package Manager used to execute scripts. |
 | <code><a href="#projen.javascript.NodePackageOptions.property.packageName">packageName</a></code> | <code>string</code> | The "name" in package.json. |
 | <code><a href="#projen.javascript.NodePackageOptions.property.peerDependencyOptions">peerDependencyOptions</a></code> | <code><a href="#projen.javascript.PeerDependencyOptions">PeerDependencyOptions</a></code> | Options for `peerDeps`. |
@@ -8424,6 +8425,19 @@ GitHub secret which contains the NPM token to use when publishing packages.
 
 ---
 
+##### `npmTrustedPublishing`<sup>Optional</sup> <a name="npmTrustedPublishing" id="projen.javascript.NodePackageOptions.property.npmTrustedPublishing"></a>
+
+```typescript
+public readonly npmTrustedPublishing: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.
+
+---
+
 ##### `packageManager`<sup>Optional</sup> <a name="packageManager" id="projen.javascript.NodePackageOptions.property.packageManager"></a>
 
 ```typescript
@@ -8655,6 +8669,7 @@ const nodeProjectOptions: javascript.NodeProjectOptions = { ... }
 | <code><a href="#projen.javascript.NodeProjectOptions.property.npmRegistry">npmRegistry</a></code> | <code>string</code> | The host name of the npm registry to publish to. |
 | <code><a href="#projen.javascript.NodeProjectOptions.property.npmRegistryUrl">npmRegistryUrl</a></code> | <code>string</code> | The base URL of the npm package registry. |
 | <code><a href="#projen.javascript.NodeProjectOptions.property.npmTokenSecret">npmTokenSecret</a></code> | <code>string</code> | GitHub secret which contains the NPM token to use when publishing packages. |
+| <code><a href="#projen.javascript.NodeProjectOptions.property.npmTrustedPublishing">npmTrustedPublishing</a></code> | <code>boolean</code> | Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work. |
 | <code><a href="#projen.javascript.NodeProjectOptions.property.packageManager">packageManager</a></code> | <code><a href="#projen.javascript.NodePackageManager">NodePackageManager</a></code> | The Node Package Manager used to execute scripts. |
 | <code><a href="#projen.javascript.NodeProjectOptions.property.packageName">packageName</a></code> | <code>string</code> | The "name" in package.json. |
 | <code><a href="#projen.javascript.NodeProjectOptions.property.peerDependencyOptions">peerDependencyOptions</a></code> | <code><a href="#projen.javascript.PeerDependencyOptions">PeerDependencyOptions</a></code> | Options for `peerDeps`. |
@@ -9575,6 +9590,19 @@ public readonly npmTokenSecret: string;
 - *Default:* "NPM_TOKEN"
 
 GitHub secret which contains the NPM token to use when publishing packages.
+
+---
+
+##### `npmTrustedPublishing`<sup>Optional</sup> <a name="npmTrustedPublishing" id="projen.javascript.NodeProjectOptions.property.npmTrustedPublishing"></a>
+
+```typescript
+public readonly npmTrustedPublishing: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.
 
 ---
 

--- a/docs/api/release.md
+++ b/docs/api/release.md
@@ -1968,8 +1968,9 @@ const jsiiReleaseNpm: release.JsiiReleaseNpm = { ... }
 | <code><a href="#projen.release.JsiiReleaseNpm.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code><a href="#projen.release.CodeArtifactOptions">CodeArtifactOptions</a></code> | Options for publishing npm package to AWS CodeArtifact. |
 | <code><a href="#projen.release.JsiiReleaseNpm.property.distTag">distTag</a></code> | <code>string</code> | Tags can be used to provide an alias instead of version numbers. |
 | <code><a href="#projen.release.JsiiReleaseNpm.property.npmProvenance">npmProvenance</a></code> | <code>boolean</code> | Should provenance statements be generated when package is published. |
-| <code><a href="#projen.release.JsiiReleaseNpm.property.npmTokenSecret">npmTokenSecret</a></code> | <code>string</code> | GitHub secret which contains the NPM token to use when publishing packages. |
+| <code><a href="#projen.release.JsiiReleaseNpm.property.npmTokenSecret">npmTokenSecret</a></code> | <code>string</code> | GitHub secret which contains the NPM token to use for publishing packages. |
 | <code><a href="#projen.release.JsiiReleaseNpm.property.registry">registry</a></code> | <code>string</code> | The domain name of the npm package registry. |
+| <code><a href="#projen.release.JsiiReleaseNpm.property.trustedPublishing">trustedPublishing</a></code> | <code>boolean</code> | Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work. |
 
 ---
 
@@ -2056,7 +2057,7 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 ```
 
 - *Type:* <a href="#projen.release.CodeArtifactOptions">CodeArtifactOptions</a>
-- *Default:* undefined
+- *Default:* package is not published to
 
 Options for publishing npm package to AWS CodeArtifact.
 
@@ -2097,12 +2098,14 @@ public readonly npmProvenance: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* undefined
+- *Default:* enabled for for public packages using trusted publishing, disabled otherwise
 
 Should provenance statements be generated when package is published.
 
 Note that this component is using `publib` to publish packages,
 which is using npm internally and supports provenance statements independently of the package manager used.
+
+Only works in supported CI/CD environments.
 
 > [https://docs.npmjs.com/generating-provenance-statements](https://docs.npmjs.com/generating-provenance-statements)
 
@@ -2119,7 +2122,7 @@ public readonly npmTokenSecret: string;
 - *Type:* string
 - *Default:* "NPM_TOKEN" or "GITHUB_TOKEN" if `registry` is set to `npm.pkg.github.com`.
 
-GitHub secret which contains the NPM token to use when publishing packages.
+GitHub secret which contains the NPM token to use for publishing packages.
 
 ---
 
@@ -2150,6 +2153,26 @@ correctly defined.
 "npm.pkg.github.com"
 ```
 
+
+##### ~~`trustedPublishing`~~<sup>Optional</sup> <a name="trustedPublishing" id="projen.release.JsiiReleaseNpm.property.trustedPublishing"></a>
+
+- *Deprecated:* Use `NpmPublishOptions` instead.
+
+```typescript
+public readonly trustedPublishing: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.
+
+Requires npm CLI version 11.5.1 or later, this is NOT ensured automatically.
+When used, `npmTokenSecret` will be ignored.
+
+> [https://docs.npmjs.com/trusted-publishers](https://docs.npmjs.com/trusted-publishers)
+
+---
 
 ### JsiiReleaseNuget <a name="JsiiReleaseNuget" id="projen.release.JsiiReleaseNuget"></a>
 
@@ -2295,7 +2318,9 @@ const jsiiReleasePyPi: release.JsiiReleasePyPi = { ... }
 | <code><a href="#projen.release.JsiiReleasePyPi.property.postPublishSteps">postPublishSteps</a></code> | <code>projen.github.workflows.JobStep[]</code> | Steps to execute after executing the publishing command. |
 | <code><a href="#projen.release.JsiiReleasePyPi.property.prePublishSteps">prePublishSteps</a></code> | <code>projen.github.workflows.JobStep[]</code> | Steps to execute before executing the publishing command. These can be used to prepare the artifact for publishing if needed. |
 | <code><a href="#projen.release.JsiiReleasePyPi.property.publishTools">publishTools</a></code> | <code>projen.github.workflows.Tools</code> | Additional tools to install in the publishing job. |
+| <code><a href="#projen.release.JsiiReleasePyPi.property.attestations">attestations</a></code> | <code>boolean</code> | Generate and publish cryptographic attestations for files uploaded to PyPI. |
 | <code><a href="#projen.release.JsiiReleasePyPi.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code><a href="#projen.release.CodeArtifactOptions">CodeArtifactOptions</a></code> | Options for publishing to AWS CodeArtifact. |
+| <code><a href="#projen.release.JsiiReleasePyPi.property.trustedPublishing">trustedPublishing</a></code> | <code>boolean</code> | Use PyPI trusted publishing instead of tokens or username & password. |
 | <code><a href="#projen.release.JsiiReleasePyPi.property.twinePasswordSecret">twinePasswordSecret</a></code> | <code>string</code> | The GitHub secret which contains PyPI password. |
 | <code><a href="#projen.release.JsiiReleasePyPi.property.twineRegistryUrl">twineRegistryUrl</a></code> | <code>string</code> | The registry url to use when releasing packages. |
 | <code><a href="#projen.release.JsiiReleasePyPi.property.twineUsernameSecret">twineUsernameSecret</a></code> | <code>string</code> | The GitHub secret which contains PyPI user name. |
@@ -2376,6 +2401,26 @@ Additional tools to install in the publishing job.
 
 ---
 
+##### ~~`attestations`~~<sup>Optional</sup> <a name="attestations" id="projen.release.JsiiReleasePyPi.property.attestations"></a>
+
+- *Deprecated:* Use `PyPiPublishOptions` instead.
+
+```typescript
+public readonly attestations: boolean;
+```
+
+- *Type:* boolean
+- *Default:* enabled when using trusted publishing, otherwise not applicable
+
+Generate and publish cryptographic attestations for files uploaded to PyPI.
+
+Attestations provide package provenance and integrity an can be viewed on PyPI.
+They are only available when using a Trusted Publisher for publishing.
+
+> [https://docs.pypi.org/attestations/producing-attestations/](https://docs.pypi.org/attestations/producing-attestations/)
+
+---
+
 ##### ~~`codeArtifactOptions`~~<sup>Optional</sup> <a name="codeArtifactOptions" id="projen.release.JsiiReleasePyPi.property.codeArtifactOptions"></a>
 
 - *Deprecated:* Use `PyPiPublishOptions` instead.
@@ -2388,6 +2433,24 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 - *Default:* undefined
 
 Options for publishing to AWS CodeArtifact.
+
+---
+
+##### ~~`trustedPublishing`~~<sup>Optional</sup> <a name="trustedPublishing" id="projen.release.JsiiReleasePyPi.property.trustedPublishing"></a>
+
+- *Deprecated:* Use `PyPiPublishOptions` instead.
+
+```typescript
+public readonly trustedPublishing: boolean;
+```
+
+- *Type:* boolean
+
+Use PyPI trusted publishing instead of tokens or username & password.
+
+Needs to be setup in PyPI.
+
+> [https://docs.pypi.org/trusted-publishers/adding-a-publisher/](https://docs.pypi.org/trusted-publishers/adding-a-publisher/)
 
 ---
 
@@ -2745,8 +2808,9 @@ const npmPublishOptions: release.NpmPublishOptions = { ... }
 | <code><a href="#projen.release.NpmPublishOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code><a href="#projen.release.CodeArtifactOptions">CodeArtifactOptions</a></code> | Options for publishing npm package to AWS CodeArtifact. |
 | <code><a href="#projen.release.NpmPublishOptions.property.distTag">distTag</a></code> | <code>string</code> | Tags can be used to provide an alias instead of version numbers. |
 | <code><a href="#projen.release.NpmPublishOptions.property.npmProvenance">npmProvenance</a></code> | <code>boolean</code> | Should provenance statements be generated when package is published. |
-| <code><a href="#projen.release.NpmPublishOptions.property.npmTokenSecret">npmTokenSecret</a></code> | <code>string</code> | GitHub secret which contains the NPM token to use when publishing packages. |
+| <code><a href="#projen.release.NpmPublishOptions.property.npmTokenSecret">npmTokenSecret</a></code> | <code>string</code> | GitHub secret which contains the NPM token to use for publishing packages. |
 | <code><a href="#projen.release.NpmPublishOptions.property.registry">registry</a></code> | <code>string</code> | The domain name of the npm package registry. |
+| <code><a href="#projen.release.NpmPublishOptions.property.trustedPublishing">trustedPublishing</a></code> | <code>boolean</code> | Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work. |
 
 ---
 
@@ -2823,7 +2887,7 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 ```
 
 - *Type:* <a href="#projen.release.CodeArtifactOptions">CodeArtifactOptions</a>
-- *Default:* undefined
+- *Default:* package is not published to
 
 Options for publishing npm package to AWS CodeArtifact.
 
@@ -2862,12 +2926,14 @@ public readonly npmProvenance: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* undefined
+- *Default:* enabled for for public packages using trusted publishing, disabled otherwise
 
 Should provenance statements be generated when package is published.
 
 Note that this component is using `publib` to publish packages,
 which is using npm internally and supports provenance statements independently of the package manager used.
+
+Only works in supported CI/CD environments.
 
 > [https://docs.npmjs.com/generating-provenance-statements](https://docs.npmjs.com/generating-provenance-statements)
 
@@ -2882,7 +2948,7 @@ public readonly npmTokenSecret: string;
 - *Type:* string
 - *Default:* "NPM_TOKEN" or "GITHUB_TOKEN" if `registry` is set to `npm.pkg.github.com`.
 
-GitHub secret which contains the NPM token to use when publishing packages.
+GitHub secret which contains the NPM token to use for publishing packages.
 
 ---
 
@@ -2911,6 +2977,24 @@ correctly defined.
 "npm.pkg.github.com"
 ```
 
+
+##### `trustedPublishing`<sup>Optional</sup> <a name="trustedPublishing" id="projen.release.NpmPublishOptions.property.trustedPublishing"></a>
+
+```typescript
+public readonly trustedPublishing: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.
+
+Requires npm CLI version 11.5.1 or later, this is NOT ensured automatically.
+When used, `npmTokenSecret` will be ignored.
+
+> [https://docs.npmjs.com/trusted-publishers](https://docs.npmjs.com/trusted-publishers)
+
+---
 
 ### NugetPublishOptions <a name="NugetPublishOptions" id="projen.release.NugetPublishOptions"></a>
 
@@ -3262,7 +3346,9 @@ const pyPiPublishOptions: release.PyPiPublishOptions = { ... }
 | <code><a href="#projen.release.PyPiPublishOptions.property.postPublishSteps">postPublishSteps</a></code> | <code>projen.github.workflows.JobStep[]</code> | Steps to execute after executing the publishing command. |
 | <code><a href="#projen.release.PyPiPublishOptions.property.prePublishSteps">prePublishSteps</a></code> | <code>projen.github.workflows.JobStep[]</code> | Steps to execute before executing the publishing command. These can be used to prepare the artifact for publishing if needed. |
 | <code><a href="#projen.release.PyPiPublishOptions.property.publishTools">publishTools</a></code> | <code>projen.github.workflows.Tools</code> | Additional tools to install in the publishing job. |
+| <code><a href="#projen.release.PyPiPublishOptions.property.attestations">attestations</a></code> | <code>boolean</code> | Generate and publish cryptographic attestations for files uploaded to PyPI. |
 | <code><a href="#projen.release.PyPiPublishOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code><a href="#projen.release.CodeArtifactOptions">CodeArtifactOptions</a></code> | Options for publishing to AWS CodeArtifact. |
+| <code><a href="#projen.release.PyPiPublishOptions.property.trustedPublishing">trustedPublishing</a></code> | <code>boolean</code> | Use PyPI trusted publishing instead of tokens or username & password. |
 | <code><a href="#projen.release.PyPiPublishOptions.property.twinePasswordSecret">twinePasswordSecret</a></code> | <code>string</code> | The GitHub secret which contains PyPI password. |
 | <code><a href="#projen.release.PyPiPublishOptions.property.twineRegistryUrl">twineRegistryUrl</a></code> | <code>string</code> | The registry url to use when releasing packages. |
 | <code><a href="#projen.release.PyPiPublishOptions.property.twineUsernameSecret">twineUsernameSecret</a></code> | <code>string</code> | The GitHub secret which contains PyPI user name. |
@@ -3335,6 +3421,24 @@ Additional tools to install in the publishing job.
 
 ---
 
+##### `attestations`<sup>Optional</sup> <a name="attestations" id="projen.release.PyPiPublishOptions.property.attestations"></a>
+
+```typescript
+public readonly attestations: boolean;
+```
+
+- *Type:* boolean
+- *Default:* enabled when using trusted publishing, otherwise not applicable
+
+Generate and publish cryptographic attestations for files uploaded to PyPI.
+
+Attestations provide package provenance and integrity an can be viewed on PyPI.
+They are only available when using a Trusted Publisher for publishing.
+
+> [https://docs.pypi.org/attestations/producing-attestations/](https://docs.pypi.org/attestations/producing-attestations/)
+
+---
+
 ##### `codeArtifactOptions`<sup>Optional</sup> <a name="codeArtifactOptions" id="projen.release.PyPiPublishOptions.property.codeArtifactOptions"></a>
 
 ```typescript
@@ -3345,6 +3449,22 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 - *Default:* undefined
 
 Options for publishing to AWS CodeArtifact.
+
+---
+
+##### `trustedPublishing`<sup>Optional</sup> <a name="trustedPublishing" id="projen.release.PyPiPublishOptions.property.trustedPublishing"></a>
+
+```typescript
+public readonly trustedPublishing: boolean;
+```
+
+- *Type:* boolean
+
+Use PyPI trusted publishing instead of tokens or username & password.
+
+Needs to be setup in PyPI.
+
+> [https://docs.pypi.org/trusted-publishers/adding-a-publisher/](https://docs.pypi.org/trusted-publishers/adding-a-publisher/)
 
 ---
 

--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -5457,6 +5457,7 @@ const typeScriptLibraryProjectOptions: typescript.TypeScriptLibraryProjectOption
 | <code><a href="#projen.typescript.TypeScriptLibraryProjectOptions.property.npmRegistry">npmRegistry</a></code> | <code>string</code> | The host name of the npm registry to publish to. |
 | <code><a href="#projen.typescript.TypeScriptLibraryProjectOptions.property.npmRegistryUrl">npmRegistryUrl</a></code> | <code>string</code> | The base URL of the npm package registry. |
 | <code><a href="#projen.typescript.TypeScriptLibraryProjectOptions.property.npmTokenSecret">npmTokenSecret</a></code> | <code>string</code> | GitHub secret which contains the NPM token to use when publishing packages. |
+| <code><a href="#projen.typescript.TypeScriptLibraryProjectOptions.property.npmTrustedPublishing">npmTrustedPublishing</a></code> | <code>boolean</code> | Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work. |
 | <code><a href="#projen.typescript.TypeScriptLibraryProjectOptions.property.packageManager">packageManager</a></code> | <code>projen.javascript.NodePackageManager</code> | The Node Package Manager used to execute scripts. |
 | <code><a href="#projen.typescript.TypeScriptLibraryProjectOptions.property.packageName">packageName</a></code> | <code>string</code> | The "name" in package.json. |
 | <code><a href="#projen.typescript.TypeScriptLibraryProjectOptions.property.peerDependencyOptions">peerDependencyOptions</a></code> | <code>projen.javascript.PeerDependencyOptions</code> | Options for `peerDeps`. |
@@ -6497,6 +6498,21 @@ public readonly npmTokenSecret: string;
 - *Default:* "NPM_TOKEN"
 
 GitHub secret which contains the NPM token to use when publishing packages.
+
+---
+
+##### ~~`npmTrustedPublishing`~~<sup>Optional</sup> <a name="npmTrustedPublishing" id="projen.typescript.TypeScriptLibraryProjectOptions.property.npmTrustedPublishing"></a>
+
+- *Deprecated:* use TypeScriptProjectOptions
+
+```typescript
+public readonly npmTrustedPublishing: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.
 
 ---
 
@@ -8083,6 +8099,7 @@ const typeScriptProjectOptions: typescript.TypeScriptProjectOptions = { ... }
 | <code><a href="#projen.typescript.TypeScriptProjectOptions.property.npmRegistry">npmRegistry</a></code> | <code>string</code> | The host name of the npm registry to publish to. |
 | <code><a href="#projen.typescript.TypeScriptProjectOptions.property.npmRegistryUrl">npmRegistryUrl</a></code> | <code>string</code> | The base URL of the npm package registry. |
 | <code><a href="#projen.typescript.TypeScriptProjectOptions.property.npmTokenSecret">npmTokenSecret</a></code> | <code>string</code> | GitHub secret which contains the NPM token to use when publishing packages. |
+| <code><a href="#projen.typescript.TypeScriptProjectOptions.property.npmTrustedPublishing">npmTrustedPublishing</a></code> | <code>boolean</code> | Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work. |
 | <code><a href="#projen.typescript.TypeScriptProjectOptions.property.packageManager">packageManager</a></code> | <code>projen.javascript.NodePackageManager</code> | The Node Package Manager used to execute scripts. |
 | <code><a href="#projen.typescript.TypeScriptProjectOptions.property.packageName">packageName</a></code> | <code>string</code> | The "name" in package.json. |
 | <code><a href="#projen.typescript.TypeScriptProjectOptions.property.peerDependencyOptions">peerDependencyOptions</a></code> | <code>projen.javascript.PeerDependencyOptions</code> | Options for `peerDeps`. |
@@ -9021,6 +9038,19 @@ public readonly npmTokenSecret: string;
 - *Default:* "NPM_TOKEN"
 
 GitHub secret which contains the NPM token to use when publishing packages.
+
+---
+
+##### `npmTrustedPublishing`<sup>Optional</sup> <a name="npmTrustedPublishing" id="projen.typescript.TypeScriptProjectOptions.property.npmTrustedPublishing"></a>
+
+```typescript
+public readonly npmTrustedPublishing: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.
 
 ---
 

--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -6659,6 +6659,7 @@ const nextJsProjectOptions: web.NextJsProjectOptions = { ... }
 | <code><a href="#projen.web.NextJsProjectOptions.property.npmRegistry">npmRegistry</a></code> | <code>string</code> | The host name of the npm registry to publish to. |
 | <code><a href="#projen.web.NextJsProjectOptions.property.npmRegistryUrl">npmRegistryUrl</a></code> | <code>string</code> | The base URL of the npm package registry. |
 | <code><a href="#projen.web.NextJsProjectOptions.property.npmTokenSecret">npmTokenSecret</a></code> | <code>string</code> | GitHub secret which contains the NPM token to use when publishing packages. |
+| <code><a href="#projen.web.NextJsProjectOptions.property.npmTrustedPublishing">npmTrustedPublishing</a></code> | <code>boolean</code> | Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work. |
 | <code><a href="#projen.web.NextJsProjectOptions.property.packageManager">packageManager</a></code> | <code>projen.javascript.NodePackageManager</code> | The Node Package Manager used to execute scripts. |
 | <code><a href="#projen.web.NextJsProjectOptions.property.packageName">packageName</a></code> | <code>string</code> | The "name" in package.json. |
 | <code><a href="#projen.web.NextJsProjectOptions.property.peerDependencyOptions">peerDependencyOptions</a></code> | <code>projen.javascript.PeerDependencyOptions</code> | Options for `peerDeps`. |
@@ -7609,6 +7610,19 @@ public readonly npmTokenSecret: string;
 - *Default:* "NPM_TOKEN"
 
 GitHub secret which contains the NPM token to use when publishing packages.
+
+---
+
+##### `npmTrustedPublishing`<sup>Optional</sup> <a name="npmTrustedPublishing" id="projen.web.NextJsProjectOptions.property.npmTrustedPublishing"></a>
+
+```typescript
+public readonly npmTrustedPublishing: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.
 
 ---
 
@@ -8807,6 +8821,7 @@ const nextJsTypeScriptProjectOptions: web.NextJsTypeScriptProjectOptions = { ...
 | <code><a href="#projen.web.NextJsTypeScriptProjectOptions.property.npmRegistry">npmRegistry</a></code> | <code>string</code> | The host name of the npm registry to publish to. |
 | <code><a href="#projen.web.NextJsTypeScriptProjectOptions.property.npmRegistryUrl">npmRegistryUrl</a></code> | <code>string</code> | The base URL of the npm package registry. |
 | <code><a href="#projen.web.NextJsTypeScriptProjectOptions.property.npmTokenSecret">npmTokenSecret</a></code> | <code>string</code> | GitHub secret which contains the NPM token to use when publishing packages. |
+| <code><a href="#projen.web.NextJsTypeScriptProjectOptions.property.npmTrustedPublishing">npmTrustedPublishing</a></code> | <code>boolean</code> | Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work. |
 | <code><a href="#projen.web.NextJsTypeScriptProjectOptions.property.packageManager">packageManager</a></code> | <code>projen.javascript.NodePackageManager</code> | The Node Package Manager used to execute scripts. |
 | <code><a href="#projen.web.NextJsTypeScriptProjectOptions.property.packageName">packageName</a></code> | <code>string</code> | The "name" in package.json. |
 | <code><a href="#projen.web.NextJsTypeScriptProjectOptions.property.peerDependencyOptions">peerDependencyOptions</a></code> | <code>projen.javascript.PeerDependencyOptions</code> | Options for `peerDeps`. |
@@ -9773,6 +9788,19 @@ public readonly npmTokenSecret: string;
 - *Default:* "NPM_TOKEN"
 
 GitHub secret which contains the NPM token to use when publishing packages.
+
+---
+
+##### `npmTrustedPublishing`<sup>Optional</sup> <a name="npmTrustedPublishing" id="projen.web.NextJsTypeScriptProjectOptions.property.npmTrustedPublishing"></a>
+
+```typescript
+public readonly npmTrustedPublishing: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.
 
 ---
 
@@ -11310,6 +11338,7 @@ const reactProjectOptions: web.ReactProjectOptions = { ... }
 | <code><a href="#projen.web.ReactProjectOptions.property.npmRegistry">npmRegistry</a></code> | <code>string</code> | The host name of the npm registry to publish to. |
 | <code><a href="#projen.web.ReactProjectOptions.property.npmRegistryUrl">npmRegistryUrl</a></code> | <code>string</code> | The base URL of the npm package registry. |
 | <code><a href="#projen.web.ReactProjectOptions.property.npmTokenSecret">npmTokenSecret</a></code> | <code>string</code> | GitHub secret which contains the NPM token to use when publishing packages. |
+| <code><a href="#projen.web.ReactProjectOptions.property.npmTrustedPublishing">npmTrustedPublishing</a></code> | <code>boolean</code> | Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work. |
 | <code><a href="#projen.web.ReactProjectOptions.property.packageManager">packageManager</a></code> | <code>projen.javascript.NodePackageManager</code> | The Node Package Manager used to execute scripts. |
 | <code><a href="#projen.web.ReactProjectOptions.property.packageName">packageName</a></code> | <code>string</code> | The "name" in package.json. |
 | <code><a href="#projen.web.ReactProjectOptions.property.peerDependencyOptions">peerDependencyOptions</a></code> | <code>projen.javascript.PeerDependencyOptions</code> | Options for `peerDeps`. |
@@ -12233,6 +12262,19 @@ public readonly npmTokenSecret: string;
 - *Default:* "NPM_TOKEN"
 
 GitHub secret which contains the NPM token to use when publishing packages.
+
+---
+
+##### `npmTrustedPublishing`<sup>Optional</sup> <a name="npmTrustedPublishing" id="projen.web.ReactProjectOptions.property.npmTrustedPublishing"></a>
+
+```typescript
+public readonly npmTrustedPublishing: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.
 
 ---
 
@@ -13626,6 +13668,7 @@ const reactTypeScriptProjectOptions: web.ReactTypeScriptProjectOptions = { ... }
 | <code><a href="#projen.web.ReactTypeScriptProjectOptions.property.npmRegistry">npmRegistry</a></code> | <code>string</code> | The host name of the npm registry to publish to. |
 | <code><a href="#projen.web.ReactTypeScriptProjectOptions.property.npmRegistryUrl">npmRegistryUrl</a></code> | <code>string</code> | The base URL of the npm package registry. |
 | <code><a href="#projen.web.ReactTypeScriptProjectOptions.property.npmTokenSecret">npmTokenSecret</a></code> | <code>string</code> | GitHub secret which contains the NPM token to use when publishing packages. |
+| <code><a href="#projen.web.ReactTypeScriptProjectOptions.property.npmTrustedPublishing">npmTrustedPublishing</a></code> | <code>boolean</code> | Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work. |
 | <code><a href="#projen.web.ReactTypeScriptProjectOptions.property.packageManager">packageManager</a></code> | <code>projen.javascript.NodePackageManager</code> | The Node Package Manager used to execute scripts. |
 | <code><a href="#projen.web.ReactTypeScriptProjectOptions.property.packageName">packageName</a></code> | <code>string</code> | The "name" in package.json. |
 | <code><a href="#projen.web.ReactTypeScriptProjectOptions.property.peerDependencyOptions">peerDependencyOptions</a></code> | <code>projen.javascript.PeerDependencyOptions</code> | Options for `peerDeps`. |
@@ -14565,6 +14608,19 @@ public readonly npmTokenSecret: string;
 - *Default:* "NPM_TOKEN"
 
 GitHub secret which contains the NPM token to use when publishing packages.
+
+---
+
+##### `npmTrustedPublishing`<sup>Optional</sup> <a name="npmTrustedPublishing" id="projen.web.ReactTypeScriptProjectOptions.property.npmTrustedPublishing"></a>
+
+```typescript
+public readonly npmTrustedPublishing: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.
 
 ---
 

--- a/docs/publishing/publisher-component.md
+++ b/docs/publishing/publisher-component.md
@@ -73,6 +73,30 @@ publisher.publishToNuGet({
 });
 ```
 
+## Trusted Publishing
+
+Trusted publishing eliminates the need for long-lived API tokens by using OpenID Connect (OIDC) to authenticate with package repositories. This is more secure and easier to maintain.
+
+**npm**
+
+```ts
+publisher.publishToNpm({
+  trustedPublishing: true,
+  npmProvenance: true, // optional, enables provenance statements
+});
+```
+
+**PyPI**
+
+```ts
+publisher.publishToPyPi({
+  trustedPublishing: true,
+  attestations: true, // optional, enabled by default with trusted publishing
+});
+```
+
+Before using trusted publishing, you must configure your package on the respective registry to accept tokens from your GitHub repository. See the [Trusted Publishing guide](./trusted-publishing.md) for detailed setup instructions.
+
 ## Publishing to GitHub Packages
 
 Some targets come with dynamic defaults that support GitHub Packages.

--- a/docs/publishing/releases-and-versioning.md
+++ b/docs/publishing/releases-and-versioning.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # Releases and Versioning

--- a/docs/publishing/trusted-publishing.md
+++ b/docs/publishing/trusted-publishing.md
@@ -1,0 +1,184 @@
+---
+sidebar_position: 3
+---
+
+# Trusted Publishers
+
+Trusted Publishers is a modern authentication method that helps you publish packages more securely by eliminating the need for long-lived API tokens.
+Instead of managing sensitive credentials, it uses OpenID Connect (OIDC) to generate short-lived tokens from your CI system (like GitHub Actions or GitLab Pipelines).
+This means less security risk and easier maintenance, as you don't need to regularly rotate or protect long-lived tokens.
+Trusted Publishers ensures packages come from specific CI systems or build pipelines, reducing the risk of token theft and unauthorized publications.
+
+## How Trusted Publishers Work
+
+Trusted Publishers leverage OpenID Connect (OIDC) to establish trust between your CI/CD system and package repositories:
+
+1. **Identity Provider**: Your CI system (GitHub Actions) acts as an OIDC identity provider
+2. **Token Exchange**: The CI system generates a short-lived OIDC token containing metadata about the workflow
+3. **Verification**: The package repository verifies the token and checks it against configured trusted publishers
+4. **API Token**: If verification succeeds, the repository issues a temporary API token for publishing
+
+This eliminates the need to store long-lived secrets in your repository.
+
+## Supported Package Repositories
+
+Projen currently supports trusted publishing for:
+
+- **npmjs.com** - Node.js packages with trusted publishing and provenance statements
+- **PyPI** - Python Package Index with attestations
+
+## npm Trusted Publishing
+
+### Setup
+
+To enable npm trusted publishing in your projen project:
+
+```typescript
+const project = new NodeProject({
+  // ... other options
+  publishToNpm: true,
+  npmPublishOptions: {
+    trustedPublishing: true,
+  },
+});
+```
+
+Or for JSII projects:
+
+```typescript
+const project = new JsiiProject({
+  // ... other options
+  publishToNpm: {
+    trustedPublishing: true,
+  },
+});
+```
+
+### npm Configuration
+
+Before using trusted publishing, you must configure your npm package:
+
+1. **Go to npm**: Navigate to your package's settings on [npmjs.com](https://www.npmjs.com)
+2. **Add Publisher**: Under "Publishing access", click "Require two-factor authentication or automation tokens"
+3. **Configure GitHub Actions**:
+   - **Subject**: `repo:owner/repository:ref:refs/heads/main`
+   - **Issuer**: `https://token.actions.githubusercontent.com`
+   - Replace `owner/repository` with your GitHub username/organization and repository name
+   - Adjust the branch name if different from `main`
+
+Or follow the [official npm documentation](https://docs.npmjs.com/trusted-publishers).
+
+### Requirements
+
+- npm CLI version 11.5.1 or later (this is NOT ensured automatically by projen)
+- Package must be configured for trusted publishing on npmjs.com
+- GitHub Actions workflow must run from the configured repository and branch
+
+### How It Works
+
+When publishing with trusted publishing enabled:
+
+1. GitHub Actions generates an OIDC token containing workflow metadata
+2. The publishing job uses this token to authenticate with npm
+3. npm verifies the token against your configured trusted publisher settings
+4. No long-lived NPM_TOKEN secrets are needed in your repository
+
+### Provenance Statements
+
+By default, when using trusted publishing, npm will generate provenance statements that:
+
+- Provide cryptographic proof of where and how your package was built
+- Are automatically displayed on the npm package page
+- Help users verify package integrity and authenticity
+- Work with tools like `npm audit signatures`
+
+## PyPI Trusted Publishing
+
+### Setup
+
+To enable PyPI trusted publishing in your projen project:
+
+```typescript
+const project = new PythonProject({
+  // ... other options
+  publishToPypi: {
+    trustedPublishing: true,
+  },
+});
+```
+
+### PyPI Configuration
+
+Before using trusted publishing, you must configure your PyPI project:
+
+1. **Go to PyPI**: Navigate to your project's settings on [PyPI](https://pypi.org)
+2. **Add Publisher**: Under "Publishing", click "Add a new publisher"
+3. **Configure GitHub Actions**:
+   - **Owner**: Your GitHub username or organization
+   - **Repository name**: Your repository name
+   - **Workflow name**: `release.yml` (or your release workflow filename)
+   - **Environment name**: Leave empty unless using GitHub environments
+
+Or follow the [official PyPI documentation](https://docs.pypi.org/trusted-publishers/adding-a-publisher/).
+
+### How It Works
+
+When publishing with trusted publishing enabled:
+
+1. GitHub Actions generates an OIDC token containing workflow metadata
+2. The publishing job exchanges this token for a PyPI API token
+3. The temporary API token is used to publish your package
+4. No long-lived secrets are stored in your repository
+
+## Migration Guide
+
+### From Token-Based to Trusted Publishing
+
+#### For npm packages
+
+1. **Update your projen configuration**:
+
+   ```typescript
+   publishToNpm: {
+     trustedPublishing: true,
+     // Remove npmTokenSecret if present
+   }
+   ```
+
+2. **Configure npm trusted publisher** (see npm Configuration above)
+
+3. **Remove secrets from GitHub**:
+   - You can safely remove `NPM_TOKEN` secrets
+   - Keep them temporarily during transition for rollback capability
+
+4. **Test the setup**:
+   - Create a test release to verify trusted publishing works
+   - Monitor the workflow logs for successful authentication
+   - Check that provenance statements appear on npm (if enabled)
+
+5. **Clean up**:
+   - Delete old API tokens in npm once you are confident with the new setup
+
+#### For PyPI packages
+
+1. **Update your projen configuration**:
+
+   ```typescript
+   publishToPypi: {
+     trustedPublishing: true,
+     // Remove twinePasswordSecret if present
+   }
+   ```
+
+2. **Configure PyPI trusted publisher** (see PyPI Configuration above)
+
+3. **Remove secrets from GitHub**:
+   - You can safely remove `TWINE_PASSWORD` and `TWINE_USERNAME` secrets
+   - Keep them temporarily during transition for rollback capability
+
+4. **Test the setup**:
+   - Create a test release to verify trusted publishing works
+   - Monitor the workflow logs for successful token minting
+
+5. **Clean up**:
+   - Delete old API tokens in PyPI once you are confident with the new setup

--- a/src/cdk/jsii-project.ts
+++ b/src/cdk/jsii-project.ts
@@ -317,6 +317,7 @@ export class JsiiProject extends TypeScriptProject {
         npmTokenSecret: this.package.npmTokenSecret,
         npmProvenance: this.package.npmProvenance,
         codeArtifactOptions: options.codeArtifactOptions,
+        trustedPublishing: options.npmTrustedPublishing ?? false,
       };
       this.addTargetToBuild("js", this.packageJsTask, extraJobOptions);
       this.addTargetToRelease("js", this.packageJsTask, npmjs);

--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -335,6 +335,16 @@ export interface NodePackageOptions {
   readonly npmTokenSecret?: string;
 
   /**
+   * Use trusted publishing for publishing to npmjs.com
+   * Needs to be pre-configured on npm.js to work.
+   *
+   * @see
+   *
+   * @default - false
+   */
+  readonly npmTrustedPublishing?: boolean;
+
+  /**
    * Options for npm packages using AWS CodeArtifact.
    * This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
    *
@@ -1067,7 +1077,9 @@ export class NodePackage extends Component {
       npmAccess,
       npmRegistry: npmr.hostname + this.renderNpmRegistryPath(npmr.pathname!),
       npmRegistryUrl: npmr.href,
-      npmTokenSecret: defaultNpmToken(options.npmTokenSecret, npmr.hostname),
+      npmTokenSecret: options.npmTrustedPublishing
+        ? undefined
+        : defaultNpmToken(options.npmTokenSecret, npmr.hostname),
       codeArtifactOptions,
       scopedPackagesOptions: this.parseScopedPackagesOptions(
         options.scopedPackagesOptions
@@ -1769,7 +1781,7 @@ export function defaultNpmToken(
   npmToken: string | undefined,
   registry: string | undefined
 ) {
-  // if we are publishing to AWS CdodeArtifact, no NPM_TOKEN used (will be requested using AWS CLI later).
+  // if we are publishing to AWS CodeArtifact, no NPM_TOKEN used (will be requested using AWS CLI later).
   if (isAwsCodeArtifactRegistry(registry)) {
     return undefined;
   }

--- a/src/javascript/node-project.ts
+++ b/src/javascript/node-project.ts
@@ -747,6 +747,7 @@ export class NodeProject extends GitHubProject {
           registry: this.package.npmRegistry,
           npmTokenSecret: this.package.npmTokenSecret,
           npmProvenance: this.package.npmProvenance,
+          trustedPublishing: options.npmTrustedPublishing ?? false,
           codeArtifactOptions,
         });
       }

--- a/src/release/publisher.ts
+++ b/src/release/publisher.ts
@@ -311,6 +311,9 @@ export class Publisher extends Component {
    * @param options Options
    */
   public publishToNpm(options: NpmPublishOptions = {}) {
+    const trustedPublisher = options.trustedPublishing ? "true" : undefined;
+    const npmProvenance = options.npmProvenance ? "true" : undefined;
+
     const isGitHubPackages = options.registry?.startsWith(
       GITHUB_PACKAGES_REGISTRY
     );
@@ -319,7 +322,11 @@ export class Publisher extends Component {
       isAwsCodeArtifact &&
       options.codeArtifactOptions?.authProvider ===
         CodeArtifactAuthProvider.GITHUB_OIDC;
-    const npmToken = defaultNpmToken(options.npmTokenSecret, options.registry);
+    const needsIdTokenWrite =
+      isAwsCodeArtifactWithOidc || trustedPublisher || npmProvenance;
+    const npmToken = trustedPublisher
+      ? undefined
+      : defaultNpmToken(options.npmTokenSecret, options.registry);
 
     if (options.distTag) {
       this.project.logger.warn(
@@ -361,8 +368,6 @@ export class Publisher extends Component {
         );
       }
 
-      const npmProvenance = options.npmProvenance ? "true" : undefined;
-      const needsIdTokenWrite = isAwsCodeArtifactWithOidc || npmProvenance;
       return {
         publishTools: PUBLIB_TOOLCHAIN.js,
         prePublishSteps,
@@ -374,6 +379,7 @@ export class Publisher extends Component {
           NPM_DIST_TAG: branchOptions.npmDistTag ?? options.distTag ?? "latest",
           NPM_REGISTRY: options.registry,
           NPM_CONFIG_PROVENANCE: npmProvenance,
+          NPM_TRUSTED_PUBLISHER: trustedPublisher,
         },
         permissions: {
           idToken: needsIdTokenWrite ? JobPermission.WRITE : undefined,
@@ -565,6 +571,15 @@ export class Publisher extends Component {
             },
       });
       workflowEnv = { TWINE_USERNAME: "aws" };
+    } else if (options.trustedPublishing) {
+      permissions = { ...permissions, idToken: JobPermission.WRITE };
+      workflowEnv = {
+        PYPI_TRUSTED_PUBLISHER: "true",
+      };
+      // attestations default to true, only disable when explicitly requested
+      if (options.attestations === false) {
+        workflowEnv.PYPI_DISABLE_ATTESTATIONS = "true";
+      }
     } else {
       workflowEnv = {
         TWINE_USERNAME: secret(options.twineUsernameSecret ?? "TWINE_USERNAME"),
@@ -959,10 +974,24 @@ export interface NpmPublishOptions extends CommonPublishOptions {
   readonly registry?: string;
 
   /**
-   * GitHub secret which contains the NPM token to use when publishing packages.
+   * GitHub secret which contains the NPM token to use for publishing packages.
+   *
    * @default - "NPM_TOKEN" or "GITHUB_TOKEN" if `registry` is set to `npm.pkg.github.com`.
    */
   readonly npmTokenSecret?: string;
+
+  /**
+   * Use trusted publishing for publishing to npmjs.com
+   * Needs to be pre-configured on npm.js to work.
+   *
+   * Requires npm CLI version 11.5.1 or later, this is NOT ensured automatically.
+   * When used, `npmTokenSecret` will be ignored.
+   *
+   * @see https://docs.npmjs.com/trusted-publishers
+   *
+   * @default - false
+   */
+  readonly trustedPublishing?: boolean;
 
   /**
    * Should provenance statements be generated when package is published.
@@ -970,15 +999,17 @@ export interface NpmPublishOptions extends CommonPublishOptions {
    * Note that this component is using `publib` to publish packages,
    * which is using npm internally and supports provenance statements independently of the package manager used.
    *
+   * Only works in supported CI/CD environments.
+   *
    * @see https://docs.npmjs.com/generating-provenance-statements
-   * @default - undefined
+   * @default - enabled for for public packages using trusted publishing, disabled otherwise
    */
   readonly npmProvenance?: boolean;
 
   /**
    * Options for publishing npm package to AWS CodeArtifact.
    *
-   * @default - undefined
+   * @default - package is not published to
    */
   readonly codeArtifactOptions?: CodeArtifactOptions;
 }
@@ -1070,6 +1101,26 @@ export interface PyPiPublishOptions extends CommonPublishOptions {
    * @default "TWINE_PASSWORD"
    */
   readonly twinePasswordSecret?: string;
+
+  /**
+   * Use PyPI trusted publishing instead of tokens or username & password.
+   *
+   * Needs to be setup in PyPI.
+   *
+   * @see https://docs.pypi.org/trusted-publishers/adding-a-publisher/
+   */
+  readonly trustedPublishing?: boolean;
+
+  /**
+   * Generate and publish cryptographic attestations for files uploaded to PyPI.
+   *
+   * Attestations provide package provenance and integrity an can be viewed on PyPI.
+   * They are only available when using a Trusted Publisher for publishing.
+   *
+   * @see https://docs.pypi.org/attestations/producing-attestations/
+   * @default - enabled when using trusted publishing, otherwise not applicable
+   */
+  readonly attestations?: boolean;
 
   /**
    * Options for publishing to AWS CodeArtifact.

--- a/src/task-runtime.ts
+++ b/src/task-runtime.ts
@@ -4,11 +4,14 @@ import { dirname, join, resolve } from "path";
 import * as path from "path";
 import { format } from "util";
 import { gray, underline } from "chalk";
-import * as parseConflictJSON from "parse-conflict-json";
 import { PROJEN_DIR } from "./common";
 import * as logging from "./logging";
 import { TasksManifest, TaskSpec, TaskStep } from "./task-model";
 import { makeCrossPlatform } from "./util/tasks";
+
+// avoids a (false positive) esbuild warning about incorrect imports
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const parseConflictJSON = require("parse-conflict-json");
 
 const ENV_TRIM_LEN = 20;
 const ARGS_MARKER = "$@";

--- a/test/__snapshots__/inventory.test.ts.snap
+++ b/test/__snapshots__/inventory.test.ts.snap
@@ -4382,6 +4382,23 @@ exports[`inventory 1`] = `
         "switch": "npm-token-secret",
       },
       {
+        "default": "- false",
+        "docs": "Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.",
+        "featured": false,
+        "fullType": {
+          "primitive": "boolean",
+        },
+        "jsonLike": true,
+        "name": "npmTrustedPublishing",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "npmTrustedPublishing",
+        ],
+        "simpleType": "boolean",
+        "switch": "npm-trusted-publishing",
+      },
+      {
         "default": ""."",
         "docs": "The root directory of the project.",
         "featured": false,
@@ -7618,6 +7635,23 @@ exports[`inventory 1`] = `
         ],
         "simpleType": "string",
         "switch": "npm-token-secret",
+      },
+      {
+        "default": "- false",
+        "docs": "Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.",
+        "featured": false,
+        "fullType": {
+          "primitive": "boolean",
+        },
+        "jsonLike": true,
+        "name": "npmTrustedPublishing",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "npmTrustedPublishing",
+        ],
+        "simpleType": "boolean",
+        "switch": "npm-trusted-publishing",
       },
       {
         "default": ""."",
@@ -11994,6 +12028,23 @@ exports[`inventory 1`] = `
         "switch": "npm-token-secret",
       },
       {
+        "default": "- false",
+        "docs": "Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.",
+        "featured": false,
+        "fullType": {
+          "primitive": "boolean",
+        },
+        "jsonLike": true,
+        "name": "npmTrustedPublishing",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "npmTrustedPublishing",
+        ],
+        "simpleType": "boolean",
+        "switch": "npm-trusted-publishing",
+      },
+      {
         "default": ""."",
         "docs": "The root directory of the project.",
         "featured": false,
@@ -15000,6 +15051,23 @@ exports[`inventory 1`] = `
         ],
         "simpleType": "string",
         "switch": "npm-token-secret",
+      },
+      {
+        "default": "- false",
+        "docs": "Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.",
+        "featured": false,
+        "fullType": {
+          "primitive": "boolean",
+        },
+        "jsonLike": true,
+        "name": "npmTrustedPublishing",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "npmTrustedPublishing",
+        ],
+        "simpleType": "boolean",
+        "switch": "npm-trusted-publishing",
       },
       {
         "default": ""."",
@@ -18067,6 +18135,23 @@ exports[`inventory 1`] = `
         ],
         "simpleType": "string",
         "switch": "npm-token-secret",
+      },
+      {
+        "default": "- false",
+        "docs": "Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.",
+        "featured": false,
+        "fullType": {
+          "primitive": "boolean",
+        },
+        "jsonLike": true,
+        "name": "npmTrustedPublishing",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "npmTrustedPublishing",
+        ],
+        "simpleType": "boolean",
+        "switch": "npm-trusted-publishing",
       },
       {
         "default": ""."",
@@ -21938,6 +22023,23 @@ exports[`inventory 1`] = `
         "switch": "npm-token-secret",
       },
       {
+        "default": "- false",
+        "docs": "Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.",
+        "featured": false,
+        "fullType": {
+          "primitive": "boolean",
+        },
+        "jsonLike": true,
+        "name": "npmTrustedPublishing",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "npmTrustedPublishing",
+        ],
+        "simpleType": "boolean",
+        "switch": "npm-trusted-publishing",
+      },
+      {
         "default": ""."",
         "docs": "The root directory of the project.",
         "featured": false,
@@ -24672,6 +24774,23 @@ exports[`inventory 1`] = `
         "switch": "npm-token-secret",
       },
       {
+        "default": "- false",
+        "docs": "Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.",
+        "featured": false,
+        "fullType": {
+          "primitive": "boolean",
+        },
+        "jsonLike": true,
+        "name": "npmTrustedPublishing",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "npmTrustedPublishing",
+        ],
+        "simpleType": "boolean",
+        "switch": "npm-trusted-publishing",
+      },
+      {
         "default": ""."",
         "docs": "The root directory of the project.",
         "featured": false,
@@ -27291,6 +27410,23 @@ exports[`inventory 1`] = `
         "switch": "npm-token-secret",
       },
       {
+        "default": "- false",
+        "docs": "Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.",
+        "featured": false,
+        "fullType": {
+          "primitive": "boolean",
+        },
+        "jsonLike": true,
+        "name": "npmTrustedPublishing",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "npmTrustedPublishing",
+        ],
+        "simpleType": "boolean",
+        "switch": "npm-trusted-publishing",
+      },
+      {
         "default": ""."",
         "docs": "The root directory of the project.",
         "featured": false,
@@ -29896,6 +30032,23 @@ exports[`inventory 1`] = `
         ],
         "simpleType": "string",
         "switch": "npm-token-secret",
+      },
+      {
+        "default": "- false",
+        "docs": "Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.",
+        "featured": false,
+        "fullType": {
+          "primitive": "boolean",
+        },
+        "jsonLike": true,
+        "name": "npmTrustedPublishing",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "npmTrustedPublishing",
+        ],
+        "simpleType": "boolean",
+        "switch": "npm-trusted-publishing",
       },
       {
         "default": ""."",
@@ -33584,6 +33737,23 @@ exports[`inventory 1`] = `
         "switch": "npm-token-secret",
       },
       {
+        "default": "- false",
+        "docs": "Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.",
+        "featured": false,
+        "fullType": {
+          "primitive": "boolean",
+        },
+        "jsonLike": true,
+        "name": "npmTrustedPublishing",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "npmTrustedPublishing",
+        ],
+        "simpleType": "boolean",
+        "switch": "npm-trusted-publishing",
+      },
+      {
         "default": ""."",
         "docs": "The root directory of the project.",
         "featured": false,
@@ -36189,6 +36359,23 @@ exports[`inventory 1`] = `
         ],
         "simpleType": "string",
         "switch": "npm-token-secret",
+      },
+      {
+        "default": "- false",
+        "docs": "Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.",
+        "featured": false,
+        "fullType": {
+          "primitive": "boolean",
+        },
+        "jsonLike": true,
+        "name": "npmTrustedPublishing",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "npmTrustedPublishing",
+        ],
+        "simpleType": "boolean",
+        "switch": "npm-trusted-publishing",
       },
       {
         "default": ""."",
@@ -38941,6 +39128,23 @@ exports[`inventory 1`] = `
         "switch": "npm-token-secret",
       },
       {
+        "default": "- false",
+        "docs": "Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.",
+        "featured": false,
+        "fullType": {
+          "primitive": "boolean",
+        },
+        "jsonLike": true,
+        "name": "npmTrustedPublishing",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "npmTrustedPublishing",
+        ],
+        "simpleType": "boolean",
+        "switch": "npm-trusted-publishing",
+      },
+      {
         "default": ""."",
         "docs": "The root directory of the project.",
         "featured": false,
@@ -41667,6 +41871,23 @@ exports[`inventory 1`] = `
         ],
         "simpleType": "string",
         "switch": "npm-token-secret",
+      },
+      {
+        "default": "- false",
+        "docs": "Use trusted publishing for publishing to npmjs.com Needs to be pre-configured on npm.js to work.",
+        "featured": false,
+        "fullType": {
+          "primitive": "boolean",
+        },
+        "jsonLike": true,
+        "name": "npmTrustedPublishing",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "npmTrustedPublishing",
+        ],
+        "simpleType": "boolean",
+        "switch": "npm-trusted-publishing",
       },
       {
         "default": ""."",

--- a/test/javascript/node-project.test.ts
+++ b/test/javascript/node-project.test.ts
@@ -361,6 +361,24 @@ describe("npm publishing options", () => {
       ).toBeUndefined();
     });
 
+    test("defaults with npmTrustedPublishing enabled", () => {
+      // GIVEN
+      const project = new TestProject();
+
+      // WHEN
+      const npm = new NodePackage(project, {
+        packageName: "my-package",
+        npmTrustedPublishing: true,
+        npmProvenance: false,
+      });
+
+      // THEN
+      expect(npm.npmAccess).toStrictEqual(NpmAccess.PUBLIC);
+      expect(npm.npmRegistry).toStrictEqual("registry.npmjs.org");
+      expect(npm.npmRegistryUrl).toStrictEqual("https://registry.npmjs.org/");
+      expect(npm.npmTokenSecret).toStrictEqual(undefined);
+    });
+
     test("unscoped package cannot be RESTRICTED", () => {
       // GIVEN
       const project = new TestProject();


### PR DESCRIPTION
This PR adds support for publishing with Trusted Publishers to PyPI and npmjs.com.

Trusted Publishing is a standard to authenticate with package repositories using OIDC and short-lived identity tokens. This method can be used in automated environments and eliminates the need to use manually generated API tokens.

PyPI docs: https://docs.pypi.org/trusted-publishers/
npm docs: https://docs.npmjs.com/trusted-publishers
OSSF standard: https://repos.openssf.org/trusted-publishers-for-all-package-repositories


todo: tests, jsii, NPM_TOKEN on build must stay

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
