### PR TITLE
fix(typescript): default tsconfig types not automatically populated for TypeScript 6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11750,19 +11750,19 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.6",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
-      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
+      "version": "29.4.9",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
+      "integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
         "fast-json-stable-stringify": "^2.1.0",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.3",
+        "semver": "^7.7.4",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -11779,7 +11779,7 @@
         "babel-jest": "^29.0.0 || ^30.0.0",
         "jest": "^29.0.0 || ^30.0.0",
         "jest-util": "^29.0.0 || ^30.0.0",
-        "typescript": ">=4.3 <6"
+        "typescript": ">=4.3 <7"
       },
       "peerDependenciesMeta": {
         "@babel/core": {

--- a/src/typescript/typescript.ts
+++ b/src/typescript/typescript.ts
@@ -617,6 +617,7 @@ export class TypeScriptProject extends NodeProject {
       strictPropertyInitialization: true,
       stripInternal: true,
       target: "ES2020",
+      types: (() => this.resolveInstalledTypes()) as any, // TS6.0 compat, @see https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/#up-front-adjustments
     };
   }
 
@@ -649,6 +650,16 @@ export class TypeScriptProject extends NodeProject {
     }
 
     this.addDevDeps(name);
+  }
+
+  /**
+   * Resolve the `types` compiler option from all installed `@types` dependencies.
+   * Called lazily at synth time so all deps are available.
+   */
+  private resolveInstalledTypes(): string[] {
+    return this.deps.all
+      .filter((d) => d.name.startsWith("@types/"))
+      .map((d) => d.name.replace("@types/", ""));
   }
 
   /**

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -1564,7 +1564,11 @@ test('hello', () => {
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "stripInternal": true,
-    "target": "ES2020"
+    "target": "ES2020",
+    "types": [
+      "jest",
+      "node"
+    ]
   },
   "include": [
     "src/**/*.ts",
