### PR TITLE
feat(github): add cooldown option to Dependabot and minimum release age options to Renovatebot

### DIFF
--- a/docs/api/github.md
+++ b/docs/api/github.md
@@ -5884,6 +5884,116 @@ For Java dependencies, the format of the dependency-name attribute is:
 
 ---
 
+### DependabotCooldown <a name="DependabotCooldown" id="projen.github.DependabotCooldown"></a>
+
+Defines a cooldown period for dependency version updates.
+
+> [https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown-](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown-)
+
+#### Initializer <a name="Initializer" id="projen.github.DependabotCooldown.Initializer"></a>
+
+```typescript
+import { github } from 'projen'
+
+const dependabotCooldown: github.DependabotCooldown = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen.github.DependabotCooldown.property.defaultDays">defaultDays</a></code> | <code>number</code> | Default cooldown period (in days) for all dependencies without specific semver rules. |
+| <code><a href="#projen.github.DependabotCooldown.property.exclude">exclude</a></code> | <code>string[]</code> | List of dependencies excluded from cooldown. |
+| <code><a href="#projen.github.DependabotCooldown.property.include">include</a></code> | <code>string[]</code> | List of dependencies to apply cooldown to. |
+| <code><a href="#projen.github.DependabotCooldown.property.semverMajorDays">semverMajorDays</a></code> | <code>number</code> | Cooldown period (in days) for major version updates. |
+| <code><a href="#projen.github.DependabotCooldown.property.semverMinorDays">semverMinorDays</a></code> | <code>number</code> | Cooldown period (in days) for minor version updates. |
+| <code><a href="#projen.github.DependabotCooldown.property.semverPatchDays">semverPatchDays</a></code> | <code>number</code> | Cooldown period (in days) for patch version updates. |
+
+---
+
+##### `defaultDays`<sup>Optional</sup> <a name="defaultDays" id="projen.github.DependabotCooldown.property.defaultDays"></a>
+
+```typescript
+public readonly defaultDays: number;
+```
+
+- *Type:* number
+- *Default:* no default cooldown
+
+Default cooldown period (in days) for all dependencies without specific semver rules.
+
+---
+
+##### `exclude`<sup>Optional</sup> <a name="exclude" id="projen.github.DependabotCooldown.property.exclude"></a>
+
+```typescript
+public readonly exclude: string[];
+```
+
+- *Type:* string[]
+- *Default:* no exclusions
+
+List of dependencies excluded from cooldown.
+
+Supports wildcards.
+Takes precedence over `include`.
+
+---
+
+##### `include`<sup>Optional</sup> <a name="include" id="projen.github.DependabotCooldown.property.include"></a>
+
+```typescript
+public readonly include: string[];
+```
+
+- *Type:* string[]
+- *Default:* all dependencies
+
+List of dependencies to apply cooldown to.
+
+Supports wildcards.
+
+---
+
+##### `semverMajorDays`<sup>Optional</sup> <a name="semverMajorDays" id="projen.github.DependabotCooldown.property.semverMajorDays"></a>
+
+```typescript
+public readonly semverMajorDays: number;
+```
+
+- *Type:* number
+- *Default:* uses defaultDays
+
+Cooldown period (in days) for major version updates.
+
+---
+
+##### `semverMinorDays`<sup>Optional</sup> <a name="semverMinorDays" id="projen.github.DependabotCooldown.property.semverMinorDays"></a>
+
+```typescript
+public readonly semverMinorDays: number;
+```
+
+- *Type:* number
+- *Default:* uses defaultDays
+
+Cooldown period (in days) for minor version updates.
+
+---
+
+##### `semverPatchDays`<sup>Optional</sup> <a name="semverPatchDays" id="projen.github.DependabotCooldown.property.semverPatchDays"></a>
+
+```typescript
+public readonly semverPatchDays: number;
+```
+
+- *Type:* number
+- *Default:* uses defaultDays
+
+Cooldown period (in days) for patch version updates.
+
+---
+
 ### DependabotGroup <a name="DependabotGroup" id="projen.github.DependabotGroup"></a>
 
 Defines a single group for dependency updates.
@@ -6049,6 +6159,7 @@ const dependabotOptions: github.DependabotOptions = { ... }
 | --- | --- | --- |
 | <code><a href="#projen.github.DependabotOptions.property.allow">allow</a></code> | <code><a href="#projen.github.DependabotAllow">DependabotAllow</a>[]</code> | https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#allow. |
 | <code><a href="#projen.github.DependabotOptions.property.assignees">assignees</a></code> | <code>string[]</code> | Specify individual assignees or teams of assignees for all pull requests raised for a package manager. |
+| <code><a href="#projen.github.DependabotOptions.property.cooldown">cooldown</a></code> | <code><a href="#projen.github.DependabotCooldown">DependabotCooldown</a></code> | Defines a cooldown period for dependency version updates. |
 | <code><a href="#projen.github.DependabotOptions.property.groups">groups</a></code> | <code>{[ key: string ]: <a href="#projen.github.DependabotGroup">DependabotGroup</a>}</code> | https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups. |
 | <code><a href="#projen.github.DependabotOptions.property.ignore">ignore</a></code> | <code><a href="#projen.github.DependabotIgnore">DependabotIgnore</a>[]</code> | You can use the `ignore` option to customize which dependencies are updated. |
 | <code><a href="#projen.github.DependabotOptions.property.ignoreProjen">ignoreProjen</a></code> | <code>boolean</code> | Ignores updates to `projen`. |
@@ -6088,6 +6199,24 @@ public readonly assignees: string[];
 - *Default:* []
 
 Specify individual assignees or teams of assignees for all pull requests raised for a package manager.
+
+---
+
+##### `cooldown`<sup>Optional</sup> <a name="cooldown" id="projen.github.DependabotOptions.property.cooldown"></a>
+
+```typescript
+public readonly cooldown: DependabotCooldown;
+```
+
+- *Type:* <a href="#projen.github.DependabotCooldown">DependabotCooldown</a>
+- *Default:* no cooldown
+
+Defines a cooldown period for dependency version updates.
+
+During the cooldown, Dependabot will not propose updates for a dependency.
+This only applies to version updates, not security updates.
+
+> [https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown-](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown-)
 
 ---
 

--- a/docs/api/projen.md
+++ b/docs/api/projen.md
@@ -13564,6 +13564,8 @@ const renovatebotOptions: RenovatebotOptions = { ... }
 | <code><a href="#projen.RenovatebotOptions.property.ignoreProjen">ignoreProjen</a></code> | <code>boolean</code> | Ignores updates to `projen`. |
 | <code><a href="#projen.RenovatebotOptions.property.labels">labels</a></code> | <code>string[]</code> | List of labels to apply to the created PR's. |
 | <code><a href="#projen.RenovatebotOptions.property.marker">marker</a></code> | <code>boolean</code> | *No description.* |
+| <code><a href="#projen.RenovatebotOptions.property.minimumReleaseAge">minimumReleaseAge</a></code> | <code>string</code> | Minimum release age for packages before Renovate will propose an update. |
+| <code><a href="#projen.RenovatebotOptions.property.minimumReleaseAgeBehaviour">minimumReleaseAgeBehaviour</a></code> | <code><a href="#projen.RenovatebotMinimumReleaseAgeBehaviour">RenovatebotMinimumReleaseAgeBehaviour</a></code> | Controls whether a release timestamp is required when using `minimumReleaseAge`. |
 | <code><a href="#projen.RenovatebotOptions.property.overrideConfig">overrideConfig</a></code> | <code>any</code> | *No description.* |
 | <code><a href="#projen.RenovatebotOptions.property.scheduleInterval">scheduleInterval</a></code> | <code>string[]</code> | How often to check for new versions and raise pull requests. |
 
@@ -13621,6 +13623,39 @@ public readonly marker: boolean;
 ```
 
 - *Type:* boolean
