### PR TITLE
chore: use projen-automation user for repo automation

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    if: contains(github.event.pull_request.labels.*.name, 'auto-approve') && (github.event.pull_request.user.login == 'cdklabs-automation')
+    if: contains(github.event.pull_request.labels.*.name, 'auto-approve') && (github.event.pull_request.user.login == 'projen-automation')
     steps:
       - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363
         with:

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -37,7 +37,7 @@ jobs:
       PR_BODY: ${{ github.event.pull_request.body }}
       EXPECTED: By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
       HELP: Contributor statement missing from PR description. Please include the following text in the PR description
-    if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && !(github.event.pull_request.user.login == 'cdklabs-automation' || github.event.pull_request.user.login == 'dependabot[bot]')
+    if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && !(github.event.pull_request.user.login == 'projen-automation' || github.event.pull_request.user.login == 'dependabot[bot]')
     steps:
       - uses: actions/github-script@v8
         with:

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -124,7 +124,7 @@
       "name": "contributors:update",
       "steps": [
         {
-          "exec": "all-contributors check | grep \"Missing contributors\" -A 1 | tail -n1 | sed -e \"s/,//g\" | xargs -n1 | grep -v \"\\[bot\\]\" | grep -v \"cdklabs-automation\" | xargs -n1 -I{} all-contributors add {} code"
+          "exec": "all-contributors check | grep \"Missing contributors\" -A 1 | tail -n1 | sed -e \"s/,//g\" | xargs -n1 | grep -v \"\\[bot\\]\" | grep -v \"cdklabs-automation\" | grep -v \"projen-automation\" | xargs -n1 -I{} all-contributors add {} code"
         }
       ]
     },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -27,7 +27,8 @@ import {
 import { JsiiProject } from "./src/cdk";
 import { tryResolveDependencyVersion } from "./src/javascript/util";
 
-const bootstrapScriptFile = "projen.js";
+const AUTOMATION_USER = "projen-automation";
+const BOOTSTRAP_SCRIPT = "projen.js";
 
 const project = new JsiiProject({
   name: "projen",
@@ -55,7 +56,7 @@ const project = new JsiiProject({
       contributorStatement:
         "By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.",
       contributorStatementOptions: {
-        exemptUsers: ["cdklabs-automation", "dependabot[bot]"],
+        exemptUsers: [AUTOMATION_USER, "dependabot[bot]"],
       },
     },
   },
@@ -121,7 +122,7 @@ const project = new JsiiProject({
   gitpod: true,
   devContainer: true,
   // since this is projen, we need to always compile before we run
-  projenCommand: `node ./${bootstrapScriptFile}`,
+  projenCommand: `node ./${BOOTSTRAP_SCRIPT}`,
   projenrcTs: true,
 
   // Disable interop since it's disabled available in jsii
@@ -177,7 +178,7 @@ const project = new JsiiProject({
   releaseFailureIssue: true,
 
   autoApproveUpgrades: true,
-  autoApproveOptions: { allowedUsernames: ["cdklabs-automation"] },
+  autoApproveOptions: { allowedUsernames: [AUTOMATION_USER] },
   checkLicenses: {
     allow: [
       "MIT",
@@ -204,7 +205,7 @@ setupUpgradeDependencies(project);
 
 setupJsiiDocgen(project);
 
-setupProjenBootstrap(project, bootstrapScriptFile);
+setupProjenBootstrap(project, BOOTSTRAP_SCRIPT);
 
 // because snapshots include the projen marker...
 project.addExcludeFromCleanup("test/**");

--- a/projenrc/index.ts
+++ b/projenrc/index.ts
@@ -302,7 +302,7 @@ export function setupDevcontainer(project: NodeProject) {
  */
 export function setupAllContributors(project: NodeProject) {
   project.addTask("contributors:update", {
-    exec: 'all-contributors check | grep "Missing contributors" -A 1 | tail -n1 | sed -e "s/,//g" | xargs -n1 | grep -v "\\[bot\\]" | grep -v "cdklabs-automation" | xargs -n1 -I{} all-contributors add {} code',
+    exec: 'all-contributors check | grep "Missing contributors" -A 1 | tail -n1 | sed -e "s/,//g" | xargs -n1 | grep -v "\\[bot\\]" | grep -v "cdklabs-automation" | grep -v "projen-automation" | xargs -n1 -I{} all-contributors add {} code',
   });
   project.npmignore?.exclude("/.all-contributorsrc");
 }


### PR DESCRIPTION
Updates the repository automation to use the new `projen-automation` GitHub user instead of `cdklabs-automation`.

This change affects:
- Auto-approve workflow conditions
- PR lint contributor statement exemptions  
- All-contributors update task to exclude the new bot user

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
