### PR TITLE
Support for tag based release triggers

### DIFF
--- a/src/release/release-trigger.ts
+++ b/src/release/release-trigger.ts
@@ -41,6 +41,13 @@ export interface ContinuousReleaseOptions {
   readonly paths?: string[];
 }
 
+export interface TagReleaseOptions {
+  /**
+   * Tag patterns for which pushes should trigger a release
+   */
+  readonly tags?: string[];
+}
+
 interface ReleaseTriggerOptions {
   /**
    * Project-level changelog file path.
@@ -81,6 +88,11 @@ interface ReleaseTriggerOptions {
    * Only a workflowDispatch trigger
    */
   readonly workflowDispatchOnly?: boolean;
+
+  /**
+   * Tag patterns for which pushes should trigger a release
+   */
+  readonly tags?: string[];
 }
 
 /**
@@ -158,6 +170,17 @@ export class ReleaseTrigger {
   }
 
   /**
+   * Creates a tag-based release trigger.
+   *
+   * Automated releases will occur on every new tag matching the provided patterns.
+   */
+  public static tagged(options: TagReleaseOptions = {}) {
+    return new ReleaseTrigger({
+      tags: options.tags,
+    });
+  }
+
+  /**
    * Project-level changelog file path.
    */
   public readonly changelogPath?: string;
@@ -182,6 +205,11 @@ export class ReleaseTrigger {
   public readonly paths?: string[];
 
   /**
+   * Tag patterns for which pushes will trigger a release
+   */
+  public readonly tags?: string[];
+
+  /**
    * Override git-push command used when releasing manually.
    *
    * Set to an empty string to disable pushing.
@@ -197,6 +225,7 @@ export class ReleaseTrigger {
     this.changelogPath = options.changelogPath;
     this.gitPushCommand = options.gitPushCommand;
     this.workflowDispatchOnly = options.workflowDispatchOnly;
+    this.tags = options.tags;
   }
 
   /**
@@ -205,6 +234,9 @@ export class ReleaseTrigger {
    * If the `ReleaseTrigger` is a GitHub-only manual task, this will return `false`.
    */
   public get isManual() {
-    return !(this.isContinuous || this.schedule) && !this.workflowDispatchOnly;
+    return (
+      !(this.isContinuous || this.schedule || this.tags) &&
+      !this.workflowDispatchOnly
+    );
   }
 }

--- a/test/release/release-trigger.test.ts
+++ b/test/release/release-trigger.test.ts
@@ -19,6 +19,10 @@ describe("manual release", () => {
     expect(releaseTrigger.schedule).toBeUndefined();
   });
 
+  test("does not have tags", () => {
+    expect(releaseTrigger.tags).toBeUndefined();
+  });
+
   test("is manual", () => {
     expect(releaseTrigger.isManual).toBe(true);
   });
@@ -70,6 +74,10 @@ describe("continuous release", () => {
     expect(releaseTrigger.schedule).toBeUndefined();
   });
 
+  test("does not have tags", () => {
+    expect(releaseTrigger.tags).toBeUndefined();
+  });
+
   test("does not have a changelog", () => {
     expect(releaseTrigger.changelogPath).toBeUndefined();
   });
@@ -108,6 +116,40 @@ describe("scheduled release", () => {
 
   test("has a schedule", () => {
     expect(releaseTrigger.schedule).toEqual(releaseSchedule);
+  });
+
+  test("does not have tags", () => {
+    expect(releaseTrigger.tags).toBeUndefined();
+  });
+
+  test("does not have a changelog", () => {
+    expect(releaseTrigger.changelogPath).toBeUndefined();
+  });
+});
+
+describe("tagged release", () => {
+  let tags = ["v*.*.*", "!v*.*.*-**"];
+
+  beforeAll(() => {
+    releaseTrigger = ReleaseTrigger.tagged({
+      tags: tags,
+    });
+  });
+
+  test("is not continuous", () => {
+    expect(releaseTrigger.isContinuous).toBe(false);
+  });
+
+  test("is not manual", () => {
+    expect(releaseTrigger.isManual).toBe(false);
+  });
+
+  test("does not have a schedule", () => {
+    expect(releaseTrigger.schedule).toBeUndefined();
+  });
+
+  test("does have tags", () => {
+    expect(releaseTrigger.tags).toEqual(tags);
   });
 
   test("does not have a changelog", () => {


### PR DESCRIPTION
Fixes #4048

This PR only provides the required changes for the first part of the linked issue:
* A new `ReleaseTrigger` for tags

Changes:

* Extended `ReleaseTrigger` to accept tags

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