+
+---
+
+##### `minimumReleaseAge`<sup>Optional</sup> <a name="minimumReleaseAge" id="projen.RenovatebotOptions.property.minimumReleaseAge"></a>
+
+```typescript
+public readonly minimumReleaseAge: string;
+```
+
+- *Type:* string
+- *Default:* no minimum release age
+
+Minimum release age for packages before Renovate will propose an update.
+
+This is a supply chain security feature to avoid updating to newly published,
+potentially malicious versions.
+
+> [https://docs.renovatebot.com/configuration-options/#minimumreleaseage](https://docs.renovatebot.com/configuration-options/#minimumreleaseage)
+
+---
+
+##### `minimumReleaseAgeBehaviour`<sup>Optional</sup> <a name="minimumReleaseAgeBehaviour" id="projen.RenovatebotOptions.property.minimumReleaseAgeBehaviour"></a>
+
+```typescript
+public readonly minimumReleaseAgeBehaviour: RenovatebotMinimumReleaseAgeBehaviour;
+```
+
+- *Type:* <a href="#projen.RenovatebotMinimumReleaseAgeBehaviour">RenovatebotMinimumReleaseAgeBehaviour</a>
+- *Default:* RenovatebotMinimumReleaseAgeBehaviour.TIMESTAMP_REQUIRED
+
+Controls whether a release timestamp is required when using `minimumReleaseAge`.
+
+> [https://docs.renovatebot.com/configuration-options/#minimumreleaseagebehaviour](https://docs.renovatebot.com/configuration-options/#minimumreleaseagebehaviour)
 
 ---
 
@@ -18136,6 +18171,35 @@ This is an app (service, tool, website, etc).
 
 Its artifacts are intended to
 be deployed or published for end-user consumption.
+
+---
+
+
+### RenovatebotMinimumReleaseAgeBehaviour <a name="RenovatebotMinimumReleaseAgeBehaviour" id="projen.RenovatebotMinimumReleaseAgeBehaviour"></a>
+
+Behaviour when a release timestamp is missing for `minimumReleaseAge`.
+
+> [https://docs.renovatebot.com/configuration-options/#minimumreleaseagebehaviour](https://docs.renovatebot.com/configuration-options/#minimumreleaseagebehaviour)
+
+#### Members <a name="Members" id="Members"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#projen.RenovatebotMinimumReleaseAgeBehaviour.TIMESTAMP_REQUIRED">TIMESTAMP_REQUIRED</a></code> | A release without a timestamp is not treated as stable. |
+| <code><a href="#projen.RenovatebotMinimumReleaseAgeBehaviour.TIMESTAMP_OPTIONAL">TIMESTAMP_OPTIONAL</a></code> | A release without a timestamp is treated as stable. |
+
+---
+
+##### `TIMESTAMP_REQUIRED` <a name="TIMESTAMP_REQUIRED" id="projen.RenovatebotMinimumReleaseAgeBehaviour.TIMESTAMP_REQUIRED"></a>
+
+A release without a timestamp is not treated as stable.
+
+---
+
+
+##### `TIMESTAMP_OPTIONAL` <a name="TIMESTAMP_OPTIONAL" id="projen.RenovatebotMinimumReleaseAgeBehaviour.TIMESTAMP_OPTIONAL"></a>
+
+A release without a timestamp is treated as stable.
 
 ---
 

--- a/src/github/dependabot.ts
+++ b/src/github/dependabot.ts
@@ -97,6 +97,61 @@ export interface DependabotOptions {
    * You can configure the target branch for raising pull requests for version updates against
    */
   readonly targetBranch?: string;
+
+  /**
+   * Defines a cooldown period for dependency version updates.
+   *
+   * During the cooldown, Dependabot will not propose updates for a dependency.
+   * This only applies to version updates, not security updates.
+   *
+   * @see https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown-
+   * @default - no cooldown
+   */
+  readonly cooldown?: DependabotCooldown;
+}
+
+/**
+ * Defines a cooldown period for dependency version updates.
+ *
+ * @see https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown-
+ */
+export interface DependabotCooldown {
+  /**
+   * Default cooldown period (in days) for all dependencies without specific semver rules.
+   * @default - no default cooldown
+   */
+  readonly defaultDays?: number;
+
+  /**
+   * Cooldown period (in days) for major version updates.
+   * @default - uses defaultDays
+   */
+  readonly semverMajorDays?: number;
+
+  /**
+   * Cooldown period (in days) for minor version updates.
+   * @default - uses defaultDays
+   */
+  readonly semverMinorDays?: number;
+
+  /**
+   * Cooldown period (in days) for patch version updates.
+   * @default - uses defaultDays
+   */
+  readonly semverPatchDays?: number;
+
+  /**
+   * List of dependencies to apply cooldown to. Supports wildcards.
+   * @default - all dependencies
+   */
+  readonly include?: string[];
+
+  /**
+   * List of dependencies excluded from cooldown. Supports wildcards.
+   * Takes precedence over `include`.
+   * @default - no exclusions
+   */
+  readonly exclude?: string[];
 }
 
 /**
@@ -474,6 +529,9 @@ export class Dependabot extends Component {
               ? options.openPullRequestsLimit
               : undefined,
           "target-branch": options.targetBranch,
+          cooldown: options.cooldown
+            ? kebabCaseKeys(options.cooldown)
+            : undefined,
         },
       ],
     };

--- a/src/renovatebot.ts
+++ b/src/renovatebot.ts
@@ -50,6 +50,25 @@ export interface RenovatebotOptions {
   readonly overrideConfig?: any;
 
   readonly marker?: boolean;
+
+  /**
+   * Minimum release age for packages before Renovate will propose an update.
+   *
+   * This is a supply chain security feature to avoid updating to newly published,
+   * potentially malicious versions.
+   *
+   * @see https://docs.renovatebot.com/configuration-options/#minimumreleaseage
+   * @default - no minimum release age
+   */
+  readonly minimumReleaseAge?: string;
+
+  /**
+   * Controls whether a release timestamp is required when using `minimumReleaseAge`.
+   *
+   * @see https://docs.renovatebot.com/configuration-options/#minimumreleaseagebehaviour
+   * @default RenovatebotMinimumReleaseAgeBehaviour.TIMESTAMP_REQUIRED
+   */
+  readonly minimumReleaseAgeBehaviour?: RenovatebotMinimumReleaseAgeBehaviour;
 }
 
 /**
@@ -101,6 +120,23 @@ export enum RenovatebotScheduleInterval {
 }
 
 /**
+ * Behaviour when a release timestamp is missing for `minimumReleaseAge`.
+ *
+ * @see https://docs.renovatebot.com/configuration-options/#minimumreleaseagebehaviour
+ */
+export enum RenovatebotMinimumReleaseAgeBehaviour {
+  /**
+   * A release without a timestamp is not treated as stable.
+   */
+  TIMESTAMP_REQUIRED = "timestamp-required",
+
+  /**
+   * A release without a timestamp is treated as stable.
+   */
+  TIMESTAMP_OPTIONAL = "timestamp-optional",
+}
+
+/**
  * Defines renovatebot configuration for projen project.
  *
  * Ignores the versions controlled by Projen.
@@ -123,6 +159,10 @@ export class Renovatebot extends Component {
 
   private readonly overrideConfig?: any;
 
+  private readonly minimumReleaseAge?: string;
+
+  private readonly minimumReleaseAgeBehaviour?: RenovatebotMinimumReleaseAgeBehaviour;
+
   constructor(project: Project, options: RenovatebotOptions = {}) {
     super(project);
 
@@ -135,6 +175,8 @@ export class Renovatebot extends Component {
     (options.ignoreProjen ?? true) && this.explicitIgnores.push("projen");
     this.overrideConfig = options.overrideConfig ?? {};
     this.marker = options.marker ?? true;
+    this.minimumReleaseAge = options.minimumReleaseAge;
+    this.minimumReleaseAgeBehaviour = options.minimumReleaseAgeBehaviour;
 
     this.file = new JsonFile(this._project, "renovate.json5", {
       obj: () => this.createRenovateConfiguration(),
@@ -174,6 +216,8 @@ export class Renovatebot extends Component {
     return {
       labels: this.labels,
       schedule: this.scheduleInterval,
+      minimumReleaseAge: this.minimumReleaseAge,
+      minimumReleaseAgeBehaviour: this.minimumReleaseAgeBehaviour,
       extends: [
         ":preserveSemverRanges",
         "config:recommended",

--- a/test/github/dependabot.test.ts
+++ b/test/github/dependabot.test.ts
@@ -375,6 +375,65 @@ describe("dependabot", () => {
     });
   });
 
+  describe("cooldown", () => {
+    test("no cooldown by default", () => {
+      const project = createProject();
+      new Dependabot(project.github!);
+      const snapshot = synthSnapshot(project);
+      const dependabot = snapshot[".github/dependabot.yml"];
+      expect(dependabot).not.toContain("cooldown");
+    });
+
+    test("cooldown with default-days only", () => {
+      const project = createProject();
+      new Dependabot(project.github!, {
+        cooldown: { defaultDays: 3 },
+      });
+      const snapshot = synthSnapshot(project);
+      const dependabot = snapshot[".github/dependabot.yml"];
+      expect(dependabot).toContain("cooldown:");
+      expect(dependabot).toContain("default-days: 3");
+    });
+
+    test("cooldown with all semver options", () => {
+      const project = createProject();
+      new Dependabot(project.github!, {
+        cooldown: {
+          defaultDays: 1,
+          semverMajorDays: 7,
+          semverMinorDays: 3,
+          semverPatchDays: 1,
+        },
+      });
+      const snapshot = synthSnapshot(project);
+      const dependabot = snapshot[".github/dependabot.yml"];
+      expect(dependabot).toContain("cooldown:");
+      expect(dependabot).toContain("default-days: 1");
+      expect(dependabot).toContain("semver-major-days: 7");
+      expect(dependabot).toContain("semver-minor-days: 3");
+      expect(dependabot).toContain("semver-patch-days: 1");
+    });
+
+    test("cooldown with include and exclude", () => {
+      const project = createProject();
+      new Dependabot(project.github!, {
+        cooldown: {
+          defaultDays: 5,
+          include: ["@types/*"],
+          exclude: ["@types/node"],
+        },
+      });
+      const snapshot = synthSnapshot(project);
+      const dependabot = snapshot[".github/dependabot.yml"];
+      expect(dependabot).toContain("cooldown:");
+      expect(dependabot).toContain("default-days: 5");
+      expect(dependabot).toContain("include:");
+      expect(dependabot).toContain("@types/*");
+      expect(dependabot).toContain("exclude:");
+      expect(dependabot).toContain("@types/node");
+    });
+  });
+
   describe("target branch", () => {
     test("empty target branch", () => {
       const project = createProject();

--- a/test/renovatebot.test.ts
+++ b/test/renovatebot.test.ts
@@ -1,5 +1,5 @@
 import { synthSnapshot, TestProject } from "./util";
-import { DependencyType } from "../src";
+import { DependencyType, RenovatebotMinimumReleaseAgeBehaviour } from "../src";
 
 describe("renovatebot", () => {
   test("renovatebot: true creates renovatebot configuration", () => {
@@ -156,6 +156,42 @@ describe("renovatebot", () => {
     // THEN
     expect(snapshot).toMatchSnapshot();
     expect(snapshot).toStrictEqual(overrideConfig);
+  });
+
+  test("renovatebot: no minimumReleaseAge by default", () => {
+    const p = new TestProject({ renovatebot: true });
+    const snapshot = synthSnapshot(p);
+    expect(snapshot["renovate.json5"]).not.toHaveProperty("minimumReleaseAge");
+  });
+
+  test("renovatebot: sets minimumReleaseAge", () => {
+    const p = new TestProject({
+      renovatebot: true,
+      renovatebotOptions: {
+        minimumReleaseAge: "3 days",
+      },
+    });
+    const snapshot = synthSnapshot(p);
+    expect(snapshot["renovate.json5"]).toHaveProperty(
+      "minimumReleaseAge",
+      "3 days",
+    );
+  });
+
+  test("renovatebot: sets minimumReleaseAgeBehaviour", () => {
+    const p = new TestProject({
+      renovatebot: true,
+      renovatebotOptions: {
+        minimumReleaseAge: "3 days",
+        minimumReleaseAgeBehaviour:
+          RenovatebotMinimumReleaseAgeBehaviour.TIMESTAMP_OPTIONAL,
+      },
+    });
+    const snapshot = synthSnapshot(p);
+    expect(snapshot["renovate.json5"]).toHaveProperty(
+      "minimumReleaseAgeBehaviour",
+      "timestamp-optional",
+    );
   });
 
   test("renovatebot: can use file escape hatch", () => {


### PR DESCRIPTION
Both Dependabot and Renovatebot have introduced options to delay dependency updates after a new version is published. This is a supply chain security measure that gives time for malicious packages to be detected and removed before they are adopted.

This change adds support for Dependabot's `cooldown` option, which allows configuring a waiting period per semver level (`default-days`, `semver-major-days`, `semver-minor-days`, `semver-patch-days`) with optional `include`/`exclude` dependency filters. The cooldown only applies to version updates, not security updates.

For Renovatebot, this adds support for `minimumReleaseAge` (e.g. `"3 days"`) and `minimumReleaseAgeBehaviour` which controls whether a release timestamp is required (`timestamp-required`) or optional (`timestamp-optional`) when enforcing the minimum age.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
