### PR TITLE
feat(upgrade-dependencies): add option to control transitive dependency upgrades

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -413,13 +413,13 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@jsii/check-node,@types/conventional-changelog-config-spec,@types/ini,@types/jest,@types/parse-conflict-json,@types/semver,@types/yargs,all-contributors-cli,aws-cdk-lib,esbuild,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,jest,jsii-diff,jsii-pacmak,json2jsii,license-checker,prettier,ts-jest,ts-node"
+          "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@jsii/check-node,@types/conventional-changelog-config-spec,@types/ini,@types/jest,@types/parse-conflict-json,@types/semver,@types/yargs,all-contributors-cli,aws-cdk-lib,esbuild,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,jest,jsii-diff,jsii-pacmak,json2jsii,license-checker,markmac,prettier,ts-jest,ts-node"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @biomejs/biome @jsii/check-node @types/conventional-changelog-config-spec @types/ini @types/jest @types/node @types/parse-conflict-json @types/semver @types/yargs @typescript-eslint/eslint-plugin @typescript-eslint/parser all-contributors-cli aws-cdk-lib commit-and-tag-version esbuild eslint-config-prettier eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint jest jest-junit jsii-diff jsii-docgen jsii-pacmak jsii-rosetta jsii json2jsii license-checker prettier ts-jest ts-node typescript"
+          "exec": "yarn upgrade @biomejs/biome @jsii/check-node @types/conventional-changelog-config-spec @types/ini @types/jest @types/node @types/parse-conflict-json @types/semver @types/yargs @typescript-eslint/eslint-plugin @typescript-eslint/parser all-contributors-cli aws-cdk-lib commit-and-tag-version esbuild eslint-config-prettier eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint jest jest-junit jsii-diff jsii-docgen jsii-pacmak jsii-rosetta jsii json2jsii license-checker markmac prettier ts-jest ts-node typescript"
         },
         {
           "exec": "node ./projen.js"
@@ -437,7 +437,7 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep= --filter=@iarna/toml,case,chalk,conventional-changelog-config-spec,fast-glob,fast-json-patch,ini,parse-conflict-json,semver,shx,xmlbuilder2,yargs"
+          "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep= --filter=@iarna/toml,case,chalk,conventional-changelog-config-spec,fast-glob,fast-json-patch,ini,parse-conflict-json,semver,shx,xmlbuilder2,yargs"
         },
         {
           "exec": "yarn install --check-files"

--- a/docs/api/javascript.md
+++ b/docs/api/javascript.md
@@ -4802,7 +4802,7 @@ Test whether the given construct is a component.
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#projen.javascript.UpgradeDependencies.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
-| <code><a href="#projen.javascript.UpgradeDependencies.property.project">project</a></code> | <code>projen.Project</code> | *No description.* |
+| <code><a href="#projen.javascript.UpgradeDependencies.property.project">project</a></code> | <code><a href="#projen.javascript.NodeProject">NodeProject</a></code> | *No description.* |
 | <code><a href="#projen.javascript.UpgradeDependencies.property.postUpgradeTask">postUpgradeTask</a></code> | <code>projen.Task</code> | A task run after the upgrade task. |
 | <code><a href="#projen.javascript.UpgradeDependencies.property.upgradeTask">upgradeTask</a></code> | <code>projen.Task</code> | The upgrade task. |
 | <code><a href="#projen.javascript.UpgradeDependencies.property.workflows">workflows</a></code> | <code>projen.github.GithubWorkflow[]</code> | The workflows that execute the upgrades. |
@@ -4825,10 +4825,10 @@ The tree node.
 ##### `project`<sup>Required</sup> <a name="project" id="projen.javascript.UpgradeDependencies.property.project"></a>
 
 ```typescript
-public readonly project: Project;
+public readonly project: NodeProject;
 ```
 
-- *Type:* projen.Project
+- *Type:* <a href="#projen.javascript.NodeProject">NodeProject</a>
 
 ---
 
@@ -12640,6 +12640,7 @@ const upgradeDependenciesOptions: javascript.UpgradeDependenciesOptions = { ... 
 | <code><a href="#projen.javascript.UpgradeDependenciesOptions.property.target">target</a></code> | <code>string</code> | Determines the target version to upgrade dependencies to. |
 | <code><a href="#projen.javascript.UpgradeDependenciesOptions.property.taskName">taskName</a></code> | <code>string</code> | The name of the task that will be created. |
 | <code><a href="#projen.javascript.UpgradeDependenciesOptions.property.types">types</a></code> | <code>projen.DependencyType[]</code> | Specify which dependency types the upgrade should operate on. |
+| <code><a href="#projen.javascript.UpgradeDependenciesOptions.property.upgradeTransitiveDependencies">upgradeTransitiveDependencies</a></code> | <code>boolean</code> | Whether to upgrade transitive dependencies. |
 | <code><a href="#projen.javascript.UpgradeDependenciesOptions.property.workflow">workflow</a></code> | <code>boolean</code> | Include a github workflow for creating PR's that upgrades the required dependencies, either by manual dispatch, or by a schedule. |
 | <code><a href="#projen.javascript.UpgradeDependenciesOptions.property.workflowOptions">workflowOptions</a></code> | <code><a href="#projen.javascript.UpgradeDependenciesWorkflowOptions">UpgradeDependenciesWorkflowOptions</a></code> | Options for the github workflow. |
 
@@ -12785,6 +12786,23 @@ public readonly types: DependencyType[];
 - *Default:* All dependency types.
 
 Specify which dependency types the upgrade should operate on.
+
+---
+
+##### `upgradeTransitiveDependencies`<sup>Optional</sup> <a name="upgradeTransitiveDependencies" id="projen.javascript.UpgradeDependenciesOptions.property.upgradeTransitiveDependencies"></a>
+
+```typescript
+public readonly upgradeTransitiveDependencies: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Whether to upgrade transitive dependencies.
+
+When enabled, the upgrade process will use the package manager's upgrade command
+to update transitive dependencies. When disabled, only direct dependencies are
+upgraded using npm-check-updates with the --install=always flag.
 
 ---
 

--- a/projenrc/index.ts
+++ b/projenrc/index.ts
@@ -205,8 +205,6 @@ export function setupUpgradeDependencies(project: NodeProject) {
         .map((d: any) => d.name),
       // constructs version constraint should not be changed
       "constructs",
-      // markmac depends on projen, we are excluding it here to avoid a circular update loop
-      "markmac",
     ],
     workflowOptions: {
       labels: ["auto-approve"],

--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -1795,20 +1795,19 @@ export function defaultNpmToken(
 }
 
 function determineLockfile(packageManager: NodePackageManager) {
-  if (
-    packageManager === NodePackageManager.YARN ||
-    packageManager === NodePackageManager.YARN2 ||
-    packageManager === NodePackageManager.YARN_CLASSIC ||
-    packageManager === NodePackageManager.YARN_BERRY
-  ) {
-    return "yarn.lock";
-  } else if (packageManager === NodePackageManager.NPM) {
-    return "package-lock.json";
-  } else if (packageManager === NodePackageManager.PNPM) {
-    return "pnpm-lock.yaml";
-  } else if (packageManager === NodePackageManager.BUN) {
-    return "bun.lockb";
+  switch (packageManager) {
+    case NodePackageManager.YARN:
+    case NodePackageManager.YARN_CLASSIC:
+    case NodePackageManager.YARN2:
+    case NodePackageManager.YARN_BERRY:
+      return "yarn.lock";
+    case NodePackageManager.NPM:
+      return "package-lock.json";
+    case NodePackageManager.PNPM:
+      return "pnpm-lock.yaml";
+    case NodePackageManager.BUN:
+      return "bun.lockb";
+    default:
+      throw new Error(`unsupported package manager ${packageManager}`);
   }
-
-  throw new Error(`unsupported package manager ${packageManager}`);
 }

--- a/src/javascript/node-project.ts
+++ b/src/javascript/node-project.ts
@@ -23,6 +23,7 @@ import {
   GitIdentity,
 } from "../github";
 import { Biome, BiomeOptions } from "./biome/biome";
+import { isYarnBerry, isYarnClassic } from "./util";
 import { DEFAULT_GITHUB_ACTIONS_USER } from "../github/constants";
 import { ensureNotHiddenPath, secretToString } from "../github/private/util";
 import {
@@ -1215,18 +1216,11 @@ export class NodeProject extends GitHubProject {
 
     if (this.package.packageManager !== NodePackageManager.BUN) {
       if (this.nodeVersion || this.workflowPackageCache) {
+        const pm: NodePackageManager = this.package.packageManager;
         const cache =
-          this.package.packageManager === NodePackageManager.YARN
+          isYarnClassic(pm) || isYarnBerry(pm)
             ? "yarn"
-            : this.package.packageManager === NodePackageManager.YARN2
-            ? "yarn"
-            : this.package.packageManager === NodePackageManager.YARN_CLASSIC
-            ? "yarn"
-            : this.package.packageManager === NodePackageManager.YARN_BERRY
-            ? "yarn"
-            : this.packageManager === NodePackageManager.BUN
-            ? "bun"
-            : this.package.packageManager === NodePackageManager.PNPM
+            : pm === NodePackageManager.PNPM
             ? "pnpm"
             : "npm";
         install.push({

--- a/src/javascript/util.ts
+++ b/src/javascript/util.ts
@@ -1,9 +1,36 @@
 import { existsSync, readFileSync } from "fs";
 import { basename, dirname, extname, join, sep, resolve, posix } from "path";
 import * as semver from "semver";
-import { NodePackage } from "./node-package";
+import { NodePackage, NodePackageManager } from "./node-package";
 import { Project } from "../project";
 import { findUp } from "../util";
+
+/**
+ * Check if package manager is yarn classic.
+ */
+export function isYarnClassic(packageManager: NodePackageManager): boolean {
+  return (
+    packageManager === NodePackageManager.YARN ||
+    packageManager === NodePackageManager.YARN_CLASSIC
+  );
+}
+
+/**
+ * Check if package manager is yarn berry.
+ */
+export function isYarnBerry(packageManager: NodePackageManager): boolean {
+  return (
+    packageManager === NodePackageManager.YARN2 ||
+    packageManager === NodePackageManager.YARN_BERRY
+  );
+}
+
+/**
+ * Check if package manager is npm.
+ */
+export function isNpm(packageManager: NodePackageManager): boolean {
+  return packageManager === NodePackageManager.NPM;
+}
 
 /**
  * Basic interface for `package.json`.

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -1226,7 +1226,7 @@ tsconfig.tsbuildinfo
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,aws-sdk,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii-diff,jsii-pacmak,projen,ts-jest,typescript"
+          "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,aws-sdk,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii-diff,jsii-pacmak,projen,ts-jest,typescript"
         },
         {
           "exec": "yarn install --check-files"
@@ -2289,7 +2289,7 @@ tsconfig.tsbuildinfo
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/follow-redirects,@types/jest,@types/json-stable-stringify,@types/yaml,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii-diff,jsii-pacmak,json-schema-to-typescript,projen,ts-jest,typescript,fast-json-patch,follow-redirects,json-stable-stringify,yaml,constructs"
+          "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/follow-redirects,@types/jest,@types/json-stable-stringify,@types/yaml,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii-diff,jsii-pacmak,json-schema-to-typescript,projen,ts-jest,typescript,fast-json-patch,follow-redirects,json-stable-stringify,yaml,constructs"
         },
         {
           "exec": "yarn install --check-files"
@@ -3405,7 +3405,7 @@ tsconfig.tsbuildinfo
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/fs-extra,@types/jest,@types/json-schema,eslint-import-resolver-typescript,eslint-plugin-import,jest,projen,ts-jest,typescript,@types/node,codemaker,colors,constructs,fs-extra,jsii-pacmak,jsii-srcmak,json2jsii,sscaff,yaml,yargs"
+          "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/fs-extra,@types/jest,@types/json-schema,eslint-import-resolver-typescript,eslint-plugin-import,jest,projen,ts-jest,typescript,@types/node,codemaker,colors,constructs,fs-extra,jsii-pacmak,jsii-srcmak,json2jsii,sscaff,yaml,yargs"
         },
         {
           "exec": "yarn install --check-files"
@@ -4545,7 +4545,7 @@ resolution-mode=highest
       },
       "steps": [
         {
-          "exec": "pnpm dlx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=aws-sdk,jest,projen,esbuild"
+          "exec": "pnpm dlx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=aws-sdk,jest,projen,esbuild"
         },
         {
           "exec": "pnpm i --no-frozen-lockfile"

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -1116,7 +1116,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "upgrade",
         "steps": [
           {
-            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii-diff,jsii-pacmak,projen,ts-jest,typescript",
+            "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii-diff,jsii-pacmak,projen,ts-jest,typescript",
           },
           {
             "exec": "yarn install --check-files",

--- a/test/cdk8s/cdk8s-app-project-ts.test.ts
+++ b/test/cdk8s/cdk8s-app-project-ts.test.ts
@@ -186,7 +186,7 @@ test("upgrade task ignores pinned versions", () => {
   expect(tasks.upgrade.steps).toMatchInlineSnapshot(`
     [
       {
-        "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-import-resolver-typescript,eslint-plugin-import,jest,projen,ts-jest,typescript",
+        "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-import-resolver-typescript,eslint-plugin-import,jest,projen,ts-jest,typescript",
       },
       {
         "exec": "yarn install --check-files",

--- a/test/javascript/upgrade-dependencies.test.ts
+++ b/test/javascript/upgrade-dependencies.test.ts
@@ -21,7 +21,7 @@ test("allows including deprecated versions", () => {
   const tasks = synthSnapshot(project)[TaskRuntime.MANIFEST_FILE].tasks;
   expect(tasks.upgrade.steps[0]).toMatchInlineSnapshot(`
     {
-      "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --deprecated --dep=dev,peer,prod,optional --filter=jest,projen,some-dep",
+      "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --deprecated --dep=dev,peer,prod,optional --filter=jest,projen,some-dep",
     }
   `);
 });
@@ -52,7 +52,7 @@ test("allows configuring specific dependency types", () => {
   expect(tasks.upgrade.steps).toMatchInlineSnapshot(`
     [
       {
-        "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=prod,dev --filter=some-dep,jest,projen",
+        "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=prod,dev --filter=some-dep,jest,projen",
       },
       {
         "exec": "yarn install --check-files",
@@ -94,7 +94,7 @@ test("upgrades command includes all dependencies", () => {
   expect(tasks.upgrade.steps).toMatchInlineSnapshot(`
     [
       {
-        "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=jest,projen,some-dep",
+        "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=jest,projen,some-dep",
       },
       {
         "exec": "yarn install --check-files",
@@ -124,7 +124,7 @@ test("ncu upgrade command does not include dependencies with any version constra
   expect(tasks.upgrade.steps).toMatchInlineSnapshot(`
     [
       {
-        "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=jest,projen",
+        "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=jest,projen",
       },
       {
         "exec": "yarn install --check-files",
@@ -154,7 +154,7 @@ test("ncu upgrade command should include dependencies with * versions, along wit
   expect(tasks.upgrade.steps).toMatchInlineSnapshot(`
     [
       {
-        "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=jest,projen,some-dep",
+        "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=jest,projen,some-dep",
       },
       {
         "exec": "yarn install --check-files",
@@ -216,7 +216,7 @@ test("upgrades command includes dependencies added post instantiation", () => {
   expect(tasks.upgrade.steps).toMatchInlineSnapshot(`
     [
       {
-        "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=jest,projen,some-dep",
+        "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=jest,projen,some-dep",
       },
       {
         "exec": "yarn install --check-files",
@@ -246,7 +246,7 @@ test("upgrades command doesn't include ignored packages", () => {
   expect(tasks.upgrade.steps).toMatchInlineSnapshot(`
     [
       {
-        "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=jest,projen,dep1",
+        "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=jest,projen,dep1",
       },
       {
         "exec": "yarn install --check-files",
@@ -273,8 +273,8 @@ test("upgrades command includes only included packages", () => {
   });
 
   const tasks = synthSnapshot(project)[TaskRuntime.MANIFEST_FILE].tasks;
-  expect(tasks.upgrade.steps[0].exec).toStrictEqual(
-    `npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=dep1`
+  expect(tasks.upgrade.steps[0].exec).toMatchInlineSnapshot(
+    `"npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=dep1"`
   );
   expect(tasks.upgrade.steps[2].exec).toStrictEqual(`yarn upgrade dep1`);
 });
@@ -500,7 +500,7 @@ test("upgrade task created without projen defined versions at NodeProject", () =
   expect(tasks.upgrade.steps).toMatchInlineSnapshot(`
     [
       {
-        "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=jest,projen",
+        "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=jest,projen",
       },
       {
         "exec": "yarn install --check-files",
@@ -546,13 +546,37 @@ test("uses the proper yarn berry upgrade command", () => {
   expect(tasks.upgrade.steps).toMatchInlineSnapshot(`
     [
       {
-        "exec": "yarn dlx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=jest,projen",
+        "exec": "yarn dlx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=jest,projen",
       },
       {
         "exec": "yarn install",
       },
       {
         "exec": "yarn up commit-and-tag-version constructs jest jest-junit projen",
+      },
+      {
+        "exec": "npx projen",
+      },
+      {
+        "spawn": "post-upgrade",
+      },
+    ]
+  `);
+});
+
+test("disabling transitive dependency upgrades uses ncu --install=always", () => {
+  const project = createProject({
+    deps: ["some-dep"],
+    depsUpgradeOptions: {
+      upgradeTransitiveDependencies: false,
+    },
+  });
+
+  const tasks = synthSnapshot(project)[TaskRuntime.MANIFEST_FILE].tasks;
+  expect(tasks.upgrade.steps).toMatchInlineSnapshot(`
+    [
+      {
+        "exec": "npx npm-check-updates@18 --upgrade --target=minor --install=always --peer --no-deprecated --dep=dev,peer,prod,optional --filter=jest,projen,some-dep",
       },
       {
         "exec": "npx projen",

--- a/test/jsii/__snapshots__/jsii.test.ts.snap
+++ b/test/jsii/__snapshots__/jsii.test.ts.snap
@@ -1116,7 +1116,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "upgrade",
         "steps": [
           {
-            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii-diff,jsii-pacmak,projen,ts-jest,typescript",
+            "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii-diff,jsii-pacmak,projen,ts-jest,typescript",
           },
           {
             "exec": "yarn install --check-files",
@@ -2627,7 +2627,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "upgrade",
         "steps": [
           {
-            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii,jsii-diff,jsii-docgen,jsii-pacmak,jsii-rosetta,projen,ts-jest,typescript",
+            "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii,jsii-diff,jsii-docgen,jsii-pacmak,jsii-rosetta,projen,ts-jest,typescript",
           },
           {
             "exec": "yarn install --check-files",
@@ -4140,7 +4140,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "upgrade",
         "steps": [
           {
-            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii-diff,jsii-pacmak,projen,ts-jest,typescript",
+            "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii-diff,jsii-pacmak,projen,ts-jest,typescript",
           },
           {
             "exec": "yarn install --check-files",

--- a/test/typescript/__snapshots__/typescript.test.ts.snap
+++ b/test/typescript/__snapshots__/typescript.test.ts.snap
@@ -959,7 +959,7 @@ tsconfig.tsbuildinfo
         "name": "upgrade",
         "steps": [
           {
-            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-import-resolver-typescript,eslint-plugin-import,jest,projen,ts-jest,typescript",
+            "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,eslint-import-resolver-typescript,eslint-plugin-import,jest,projen,ts-jest,typescript",
           },
           {
             "exec": "yarn install --check-files",

--- a/test/typescript/typescript.test.ts
+++ b/test/typescript/typescript.test.ts
@@ -264,7 +264,7 @@ test("upgrade task ignores pinned versions", () => {
   expect(tasks.upgrade.steps).toMatchInlineSnapshot(`
     [
       {
-        "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,eslint-import-resolver-typescript,eslint-plugin-import,jest,projen,ts-jest",
+        "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,eslint-import-resolver-typescript,eslint-plugin-import,jest,projen,ts-jest",
       },
       {
         "exec": "yarn install --check-files",

--- a/test/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-project.test.ts.snap
@@ -670,7 +670,7 @@ permissions-backup.acl
         "name": "upgrade",
         "steps": [
           {
-            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=projen,autoprefixer,next,postcss,react,react-dom,tailwindcss",
+            "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=projen,autoprefixer,next,postcss,react,react-dom,tailwindcss",
           },
           {
             "exec": "yarn install --check-files",

--- a/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -543,7 +543,7 @@ tsconfig.tsbuildinfo
         "name": "upgrade",
         "steps": [
           {
-            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/react,@types/react-dom,projen,typescript,autoprefixer,next,postcss,react,react-dom,tailwindcss",
+            "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/react,@types/react-dom,projen,typescript,autoprefixer,next,postcss,react,react-dom,tailwindcss",
           },
           {
             "exec": "yarn install --check-files",

--- a/test/web/__snapshots__/react-project.test.ts.snap
+++ b/test/web/__snapshots__/react-project.test.ts.snap
@@ -637,7 +637,7 @@ permissions-backup.acl
         "name": "upgrade",
         "steps": [
           {
-            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@testing-library/dom,@testing-library/jest-dom,@testing-library/react,@testing-library/user-event,projen,react,react-dom,web-vitals",
+            "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@testing-library/dom,@testing-library/jest-dom,@testing-library/react,@testing-library/user-event,projen,react,react-dom,web-vitals",
           },
           {
             "exec": "yarn install --check-files",

--- a/test/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/react-ts-project.test.ts.snap
@@ -797,7 +797,7 @@ tsconfig.tsbuildinfo
         "name": "upgrade",
         "steps": [
           {
-            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@testing-library/dom,@testing-library/jest-dom,@testing-library/react,@testing-library/user-event,@types/jest,@types/react,@types/react-dom,eslint-import-resolver-typescript,eslint-plugin-import,projen,react,react-dom,web-vitals",
+            "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@testing-library/dom,@testing-library/jest-dom,@testing-library/react,@testing-library/user-event,@types/jest,@types/react,@types/react-dom,eslint-import-resolver-typescript,eslint-plugin-import,projen,react,react-dom,web-vitals",
           },
           {
             "exec": "yarn install --check-files",


### PR DESCRIPTION
Adds control over transitive dependency upgrades to allow users to opt out of upgrading indirect dependencies.

## Usage

```typescript
const project = new NodeProject({
  name: 'my-project',
  depsUpgradeOptions: {
    upgradeTransitiveDependencies: false,
  },
});
```

## Motivation

Currently, the upgrade workflow always upgrades both direct and transitive dependencies using the package manager's upgrade command. This can lead to unexpected changes in transitive dependencies that may not be desired in all scenarios.

Some users may want to:
- Only upgrade direct dependencies they explicitly control
- Avoid potential breaking changes from transitive dependency updates
- Have more predictable and minimal upgrade PRs
- Let the package manager resolve transitive versions based on direct dependency updates

## Changes

- Added `upgradeTransitiveDependencies` option (defaults to `true` for backward compatibility)
- When disabled, uses npm-check-updates' `--install=always` flag to handle installation
- Refactored ncu command building into `buildNcuCommand()` helper method
- Added test coverage for the new option

## Behavior

**When enabled (default):**
- Updates direct dependencies in package.json via ncu
- Runs package manager install
- Runs package manager upgrade command to also update transitive deps

**When disabled:**
- Updates direct dependencies in package.json via ncu with `--install=always`
- Skips package manager upgrade command
- Only transitive deps required by updated direct deps are changed


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
