### PR TITLE
chore(docs): remove shell prefix ($) from code blocks in docs

### DIFF
--- a/docs/concepts/projects/building-your-own.md
+++ b/docs/concepts/projects/building-your-own.md
@@ -24,7 +24,7 @@ All projen projects are [jsii](https://github.com/aws/jsii) projects, and you ca
 You start by creating a new jsii project:
 
 ```shell
-$ npx projen new jsii
+npx projen new jsii
 ```
 
 This will create a new jsii project in the current directory. 
@@ -77,7 +77,7 @@ project.synth();
 Since we've changed the contents of the .projenrc.ts file, go ahead and re-run projen:
 
 ```shell
-$ npx projen
+npx projen
 ```
 
 ## Creating the project type
@@ -180,7 +180,7 @@ Then, the `package.json` file is extracted from the snapshot and the `name` prop
 Run the test to make sure it passes:
 
 ```shell
-$ npx projen test
+npx projen test
 ```
 
 You should get some results showing you the test passed as well as some code coverage numbers:
@@ -441,7 +441,7 @@ export class MyMicroserviceProject extends TypeScriptProject {
 And to make sure we didn't break anything after this refactor, let's run the tests again:
 
 ```shell
-$ npx projen test
+npx projen test
 ```
 
 ![all the tests are passing](all-test-passing.png)

--- a/docs/concepts/tasks.md
+++ b/docs/concepts/tasks.md
@@ -19,7 +19,7 @@ hello.exec("echo hello, world!");
 Run `npx projen` and the task will be available in the CLI:
 
 ```shell
-$ npx projen hello
+npx projen hello
 🤖 hello | echo hello, world!
 hello, world!
 ```
@@ -50,7 +50,7 @@ hello.exec("echo foo bar", { name: 'print the text "foo bar"' });
 The `--inspect` option can be used to display the contents of a task:
 
 ```shell
-$ projen hello --inspect
+projen hello --inspect
 echo hello, world!
 echo step number 2
 echo foo bar
@@ -70,7 +70,7 @@ hello.prepend("echo world");
 Then:
 
 ```shell
-$ projen hello 2> /dev/null
+projen hello 2> /dev/null
 world
 hello
 ```
@@ -91,13 +91,13 @@ hello.spawn(world);
 The output will be:
 
 ```shell
-$ projen hello
+projen hello
 🤖 hello | echo hello
 hello
 🤖 hello » world | echo world!
 world!
 
-$ projen hello --inspect
+projen hello --inspect
 echo hello
 world:
    echo world!
@@ -118,7 +118,7 @@ hello.exec("echo $FOO, $BAR $BAZ!", { env: { BAZ: "world" } });
 Then:
 
 ```shell
-$ projen hello
+projen hello
 🤖 hello | echo $FOO, $BAR $BAZ!
 hello, beautiful world!
 ```
@@ -134,7 +134,7 @@ hello.exec("echo current time is $TIME");
 Then:
 
 ```shell
-$ projen hello
+projen hello
 🤖 hello | echo current time is $TIME
 current time is Tue Dec 1 09:32:33 IST 2020
 ```
@@ -155,11 +155,11 @@ const hello = project.addTask("hello", {
 Then:
 
 ```shell
-$ projen hello
+projen hello
 🤖 hello | condition: [ -n "$CI" ]
 🤖 hello | condition exited with non-zero - skipping
 
-$ CI=1 projen hello
+CI=1 projen hello
 🤖 hello | condition: [ -n "$CI" ]
 🤖 hello | echo running in a CI environment
 running in a CI environment
@@ -180,14 +180,14 @@ const hello = project.addTask("hello", {
 Then:
 
 ```shell
-$ projen hello
+projen hello
 🤖 hello | condition: [ -n "$CI" ]
 🤖 hello | condition exited with non-zero - skipping
 🤖 hello | condition: [ ! -n "$CI" ]
 🤖 hello | echo not running in a CI environment
 not running in a CI environment
 
-$ CI=1 projen hello
+CI=1 projen hello
 🤖 hello | condition: [ -n "$CI" ]
 🤖 hello | echo running in a CI environment
 running in a CI environment

--- a/docs/integrations/aws/index.md
+++ b/docs/integrations/aws/index.md
@@ -31,7 +31,7 @@ export async function handler(event: any) {
 Now run:
 
 ```sh
-$ npx projen
+npx projen
 ```
 
 You'll notice that a new file `src/resize-image-function.ts` has been added to

--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -287,7 +287,7 @@ project.gitignore.addPatterns('dist/', 'node_modules/');
 To simplify using projen, consider creating an alias:
 
 ```shell
-$ alias pj="npx projen"
+alias pj="npx projen"
 ```
 Add this line to your shell's startup script (e.g., `~/.bashrc` or `~/.zshrc`) for it to persist across sessions. This 
 documentation will always spell out commands fully in case you prefer not to use aliases.
@@ -298,7 +298,7 @@ If you are making frequent changes to your `.projenrc` file, you can use the `--
 automatically re-run whenever the file changes:
 
 ```shell
-$ npx projen --watch
+npx projen --watch
 ```
 
 This will help streamline your workflow by ensuring that projen updates are applied immediately as you make changes 

--- a/docs/quick-starts/java/hello-world/index.md
+++ b/docs/quick-starts/java/hello-world/index.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 To create a new Java project, use `npx projen new java`:
 
 ```shell
-$ npx projen new java --group-id org.acme --artifact-id hello-maven
+npx projen new java --group-id org.acme --artifact-id hello-maven
 ```
 
 This will synthesize a standard Maven project directory structure with a
@@ -26,7 +26,7 @@ At this point, you should be able to now simply run `npx projen build` to build 
 project:
 
 ```shell
-$ projen build
+projen build
 [INFO] BUILD SUCCESS
 ```
 
@@ -130,7 +130,7 @@ the default for Java projects, but at the moment this needs to be enabled when
 the project is created:
 
 ```shell
-$ npx projen new java --projenrc-java
+npx projen new java --projenrc-java
 ```
 
 Or set through:

--- a/docs/quick-starts/nodejs/rest-api/index.md
+++ b/docs/quick-starts/nodejs/rest-api/index.md
@@ -9,7 +9,7 @@ In this example, we'll guide you through create a Node.js API using [express](ht
 Start by creating a new directory for your project and then using projen to create a new project:
 
 ```shell
-$ npx projen new node
+npx projen new node
 ```
 
 Open the project in your favorite editor. You'll see a number of files and directories have been created:
@@ -69,7 +69,7 @@ project.synth();
 Now, re-run projen:
 
 ```shell
-$ npx projen
+npx projen
 ```
 
 projen regenerates all files, and the only change we see is the "name" in the package.json is now updated:
@@ -102,14 +102,14 @@ project.synth();
 Since we've made a change to the .projenrc.js file, we need to re-run projen:
 
 ```shell
-$ npx projen
+npx projen
 ```
 
 :::tip
 If you know you're going to be making a lot of changes to the .projenrc.js file, you can use the `--watch` option to have projen automatically:
 
 ```shell
-$ npx projen --watch
+npx projen --watch
 ```
 :::
 
@@ -135,7 +135,7 @@ app.listen(port, () => {
 We can start the app now using node:
 
 ```shell
-$ node src/index.js
+node src/index.js
 ```
 
 However, this isn't very convenient and doesn't align with standard practices in Node.js. 
@@ -172,15 +172,15 @@ From here on out, we're going to assume that you know that you need to re-run pr
 Now, we can run our app using the new task:
 
 ```shell
-$ pj start
+pj start
 ```
 
 For Node.js projects, tasks are standard package.json scripts, so you can also use npm, pnpm, or yarn to run the task:
 
 ```shell
-$ npm run start
-$ pnpm start
-$ yarn start
+npm run start
+pnpm start
+yarn start
 ```
 
 Once we have the task running, the website should load in your browser at [http://localhost:3001](http://localhost:3001).

--- a/docs/quick-starts/python/django/index.md
+++ b/docs/quick-starts/python/django/index.md
@@ -14,7 +14,7 @@ want to use.
 To create a new Python project, use `projen new python`:
 
 ```shell
-$ projen new python --name=my-project
+projen new python --name=my-project
 ```
 
 This will synthesize a standard project directory structure with some sample


### PR DESCRIPTION
This PR removes the leading `$` from shell command code blocks to prevent it from being included when users click the copy button on docs website.

How to reproduce:

1 - Navigate to https://projen.io/docs/concepts/projects/building-your-own#creating-a-new-project
2 - Click on the copy button
3 - Check your clipboard. The output includes the shell prefix.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
