### PR TITLE
feat(cdk): add NODEJS_24_X Lambda runtime

### DIFF
--- a/docs/api/awscdk.md
+++ b/docs/api/awscdk.md
@@ -23336,6 +23336,7 @@ The Node.js runtime to use.
 | <code><a href="#projen.awscdk.LambdaRuntime.property.NODEJS_18_X">NODEJS_18_X</a></code> | <code><a href="#projen.awscdk.LambdaRuntime">LambdaRuntime</a></code> | Node.js 18.x. |
 | <code><a href="#projen.awscdk.LambdaRuntime.property.NODEJS_20_X">NODEJS_20_X</a></code> | <code><a href="#projen.awscdk.LambdaRuntime">LambdaRuntime</a></code> | Node.js 20.x. |
 | <code><a href="#projen.awscdk.LambdaRuntime.property.NODEJS_22_X">NODEJS_22_X</a></code> | <code><a href="#projen.awscdk.LambdaRuntime">LambdaRuntime</a></code> | Node.js 22.x. |
+| <code><a href="#projen.awscdk.LambdaRuntime.property.NODEJS_24_X">NODEJS_24_X</a></code> | <code><a href="#projen.awscdk.LambdaRuntime">LambdaRuntime</a></code> | Node.js 24.x. |
 
 ---
 
@@ -23430,6 +23431,18 @@ public readonly NODEJS_22_X: LambdaRuntime;
 - *Type:* <a href="#projen.awscdk.LambdaRuntime">LambdaRuntime</a>
 
 Node.js 22.x.
+
+---
+
+##### `NODEJS_24_X`<sup>Required</sup> <a name="NODEJS_24_X" id="projen.awscdk.LambdaRuntime.property.NODEJS_24_X"></a>
+
+```typescript
+public readonly NODEJS_24_X: LambdaRuntime;
+```
+
+- *Type:* <a href="#projen.awscdk.LambdaRuntime">LambdaRuntime</a>
+
+Node.js 24.x.
 
 ---
 

--- a/src/awscdk/lambda-function.ts
+++ b/src/awscdk/lambda-function.ts
@@ -366,6 +366,14 @@ export class LambdaRuntime {
     "node22"
   );
 
+  /**
+   * Node.js 24.x
+   */
+  public static readonly NODEJS_24_X = new LambdaRuntime(
+    "nodejs24.x",
+    "node24"
+  );
+
   public readonly esbuildPlatform = "node";
 
   public readonly defaultExternals: string[];


### PR DESCRIPTION
AWS just released support for the NodeJS 24 runtime, so trying to upgrade my project.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
