### PR TITLE
fix(javascript): Yarn Berry workflows fail due to missing corepack setup

### DIFF
--- a/docs/api/javascript.md
+++ b/docs/api/javascript.md
@@ -13412,7 +13412,7 @@ public readonly version: string;
 ```
 
 - *Type:* string
-- *Default:* 4.0.1
+- *Default:* 4.13.0
 
 A fully specified version to use for yarn (e.g., x.x.x).
 

--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -1615,7 +1615,7 @@ export class NodePackage extends Component {
 
   private configureYarnBerry(project: Project, options: NodePackageOptions) {
     const {
-      version = "4.0.1",
+      version = "4.13.0",
       yarnRcOptions = {},
       zeroInstalls = false,
     } = options.yarnBerryOptions || {};
@@ -1747,7 +1747,7 @@ export interface YarnBerryOptions {
   /**
    * A fully specified version to use for yarn (e.g., x.x.x)
    *
-   * @default - 4.0.1
+   * @default - 4.13.0
    */
   readonly version?: string;
 

--- a/src/javascript/node-project.ts
+++ b/src/javascript/node-project.ts
@@ -1199,7 +1199,12 @@ export class NodeProject extends GitHubProject {
     // first run the workflow bootstrap steps
     install.push(...this.workflowBootstrapSteps);
 
-    if (this.package.packageManager === NodePackageManager.PNPM) {
+    if (isYarnBerry(this.package.packageManager)) {
+      install.push({
+        name: "Enable corepack",
+        run: "corepack enable",
+      });
+    } else if (this.package.packageManager === NodePackageManager.PNPM) {
       install.push({
         name: "Setup pnpm",
         uses: "pnpm/action-setup@v5",

--- a/src/javascript/yarnrc.ts
+++ b/src/javascript/yarnrc.ts
@@ -364,6 +364,7 @@ export class Yarnrc extends Component {
 
     new YamlFile(project, ".yarnrc.yml", {
       obj: options,
+      readonly: false,
     });
   }
 

--- a/test/javascript/__snapshots__/node-package.test.ts.snap
+++ b/test/javascript/__snapshots__/node-package.test.ts.snap
@@ -177,7 +177,7 @@ exports[`yarn_berry resolutions 1`] = `
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "name": "my-project",
-  "packageManager": "yarn@4.0.1",
+  "packageManager": "yarn@4.13.0",
   "publishConfig": {
     "access": "public",
   },
@@ -232,7 +232,7 @@ exports[`yarn2 resolutions 1`] = `
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "name": "my-project",
-  "packageManager": "yarn@4.0.1",
+  "packageManager": "yarn@4.13.0",
   "publishConfig": {
     "access": "public",
   },

--- a/test/javascript/__snapshots__/node-project.test.ts.snap
+++ b/test/javascript/__snapshots__/node-project.test.ts.snap
@@ -334,6 +334,178 @@ permissions-backup.acl
 "
 `;
 
