### PR TITLE
feat: add NuGet trusted publishing support

### DIFF
--- a/docs/api/cdk.md
+++ b/docs/api/cdk.md
@@ -6669,6 +6669,8 @@ const jsiiDotNetTarget: cdk.JsiiDotNetTarget = { ... }
 | <code><a href="#projen.cdk.JsiiDotNetTarget.property.publishTools">publishTools</a></code> | <code>projen.github.workflows.Tools</code> | Additional tools to install in the publishing job. |
 | <code><a href="#projen.cdk.JsiiDotNetTarget.property.nugetApiKeySecret">nugetApiKeySecret</a></code> | <code>string</code> | GitHub secret which contains the API key for NuGet. |
 | <code><a href="#projen.cdk.JsiiDotNetTarget.property.nugetServer">nugetServer</a></code> | <code>string</code> | NuGet Server URL (defaults to nuget.org). |
+| <code><a href="#projen.cdk.JsiiDotNetTarget.property.nugetUsernameSecret">nugetUsernameSecret</a></code> | <code>string</code> | The NuGet.org username (profile name, not email address) for trusted publisher authentication. |
+| <code><a href="#projen.cdk.JsiiDotNetTarget.property.trustedPublishing">trustedPublishing</a></code> | <code>boolean</code> | Use NuGet trusted publishing instead of API keys. |
 | <code><a href="#projen.cdk.JsiiDotNetTarget.property.dotNetNamespace">dotNetNamespace</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#projen.cdk.JsiiDotNetTarget.property.packageId">packageId</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#projen.cdk.JsiiDotNetTarget.property.iconUrl">iconUrl</a></code> | <code>string</code> | *No description.* |
@@ -6763,6 +6765,37 @@ public readonly nugetServer: string;
 - *Type:* string
 
 NuGet Server URL (defaults to nuget.org).
+
+---
+
+##### `nugetUsernameSecret`<sup>Optional</sup> <a name="nugetUsernameSecret" id="projen.cdk.JsiiDotNetTarget.property.nugetUsernameSecret"></a>
+
+```typescript
+public readonly nugetUsernameSecret: string;
+```
+
+- *Type:* string
+- *Default:* "NUGET_USERNAME"
+
+The NuGet.org username (profile name, not email address) for trusted publisher authentication.
+
+Required when using trusted publishing.
+
+---
+
+##### `trustedPublishing`<sup>Optional</sup> <a name="trustedPublishing" id="projen.cdk.JsiiDotNetTarget.property.trustedPublishing"></a>
+
+```typescript
+public readonly trustedPublishing: boolean;
+```
+
+- *Type:* boolean
+
+Use NuGet trusted publishing instead of API keys.
+
+Needs to be setup in NuGet.org.
+
+> [https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing)
 
 ---
 

--- a/docs/api/release.md
+++ b/docs/api/release.md
@@ -2194,6 +2194,8 @@ const jsiiReleaseNuget: release.JsiiReleaseNuget = { ... }
 | <code><a href="#projen.release.JsiiReleaseNuget.property.publishTools">publishTools</a></code> | <code>projen.github.workflows.Tools</code> | Additional tools to install in the publishing job. |
 | <code><a href="#projen.release.JsiiReleaseNuget.property.nugetApiKeySecret">nugetApiKeySecret</a></code> | <code>string</code> | GitHub secret which contains the API key for NuGet. |
 | <code><a href="#projen.release.JsiiReleaseNuget.property.nugetServer">nugetServer</a></code> | <code>string</code> | NuGet Server URL (defaults to nuget.org). |
+| <code><a href="#projen.release.JsiiReleaseNuget.property.nugetUsernameSecret">nugetUsernameSecret</a></code> | <code>string</code> | The NuGet.org username (profile name, not email address) for trusted publisher authentication. |
+| <code><a href="#projen.release.JsiiReleaseNuget.property.trustedPublishing">trustedPublishing</a></code> | <code>boolean</code> | Use NuGet trusted publishing instead of API keys. |
 
 ---
 
@@ -2297,6 +2299,41 @@ public readonly nugetServer: string;
 - *Type:* string
 
 NuGet Server URL (defaults to nuget.org).
+
+---
+
+##### ~~`nugetUsernameSecret`~~<sup>Optional</sup> <a name="nugetUsernameSecret" id="projen.release.JsiiReleaseNuget.property.nugetUsernameSecret"></a>
+
+- *Deprecated:* Use `NugetPublishOptions` instead.
+
+```typescript
+public readonly nugetUsernameSecret: string;
+```
+
+- *Type:* string
+- *Default:* "NUGET_USERNAME"
+
+The NuGet.org username (profile name, not email address) for trusted publisher authentication.
+
+Required when using trusted publishing.
+
+---
+
+##### ~~`trustedPublishing`~~<sup>Optional</sup> <a name="trustedPublishing" id="projen.release.JsiiReleaseNuget.property.trustedPublishing"></a>
+
+- *Deprecated:* Use `NugetPublishOptions` instead.
+
+```typescript
+public readonly trustedPublishing: boolean;
+```
+
+- *Type:* boolean
+
+Use NuGet trusted publishing instead of API keys.
+
+Needs to be setup in NuGet.org.
+
+> [https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing)
 
 ---
 
