### PR TITLE
Potential fix for code scanning alert no. 10: Incomplete URL substring sanitization

### DIFF
--- a/src/release/publisher.ts
+++ b/src/release/publisher.ts
@@ -19,6 +19,7 @@ import { CHANGES_SINCE_LAST_RELEASE } from "../version";
 
 const PUBLIB_VERSION = "latest";
 const GITHUB_PACKAGES_REGISTRY = "npm.pkg.github.com";
+const GITHUB_PACKAGES_MAVEN_HOST = "maven.pkg.github.com";
 const ARTIFACTS_DOWNLOAD_DIR = "dist";
 const GITHUB_PACKAGES_MAVEN_REPOSITORY = "https://maven.pkg.github.com";
 const GITHUB_PACKAGES_NUGET_REPOSITORY = "https://nuget.pkg.github.com";
@@ -479,9 +480,21 @@ export class Publisher extends Component {
    * @param options Options
    */
   public publishToMaven(options: MavenPublishOptions = {}) {
-    const isGitHubPackages = options.mavenRepositoryUrl?.startsWith(
-      GITHUB_PACKAGES_MAVEN_REPOSITORY
-    );
+    const isGitHubPackages = (() => {
+      const repoUrl = options.mavenRepositoryUrl;
+      if (!repoUrl) {
+        return false;
+      }
+      try {
+        const parsed = new URL(repoUrl);
+        return (
+          parsed.protocol === "https:" &&
+          parsed.hostname === GITHUB_PACKAGES_MAVEN_HOST
+        );
+      } catch {
+        return false;
+      }
+    })();
     const isGitHubActor =
       isGitHubPackages && options.mavenUsername == undefined;
     const mavenServerId =


### PR DESCRIPTION
Potential fix for [https://github.com/projen/projen/security/code-scanning/10](https://github.com/projen/projen/security/code-scanning/10)

In general, to fix incomplete URL substring/`startsWith` sanitization, parse the URL and explicitly compare the parsed `hostname` (and optionally `protocol`) to an expected value, or check against an allowlist of fully qualified hosts. Avoid relying on substring or prefix checks of the raw URL string, because they can be bypassed or mislead later code.

For this specific case in `publishToMaven`, instead of using `options.mavenRepositoryUrl?.startsWith(GITHUB_PACKAGES_MAVEN_REPOSITORY)`, we should safely parse `options.mavenRepositoryUrl` and determine whether its host equals `maven.pkg.github.com` (the host portion of `GITHUB_PACKAGES_MAVEN_REPOSITORY`) and uses the expected protocol (`https:`). This will robustly classify GitHub Packages URLs regardless of path, query string, or small formatting differences (e.g., trailing slash), and cannot be tricked by arbitrary content after the host. The best way to do this with minimal impact is:

- Import Node’s built-in `URL` class (from the global environment; no extra import strictly needed in modern Node/TS, but we can use it directly).
- Add a small helper within this file (above `publishToMaven`) that:
  - Accepts `mavenRepositoryUrl?: string`.
  - Returns `false` if absent or invalid.
  - Parses with `new URL(urlString)` in a `try/catch`.
  - Returns `true` if `url.hostname === GITHUB_PACKAGES_REGISTRY` (which is already defined as `"npm.pkg.github.com"` for npm, but we should add a new constant for the Maven host if needed) and protocol is `https:`.
- Use this helper to compute `isGitHubPackages` instead of `startsWith`.

However, the code already defines `const GITHUB_PACKAGES_REGISTRY = "npm.pkg.github.com";` for npm, and the alert references `GITHUB_PACKAGES_MAVEN_REPOSITORY` (which we haven’t been shown, but is presumably a full URL like `https://maven.pkg.github.com`). To avoid changing other parts of the codebase, we will:

1. Introduce a new constant in the same file for the Maven host (e.g., `const GITHUB_PACKAGES_MAVEN_HOST = "maven.pkg.github.com";`), derived conceptually from `GITHUB_PACKAGES_MAVEN_REPOSITORY`.
2. Replace the `startsWith` check with a helper that parses `options.mavenRepositoryUrl` with `new URL(...)` and compares `url.hostname` to `GITHUB_PACKAGES_MAVEN_HOST`. We won’t modify `GITHUB_PACKAGES_MAVEN_REPOSITORY` itself, because it is used elsewhere (in code we haven’t seen).
3. Use that helper directly inline (a simple `try`/`catch` with `new URL`) to avoid adding more public API surface.

That keeps existing behavior (identifying GitHub Packages URLs) while fixing the underlying issue.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
