### PR TITLE
fix(awscdk): correct indentation in generated Lambda function interfaces

### DIFF
--- a/src/awscdk/lambda-function.ts
+++ b/src/awscdk/lambda-function.ts
@@ -241,13 +241,13 @@ export class LambdaFunction extends Component {
     // Add runtime prop to interface only when runtime is not explicitly set
     // This allows consumers to override the default NODEJS_REGIONAL_LATEST
     if (!options.runtime) {
-      src.line("  /**");
-      src.line("   * The Lambda runtime to use.");
+      src.line("/**");
+      src.line(" * The Lambda runtime to use.");
       src.line(
-        "   * @default - Latest Node.js runtime available in the deployment region"
+        " * @default - Latest Node.js runtime available in the deployment region"
       );
-      src.line("   */");
-      src.line("  readonly runtime?: lambda.Runtime;");
+      src.line(" */");
+      src.line("readonly runtime?: lambda.Runtime;");
     }
     src.close("}");
     src.line();

--- a/test/awscdk/__snapshots__/lambda-function.test.ts.snap
+++ b/test/awscdk/__snapshots__/lambda-function.test.ts.snap
@@ -11,11 +11,11 @@ import { Construct } from '@aws-cdk/core';
  * Props for HelloFunction
  */
 export interface HelloFunctionProps extends cloudfront.experimental.EdgeFunctionProps {
-    /**
-     * The Lambda runtime to use.
-     * @default - Latest Node.js runtime available in the deployment region
-     */
-    readonly runtime?: lambda.Runtime;
+  /**
+   * The Lambda runtime to use.
+   * @default - Latest Node.js runtime available in the deployment region
+   */
+  readonly runtime?: lambda.Runtime;
 }
 
 /**
@@ -75,11 +75,11 @@ import { Construct } from 'constructs';
  * Props for HelloFunction
  */
 export interface HelloFunctionProps extends lambda.FunctionOptions {
-    /**
-     * The Lambda runtime to use.
-     * @default - Latest Node.js runtime available in the deployment region
-     */
-    readonly runtime?: lambda.Runtime;
+  /**
+   * The Lambda runtime to use.
+   * @default - Latest Node.js runtime available in the deployment region
+   */
+  readonly runtime?: lambda.Runtime;
 }
 
 /**
@@ -286,11 +286,11 @@ import { Construct } from '@aws-cdk/core';
  * Props for HelloFunction
  */
 export interface HelloFunctionProps extends lambda.FunctionOptions {
-    /**
-     * The Lambda runtime to use.
-     * @default - Latest Node.js runtime available in the deployment region
-     */
-    readonly runtime?: lambda.Runtime;
+  /**
+   * The Lambda runtime to use.
+   * @default - Latest Node.js runtime available in the deployment region
+   */
+  readonly runtime?: lambda.Runtime;
 }
 
 /**
@@ -323,11 +323,11 @@ import { Construct } from 'constructs';
  * Props for HelloFunction
  */
 export interface HelloFunctionProps extends lambda.FunctionOptions {
-    /**
-     * The Lambda runtime to use.
-     * @default - Latest Node.js runtime available in the deployment region
-     */
-    readonly runtime?: lambda.Runtime;
+  /**
+   * The Lambda runtime to use.
+   * @default - Latest Node.js runtime available in the deployment region
+   */
+  readonly runtime?: lambda.Runtime;
 }
 
 /**
@@ -357,11 +357,11 @@ import { Construct } from '@aws-cdk/core';
  * Props for HelloFunction
  */
 export interface HelloFunctionProps extends lambda.FunctionOptions {
-    /**
-     * The Lambda runtime to use.
-     * @default - Latest Node.js runtime available in the deployment region
-     */
-    readonly runtime?: lambda.Runtime;
+  /**
+   * The Lambda runtime to use.
+   * @default - Latest Node.js runtime available in the deployment region
+   */
+  readonly runtime?: lambda.Runtime;
 }
 
 /**
@@ -391,11 +391,11 @@ import { Construct } from '@aws-cdk/core';
  * Props for WorldFunction
  */
 export interface WorldFunctionProps extends lambda.FunctionOptions {
-    /**
-     * The Lambda runtime to use.
-     * @default - Latest Node.js runtime available in the deployment region
-     */
-    readonly runtime?: lambda.Runtime;
+  /**
+   * The Lambda runtime to use.
+   * @default - Latest Node.js runtime available in the deployment region
+   */
+  readonly runtime?: lambda.Runtime;
 }
 
 /**


### PR DESCRIPTION

Fixes the double indentation bug introduced in #4488 where generated Lambda function interface properties had incorrect indentation (4 spaces instead of 2), causing ESLint to fail when trying to auto-fix the readonly generated files.

## Problem

The runtime property documentation in generated Lambda function files had incorrect indentation because `src.line()` was being called with manual spacing prefixes (`"  "`, `"   "`), while the method already handles indentation automatically based on `indentLevel`.

This resulted in:
- **Double indentation**: 4 spaces instead of 2
- **ESLint failures**: `EACCES: permission denied` when trying to auto-fix readonly generated files
- **Build breaks**: Projects using projen's Lambda auto-discovery would fail on the eslint step

### Before (Incorrect - 4 spaces):
```typescript
export interface DetectDriftFunctionProps extends lambda.FunctionOptions {
    /**
     * The Lambda runtime to use.
     * @default - Latest Node.js runtime available in the deployment region
     */
    readonly runtime?: lambda.Runtime;
}
```

### After (Correct - 2 spaces):
```typescript
export interface DetectDriftFunctionProps extends lambda.FunctionOptions {
  /**
   * The Lambda runtime to use.
   * @default - Latest Node.js runtime available in the deployment region
   */
  readonly runtime?: lambda.Runtime;
}
```

## Testing

- ✅ All tests pass
- ✅ ESLint passes
- ✅ Test snapshots updated to reflect correct 2-space indentation
- ✅ Generated Lambda function files now have proper indentation

## Related

- Fixes issue introduced in #4488
- Resolves ESLint failures in projects using Lambda auto-discovery with the new `NODEJS_REGIONAL_LATEST` default runtime

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
