### PR TITLE
fix(github): replace unmaintained actions with gh CLI

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -16,6 +16,6 @@ jobs:
       pull-requests: write
     if: contains(github.event.pull_request.labels.*.name, 'auto-approve') && (github.event.pull_request.user.login == 'projen-automation')
     steps:
-      - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr review --approve "${{ github.event.pull_request.number }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,13 +102,11 @@ jobs:
         shell: bash
       - name: Create Issue
         if: ${{ failure() }}
-        uses: imjohnbo/issue-bot@v3
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          labels: failed-release
-          title: Publishing v${{ steps.extract-version.outputs.VERSION }} to GitHub Releases failed
-          body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.extract-version.outputs.VERSION }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: gh issue create --title "Publishing v$VERSION to GitHub Releases failed" --body "See $RUN_URL" --label "failed-release"
   release_npm:
     name: Publish to npm
     needs: release
@@ -159,13 +157,11 @@ jobs:
         shell: bash
       - name: Create Issue
         if: ${{ failure() }}
-        uses: imjohnbo/issue-bot@v3
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          labels: failed-release
-          title: Publishing v${{ steps.extract-version.outputs.VERSION }} to npm failed
-          body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.extract-version.outputs.VERSION }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: gh issue create --title "Publishing v$VERSION to npm failed" --body "See $RUN_URL" --label "failed-release"
   release_maven:
     name: Publish to Maven Central
     needs: release
@@ -221,13 +217,11 @@ jobs:
         shell: bash
       - name: Create Issue
         if: ${{ failure() }}
-        uses: imjohnbo/issue-bot@v3
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          labels: failed-release
-          title: Publishing v${{ steps.extract-version.outputs.VERSION }} to Maven Central failed
-          body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.extract-version.outputs.VERSION }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: gh issue create --title "Publishing v$VERSION to Maven Central failed" --body "See $RUN_URL" --label "failed-release"
   release_pypi:
     name: Publish to PyPI
     needs: release
@@ -278,13 +272,11 @@ jobs:
         shell: bash
       - name: Create Issue
         if: ${{ failure() }}
-        uses: imjohnbo/issue-bot@v3
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          labels: failed-release
-          title: Publishing v${{ steps.extract-version.outputs.VERSION }} to PyPI failed
-          body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.extract-version.outputs.VERSION }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: gh issue create --title "Publishing v$VERSION to PyPI failed" --body "See $RUN_URL" --label "failed-release"
   release_golang:
     name: Publish to GitHub Go Module Repository
     needs: release
@@ -336,10 +328,8 @@ jobs:
         shell: bash
       - name: Create Issue
         if: ${{ failure() }}
-        uses: imjohnbo/issue-bot@v3
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          labels: failed-release
-          title: Publishing v${{ steps.extract-version.outputs.VERSION }} to GitHub Go Module Repository failed
-          body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.extract-version.outputs.VERSION }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: gh issue create --title "Publishing v$VERSION to GitHub Go Module Repository failed" --body "See $RUN_URL" --label "failed-release"

