### PR TITLE
feat(awscdk)!: AutoDiscover Lambda Runtime defaulting to nodejs22.x

### DIFF
--- a/docs/api/awscdk.md
+++ b/docs/api/awscdk.md
@@ -22688,7 +22688,7 @@ public readonly runtime: LambdaRuntime;
 ```
 
 - *Type:* <a href="#projen.awscdk.LambdaRuntime">LambdaRuntime</a>
-- *Default:* Runtime.NODEJS_18_X
+- *Default:* Runtime.NODEJS_22_X
 
 The node.js version to target.
 
@@ -22778,7 +22778,7 @@ public readonly runtime: LambdaRuntime;
 ```
 
 - *Type:* <a href="#projen.awscdk.LambdaRuntime">LambdaRuntime</a>
-- *Default:* Runtime.NODEJS_18_X
+- *Default:* Runtime.NODEJS_22_X
 
 The node.js version to target.
 
@@ -23052,7 +23052,9 @@ Node.js 16.x.
 
 ---
 
-##### `NODEJS_18_X`<sup>Required</sup> <a name="NODEJS_18_X" id="projen.awscdk.LambdaRuntime.property.NODEJS_18_X"></a>
+##### ~~`NODEJS_18_X`~~<sup>Required</sup> <a name="NODEJS_18_X" id="projen.awscdk.LambdaRuntime.property.NODEJS_18_X"></a>
+
+- *Deprecated:* : Node.js 18 runtime has been deprecated on Sep 1, 2025
 
 ```typescript
 public readonly NODEJS_18_X: LambdaRuntime;
@@ -23061,8 +23063,6 @@ public readonly NODEJS_18_X: LambdaRuntime;
 - *Type:* <a href="#projen.awscdk.LambdaRuntime">LambdaRuntime</a>
 
 Node.js 18.x.
-
-Advanced notice: Node.js 18 runtime will be deprecated on Jul 31, 2025
 
 ---
 

--- a/docs/api/javascript.md
+++ b/docs/api/javascript.md
@@ -5259,7 +5259,7 @@ For example, to add the [--log-limit](https://esbuild.github.io/api/#log-limit) 
 ```text
 project.bundler.addBundle("./src/hello.ts", {
   platform: "node",
-  target: "node18",
+  target: "node22",
   sourcemap: true,
   format: "esm",
   esbuildArgs: {
@@ -15392,7 +15392,7 @@ const project = new TypeScriptProject({
 // Tell the bundler to bundle the compiled results (from the "lib" directory)
 project.bundler.addBundle("./lib/index.js", {
   platform: "node",
-  target: "node18",
+  target: "node22",
   sourcemap: false,
   format: "esm",
 });

--- a/docs/concepts/bundling.md
+++ b/docs/concepts/bundling.md
@@ -23,7 +23,7 @@ To add bundles, call `bundler.addBundle()`:
 ```ts
 project.bundler.addBundle('name-of-bundle', {
   entrypoint: 'src/foo.ts',
-  target: 'node18',
+  target: 'node22',
   platform: 'node',
   bundlingOptions: {
     externals: ['aws-sdk'], // modules not to include in bundles

--- a/docs/integrations/aws/index.md
+++ b/docs/integrations/aws/index.md
@@ -71,7 +71,7 @@ new AwsCdkConstructLibrary({
   // ...
   lambdaOptions: {
     // target node.js runtime
-    runtime: awscdk.LambdaRuntime.NODEJS_18_X,
+    runtime: awscdk.LambdaRuntime.NODEJS_22_X,
 
     bundlingOptions: {
       // list of node modules to exclude from the bundle

--- a/src/awscdk/lambda-function.ts
+++ b/src/awscdk/lambda-function.ts
@@ -21,7 +21,7 @@ export interface LambdaFunctionCommonOptions {
   /**
    * The node.js version to target.
    *
-   * @default Runtime.NODEJS_18_X
+   * @default Runtime.NODEJS_22_X
    */
   readonly runtime?: LambdaRuntime;
 
@@ -135,7 +135,7 @@ export class LambdaFunction extends Component {
       );
     }
 
-    const runtime = options.runtime ?? LambdaRuntime.NODEJS_18_X;
+    const runtime = options.runtime ?? LambdaRuntime.NODEJS_22_X;
 
     const entrypoint = normalizePersistedPath(options.entrypoint);
 
@@ -343,7 +343,7 @@ export class LambdaRuntime {
   /**
    * Node.js 18.x
    *
-   * Advanced notice: Node.js 18 runtime will be deprecated on Jul 31, 2025
+   * @deprecated: Node.js 18 runtime has been deprecated on Sep 1, 2025
    */
   public static readonly NODEJS_18_X = new LambdaRuntime(
     "nodejs18.x",

--- a/src/javascript/bundler.ts
+++ b/src/javascript/bundler.ts
@@ -518,7 +518,7 @@ export interface AddBundleOptions extends BundlingOptions {
    * ```text
    * project.bundler.addBundle("./src/hello.ts", {
    *   platform: "node",
-   *   target: "node18",
+   *   target: "node22",
    *   sourcemap: true,
    *   format: "esm",
    *   esbuildArgs: {
@@ -592,7 +592,7 @@ export enum RunBundleTask {
    * // Tell the bundler to bundle the compiled results (from the "lib" directory)
    * project.bundler.addBundle("./lib/index.js", {
    *   platform: "node",
-   *   target: "node18",
+   *   target: "node22",
    *   sourcemap: false,
    *   format: "esm",
    * });

--- a/test/awscdk/__snapshots__/lambda-function.test.ts.snap
+++ b/test/awscdk/__snapshots__/lambda-function.test.ts.snap
@@ -21,7 +21,7 @@ export class HelloFunction extends cloudfront.experimental.EdgeFunction {
     super(scope, id, {
       description: 'src/hello.edge-lambda.ts',
       ...props,
-      runtime: new lambda.Runtime('nodejs18.x', lambda.RuntimeFamily.NODEJS),
+      runtime: new lambda.Runtime('nodejs22.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../assets/hello.edge-lambda')),
     });
@@ -49,7 +49,7 @@ export class HelloFunction extends lambda.Function {
     super(scope, id, {
       description: 'src/hello.lambda.ts',
       ...props,
-      runtime: new lambda.Runtime('nodejs18.x', lambda.RuntimeFamily.NODEJS),
+      runtime: new lambda.Runtime('nodejs22.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../assets/hello.lambda')),
     });
@@ -78,7 +78,7 @@ export class WorldFunction extends lambda.Function {
     super(scope, id, {
       description: 'src/subdir/world.lambda.ts',
       ...props,
-      runtime: new lambda.Runtime('nodejs18.x', lambda.RuntimeFamily.NODEJS),
+      runtime: new lambda.Runtime('nodejs22.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../../assets/subdir/world.lambda')),
     });
@@ -107,7 +107,7 @@ export class JangyFunction extends lambda.Function {
     super(scope, id, {
       description: 'src/subdir/jangy.lambda.ts',
       ...props,
-      runtime: new lambda.Runtime('nodejs18.x', lambda.RuntimeFamily.NODEJS),
+      runtime: new lambda.Runtime('nodejs22.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../../assets/subdir/jangy.lambda')),
     });
@@ -140,7 +140,7 @@ exports[`auto-discover 5`] = `
   "name": "bundle:hello.lambda",
   "steps": [
     {
-      "exec": "esbuild --bundle src/hello.lambda.ts --target="node18" --platform="node" --outfile="assets/hello.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:@aws-sdk/*",
+      "exec": "esbuild --bundle src/hello.lambda.ts --target="node22" --platform="node" --outfile="assets/hello.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:@aws-sdk/*",
     },
   ],
 }
@@ -152,7 +152,7 @@ exports[`auto-discover 6`] = `
   "name": "bundle:hello.lambda:watch",
   "steps": [
     {
-      "exec": "esbuild --bundle src/hello.lambda.ts --target="node18" --platform="node" --outfile="assets/hello.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:@aws-sdk/* --watch",
+      "exec": "esbuild --bundle src/hello.lambda.ts --target="node22" --platform="node" --outfile="assets/hello.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:@aws-sdk/* --watch",
     },
   ],
 }
@@ -164,7 +164,7 @@ exports[`auto-discover 7`] = `
   "name": "bundle:subdir/jangy.lambda",
   "steps": [
     {
-      "exec": "esbuild --bundle src/subdir/jangy.lambda.ts --target="node18" --platform="node" --outfile="assets/subdir/jangy.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:@aws-sdk/*",
+      "exec": "esbuild --bundle src/subdir/jangy.lambda.ts --target="node22" --platform="node" --outfile="assets/subdir/jangy.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:@aws-sdk/*",
     },
   ],
 }
@@ -176,7 +176,7 @@ exports[`auto-discover 8`] = `
   "name": "bundle:subdir/jangy.lambda:watch",
   "steps": [
     {
-      "exec": "esbuild --bundle src/subdir/jangy.lambda.ts --target="node18" --platform="node" --outfile="assets/subdir/jangy.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:@aws-sdk/* --watch",
+      "exec": "esbuild --bundle src/subdir/jangy.lambda.ts --target="node22" --platform="node" --outfile="assets/subdir/jangy.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:@aws-sdk/* --watch",
     },
   ],
 }
@@ -188,7 +188,7 @@ exports[`auto-discover 9`] = `
   "name": "bundle:subdir/world.lambda",
   "steps": [
     {
-      "exec": "esbuild --bundle src/subdir/world.lambda.ts --target="node18" --platform="node" --outfile="assets/subdir/world.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:@aws-sdk/*",
+      "exec": "esbuild --bundle src/subdir/world.lambda.ts --target="node22" --platform="node" --outfile="assets/subdir/world.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:@aws-sdk/*",
     },
   ],
 }
@@ -200,7 +200,7 @@ exports[`auto-discover 10`] = `
   "name": "bundle:subdir/world.lambda:watch",
   "steps": [
     {
-      "exec": "esbuild --bundle src/subdir/world.lambda.ts --target="node18" --platform="node" --outfile="assets/subdir/world.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:@aws-sdk/* --watch",
+      "exec": "esbuild --bundle src/subdir/world.lambda.ts --target="node22" --platform="node" --outfile="assets/subdir/world.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:@aws-sdk/* --watch",
     },
   ],
 }
@@ -226,7 +226,7 @@ export class HelloFunction extends lambda.Function {
     super(scope, id, {
       description: 'src/hello.lambda.ts',
       ...props,
-      runtime: new lambda.Runtime('nodejs18.x', lambda.RuntimeFamily.NODEJS),
+      runtime: new lambda.Runtime('nodejs22.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../my-assets/hello.lambda')),
     });
@@ -257,7 +257,7 @@ export class HelloFunction extends lambda.Function {
     super(scope, id, {
       description: 'src/hello.lambda.ts',
       ...props,
-      runtime: new lambda.Runtime('nodejs18.x', lambda.RuntimeFamily.NODEJS),
+      runtime: new lambda.Runtime('nodejs22.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../assets/hello.lambda')),
     });
@@ -286,7 +286,7 @@ export class HelloFunction extends lambda.Function {
     super(scope, id, {
       description: 'src/hello.lambda.ts',
       ...props,
-      runtime: new lambda.Runtime('nodejs18.x', lambda.RuntimeFamily.NODEJS),
+      runtime: new lambda.Runtime('nodejs22.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../assets/hello.lambda')),
     });
@@ -315,7 +315,7 @@ export class WorldFunction extends lambda.Function {
     super(scope, id, {
       description: 'src/world.lambda.ts',
       ...props,
-      runtime: new lambda.Runtime('nodejs18.x', lambda.RuntimeFamily.NODEJS),
+      runtime: new lambda.Runtime('nodejs22.x', lambda.RuntimeFamily.NODEJS),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(path.join(__dirname, '../assets/world.lambda')),
     });

--- a/test/awscdk/awscdk-app.test.ts
+++ b/test/awscdk/awscdk-app.test.ts
@@ -133,7 +133,7 @@ describe("lambda functions", () => {
       cdkVersion: "1.100.0",
       libdir: "liblib",
       lambdaOptions: {
-        runtime: LambdaRuntime.NODEJS_18_X,
+        runtime: LambdaRuntime.NODEJS_22_X,
         bundlingOptions: {
           externals: ["foo", "bar"],
         },
@@ -147,7 +147,7 @@ describe("lambda functions", () => {
       snapshot[".projen/tasks.json"].tasks["bundle:my.lambda"].steps
     ).toStrictEqual([
       {
-        exec: 'esbuild --bundle src/my.lambda.ts --target="node18" --platform="node" --outfile="assets/my.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:foo --external:bar',
+        exec: 'esbuild --bundle src/my.lambda.ts --target="node22" --platform="node" --outfile="assets/my.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:foo --external:bar',
       },
     ]);
   });

--- a/test/awscdk/awscdk-construct.test.ts
+++ b/test/awscdk/awscdk-construct.test.ts
@@ -175,7 +175,7 @@ describe("lambda functions", () => {
         assetsDir: "resources",
       },
       lambdaOptions: {
-        runtime: awscdk.LambdaRuntime.NODEJS_18_X,
+        runtime: awscdk.LambdaRuntime.NODEJS_22_X,
         bundlingOptions: {
           externals: ["foo", "bar"],
           sourcemap: true,
@@ -190,7 +190,7 @@ describe("lambda functions", () => {
       snapshot[".projen/tasks.json"].tasks["bundle:my.lambda"].steps
     ).toStrictEqual([
       {
-        exec: 'esbuild --bundle src/my.lambda.ts --target="node18" --platform="node" --outfile="resources/my.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:foo --external:bar --sourcemap',
+        exec: 'esbuild --bundle src/my.lambda.ts --target="node22" --platform="node" --outfile="resources/my.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:foo --external:bar --sourcemap',
       },
     ]);
   });

--- a/test/awscdk/lambda-function.test.ts
+++ b/test/awscdk/lambda-function.test.ts
@@ -52,7 +52,7 @@ describe("bundled function", () => {
       name: "bundle:hello.lambda",
       steps: [
         {
-          exec: 'esbuild --bundle src/hello.lambda.ts --target="node18" --platform="node" --outfile="my-assets/hello.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:@aws-sdk/*',
+          exec: 'esbuild --bundle src/hello.lambda.ts --target="node22" --platform="node" --outfile="my-assets/hello.lambda/index.js" --tsconfig="tsconfig.dev.json" --external:@aws-sdk/*',
         },
       ],
     });
@@ -376,7 +376,7 @@ test("auto-discover", () => {
       dependencyType: DependencyType.RUNTIME,
     }),
     lambdaOptions: {
-      runtime: awscdk.LambdaRuntime.NODEJS_18_X,
+      runtime: awscdk.LambdaRuntime.NODEJS_22_X,
     },
   });
 


### PR DESCRIPTION
BREAKING CHANGE: The default Lambda Runtime is updated to `nodejs22.x`, as the current default runtime is `nodejs18.x` which is already deprecated (see: [here](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-deprecated)). To keep the previous version, set [`lambdaOptions.runtime`](https://projen.io/docs/api/awscdk?_highlight=runtime#projen.awscdk.LambdaFunctionCommonOptions.property.runtime) to the desired runtime.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
