### PR TITLE
feat(source-code): `SourceCode` files can be executable

### DIFF
--- a/docs/api/projen.md
+++ b/docs/api/projen.md
@@ -13180,8 +13180,22 @@ const sourceCodeOptions: SourceCodeOptions = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#projen.SourceCodeOptions.property.executable">executable</a></code> | <code>boolean</code> | Whether the generated file should be marked as executable. |
 | <code><a href="#projen.SourceCodeOptions.property.indent">indent</a></code> | <code>number</code> | Indentation size. |
 | <code><a href="#projen.SourceCodeOptions.property.readonly">readonly</a></code> | <code>boolean</code> | Whether the generated file should be readonly. |
+
+---
+
+##### `executable`<sup>Optional</sup> <a name="executable" id="projen.SourceCodeOptions.property.executable"></a>
+
+```typescript
+public readonly executable: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Whether the generated file should be marked as executable.
 
 ---
 

--- a/src/source-code.ts
+++ b/src/source-code.ts
@@ -18,6 +18,13 @@ export interface SourceCodeOptions {
    * @default true
    */
   readonly readonly?: boolean;
+
+  /**
+   * Whether the generated file should be marked as executable.
+   *
+   * @default false
+   */
+  readonly executable?: boolean;
 }
 
 /**
@@ -37,6 +44,7 @@ export class SourceCode extends Component {
     this.indent = options.indent ?? 2;
     this.file = new TextFile(project, filePath, {
       readonly: options.readonly ?? true,
+      executable: options.executable,
     });
   }
 

--- a/test/source-code.test.ts
+++ b/test/source-code.test.ts
@@ -57,3 +57,21 @@ test("trailing whitespace is trimmed", () => {
     ["", "        hello, world."].join("\n")
   );
 });
+
+test("executable option is passed through to the underlying file", () => {
+  const project = new TestProject();
+  new SourceCode(project, "script.sh", { executable: true });
+
+  const file = project.tryFindFile("script.sh");
+  expect(file).toBeDefined();
+  expect(file!.executable).toBe(true);
+});
+
+test("executable defaults to false", () => {
+  const project = new TestProject();
+  new SourceCode(project, "script.txt");
+
+  const file = project.tryFindFile("script.txt");
+  expect(file).toBeDefined();
+  expect(file!.executable).toBe(false);
+});


### PR DESCRIPTION
Add support for the `executable` option in `SourceCode` class, allowing users to create executable source files (e.g., shell scripts) using the `SourceCode` component.

- Add `executable?:` boolean to `SourceCodeOptions`
- Pass `executable` option through to `TextFile` constructor
- Add tests for executable option

Closes #4501

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
