### PR TITLE
feat(release): validate trusted publishing configurations

### DIFF
--- a/src/release/publisher.ts
+++ b/src/release/publisher.ts
@@ -311,6 +311,14 @@ export class Publisher extends Component {
    * @param options Options
    */
   public publishToNpm(options: NpmPublishOptions = {}) {
+    if (options.trustedPublishing && options.npmTokenSecret) {
+      throw new Error(
+        "Cannot use npmTokenSecret when trustedPublishing is enabled. " +
+          "Trusted publishing uses OIDC tokens for authentication instead of NPM tokens. " +
+          "Remove the npmTokenSecret option to use trusted publishing."
+      );
+    }
+
     const trustedPublisher = options.trustedPublishing ? "true" : undefined;
     const npmProvenance = options.npmProvenance ? "true" : undefined;
 
@@ -417,6 +425,14 @@ export class Publisher extends Component {
    * @param options Options
    */
   public publishToNuget(options: NugetPublishOptions = {}) {
+    if (options.trustedPublishing && options.nugetApiKeySecret) {
+      throw new Error(
+        "Cannot use nugetApiKeySecret when trustedPublishing is enabled. " +
+          "Trusted publishing uses OIDC tokens for authentication instead of API keys. " +
+          "Remove the nugetApiKeySecret option to use trusted publishing."
+      );
+    }
+
     const isGitHubPackages = options.nugetServer?.startsWith(
       GITHUB_PACKAGES_NUGET_REPOSITORY
     );
@@ -535,6 +551,17 @@ export class Publisher extends Component {
    * @param options Options
    */
   public publishToPyPi(options: PyPiPublishOptions = {}) {
+    if (
+      options.trustedPublishing &&
+      (options.twineUsernameSecret || options.twinePasswordSecret)
+    ) {
+      throw new Error(
+        "Cannot use twineUsernameSecret and twinePasswordSecret when trustedPublishing is enabled. " +
+          "Trusted publishing uses OIDC tokens for authentication instead of username/password credentials. " +
+          "Remove the twineUsernameSecret and twinePasswordSecret options to use trusted publishing."
+      );
+    }
+
     let permissions: JobPermissions = { contents: JobPermission.READ };
     const prePublishSteps = options.prePublishSteps ?? [];
     let workflowEnv: Record<string, string | undefined> = {};

--- a/test/release/publisher-trusted-publishing.test.ts
+++ b/test/release/publisher-trusted-publishing.test.ts
@@ -1,0 +1,138 @@
+import { Release } from "../../src/release";
+import { TestProject } from "../util";
+
+describe("Publisher Trusted Publishing Validation", () => {
+  let project: TestProject;
+  let release: Release;
+
+  beforeEach(() => {
+    project = new TestProject();
+    release = new Release(project, {
+      task: project.buildTask,
+      versionFile: "version.json",
+      branch: "main",
+      artifactsDirectory: "dist",
+    });
+  });
+
+  describe("publishToNpm", () => {
+    test("throws error when trustedPublishing is true and npmTokenSecret is set", () => {
+      expect(() => {
+        release.publisher.publishToNpm({
+          trustedPublishing: true,
+          npmTokenSecret: "MY_NPM_TOKEN",
+        });
+      }).toThrow(
+        "Cannot use npmTokenSecret when trustedPublishing is enabled. " +
+          "Trusted publishing uses OIDC tokens for authentication instead of NPM tokens. " +
+          "Remove the npmTokenSecret option to use trusted publishing."
+      );
+    });
+
+    test("allows trustedPublishing without npmTokenSecret", () => {
+      expect(() => {
+        release.publisher.publishToNpm({
+          trustedPublishing: true,
+        });
+      }).not.toThrow();
+    });
+
+    test("allows npmTokenSecret without trustedPublishing", () => {
+      expect(() => {
+        release.publisher.publishToNpm({
+          npmTokenSecret: "MY_NPM_TOKEN",
+        });
+      }).not.toThrow();
+    });
+  });
+
+  describe("publishToNuget", () => {
+    test("throws error when trustedPublishing is true and nugetApiKeySecret is set", () => {
+      expect(() => {
+        release.publisher.publishToNuget({
+          trustedPublishing: true,
+          nugetApiKeySecret: "MY_NUGET_KEY",
+        });
+      }).toThrow(
+        "Cannot use nugetApiKeySecret when trustedPublishing is enabled. " +
+          "Trusted publishing uses OIDC tokens for authentication instead of API keys. " +
+          "Remove the nugetApiKeySecret option to use trusted publishing."
+      );
+    });
+
+    test("allows trustedPublishing without nugetApiKeySecret", () => {
+      expect(() => {
+        release.publisher.publishToNuget({
+          trustedPublishing: true,
+        });
+      }).not.toThrow();
+    });
+
+    test("allows nugetApiKeySecret without trustedPublishing", () => {
+      expect(() => {
+        release.publisher.publishToNuget({
+          nugetApiKeySecret: "MY_NUGET_KEY",
+        });
+      }).not.toThrow();
+    });
+  });
+
+  describe("publishToPyPi", () => {
+    test("throws error when trustedPublishing is true and twineUsernameSecret is set", () => {
+      expect(() => {
+        release.publisher.publishToPyPi({
+          trustedPublishing: true,
+          twineUsernameSecret: "MY_USERNAME",
+        });
+      }).toThrow(
+        "Cannot use twineUsernameSecret and twinePasswordSecret when trustedPublishing is enabled. " +
+          "Trusted publishing uses OIDC tokens for authentication instead of username/password credentials. " +
+          "Remove the twineUsernameSecret and twinePasswordSecret options to use trusted publishing."
+      );
+    });
+
+    test("throws error when trustedPublishing is true and twinePasswordSecret is set", () => {
+      expect(() => {
+        release.publisher.publishToPyPi({
+          trustedPublishing: true,
+          twinePasswordSecret: "MY_PASSWORD",
+        });
+      }).toThrow(
+        "Cannot use twineUsernameSecret and twinePasswordSecret when trustedPublishing is enabled. " +
+          "Trusted publishing uses OIDC tokens for authentication instead of username/password credentials. " +
+          "Remove the twineUsernameSecret and twinePasswordSecret options to use trusted publishing."
+      );
+    });
+
+    test("throws error when trustedPublishing is true and both twine secrets are set", () => {
+      expect(() => {
+        release.publisher.publishToPyPi({
+          trustedPublishing: true,
+          twineUsernameSecret: "MY_USERNAME",
+          twinePasswordSecret: "MY_PASSWORD",
+        });
+      }).toThrow(
+        "Cannot use twineUsernameSecret and twinePasswordSecret when trustedPublishing is enabled. " +
+          "Trusted publishing uses OIDC tokens for authentication instead of username/password credentials. " +
+          "Remove the twineUsernameSecret and twinePasswordSecret options to use trusted publishing."
+      );
+    });
+
+    test("allows trustedPublishing without twine secrets", () => {
+      expect(() => {
+        release.publisher.publishToPyPi({
+          trustedPublishing: true,
+        });
+      }).not.toThrow();
+    });
+
+    test("allows twine secrets without trustedPublishing", () => {
+      expect(() => {
+        release.publisher.publishToPyPi({
+          twineUsernameSecret: "MY_USERNAME",
+          twinePasswordSecret: "MY_PASSWORD",
+        });
+      }).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Description

This PR adds validation to prevent conflicting authentication methods when trusted publishing is enabled for npm, NuGet, and PyPI publishers.

## Changes

- Added validation in publishToNpm() to prevent using npmTokenSecret with trustedPublishing
- Added validation in publishToNuget() to prevent using nugetApiKeySecret with trustedPublishing  
- Added validation in publishToPyPi() to prevent using twineUsernameSecret/twinePasswordSecret with trustedPublishing
- Added comprehensive test coverage for all validation scenarios

## Why

Trusted publishing uses OIDC tokens for authentication, making traditional tokens/credentials unnecessary and potentially confusing. This validation provides clear error messages to guide users toward the correct configuration.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.