### PR TITLE
fix(node): CodeArtifact login step fails in GHA workflows

### DIFF
--- a/src/javascript/node-project.ts
+++ b/src/javascript/node-project.ts
@@ -1143,6 +1143,23 @@ export class NodeProject extends GitHubProject {
       authProvider: codeArtifactOptions?.authProvider,
     };
 
+    function executeCommand(packageManager: NodePackageManager): string {
+      switch (packageManager) {
+        case NodePackageManager.NPM:
+        case NodePackageManager.YARN:
+        case NodePackageManager.YARN_CLASSIC:
+          return "npx";
+        case NodePackageManager.PNPM:
+          return "pnpm dlx";
+        case NodePackageManager.YARN2:
+        case NodePackageManager.YARN_BERRY:
+          return "yarn dlx";
+        case NodePackageManager.BUN:
+          return "bunx";
+      }
+    }
+    const executeProjenCommand = `${executeCommand(this.packageManager)} projen`;
+
     if (
       parsedCodeArtifactOptions.authProvider ===
       NodePackageCodeArtifactAuthProvider.GITHUB_OIDC
@@ -1159,7 +1176,7 @@ export class NodeProject extends GitHubProject {
         },
         {
           name: "AWS CodeArtifact Login",
-          run: `${this.runScriptCommand} ca:login`,
+          run: `${executeProjenCommand} ca:login`,
         },
       ];
     }
@@ -1183,7 +1200,7 @@ export class NodeProject extends GitHubProject {
         },
         {
           name: "AWS CodeArtifact Login",
-          run: `${this.runScriptCommand} ca:login`,
+          run: `${executeProjenCommand} ca:login`,
         },
       ];
     }