--- a/src/github/auto-approve.ts
+++ b/src/github/auto-approve.ts
@@ -82,9 +82,9 @@ export class AutoApprove extends Component {
       if: condition,
       steps: [
         {
-          uses: "hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363",
-          with: {
-            "github-token": `\${{ secrets.${secret} }}`,
+          run: 'gh pr review --approve "${{ github.event.pull_request.number }}"',
+          env: {
+            GH_TOKEN: `\${{ secrets.${secret} }}`,
           },
         },
       ],

--- a/src/release/publisher.ts
+++ b/src/release/publisher.ts
@@ -816,14 +816,12 @@ export class Publisher extends Component {
             {
               name: "Create Issue",
               if: "${{ failure() }}",
-              uses: "imjohnbo/issue-bot@v3",
-              with: {
-                labels: this.failureIssueLabel,
-                title: `Publishing v\${{ steps.extract-version.outputs.VERSION }} to ${opts.registryName} failed`,
-                body: "See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-              },
+              run: `gh issue create --title "Publishing v$VERSION to ${opts.registryName} failed" --body "See $RUN_URL" --label "${this.failureIssueLabel}"`,
               env: {
-                GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}",
+                GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}",
+                VERSION: "${{ steps.extract-version.outputs.VERSION }}",
+                RUN_URL:
+                  "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
               },
             },
           ],

--- a/test/github/__snapshots__/auto-approve.test.ts.snap
+++ b/test/github/__snapshots__/auto-approve.test.ts.snap
@@ -19,9 +19,9 @@ jobs:
       pull-requests: write
     if: contains(github.event.pull_request.labels.*.name, 'auto-approve')
     steps:
-      - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363
-        with:
-          github-token: \${{ secrets.MY_SECRET }}
+      - env:
+          GH_TOKEN: \${{ secrets.MY_SECRET }}
+        run: gh pr review --approve "\${{ github.event.pull_request.number }}"
 "
 `;
 
@@ -44,9 +44,9 @@ jobs:
       pull-requests: write
     if: contains(github.event.pull_request.labels.*.name, 'my-approve') && (github.event.pull_request.user.login == 'bot-1' || github.event.pull_request.user.login == 'bot-2')
     steps:
-      - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363
-        with:
-          github-token: \${{ secrets.MY_SECRET }}
+      - env:
+          GH_TOKEN: \${{ secrets.MY_SECRET }}
+        run: gh pr review --approve "\${{ github.event.pull_request.number }}"
 "
 `;
 
@@ -69,8 +69,8 @@ jobs:
       pull-requests: write
     if: contains(github.event.pull_request.labels.*.name, 'auto-approve') && (github.event.pull_request.user.login == 'github-actions[bot]')
     steps:
-      - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363
-        with:
-          github-token: \${{ secrets.GITHUB_TOKEN }}
+      - env:
+          GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+        run: gh pr review --approve "\${{ github.event.pull_request.number }}"
 "
 `;

--- a/test/release/__snapshots__/release.test.ts.snap
+++ b/test/release/__snapshots__/release.test.ts.snap
@@ -2933,13 +2933,11 @@ jobs:
         shell: bash
       - name: Create Issue
         if: \${{ failure() }}
-        uses: imjohnbo/issue-bot@v3
         env:
-          GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
-        with:
-          labels: custom-label
-          title: Publishing v\${{ steps.extract-version.outputs.VERSION }} to GitHub Releases failed
-          body: See https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+          GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+          VERSION: \${{ steps.extract-version.outputs.VERSION }}
+          RUN_URL: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+        run: gh issue create --title "Publishing v$VERSION to GitHub Releases failed" --body "See $RUN_URL" --label "custom-label"
   release_npm:
     name: Publish to npm
     needs: release
@@ -2974,13 +2972,11 @@ jobs:
         shell: bash
       - name: Create Issue
         if: \${{ failure() }}
-        uses: imjohnbo/issue-bot@v3
         env:
-          GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
-        with:
-          labels: custom-label
-          title: Publishing v\${{ steps.extract-version.outputs.VERSION }} to npm failed
-          body: See https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+          GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+          VERSION: \${{ steps.extract-version.outputs.VERSION }}
+          RUN_URL: https://github.com/\${{ github.repository }}/actions/runs/\${{ github.run_id }}
+        run: gh issue create --title "Publishing v$VERSION to npm failed" --body "See $RUN_URL" --label "custom-label"
 "
 `;
 


### PR DESCRIPTION
Resolves #4604

Both `hmarr/auto-approve-action` and `imjohnbo/issue-bot` appear to be unmaintained and still use Node.js 20, which GitHub is deprecating. Rather than waiting for upstream releases, this replaces them with the `gh` CLI which is pre-installed on all GitHub-hosted runners and doesn't require a third-party action at all.

`hmarr/auto-approve-action` is replaced with `gh pr review --approve` and `imjohnbo/issue-bot` is replaced with `gh issue create`. Dynamic values from GitHub expressions are passed as environment variables to avoid potential shell injection.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