+exports[`package manager build job steps bun build job steps 1`] = `
+[
+  {
+    "name": "Checkout",
+    "uses": "actions/checkout@v6",
+    "with": {
+      "ref": "\${{ github.event.pull_request.head.ref }}",
+      "repository": "\${{ github.event.pull_request.head.repo.full_name }}",
+    },
+  },
+  {
+    "name": "Setup bun",
+    "uses": "oven-sh/setup-bun@v2",
+    "with": {
+      "bun-version": "latest",
+    },
+  },
+  {
+    "name": "Install dependencies",
+    "run": "bun install",
+  },
+  {
+    "name": "build",
+    "run": "npx projen build",
+  },
+  {
+    "id": "self_mutation",
+    "name": "Find mutations",
+    "run": "git add .
+git diff --staged --patch --exit-code > repo.patch || echo "self_mutation_happened=true" >> $GITHUB_OUTPUT",
+    "shell": "bash",
+    "working-directory": "./",
+  },
+  {
+    "if": "steps.self_mutation.outputs.self_mutation_happened",
+    "name": "Upload patch",
+    "uses": "actions/upload-artifact@v7",
+    "with": {
+      "name": "repo.patch",
+      "overwrite": true,
+      "path": "repo.patch",
+    },
+  },
+  {
+    "if": "steps.self_mutation.outputs.self_mutation_happened",
+    "name": "Fail build on mutation",
+    "run": "echo "::error::Files were changed during build (see build log). If this was triggered from a fork, you will need to update your branch."
+cat repo.patch
+exit 1",
+  },
+]
+`;
+
+exports[`package manager build job steps pnpm build job steps 1`] = `
+[
+  {
+    "name": "Checkout",
+    "uses": "actions/checkout@v6",
+    "with": {
+      "ref": "\${{ github.event.pull_request.head.ref }}",
+      "repository": "\${{ github.event.pull_request.head.repo.full_name }}",
+    },
+  },
+  {
+    "name": "Setup pnpm",
+    "uses": "pnpm/action-setup@v5",
+    "with": {
+      "version": "10",
+    },
+  },
+  {
+    "name": "Setup Node.js",
+    "uses": "actions/setup-node@v6",
+    "with": {
+      "cache": "pnpm",
+      "package-manager-cache": true,
+    },
+  },
+  {
+    "name": "Install dependencies",
+    "run": "pnpm i --no-frozen-lockfile",
+  },
+  {
+    "name": "build",
+    "run": "npx projen build",
+  },
+  {
+    "id": "self_mutation",
+    "name": "Find mutations",
+    "run": "git add .
+git diff --staged --patch --exit-code > repo.patch || echo "self_mutation_happened=true" >> $GITHUB_OUTPUT",
+    "shell": "bash",
+    "working-directory": "./",
+  },
+  {
+    "if": "steps.self_mutation.outputs.self_mutation_happened",
+    "name": "Upload patch",
+    "uses": "actions/upload-artifact@v7",
+    "with": {
+      "name": "repo.patch",
+      "overwrite": true,
+      "path": "repo.patch",
+    },
+  },
+  {
+    "if": "steps.self_mutation.outputs.self_mutation_happened",
+    "name": "Fail build on mutation",
+    "run": "echo "::error::Files were changed during build (see build log). If this was triggered from a fork, you will need to update your branch."
+cat repo.patch
+exit 1",
+  },
+]
+`;
+
+exports[`package manager build job steps yarn berry build job steps 1`] = `
+[
+  {
+    "name": "Checkout",
+    "uses": "actions/checkout@v6",
+    "with": {
+      "ref": "\${{ github.event.pull_request.head.ref }}",
+      "repository": "\${{ github.event.pull_request.head.repo.full_name }}",
+    },
+  },
+  {
+    "name": "Enable corepack",
+    "run": "corepack enable",
+  },
+  {
+    "name": "Setup Node.js",
+    "uses": "actions/setup-node@v6",
+    "with": {
+      "cache": "yarn",
+      "package-manager-cache": true,
+    },
+  },
+  {
+    "name": "Install dependencies",
+    "run": "yarn install --no-immutable",
+  },
+  {
+    "name": "build",
+    "run": "npx projen build",
+  },
+  {
+    "id": "self_mutation",
+    "name": "Find mutations",
+    "run": "git add .
+git diff --staged --patch --exit-code > repo.patch || echo "self_mutation_happened=true" >> $GITHUB_OUTPUT",
+    "shell": "bash",
+    "working-directory": "./",
+  },
+  {
+    "if": "steps.self_mutation.outputs.self_mutation_happened",
+    "name": "Upload patch",
+    "uses": "actions/upload-artifact@v7",
+    "with": {
+      "name": "repo.patch",
+      "overwrite": true,
+      "path": "repo.patch",
+    },
+  },
+  {
+    "if": "steps.self_mutation.outputs.self_mutation_happened",
+    "name": "Fail build on mutation",
+    "run": "echo "::error::Files were changed during build (see build log). If this was triggered from a fork, you will need to update your branch."
+cat repo.patch
+exit 1",
+  },
+]
+`;
+
 exports[`provided preBuildSteps for build workflow get combined with setup steps 1`] = `
 [
   {

--- a/test/javascript/node-package.test.ts
+++ b/test/javascript/node-package.test.ts
@@ -801,6 +801,15 @@ describe("yarn berry", () => {
     expect(yarnrcLines).toContain("nodeLinker: node-modules");
   });
 
+  test(".yarnrc.yml is not readonly", () => {
+    const project = new TestProject();
+    new NodePackage(project, {
+      packageManager: NodePackageManager.YARN_BERRY,
+    });
+
+    expect(project.tryFindFile(".yarnrc.yml")?.readonly).toBe(false);
+  });
+
   describe("gitignore", () => {
     test("produces the expected gitignore for zero-installs", () => {
       const project = new TestProject();
@@ -898,7 +907,7 @@ describe("yarn berry", () => {
             new NodePackage(project, {
               packageManager: NodePackageManager.YARN_BERRY,
               yarnBerryOptions: {
-                version: "4.0.1",
+                version: "4.13.0",
                 yarnRcOptions: {
                   ignoreCwd: true,
                   lockfileFilename: "something-else.lock",

--- a/test/javascript/node-project.test.ts
+++ b/test/javascript/node-project.test.ts
@@ -1196,6 +1196,68 @@ describe("Setup pnpm", () => {
   });
 });
 
+describe("Setup corepack for Yarn Berry", () => {
+  const enableCorepackIndex = (job: any) =>
+    job.steps.findIndex((step: any) => step.name === "Enable corepack");
+  const setupNodeIndex = (job: any) =>
+    job.steps.findIndex((step: any) => step.name === "Setup Node.js");
+
+  test("Enable corepack should not run without yarn berry", () => {
+    const project = new TestNodeProject({});
+
+    const output = synthSnapshot(project);
+    const buildWorkflow = yaml.parse(output[".github/workflows/build.yml"]);
+    expect(enableCorepackIndex(buildWorkflow.jobs.build)).toEqual(-1);
+  });
+
+  test("Enable corepack should run before Setup Node.js", () => {
+    const project = new TestNodeProject({
+      workflowPackageCache: true,
+      packageManager: NodePackageManager.YARN_BERRY,
+    });
+
+    const output = synthSnapshot(project);
+    const buildJob = yaml.parse(output[".github/workflows/build.yml"]).jobs
+      .build;
+    expect(enableCorepackIndex(buildJob)).toBeGreaterThanOrEqual(0);
+    expect(enableCorepackIndex(buildJob)).toBeLessThan(
+      setupNodeIndex(buildJob),
+    );
+  });
+});
+
+describe("package manager build job steps", () => {
+  test.each([
+    {
+      name: "bun",
+      options: {
+        packageManager: NodePackageManager.BUN,
+        workflowPackageCache: true,
+      },
+    },
+    {
+      name: "pnpm",
+      options: {
+        packageManager: NodePackageManager.PNPM,
+        workflowPackageCache: true,
+      },
+    },
+    {
+      name: "yarn berry",
+      options: {
+        packageManager: NodePackageManager.YARN_BERRY,
+        workflowPackageCache: true,
+      },
+    },
+  ])("$name build job steps", ({ options }) => {
+    const project = new TestNodeProject(options);
+    const output = synthSnapshot(project);
+    const buildJob = yaml.parse(output[".github/workflows/build.yml"]).jobs
+      .build;
+    expect(buildJob.steps).toMatchSnapshot();
+  });
+});
+
 describe("workflowPackageCache", () => {
   const cache = (job: any) =>
     job.steps.find((step: any) => step.name === "Setup Node.js")?.with?.cache;


### PR DESCRIPTION
When using Yarn Berry as the package manager, GitHub Actions workflows fail because the runner's global Yarn 1.x conflicts with the `packageManager` field in `package.json`. The `packageManager` field is set by projen to tell corepack which version to use, but corepack was never actually enabled in the workflow.

This adds a `corepack enable` step to `renderWorkflowSetup()` for Yarn Berry projects, following the same pattern already used for pnpm (`pnpm/action-setup`) and bun (`oven-sh/setup-bun`). The step runs before `actions/setup-node` so that corepack is available when Node.js sets up package manager caching.

Additionally, the default Yarn Berry version is bumped from 4.0.1 to 4.13.0 since 4.0.1 is quite outdated at this point. The `.yarnrc.yml` file is also changed to be mutable, since Yarn Berry itself writes to this file during normal operation and having it read-only causes friction.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
