### PR TITLE
chore(github): use env variable syntax in auto-approve workflow

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -20,4 +20,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: gh pr review --approve "${{ PR_NUMBER }}" --repo "${{ GH_REPO }}"
+        run: gh pr review --approve "$PR_NUMBER" --repo "$GH_REPO"

--- a/src/github/auto-approve.ts
+++ b/src/github/auto-approve.ts
@@ -84,7 +84,7 @@ export class AutoApprove extends Component {
       if: condition,
       steps: [
         {
-          run: 'gh pr review --approve "${{ PR_NUMBER }}" --repo "${{ GH_REPO }}"',
+          run: 'gh pr review --approve "$PR_NUMBER" --repo "$GH_REPO"',
           env: {
             GH_TOKEN: `\${{ secrets.${secret} }}`,
             GH_REPO: "${{ github.repository }}",

--- a/test/github/__snapshots__/auto-approve.test.ts.snap
+++ b/test/github/__snapshots__/auto-approve.test.ts.snap
@@ -23,7 +23,7 @@ jobs:
           GH_TOKEN: \${{ secrets.MY_SECRET }}
           GH_REPO: \${{ github.repository }}
           PR_NUMBER: \${{ github.event.pull_request.number }}
-        run: gh pr review --approve "\${{ PR_NUMBER }}" --repo "\${{ GH_REPO }}"
+        run: gh pr review --approve "$PR_NUMBER" --repo "$GH_REPO"
 "
 `;
 
@@ -50,7 +50,7 @@ jobs:
           GH_TOKEN: \${{ secrets.MY_SECRET }}
           GH_REPO: \${{ github.repository }}
           PR_NUMBER: \${{ github.event.pull_request.number }}
-        run: gh pr review --approve "\${{ PR_NUMBER }}" --repo "\${{ GH_REPO }}"
+        run: gh pr review --approve "$PR_NUMBER" --repo "$GH_REPO"
 "
 `;
 
@@ -77,6 +77,6 @@ jobs:
           GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
           GH_REPO: \${{ github.repository }}
           PR_NUMBER: \${{ github.event.pull_request.number }}
-        run: gh pr review --approve "\${{ PR_NUMBER }}" --repo "\${{ GH_REPO }}"
+        run: gh pr review --approve "$PR_NUMBER" --repo "$GH_REPO"
 "
 `;


### PR DESCRIPTION
The auto-approve workflow uses `${{ PR_NUMBER }}` and `${{ GH_REPO }}` in the `run` step to reference the PR number and repository. However, the `${{ }}` syntax is for GitHub Actions expressions, not shell variable expansion. Since these values are already passed as environment variables via the `env` block, the correct way to reference them in a shell `run` step is using standard shell variable syntax (`$PR_NUMBER` and `$GH_REPO`).

~The expression syntax still works, it's just that validators aren't happy about it. See the attached screenshots using the official GitHub Actions VSCode plugin.~

Edit: No, turns out the expression syntax was indeed breaking the workflow and this PR should have been a `fix`.

### Before

<img width="629" height="132" alt="image" src="https://github.com/user-attachments/assets/c873e328-1d40-4864-a54c-112b21e95af1" />

### After

<img width="551" height="137" alt="image" src="https://github.com/user-attachments/assets/195b15b8-b1d8-4b9c-a336-c4ddf47a688a" />


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