@@ -1191,7 +1208,7 @@ export class NodeProject extends GitHubProject {
     return [
       {
         name: "AWS CodeArtifact Login",
-        run: `${this.runScriptCommand} ca:login`,
+        run: `${executeProjenCommand} ca:login`,
         env: {
           AWS_ACCESS_KEY_ID: secretToString(
             parsedCodeArtifactOptions.accessKeyIdSecret,

--- a/src/javascript/node-project.ts
+++ b/src/javascript/node-project.ts
@@ -27,7 +27,12 @@ import type {
 import { AutoMerge, GitHub, GitHubProject } from "../github";
 import type { BiomeOptions } from "./biome/biome";
 import { Biome } from "./biome/biome";
-import { execCommand, isYarnBerry, isYarnClassic } from "./util";
+import {
+  execCommand,
+  executeCommandPriorInstallation,
+  isYarnBerry,
+  isYarnClassic,
+} from "./util";
 import { DEFAULT_GITHUB_ACTIONS_USER } from "../github/constants";
 import { ensureNotHiddenPath, secretToString } from "../github/private/util";
 import type {
@@ -1143,22 +1148,7 @@ export class NodeProject extends GitHubProject {
       authProvider: codeArtifactOptions?.authProvider,
     };
 
-    function executeCommand(packageManager: NodePackageManager): string {
-      switch (packageManager) {
-        case NodePackageManager.NPM:
-        case NodePackageManager.YARN:
-        case NodePackageManager.YARN_CLASSIC:
-          return "npx";
-        case NodePackageManager.PNPM:
-          return "pnpm dlx";
-        case NodePackageManager.YARN2:
-        case NodePackageManager.YARN_BERRY:
-          return "yarn dlx";
-        case NodePackageManager.BUN:
-          return "bunx";
-      }
-    }
-    const executeProjenCommand = `${executeCommand(this.packageManager)} projen`;
+    const executeProjenCommand = `${executeCommandPriorInstallation(this.packageManager)} projen`;
 
     if (
       parsedCodeArtifactOptions.authProvider ===

--- a/src/javascript/upgrade-dependencies.ts
+++ b/src/javascript/upgrade-dependencies.ts
@@ -7,7 +7,12 @@ import type {
   workflows,
 } from "../github";
 import { GitHub, WorkflowJobs, WorkflowSteps } from "../github";
-import { isYarnClassic, isYarnBerry, isNpm } from "./util";
+import {
+  isYarnClassic,
+  isYarnBerry,
+  isNpm,
+  executeCommandPriorInstallation,
+} from "./util";
 import { DEFAULT_GITHUB_ACTIONS_USER } from "../github/constants";
 import { projectPathRelativeToRepoRoot } from "../github/private/util";
 import { WorkflowActions } from "../github/workflow-actions";
@@ -363,24 +368,8 @@ export class UpgradeDependencies extends Component {
       removeRange?: boolean;
     } = {},
   ): string {
-    function executeCommand(packageManager: NodePackageManager): string {
-      switch (packageManager) {
-        case NodePackageManager.NPM:
-        case NodePackageManager.YARN:
-        case NodePackageManager.YARN_CLASSIC:
-          return "npx";
-        case NodePackageManager.PNPM:
-          return "pnpm dlx";
-        case NodePackageManager.YARN2:
-        case NodePackageManager.YARN_BERRY:
-          return "yarn dlx";
-        case NodePackageManager.BUN:
-          return "bunx";
-      }
-    }
-
     const command = [
-      `${executeCommand(
+      `${executeCommandPriorInstallation(
         this.project.package.packageManager,
       )} npm-check-updates@20`,
     ];

--- a/src/javascript/util.ts
+++ b/src/javascript/util.ts
@@ -63,6 +63,29 @@ export function execCommand(
 }
 
 /**
+ * Returns the command to execute a binary with the given package manager, without requiring installation of that binary as a project dependency.
+ * @param packageManager The package manager to use when executing the command.
+ */
+export function executeCommandPriorInstallation(
+  packageManager: NodePackageManager,
+): string {
+  switch (packageManager) {
+    case NodePackageManager.PNPM:
+      return "pnpm dlx";
+    case NodePackageManager.YARN2:
+    case NodePackageManager.YARN_BERRY:
+      return "yarn dlx";
+    case NodePackageManager.BUN:
+      return "bunx";
+    case NodePackageManager.NPM:
+    case NodePackageManager.YARN:
+    case NodePackageManager.YARN_CLASSIC:
+    default:
+      return "npx";
+  }
+}
+
+/**
  * Basic interface for `package.json`.
  */
 interface PackageManifest {

--- a/test/javascript/node-project.test.ts
+++ b/test/javascript/node-project.test.ts
@@ -1918,7 +1918,7 @@ describe("scoped private packages", () => {
     });
   });
 
-  test('adds AWS Code Artifact Login step prior to install to workflow with specific package manager command when package manager is pnpm', () => {
+  test("adds AWS Code Artifact Login step prior to install to workflow with specific package manager command when package manager is pnpm", () => {
     const project = new TestNodeProject({
       scopedPackagesOptions: [
         {
@@ -1931,15 +1931,15 @@ describe("scoped private packages", () => {
     const output = synthSnapshot(project);
 
     const expectedSteps = [
-        {
-          name: "AWS CodeArtifact Login",
-          run: "pnpm dlx projen ca:login",
-          env: {
-            AWS_ACCESS_KEY_ID: secretToString(defaultAccessKeyIdSecret),
-            AWS_SECRET_ACCESS_KEY: secretToString(defaultSecretAccessKeySecret),
-          },
+      {
+        name: "AWS CodeArtifact Login",
+        run: "pnpm dlx projen ca:login",
+        env: {
+          AWS_ACCESS_KEY_ID: secretToString(defaultAccessKeyIdSecret),
+          AWS_SECRET_ACCESS_KEY: secretToString(defaultSecretAccessKeySecret),
         },
-      ]
+      },
+    ];
     const releaseWorkflow = yaml.parse(output[".github/workflows/release.yml"]);
     const buildWorkflow = yaml.parse(output[".github/workflows/build.yml"]);
     expect(releaseWorkflow.jobs.release.steps).toEqual(
@@ -1948,7 +1948,7 @@ describe("scoped private packages", () => {
     expect(buildWorkflow.jobs.build.steps).toEqual(
       expect.arrayContaining(expectedSteps),
     );
-  })
+  });
 });
 
 test("sets resolution-mode to highest by default for pnpm < 10", () => {

--- a/test/javascript/node-project.test.ts
+++ b/test/javascript/node-project.test.ts
@@ -1917,6 +1917,38 @@ describe("scoped private packages", () => {
       ],
     });
   });
+
+  test('adds AWS Code Artifact Login step prior to install to workflow with specific package manager command when package manager is pnpm', () => {
+    const project = new TestNodeProject({
+      scopedPackagesOptions: [
+        {
+          registryUrl,
+          scope,
+        },
+      ],
+      packageManager: NodePackageManager.PNPM,
+    });
+    const output = synthSnapshot(project);
+
+    const expectedSteps = [
+        {
+          name: "AWS CodeArtifact Login",
+          run: "pnpm dlx projen ca:login",
+          env: {
+            AWS_ACCESS_KEY_ID: secretToString(defaultAccessKeyIdSecret),
+            AWS_SECRET_ACCESS_KEY: secretToString(defaultSecretAccessKeySecret),
+          },
+        },
+      ]
+    const releaseWorkflow = yaml.parse(output[".github/workflows/release.yml"]);
+    const buildWorkflow = yaml.parse(output[".github/workflows/build.yml"]);
+    expect(releaseWorkflow.jobs.release.steps).toEqual(
+      expect.arrayContaining(expectedSteps),
+    );
+    expect(buildWorkflow.jobs.build.steps).toEqual(
+      expect.arrayContaining(expectedSteps),
+    );
+  })
 });
 
 test("sets resolution-mode to highest by default for pnpm < 10", () => {

--- a/test/javascript/node-project.test.ts
+++ b/test/javascript/node-project.test.ts
@@ -1523,7 +1523,7 @@ describe("scoped private packages", () => {
         expect.arrayContaining([
           {
             name: "AWS CodeArtifact Login",
-            run: "yarn run ca:login",
+            run: "npx projen ca:login",
             env: {
               AWS_ACCESS_KEY_ID: secretToString(defaultAccessKeyIdSecret),
               AWS_SECRET_ACCESS_KEY: secretToString(
@@ -1551,7 +1551,7 @@ describe("scoped private packages", () => {
         expect.arrayContaining([
           {
             name: "AWS CodeArtifact Login",
-            run: "yarn run ca:login",
+            run: "npx projen ca:login",
             env: {
               AWS_ACCESS_KEY_ID: secretToString(defaultAccessKeyIdSecret),
               AWS_SECRET_ACCESS_KEY: secretToString(
@@ -1614,7 +1614,7 @@ describe("scoped private packages", () => {
           },
           {
             name: "AWS CodeArtifact Login",
-            run: "yarn run ca:login",
+            run: "npx projen ca:login",
           },
           {
             name: "Install dependencies",
@@ -1652,7 +1652,7 @@ describe("scoped private packages", () => {
           },
           {
             name: "AWS CodeArtifact Login",
-            run: "yarn run ca:login",
+            run: "npx projen ca:login",
           },
           {
             name: "Install dependencies",
@@ -1707,7 +1707,7 @@ describe("scoped private packages", () => {
       expect.arrayContaining([
         {
           name: "AWS CodeArtifact Login",
-          run: "yarn run ca:login",
+          run: "npx projen ca:login",
           env: {
             AWS_ACCESS_KEY_ID: secretToString(defaultAccessKeyIdSecret),
             AWS_SECRET_ACCESS_KEY: secretToString(defaultSecretAccessKeySecret),
@@ -1742,7 +1742,7 @@ describe("scoped private packages", () => {
       expect.arrayContaining([
         {
           name: "AWS CodeArtifact Login",
-          run: "yarn run ca:login",
+          run: "npx projen ca:login",
           env: {
             AWS_ACCESS_KEY_ID: secretToString(accessKeyIdSecret),
             AWS_SECRET_ACCESS_KEY: secretToString(secretAccessKeySecret),
@@ -1789,7 +1789,7 @@ describe("scoped private packages", () => {
         },
         {
           name: "AWS CodeArtifact Login",
-          run: "yarn run ca:login",
+          run: "npx projen ca:login",
         },
         {
           name: "Install dependencies",

--- a/test/javascript/util.test.ts
+++ b/test/javascript/util.test.ts
@@ -10,8 +10,10 @@ import {
   tryResolveDependencyVersion,
   installedVersionProbablyMatches,
   extractCodeArtifactDetails,
+  executeCommandPriorInstallation,
 } from "../../src/javascript/util";
 import { mkdtemp } from "../util";
+import { NodePackageManager } from "../../src/javascript";
 
 describe("tryResolveModule", () => {
   test.each([
@@ -188,3 +190,16 @@ test.each([
     extractCodeArtifactDetails(url);
   }).toThrow(/Could not get CodeArtifact details from npm Registry/);
 });
+
+test.each([
+  [NodePackageManager.NPM, "npx"],
+  [NodePackageManager.YARN, "npx"],
+  [NodePackageManager.YARN_CLASSIC, "npx"],
+  [NodePackageManager.YARN_BERRY, "yarn dlx"],
+  [NodePackageManager.YARN2, "yarn dlx"],
+  [NodePackageManager.PNPM, "pnpm dlx"],
+  [NodePackageManager.BUN, "bunx"],
+])('executeCommandPriorInstallation(%p) should return %p', (packageManager: NodePackageManager, expectedCommand: string)=> {
+  const result = executeCommandPriorInstallation(packageManager);
+  expect(result).toBe(expectedCommand);
+})

--- a/test/javascript/util.test.ts
+++ b/test/javascript/util.test.ts
@@ -1,5 +1,6 @@
 import { mkdirSync, writeFileSync } from "fs";
 import * as path from "path";
+import { NodePackageManager } from "../../src/javascript";
 import {
   tryResolveModule,
   tryResolveModuleManifestPath,
@@ -13,7 +14,6 @@ import {
   executeCommandPriorInstallation,
 } from "../../src/javascript/util";
 import { mkdtemp } from "../util";
-import { NodePackageManager } from "../../src/javascript";
 
 describe("tryResolveModule", () => {
   test.each([
@@ -199,7 +199,10 @@ test.each([
   [NodePackageManager.YARN2, "yarn dlx"],
   [NodePackageManager.PNPM, "pnpm dlx"],
   [NodePackageManager.BUN, "bunx"],
-])('executeCommandPriorInstallation(%p) should return %p', (packageManager: NodePackageManager, expectedCommand: string)=> {
-  const result = executeCommandPriorInstallation(packageManager);
-  expect(result).toBe(expectedCommand);
-})
+])(
+  "executeCommandPriorInstallation(%p) should return %p",
+  (packageManager: NodePackageManager, expectedCommand: string) => {
+    const result = executeCommandPriorInstallation(packageManager);
+    expect(result).toBe(expectedCommand);
+  },
+);


### PR DESCRIPTION
Fixes the AWS CodeArtifact login command (#4654 ) to ensure it executes correctly before package installation by updating the command to use the appropriate package manager. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

