### PR TITLE
fix(cli): running projen in subdirectory fails with default task not found

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,8 +12,6 @@ import * as logging from "../logging";
 import { TaskRuntime } from "../task-runtime";
 import { findUp, getNodeMajorVersion } from "../util";
 
-const DEFAULT_RC = resolve(DEFAULT_PROJEN_RC_JS_FILENAME);
-
 async function main() {
   const ya = yargs;
   ya.command(newCommand);
@@ -41,7 +39,11 @@ async function main() {
   ya.options("rc", {
     deprecated: true,
     desc: "path to .projenrc.js file",
-    default: DEFAULT_RC,
+    // must be `defaultDescription` and not an actual `default` value,
+    // since a default would make the CLI think --rc was passed
+    // and later skip a perfectly fine modern default task.
+    // The actual default value is set again later on.
+    defaultDescription: resolve(DEFAULT_PROJEN_RC_JS_FILENAME),
     type: "string",
   });
   ya.completion();

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -74,6 +74,14 @@ test('running "projen" with task in subdirectory of a project will execute task 
   expect(directorySnapshot(project.outdir)["bar.txt"]).toStrictEqual("foo\n");
 });
 
+test('running "projen" without specifying a task it in subdirectory of a project will execute default task of the project', () => {
+  const project = new Project({ name: "my-project" });
+  project.synth();
+  const subdirectory = mkdtemp({ dir: project.outdir });
+
+  execProjenCLI(subdirectory, []); // no task specified
+});
+
 test('running "projen" with task in root of a subproject will execute task of the subproject', () => {
   const project = new Project({ name: "my-project" });
   const subProject = new Project({


### PR DESCRIPTION
Running `projen` without arguments in a subdirectory would fail with:

```
👾 Default task skipped. Trying legacy synthesis since --rc is specified
👾 Synthesis failed: Unable to find a task named "default"
```

This happened because the deprecated `--rc` option had an actual `default` value set. Yargs treats this as if the user explicitly passed the option, causing the CLI to think an explicit `--rc` file was requested and skip the modern default task execution path.

Switching to `defaultDescription` fixes this. The help text still shows the default value, but yargs no longer considers the option as "provided" when the user didn't pass it.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
