### PR TITLE
fix(new): `projen new --from` fails when `NODE_ENV=production`

### DIFF
--- a/src/cli/util.ts
+++ b/src/cli/util.ts
@@ -56,7 +56,10 @@ export function installPackage(
  * @returns The string that includes the install command ("npm install ...")
  */
 export function renderInstallCommand(dir: string, module: string): string {
-  return `npm install --save --save-dev -f --no-package-lock --prefix="${dir}" ${module}`;
+  // --save is needed to override any global save: false config
+  // --save-dev to install as dev dependency
+  // --include=dev to force saving the dependencies with NODE_ENV=production
+  return `npm install --save --save-dev -f --no-package-lock --include=dev --prefix="${dir}" ${module}`;
 }
 
 export function findJsiiFilePath(

--- a/test/new.test.ts
+++ b/test/new.test.ts
@@ -504,6 +504,23 @@ describe("projen new --from", () => {
       });
     });
   });
+
+  describe("projen new --from with NODE_ENV=production", () => {
+    test("should install external module successfully", () => {
+      withProjectDir((projectdir) => {
+        execProjenCLI(
+          projectdir,
+          [
+            "new",
+            "--from",
+            "@pepperize/projen-awscdk-app-ts@0.0.333",
+            "--no-post",
+          ],
+          { ...process.env, NODE_ENV: "production" }
+        );
+      });
+    });
+  });
 });
 
 describe("typescript project", () => {


### PR DESCRIPTION
Fixes #4456

When `NODE_ENV=production` is set, `npm` refuses to install packages as dev dependencies. So we add an `--include=dev` to tell `npm` that we really mean it. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
