### PR TITLE
fix: `deepMerge` can pollute the prototype of the target

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -268,6 +268,10 @@ export function deepMerge(
 ) {
   function mergeOne(target: Obj<any>, source: Obj<any>) {
     for (const key of Object.keys(source)) {
+      // Prevent prototype pollution by blocking dangerous keys
+      if (key === "__proto__" || key === "constructor" || key === "prototype") {
+        continue;
+      }
       const value = source[key];
 
       // if the current value is a plain object, we recursively merge it


### PR DESCRIPTION
Fix for [https://github.com/projen/projen/security/code-scanning/13](https://github.com/projen/projen/security/code-scanning/13) and https://github.com/projen/projen/security/code-scanning/12

In general, to fix prototype pollution in deep merge / assignment helpers, you must prevent writes to dangerous keys (`__proto__`, `constructor`, and `prototype`) or only recurse into properties that are safe and belong to the destination. This can be done by short‑circuiting the loop when encountering these keys, thereby preventing attackers from modifying `Object.prototype` or other prototypes via crafted objects.

For this specific `deepMerge` implementation in `src/util.ts`, the minimal, behavior-preserving fix is to add an explicit guard at the top of the `for (const key of Object.keys(source))` loop inside `mergeOne`. That guard should skip keys that can lead to prototype pollution: at least `"__proto__"` and `"constructor"`. Because pollution via `constructor.prototype` is also a common vector, we should additionally skip `"prototype"` to be safe, especially since `mergeOne` can be invoked on nested objects (including possibly a `constructor` object). This change happens entirely inside the `mergeOne` function, does not alter how ordinary keys are merged, and requires no new imports or helpers. All other logic—recursive merging, destructive deletes, and array merging—remains unchanged.

Because projen operates on user controlled machines, with user provided input, this more a theoretical risk.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
