### PR TITLE
feat(release): extend `Release` component with git tag support

### DIFF
--- a/src/release/release.ts
+++ b/src/release/release.ts
@@ -782,9 +782,14 @@ export class Release extends Component {
         schedule: this.releaseTrigger.schedule
           ? [{ cron: this.releaseTrigger.schedule }]
           : undefined,
-        push: this.releaseTrigger.isContinuous
-          ? { branches: [branchName], paths: this.releaseTrigger.paths }
-          : undefined,
+        push:
+          this.releaseTrigger.isContinuous || this.releaseTrigger.tags
+            ? {
+                branches: [branchName],
+                tags: this.releaseTrigger.tags,
+                paths: this.releaseTrigger.paths,
+              }
+            : undefined,
         workflowDispatch: {}, // allow manual triggering
       });
 

--- a/test/release/release.test.ts
+++ b/test/release/release.test.ts
@@ -377,6 +377,33 @@ describe("Single Project", () => {
     });
   });
 
+  test("release on push of new tag", () => {
+    // GIVEN
+    const project = new TestProject();
+
+    // WHEN
+    new Release(project, {
+      task: project.buildTask,
+      versionFile: "version.json",
+      branch: "main",
+      releaseTrigger: ReleaseTrigger.tagged({ tags: ["v*.*.*"] }),
+      publishTasks: true, // to increase coverage
+      artifactsDirectory: "dist",
+    });
+
+    // THEN
+    const outdir = synthSnapshot(project);
+    const workflow = YAML.parse(outdir[".github/workflows/release.yml"]);
+    expect(workflow).toMatchObject({
+      on: {
+        push: {
+          tags: ["v*.*.*"],
+        },
+      },
+    });
+    expect(workflow.on.push.paths).toBeUndefined();
+  });
+
   test("workflowDispatch only leads to workflow dispatch trigger", () => {
     // GIVEN
     const project = new TestProject();


### PR DESCRIPTION
Contributes to: #4048

In #4534, I extended `ReleaseTrigger` with git tag support. In this PR, I extended the `Release` component to support workflows based on git tags

@mrgrain can you review please?

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.