### PR TITLE
chore: override projen.version in tree.json for projen repo

### DIFF
--- a/.projen/tree.json
+++ b/.projen/tree.json
@@ -4,7 +4,7 @@
     "metadata": {
       "type": "project",
       "construct": "JsiiProject",
-      "projen.version": "0.0.0"
+      "projen.version": "https://github.com/projen/projen"
     },
     "nodes": {
       "GitAttributesFile@.gitattributes": {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -286,6 +286,11 @@ if (project.defaultTask) {
   project.postCompileTask.spawn(project.defaultTask);
 }
 
+// This is the projen repo itself.
+// We cannot report a version here as it would change during the release version bump and cause the tampering check to fail.
+// Instead we report the repo as fake version. Has no effect on the published package.
+project.node.addMetadata("projen.version", "https://github.com/projen/projen");
+
 new AiInstructions(project, {
   instructions: [
     `# Developing projen itself


### PR DESCRIPTION
The projen repo itself now generates a `tree.json` file with the `projectTree` option. However, the version reported in this file would change during the release version bump, causing the anti-tampering check and thus the release to fail.

This change overrides the `projen.version` metadata with the repository URL as a placeholder. This has no effect on the published package since the metadata is only used for the tree.json file.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
