### PR TITLE
fix(eslint): suppress confusing legacy config warnings

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -164,7 +164,8 @@
       "name": "eslint",
       "description": "Runs eslint against the codebase",
       "env": {
-        "ESLINT_USE_FLAT_CONFIG": "false"
+        "ESLINT_USE_FLAT_CONFIG": "false",
+        "NODE_NO_WARNINGS": "1"
       },
       "steps": [
         {

--- a/src/javascript/eslint.ts
+++ b/src/javascript/eslint.ts
@@ -250,6 +250,7 @@ export class Eslint extends Component {
       description: "Runs eslint against the codebase",
       env: {
         ESLINT_USE_FLAT_CONFIG: "false",
+        NODE_NO_WARNINGS: "1", // Suppress eslint warning about legacy config format, as it just confuses users. This will suppress all node warnings, but in practice users cannot action warnings from eslint anyway.
       },
     });
     this.updateTask();

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -1054,7 +1054,8 @@ tsconfig.tsbuildinfo
       "name": "eslint",
       "description": "Runs eslint against the codebase",
       "env": {
-        "ESLINT_USE_FLAT_CONFIG": "false"
+        "ESLINT_USE_FLAT_CONFIG": "false",
+        "NODE_NO_WARNINGS": "1"
       },
       "steps": [
         {
@@ -2142,7 +2143,8 @@ tsconfig.tsbuildinfo
       "name": "eslint",
       "description": "Runs eslint against the codebase",
       "env": {
-        "ESLINT_USE_FLAT_CONFIG": "false"
+        "ESLINT_USE_FLAT_CONFIG": "false",
+        "NODE_NO_WARNINGS": "1"
       },
       "steps": [
         {
@@ -3318,7 +3320,8 @@ tsconfig.tsbuildinfo
       "name": "eslint",
       "description": "Runs eslint against the codebase",
       "env": {
-        "ESLINT_USE_FLAT_CONFIG": "false"
+        "ESLINT_USE_FLAT_CONFIG": "false",
+        "NODE_NO_WARNINGS": "1"
       },
       "steps": [
         {

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -968,6 +968,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "description": "Runs eslint against the codebase",
         "env": {
           "ESLINT_USE_FLAT_CONFIG": "false",
+          "NODE_NO_WARNINGS": "1",
         },
         "name": "eslint",
         "steps": [

--- a/test/jsii/__snapshots__/jsii.test.ts.snap
+++ b/test/jsii/__snapshots__/jsii.test.ts.snap
@@ -968,6 +968,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "description": "Runs eslint against the codebase",
         "env": {
           "ESLINT_USE_FLAT_CONFIG": "false",
+          "NODE_NO_WARNINGS": "1",
         },
         "name": "eslint",
         "steps": [
@@ -2478,6 +2479,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "description": "Runs eslint against the codebase",
         "env": {
           "ESLINT_USE_FLAT_CONFIG": "false",
+          "NODE_NO_WARNINGS": "1",
         },
         "name": "eslint",
         "steps": [
@@ -3990,6 +3992,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "description": "Runs eslint against the codebase",
         "env": {
           "ESLINT_USE_FLAT_CONFIG": "false",
+          "NODE_NO_WARNINGS": "1",
         },
         "name": "eslint",
         "steps": [

--- a/test/typescript/__snapshots__/typescript.test.ts.snap
+++ b/test/typescript/__snapshots__/typescript.test.ts.snap
@@ -836,6 +836,7 @@ tsconfig.tsbuildinfo
         "description": "Runs eslint against the codebase",
         "env": {
           "ESLINT_USE_FLAT_CONFIG": "false",
+          "NODE_NO_WARNINGS": "1",
         },
         "name": "eslint",
         "steps": [

--- a/test/typescript/typescript.test.ts
+++ b/test/typescript/typescript.test.ts
@@ -224,6 +224,7 @@ test("eslint configured to support .projenrc.ts and projenrc src dir", () => {
     description: "Runs eslint against the codebase",
     env: {
       ESLINT_USE_FLAT_CONFIG: "false",
+      NODE_NO_WARNINGS: "1",
     },
     name: "eslint",
     steps: [

--- a/test/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/react-ts-project.test.ts.snap
@@ -733,6 +733,7 @@ tsconfig.tsbuildinfo
         "description": "Runs eslint against the codebase",
         "env": {
           "ESLINT_USE_FLAT_CONFIG": "false",
+          "NODE_NO_WARNINGS": "1",
         },
         "name": "eslint",
         "steps": [


### PR DESCRIPTION
Fixes confusing eslint warnings about legacy config format that appear during normal usage.

When users run `npx projen eslint`, they see warnings about using the legacy eslint configuration format. These warnings are confusing because users cannot take any action since projen manages the eslint configuration. The warnings suggest migrating to flat config, but that's not the user's responsibility and creates unnecessary noise that distracts from actual linting issues.

This change adds `NODE_NO_WARNINGS=1` to the eslint task environment to suppress these warnings while preserving actual eslint output.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.