@@ -3018,6 +3055,8 @@ const nugetPublishOptions: release.NugetPublishOptions = { ... }
 | <code><a href="#projen.release.NugetPublishOptions.property.publishTools">publishTools</a></code> | <code>projen.github.workflows.Tools</code> | Additional tools to install in the publishing job. |
 | <code><a href="#projen.release.NugetPublishOptions.property.nugetApiKeySecret">nugetApiKeySecret</a></code> | <code>string</code> | GitHub secret which contains the API key for NuGet. |
 | <code><a href="#projen.release.NugetPublishOptions.property.nugetServer">nugetServer</a></code> | <code>string</code> | NuGet Server URL (defaults to nuget.org). |
+| <code><a href="#projen.release.NugetPublishOptions.property.nugetUsernameSecret">nugetUsernameSecret</a></code> | <code>string</code> | The NuGet.org username (profile name, not email address) for trusted publisher authentication. |
+| <code><a href="#projen.release.NugetPublishOptions.property.trustedPublishing">trustedPublishing</a></code> | <code>boolean</code> | Use NuGet trusted publishing instead of API keys. |
 
 ---
 
@@ -3109,6 +3148,37 @@ public readonly nugetServer: string;
 - *Type:* string
 
 NuGet Server URL (defaults to nuget.org).
+
+---
+
+##### `nugetUsernameSecret`<sup>Optional</sup> <a name="nugetUsernameSecret" id="projen.release.NugetPublishOptions.property.nugetUsernameSecret"></a>
+
+```typescript
+public readonly nugetUsernameSecret: string;
+```
+
+- *Type:* string
+- *Default:* "NUGET_USERNAME"
+
+The NuGet.org username (profile name, not email address) for trusted publisher authentication.
+
+Required when using trusted publishing.
+
+---
+
+##### `trustedPublishing`<sup>Optional</sup> <a name="trustedPublishing" id="projen.release.NugetPublishOptions.property.trustedPublishing"></a>
+
+```typescript
+public readonly trustedPublishing: boolean;
+```
+
+- *Type:* boolean
+
+Use NuGet trusted publishing instead of API keys.
+
+Needs to be setup in NuGet.org.
+
+> [https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing)
 
 ---
 

--- a/docs/publishing/publisher-component.md
+++ b/docs/publishing/publisher-component.md
@@ -98,7 +98,19 @@ publisher.publishToPyPi({
 });
 ```
 
-Before using trusted publishing, you must configure your package on the respective registry to accept tokens from your GitHub repository. See the [Trusted Publishing guide](./trusted-publishing.md) for detailed setup instructions.
+**NuGet**
+
+You must configure the `NUGET_USERNAME` secret (or a different secret name if customized) with your NuGet.org username (profile name, not email address).
+
+```ts
+publisher.publishToNuget({
+  trustedPublishing: true,
+  nugetUsernameSecret: "NUGET_USERNAME", // optional, defaults to "NUGET_USERNAME"
+});
+```
+
+Before using trusted publishing, you must configure your package on the respective registry to accept tokens from your GitHub repository.
+See the [Trusted Publishing guide](./trusted-publishing.md) for detailed setup instructions.
 
 ## Publishing to GitHub Packages
 


### PR DESCRIPTION
Add support for NuGet trusted publishing similar to existing PyPI implementation.

## Changes

- **Add trusted publishing options** to  interface
- **Update  method** to support OIDC authentication with proper permissions
- **Add comprehensive test coverage** for trusted publishing workflow generation
- **Update documentation** with setup instructions and migration guide
- **Improve trusted publishing docs** by consolidating redundant "How It Works" sections

## Features

- Secure authentication using OIDC tokens instead of long-lived API keys
- Automatic permission setup with `id-token: write` when trusted publishing is enabled
- Flexible configuration allowing custom secret names for the NuGet username
- Backward compatibility - existing API key-based publishing continues to work

## Usage

```typescript
publisher.publishToNuget({
  trustedPublishing: true,
  nugetUsernameSecret: "NUGET_USERNAME", // optional, defaults to "NUGET_USERNAME"
});
```

Requires configuring trusted publishing on NuGet.org and setting the `NUGET_USERNAME` secret with your NuGet.org username (profile name, not email).

## References

- [NuGet Trusted Publishing Documentation](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing)
- [publib NuGet Support](https://github.com/cdklabs/publib#nuget)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
