### PR TITLE
chore(ci): add explicit permissions to workflow jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -262,6 +262,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build_matrix
+    permissions: {}
     if: always()
     outputs:
       self_mutation_happened: ${{ needs.build_matrix.outputs.self_mutation_happened }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -15,9 +15,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
-
       - name: Build docs
         working-directory: docusaurus
         run: |

--- a/projenrc/windows-build.ts
+++ b/projenrc/windows-build.ts
@@ -102,6 +102,7 @@ export class WindowsBuild extends Component {
       JsonPatch.add(buildJobPath(), {
         "runs-on": "ubuntu-latest",
         needs: [JOB_BUILD_MATRIX],
+        permissions: {},
         if: "always()",
         outputs: {
           self_mutation_happened: `\${{ needs.${JOB_BUILD_MATRIX}.outputs.self_mutation_happened }}`,


### PR DESCRIPTION
This change hardens the GitHub Actions workflows by adding explicit job-level permissions following the principle of least privilege.

The `build` job in the build workflow and the `build` job in the publish-docs workflow were missing explicit permissions, which means they would inherit the workflow-level permissions. By setting `permissions: {}` (no permissions) or `permissions: { contents: read }` (read-only), we reduce the potential attack surface if a workflow is compromised.

Resolves https://github.com/projen/projen/security/code-scanning/21 and https://github.com/projen/projen/security/code-scanning/2

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
