### PR TITLE
fix(release): remove node 24.x workaround for trusted publishing

### DIFF
--- a/src/release/publisher.ts
+++ b/src/release/publisher.ts
@@ -376,20 +376,8 @@ export class Publisher extends Component {
         );
       }
 
-      let publishTools = PUBLIB_TOOLCHAIN.js;
-      if (options.trustedPublishing && this.workflowNodeVersion == "lts/*") {
-        // trusted publishing requires node 24.x and above
-        // lts/* is currently 22.x
-        // @todo remove once node 24.x is lts
-        publishTools = {
-          node: {
-            version: "24.x",
-          },
-        };
-      }
-
       return {
-        publishTools,
+        publishTools: PUBLIB_TOOLCHAIN.js,
         prePublishSteps,
         postPublishSteps: options.postPublishSteps ?? [],
         environment: options.githubEnvironment ?? branchOptions.environment,

--- a/test/release/publisher-trusted-publishing.test.ts
+++ b/test/release/publisher-trusted-publishing.test.ts
@@ -52,16 +52,6 @@ describe("Publisher Trusted Publishing Validation", () => {
       const workflow = release.publisher._renderJobsForBranch("main", {});
       expect(workflow.release_npm.tools?.node?.version).toBe("lts/*");
     });
-
-    test("node version is set to 24 when trustedPublishing is enabled", () => {
-      expect(() => {
-        release.publisher.publishToNpm({
-          trustedPublishing: true,
-        });
-      }).not.toThrow();
-      const workflow = release.publisher._renderJobsForBranch("main", {});
-      expect(workflow.release_npm.tools?.node?.version).toBe("24.x");
-    });
   });
 
   describe("publishToNuget", () => {


### PR DESCRIPTION
Removes the temporary workaround that forced Node 24.x for trusted publishing when `lts/*` was configured.

Since Node 24.x is now LTS, the workaround introduced in #4405 is no longer necessary and can be safely removed.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.