### PR TITLE
feat: support for Jest 30 with Typescript

### DIFF
--- a/docs/api/javascript.md
+++ b/docs/api/javascript.md
@@ -7789,6 +7789,8 @@ The version of jest to use.
 
 Note that same version is used as version of `@types/jest` and `ts-jest` (if Typescript in use), so given version should work also for those.
 
+With Jest 30 ts-jest version 29 is used (if Typescript in use)
+
 ---
 
 ##### `junitReporting`<sup>Optional</sup> <a name="junitReporting" id="projen.javascript.JestOptions.property.junitReporting"></a>

--- a/src/javascript/jest.ts
+++ b/src/javascript/jest.ts
@@ -584,6 +584,8 @@ export interface JestOptions {
    *
    * Note that same version is used as version of `@types/jest` and `ts-jest` (if Typescript in use), so given version should work also for those.
    *
+   * With Jest 30 ts-jest version 29 is used (if Typescript in use)
+   *
    * @default - installs the latest jest version
    */
   readonly jestVersion?: string;

--- a/src/typescript/typescript.ts
+++ b/src/typescript/typescript.ts
@@ -712,9 +712,13 @@ export class TypeScriptProject extends NodeProject {
     jest: Jest,
     tsJestOptions: TsJestOptions | undefined
   ) {
+    // Ts-jest doesn't follow semver, but major should match to Jest's major.
+    // For some reason this is not the case with Jest 30 anymore.
+    const jestMajor = semver.coerce(jest.jestVersion)?.major ?? 0;
+    const tsJestVersion = jestMajor > 29 ? "@^29" : jest.jestVersion;
     this.addDevDeps(
       `@types/jest${jest.jestVersion}`,
-      `ts-jest${jest.jestVersion}`
+      `ts-jest${tsJestVersion}`
     );
 
     jest.discoverTestMatchPatternsForDirs([this.srcdir, this.testdir], {

--- a/test/typescript/typescript.test.ts
+++ b/test/typescript/typescript.test.ts
@@ -458,6 +458,21 @@ describe("jestConfig", () => {
         "<rootDir>/@(src|test)/**/__tests__/**/*.ts?(x)",
       ]);
     });
+
+    test("allows using Jest 30", () => {
+      const prj = new TypeScriptProject({
+        defaultReleaseBranch: "main",
+        name: "test",
+        jestOptions: {
+          jestVersion: "30",
+          jestConfig: {},
+        },
+      });
+      const snapshot = synthSnapshot(prj);
+      const devDeps = snapshot["package.json"].devDependencies;
+      expect(devDeps.jest).toMatch("30");
+      expect(devDeps["ts-jest"]).toMatch("29");
+    });
   });
 
   describe("Legacy", () => {


### PR DESCRIPTION
Install ts-jest 29 when Jest's major is higher than 29

Affects only if jest version is explicitly set. Newly initialized project gets both version correctly as latest which works.

Fixes #4308

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
