### PR TITLE
fix(upgrade-dependencies): Explicitly set `--no-immutable` on `yarn install` when `frozen` is false.

### DIFF
--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -1183,7 +1183,10 @@ export class NodePackage extends Component {
         ].join(" ");
       case NodePackageManager.YARN2:
       case NodePackageManager.YARN_BERRY:
-        return ["yarn install", ...(frozen ? ["--immutable"] : [])].join(" ");
+        return [
+          "yarn install",
+          ...(frozen ? ["--immutable"] : ["--no-immutable"]),
+        ].join(" ");
       case NodePackageManager.NPM:
         return frozen ? "npm ci" : "npm install";
       case NodePackageManager.PNPM:

--- a/test/javascript/upgrade-dependencies.test.ts
+++ b/test/javascript/upgrade-dependencies.test.ts
@@ -545,23 +545,23 @@ test("uses the proper yarn berry upgrade command", () => {
 
   const tasks = synthSnapshot(project)[TaskRuntime.MANIFEST_FILE].tasks;
   expect(tasks.upgrade.steps).toMatchInlineSnapshot(`
-    [
-      {
-        "exec": "yarn dlx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=jest,projen",
-      },
-      {
-        "exec": "yarn install",
-      },
-      {
-        "exec": "yarn up commit-and-tag-version constructs jest jest-junit projen",
-      },
-      {
-        "exec": "npx projen",
-      },
-      {
-        "spawn": "post-upgrade",
-      },
-    ]
+   [
+     {
+       "exec": "yarn dlx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=jest,projen",
+     },
+     {
+       "exec": "yarn install --no-immutable",
+     },
+     {
+       "exec": "yarn up commit-and-tag-version constructs jest jest-junit projen",
+     },
+     {
+       "exec": "npx projen",
+     },
+     {
+       "spawn": "post-upgrade",
+     },
+   ]
   `);
 });
 


### PR DESCRIPTION
When `CI` is present as an  environment variable, `yarn` 4 defaults to
`--immutable` when executing `yarn install`. PR#4431 added this
environment variable for the `upgrade` command. As a result, `upgrade` always
fails with "The lockfile would have been modified by this install, which
is explicitly forbidden."

Fixes #

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