@@ -2763,7 +2767,14 @@ test('hello', () => {
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "stripInternal": true,
-    "target": "ES2020"
+    "target": "ES2020",
+    "types": [
+      "follow-redirects",
+      "jest",
+      "json-stable-stringify",
+      "node",
+      "yaml"
+    ]
   },
   "include": [
     "src/**/*.ts",
@@ -3861,7 +3872,14 @@ test('hello', () => {
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "stripInternal": true,
-    "target": "ES2020"
+    "target": "ES2020",
+    "types": [
+      "fs-extra",
+      "jest",
+      "json-schema",
+      "node",
+      "node"
+    ]
   },
   "include": [
     "src/**/*.ts",
@@ -3900,7 +3918,14 @@ test('hello', () => {
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "stripInternal": true,
-    "target": "ES2020"
+    "target": "ES2020",
+    "types": [
+      "fs-extra",
+      "jest",
+      "json-schema",
+      "node",
+      "node"
+    ]
   },
   "include": [
     "src/**/*.ts"

--- a/test/awscdk/__snapshots__/typescript-app.test.ts.snap
+++ b/test/awscdk/__snapshots__/typescript-app.test.ts.snap
@@ -32,6 +32,10 @@ exports[`AwsCdkTypeScriptApp synthesizes with updated tsconfig defaults 1`] = `
     "typeRoots": [
       "./node_modules/@types",
     ],
+    "types": [
+      "jest",
+      "node",
+    ],
   },
   "exclude": [
     "node_modules",

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -1500,6 +1500,10 @@ test('hello', () => {
       "strictPropertyInitialization": true,
       "stripInternal": true,
       "target": "ES2020",
+      "types": [
+        "jest",
+        "node",
+      ],
     },
     "exclude": [
       "node_modules",

--- a/test/javascript/jest.test.ts
+++ b/test/javascript/jest.test.ts
@@ -27,6 +27,7 @@ const compilerOptionDefaults = {
   strictPropertyInitialization: true,
   stripInternal: true,
   target: "ES2020",
+  types: ["jest", "node"],
 };
 
 test("Node Project Jest Defaults Configured", () => {

--- a/test/jsii/__snapshots__/jsii.test.ts.snap
+++ b/test/jsii/__snapshots__/jsii.test.ts.snap
@@ -1500,6 +1500,10 @@ test('hello', () => {
       "strictPropertyInitialization": true,
       "stripInternal": true,
       "target": "ES2020",
+      "types": [
+        "jest",
+        "node",
+      ],
     },
     "exclude": [
       "node_modules",
@@ -3011,6 +3015,10 @@ test('hello', () => {
       "strictPropertyInitialization": true,
       "stripInternal": true,
       "target": "ES2020",
+      "types": [
+        "jest",
+        "node",
+      ],
     },
     "exclude": [
       "node_modules",
@@ -4524,6 +4532,10 @@ test('hello', () => {
       "strictPropertyInitialization": true,
       "stripInternal": true,
       "target": "ES2020",
+      "types": [
+        "jest",
+        "node",
+      ],
     },
     "exclude": [
       "node_modules",

--- a/test/typescript/__snapshots__/typescript.test.ts.snap
+++ b/test/typescript/__snapshots__/typescript.test.ts.snap
@@ -1316,6 +1316,10 @@ test('hello', () => {
       "strictPropertyInitialization": true,
       "stripInternal": true,
       "target": "ES2020",
+      "types": [
+        "jest",
+        "node",
+      ],
     },
     "exclude": [
       "node_modules",
@@ -1353,6 +1357,10 @@ test('hello', () => {
       "strictPropertyInitialization": true,
       "stripInternal": true,
       "target": "ES2020",
+      "types": [
+        "jest",
+        "node",
+      ],
     },
     "exclude": [],
     "include": [

--- a/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -1105,6 +1105,11 @@ export default function Home() {
       "strictPropertyInitialization": true,
       "stripInternal": true,
       "target": "es5",
+      "types": [
+        "node",
+        "react",
+        "react-dom",
+      ],
     },
     "exclude": [
       "node_modules",
@@ -1166,6 +1171,11 @@ export default function Home() {
       "strictPropertyInitialization": true,
       "stripInternal": true,
       "target": "es5",
+      "types": [
+        "node",
+        "react",
+        "react-dom",
+      ],
     },
     "exclude": [],
     "include": [

--- a/test/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/react-ts-project.test.ts.snap
@@ -1346,6 +1346,14 @@ import '@testing-library/jest-dom';
       "strictPropertyInitialization": true,
       "stripInternal": true,
       "target": "es5",
+      "types": [
+        "jest",
+        "node",
+        "react",
+        "react-dom",
+        "express-serve-static-core",
+        "express",
+      ],
     },
     "exclude": [
       "node_modules",
@@ -1394,6 +1402,14 @@ import '@testing-library/jest-dom';
       "strictPropertyInitialization": true,
       "stripInternal": true,
       "target": "es5",
+      "types": [
+        "jest",
+        "node",
+        "react",
+        "react-dom",
+        "express-serve-static-core",
+        "express",
+      ],
     },
     "exclude": [],
     "include": [

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -23,7 +23,16 @@
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "stripInternal": true,
-    "target": "ES2020"
+    "target": "ES2020",
+    "types": [
+      "conventional-changelog-config-spec",
+      "ini",
+      "jest",
+      "node",
+      "parse-conflict-json",
+      "semver",
+      "yargs"
+    ]
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
TypeScript 6.0 changes the default behavior of the `types` compiler option. Previously, TypeScript would automatically include all `@types/*` packages. In TS 6.0, only `@types/node` is included by default, which breaks projects that rely on ambient type definitions from other `@types` packages (like `@types/jest`).

This change dynamically populates the `types` compiler option at synth time by reading all installed `@types` dependencies from the project. The resolution is deferred using a lazy function so that all dependencies are available when the tsconfig is synthesized.

See https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/#up-front-adjustments

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
