### PR TITLE
feat(github): support checking out Git submodules in workflows

### DIFF
--- a/docs/api/github.md
+++ b/docs/api/github.md
@@ -1317,6 +1317,7 @@ Returns the `GitHub` component of a project or `undefined` if the project does n
 | <code><a href="#projen.github.GitHub.property.project">project</a></code> | <code>projen.Project</code> | *No description.* |
 | <code><a href="#projen.github.GitHub.property.actions">actions</a></code> | <code><a href="#projen.github.GitHubActionsProvider">GitHubActionsProvider</a></code> | The GitHub Actions provider used to manage the versions of actions used in steps. |
 | <code><a href="#projen.github.GitHub.property.downloadLfs">downloadLfs</a></code> | <code>boolean</code> | Whether downloading from LFS is enabled for this GitHub project. |
+| <code><a href="#projen.github.GitHub.property.downloadSubmodules">downloadSubmodules</a></code> | <code>boolean \| string</code> | Whether checking out Git submodules is enabled for this GitHub project. |
 | <code><a href="#projen.github.GitHub.property.projenCredentials">projenCredentials</a></code> | <code><a href="#projen.github.GithubCredentials">GithubCredentials</a></code> | GitHub API authentication method used by projen workflows. |
 | <code><a href="#projen.github.GitHub.property.workflows">workflows</a></code> | <code><a href="#projen.github.GithubWorkflow">GithubWorkflow</a>[]</code> | All workflows. |
 | <code><a href="#projen.github.GitHub.property.workflowsEnabled">workflowsEnabled</a></code> | <code>boolean</code> | Are workflows enabled? |
@@ -1368,6 +1369,20 @@ public readonly downloadLfs: boolean;
 - *Type:* boolean
 
 Whether downloading from LFS is enabled for this GitHub project.
+
+---
+
+##### `downloadSubmodules`<sup>Required</sup> <a name="downloadSubmodules" id="projen.github.GitHub.property.downloadSubmodules"></a>
+
+```typescript
+public readonly downloadSubmodules: boolean | string;
+```
+
+- *Type:* boolean | string
+
+Whether checking out Git submodules is enabled for this GitHub project.
+
+Returns `false` (default), `true` (top-level submodules), or `"recursive"`.
 
 ---
 
@@ -5574,6 +5589,7 @@ const checkoutWith: github.CheckoutWith = { ... }
 | <code><a href="#projen.github.CheckoutWith.property.path">path</a></code> | <code>string</code> | Relative path under $GITHUB_WORKSPACE to place the repository. |
 | <code><a href="#projen.github.CheckoutWith.property.ref">ref</a></code> | <code>string</code> | Branch or tag name. |
 | <code><a href="#projen.github.CheckoutWith.property.repository">repository</a></code> | <code>string</code> | The repository (owner/repo) to use. |
+| <code><a href="#projen.github.CheckoutWith.property.submodules">submodules</a></code> | <code>boolean \| string</code> | Whether to checkout Git submodules. |
 | <code><a href="#projen.github.CheckoutWith.property.token">token</a></code> | <code>string</code> | A GitHub token to use when checking out the repository. |
 
 ---
@@ -5645,6 +5661,22 @@ The repository (owner/repo) to use.
 
 ---
 
+##### `submodules`<sup>Optional</sup> <a name="submodules" id="projen.github.CheckoutWith.property.submodules"></a>
+
+```typescript
+public readonly submodules: boolean | string;
+```
+
+- *Type:* boolean | string
+- *Default:* false
+
+Whether to checkout Git submodules.
+
+Pass `true` to clone only the
+top-level submodules, or `"recursive"` to clone submodules recursively.
+
+---
+
 ##### `token`<sup>Optional</sup> <a name="token" id="projen.github.CheckoutWith.property.token"></a>
 
 ```typescript
@@ -5682,6 +5714,7 @@ const checkoutWithPatchOptions: github.CheckoutWithPatchOptions = { ... }
 | <code><a href="#projen.github.CheckoutWithPatchOptions.property.path">path</a></code> | <code>string</code> | Relative path under $GITHUB_WORKSPACE to place the repository. |
 | <code><a href="#projen.github.CheckoutWithPatchOptions.property.ref">ref</a></code> | <code>string</code> | Branch or tag name. |
 | <code><a href="#projen.github.CheckoutWithPatchOptions.property.repository">repository</a></code> | <code>string</code> | The repository (owner/repo) to use. |
+| <code><a href="#projen.github.CheckoutWithPatchOptions.property.submodules">submodules</a></code> | <code>boolean \| string</code> | Whether to checkout Git submodules. |
 | <code><a href="#projen.github.CheckoutWithPatchOptions.property.token">token</a></code> | <code>string</code> | A GitHub token to use when checking out the repository. |
 | <code><a href="#projen.github.CheckoutWithPatchOptions.property.patchFile">patchFile</a></code> | <code>string</code> | The name of the artifact the patch is stored as. |
 
@@ -5751,6 +5784,22 @@ public readonly repository: string;
 - *Default:* the default repository is implicitly used
 
 The repository (owner/repo) to use.
+
+---
+
+##### `submodules`<sup>Optional</sup> <a name="submodules" id="projen.github.CheckoutWithPatchOptions.property.submodules"></a>
+
+```typescript
+public readonly submodules: boolean | string;
+```
+
+- *Type:* boolean | string
+- *Default:* false
+
+Whether to checkout Git submodules.
+
+Pass `true` to clone only the
+top-level submodules, or `"recursive"` to clone submodules recursively.
 
 ---
 
@@ -7369,6 +7418,7 @@ const gitHubOptions: github.GitHubOptions = { ... }
 | <code><a href="#projen.github.GitHubOptions.property.dependencyReview">dependencyReview</a></code> | <code>boolean</code> | Enable the dependency-review-action workflow on pull requests. |
 | <code><a href="#projen.github.GitHubOptions.property.dependencyReviewOptions">dependencyReviewOptions</a></code> | <code><a href="#projen.github.DependencyReviewOptions">DependencyReviewOptions</a></code> | Options for the dependency review workflow. |
 | <code><a href="#projen.github.GitHubOptions.property.downloadLfs">downloadLfs</a></code> | <code>boolean</code> | Download files in LFS in workflows. |
+| <code><a href="#projen.github.GitHubOptions.property.downloadSubmodules">downloadSubmodules</a></code> | <code>boolean \| string</code> | Whether to checkout Git submodules in workflows. |
 | <code><a href="#projen.github.GitHubOptions.property.mergeQueue">mergeQueue</a></code> | <code>boolean</code> | Whether a merge queue should be used on this repository to merge pull requests. |
 | <code><a href="#projen.github.GitHubOptions.property.mergeQueueOptions">mergeQueueOptions</a></code> | <code><a href="#projen.github.MergeQueueOptions">MergeQueueOptions</a></code> | Options for MergeQueue. |
 | <code><a href="#projen.github.GitHubOptions.property.mergify">mergify</a></code> | <code>boolean</code> | Whether mergify should be enabled on this repository or not. |
@@ -7425,6 +7475,23 @@ public readonly downloadLfs: boolean;
 - *Default:* true if the associated project has `lfsPatterns`, `false` otherwise
 
 Download files in LFS in workflows.
+
+---
+
+##### `downloadSubmodules`<sup>Optional</sup> <a name="downloadSubmodules" id="projen.github.GitHubOptions.property.downloadSubmodules"></a>
+
+```typescript
+public readonly downloadSubmodules: boolean | string;
+```
+
+- *Type:* boolean | string
+- *Default:* false
+
+Whether to checkout Git submodules in workflows.
+
+Pass `true` to clone
+only the top-level submodules, or `"recursive"` to clone submodules
+recursively.
 
 ---
 
@@ -9048,6 +9115,7 @@ const pullRequestPatchSource: github.PullRequestPatchSource = { ... }
 | <code><a href="#projen.github.PullRequestPatchSource.property.path">path</a></code> | <code>string</code> | Relative path under $GITHUB_WORKSPACE to place the repository. |
 | <code><a href="#projen.github.PullRequestPatchSource.property.ref">ref</a></code> | <code>string</code> | Branch or tag name. |
 | <code><a href="#projen.github.PullRequestPatchSource.property.repository">repository</a></code> | <code>string</code> | The repository (owner/repo) to use. |
+| <code><a href="#projen.github.PullRequestPatchSource.property.submodules">submodules</a></code> | <code>boolean \| string</code> | Whether to checkout Git submodules. |
 | <code><a href="#projen.github.PullRequestPatchSource.property.token">token</a></code> | <code>string</code> | A GitHub token to use when checking out the repository. |
 | <code><a href="#projen.github.PullRequestPatchSource.property.patchFile">patchFile</a></code> | <code>string</code> | The name of the artifact the patch is stored as. |
 | <code><a href="#projen.github.PullRequestPatchSource.property.jobId">jobId</a></code> | <code>string</code> | The id of the job that created the patch file. |
@@ -9119,6 +9187,22 @@ public readonly repository: string;
 - *Default:* the default repository is implicitly used
 
 The repository (owner/repo) to use.
+
+---
+
+##### `submodules`<sup>Optional</sup> <a name="submodules" id="projen.github.PullRequestPatchSource.property.submodules"></a>
+
+```typescript
+public readonly submodules: boolean | string;
+```
+
+- *Type:* boolean | string
+- *Default:* false
+
+Whether to checkout Git submodules.
+
+Pass `true` to clone only the
+top-level submodules, or `"recursive"` to clone submodules recursively.
 
 ---
 
@@ -9649,6 +9733,7 @@ const taskWorkflowJobOptions: github.TaskWorkflowJobOptions = { ... }
 | <code><a href="#projen.github.TaskWorkflowJobOptions.property.condition">condition</a></code> | <code>string</code> | Adds an 'if' condition to the workflow. |
 | <code><a href="#projen.github.TaskWorkflowJobOptions.property.container">container</a></code> | <code><a href="#projen.github.workflows.ContainerOptions">ContainerOptions</a></code> | *No description.* |
 | <code><a href="#projen.github.TaskWorkflowJobOptions.property.downloadLfs">downloadLfs</a></code> | <code>boolean</code> | Whether to download files from Git LFS for this workflow. |
+| <code><a href="#projen.github.TaskWorkflowJobOptions.property.downloadSubmodules">downloadSubmodules</a></code> | <code>boolean \| string</code> | Whether to checkout Git submodules for this workflow. |
 | <code><a href="#projen.github.TaskWorkflowJobOptions.property.env">env</a></code> | <code>{[ key: string ]: string}</code> | Workflow environment variables. |
 | <code><a href="#projen.github.TaskWorkflowJobOptions.property.environment">environment</a></code> | <code>string</code> | The GitHub Actions environment used for the job. |
 | <code><a href="#projen.github.TaskWorkflowJobOptions.property.gitIdentity">gitIdentity</a></code> | <code><a href="#projen.github.GitIdentity">GitIdentity</a></code> | The git identity to use in this workflow. |
@@ -9733,6 +9818,23 @@ public readonly downloadLfs: boolean;
 - *Default:* Use the setting on the corresponding GitHub project
 
 Whether to download files from Git LFS for this workflow.
+
+---
+
+##### `downloadSubmodules`<sup>Optional</sup> <a name="downloadSubmodules" id="projen.github.TaskWorkflowJobOptions.property.downloadSubmodules"></a>
+
+```typescript
+public readonly downloadSubmodules: boolean | string;
+```
+
+- *Type:* boolean | string
+- *Default:* Use the setting on the corresponding GitHub project
+
+Whether to checkout Git submodules for this workflow.
+
+Pass `true` to
+clone only the top-level submodules, or `"recursive"` for nested
+submodules.
 
 ---
 
@@ -9886,6 +9988,7 @@ const taskWorkflowOptions: github.TaskWorkflowOptions = { ... }
 | <code><a href="#projen.github.TaskWorkflowOptions.property.condition">condition</a></code> | <code>string</code> | Adds an 'if' condition to the workflow. |
 | <code><a href="#projen.github.TaskWorkflowOptions.property.container">container</a></code> | <code><a href="#projen.github.workflows.ContainerOptions">ContainerOptions</a></code> | *No description.* |
 | <code><a href="#projen.github.TaskWorkflowOptions.property.downloadLfs">downloadLfs</a></code> | <code>boolean</code> | Whether to download files from Git LFS for this workflow. |
+| <code><a href="#projen.github.TaskWorkflowOptions.property.downloadSubmodules">downloadSubmodules</a></code> | <code>boolean \| string</code> | Whether to checkout Git submodules for this workflow. |
 | <code><a href="#projen.github.TaskWorkflowOptions.property.env">env</a></code> | <code>{[ key: string ]: string}</code> | Workflow environment variables. |
 | <code><a href="#projen.github.TaskWorkflowOptions.property.environment">environment</a></code> | <code>string</code> | The GitHub Actions environment used for the job. |
 | <code><a href="#projen.github.TaskWorkflowOptions.property.gitIdentity">gitIdentity</a></code> | <code><a href="#projen.github.GitIdentity">GitIdentity</a></code> | The git identity to use in this workflow. |
@@ -9974,6 +10077,23 @@ public readonly downloadLfs: boolean;
 - *Default:* Use the setting on the corresponding GitHub project
 
 Whether to download files from Git LFS for this workflow.
+
+---
+
+##### `downloadSubmodules`<sup>Optional</sup> <a name="downloadSubmodules" id="projen.github.TaskWorkflowOptions.property.downloadSubmodules"></a>
+
+```typescript
+public readonly downloadSubmodules: boolean | string;
+```
+
+- *Type:* boolean | string
+- *Default:* Use the setting on the corresponding GitHub project
+
+Whether to checkout Git submodules for this workflow.
+
+Pass `true` to
+clone only the top-level submodules, or `"recursive"` for nested
+submodules.
 
 ---
 

--- a/docs/api/github.md
+++ b/docs/api/github.md
@@ -1316,8 +1316,8 @@ Returns the `GitHub` component of a project or `undefined` if the project does n
 | <code><a href="#projen.github.GitHub.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#projen.github.GitHub.property.project">project</a></code> | <code>projen.Project</code> | *No description.* |
 | <code><a href="#projen.github.GitHub.property.actions">actions</a></code> | <code><a href="#projen.github.GitHubActionsProvider">GitHubActionsProvider</a></code> | The GitHub Actions provider used to manage the versions of actions used in steps. |
+| <code><a href="#projen.github.GitHub.property.checkoutSubmodules">checkoutSubmodules</a></code> | <code><a href="#projen.github.CheckoutSubmodules">CheckoutSubmodules</a></code> | Whether checking out Git submodules is enabled for this GitHub project. |
 | <code><a href="#projen.github.GitHub.property.downloadLfs">downloadLfs</a></code> | <code>boolean</code> | Whether downloading from LFS is enabled for this GitHub project. |
-| <code><a href="#projen.github.GitHub.property.downloadSubmodules">downloadSubmodules</a></code> | <code>boolean \| string</code> | Whether checking out Git submodules is enabled for this GitHub project. |
 | <code><a href="#projen.github.GitHub.property.projenCredentials">projenCredentials</a></code> | <code><a href="#projen.github.GithubCredentials">GithubCredentials</a></code> | GitHub API authentication method used by projen workflows. |
 | <code><a href="#projen.github.GitHub.property.workflows">workflows</a></code> | <code><a href="#projen.github.GithubWorkflow">GithubWorkflow</a>[]</code> | All workflows. |
 | <code><a href="#projen.github.GitHub.property.workflowsEnabled">workflowsEnabled</a></code> | <code>boolean</code> | Are workflows enabled? |
@@ -1360,6 +1360,18 @@ The GitHub Actions provider used to manage the versions of actions used in steps
 
 ---
 
+##### `checkoutSubmodules`<sup>Required</sup> <a name="checkoutSubmodules" id="projen.github.GitHub.property.checkoutSubmodules"></a>
+
+```typescript
+public readonly checkoutSubmodules: CheckoutSubmodules;
+```
+
+- *Type:* <a href="#projen.github.CheckoutSubmodules">CheckoutSubmodules</a>
+
+Whether checking out Git submodules is enabled for this GitHub project.
+
+---
+
 ##### `downloadLfs`<sup>Required</sup> <a name="downloadLfs" id="projen.github.GitHub.property.downloadLfs"></a>
 
 ```typescript
@@ -1369,20 +1381,6 @@ public readonly downloadLfs: boolean;
 - *Type:* boolean
 
 Whether downloading from LFS is enabled for this GitHub project.
-
----
-
-##### `downloadSubmodules`<sup>Required</sup> <a name="downloadSubmodules" id="projen.github.GitHub.property.downloadSubmodules"></a>
-
-```typescript
-public readonly downloadSubmodules: boolean | string;
-```
-
-- *Type:* boolean | string
-
-Whether checking out Git submodules is enabled for this GitHub project.
-
-Returns `false` (default), `true` (top-level submodules), or `"recursive"`.
 
 ---
 
@@ -5589,7 +5587,7 @@ const checkoutWith: github.CheckoutWith = { ... }
 | <code><a href="#projen.github.CheckoutWith.property.path">path</a></code> | <code>string</code> | Relative path under $GITHUB_WORKSPACE to place the repository. |
 | <code><a href="#projen.github.CheckoutWith.property.ref">ref</a></code> | <code>string</code> | Branch or tag name. |
 | <code><a href="#projen.github.CheckoutWith.property.repository">repository</a></code> | <code>string</code> | The repository (owner/repo) to use. |
-| <code><a href="#projen.github.CheckoutWith.property.submodules">submodules</a></code> | <code>boolean \| string</code> | Whether to checkout Git submodules. |
+| <code><a href="#projen.github.CheckoutWith.property.submodules">submodules</a></code> | <code><a href="#projen.github.CheckoutSubmodules">CheckoutSubmodules</a></code> | Whether to checkout Git submodules. |
 | <code><a href="#projen.github.CheckoutWith.property.token">token</a></code> | <code>string</code> | A GitHub token to use when checking out the repository. |
 
 ---
@@ -5664,16 +5662,13 @@ The repository (owner/repo) to use.
 ##### `submodules`<sup>Optional</sup> <a name="submodules" id="projen.github.CheckoutWith.property.submodules"></a>
 
 ```typescript
-public readonly submodules: boolean | string;
+public readonly submodules: CheckoutSubmodules;
 ```
 
-- *Type:* boolean | string
-- *Default:* false
+- *Type:* <a href="#projen.github.CheckoutSubmodules">CheckoutSubmodules</a>
+- *Default:* CheckoutSubmodules.DISABLED
 
 Whether to checkout Git submodules.
-
-Pass `true` to clone only the
-top-level submodules, or `"recursive"` to clone submodules recursively.
 
 ---
 
@@ -5714,7 +5709,7 @@ const checkoutWithPatchOptions: github.CheckoutWithPatchOptions = { ... }
 | <code><a href="#projen.github.CheckoutWithPatchOptions.property.path">path</a></code> | <code>string</code> | Relative path under $GITHUB_WORKSPACE to place the repository. |
 | <code><a href="#projen.github.CheckoutWithPatchOptions.property.ref">ref</a></code> | <code>string</code> | Branch or tag name. |
 | <code><a href="#projen.github.CheckoutWithPatchOptions.property.repository">repository</a></code> | <code>string</code> | The repository (owner/repo) to use. |
-| <code><a href="#projen.github.CheckoutWithPatchOptions.property.submodules">submodules</a></code> | <code>boolean \| string</code> | Whether to checkout Git submodules. |
+| <code><a href="#projen.github.CheckoutWithPatchOptions.property.submodules">submodules</a></code> | <code><a href="#projen.github.CheckoutSubmodules">CheckoutSubmodules</a></code> | Whether to checkout Git submodules. |
 | <code><a href="#projen.github.CheckoutWithPatchOptions.property.token">token</a></code> | <code>string</code> | A GitHub token to use when checking out the repository. |
 | <code><a href="#projen.github.CheckoutWithPatchOptions.property.patchFile">patchFile</a></code> | <code>string</code> | The name of the artifact the patch is stored as. |
 
@@ -5790,16 +5785,13 @@ The repository (owner/repo) to use.
 ##### `submodules`<sup>Optional</sup> <a name="submodules" id="projen.github.CheckoutWithPatchOptions.property.submodules"></a>
 
 ```typescript
-public readonly submodules: boolean | string;
+public readonly submodules: CheckoutSubmodules;
 ```
 
-- *Type:* boolean | string
-- *Default:* false
+- *Type:* <a href="#projen.github.CheckoutSubmodules">CheckoutSubmodules</a>
+- *Default:* CheckoutSubmodules.DISABLED
 
 Whether to checkout Git submodules.
-
-Pass `true` to clone only the
-top-level submodules, or `"recursive"` to clone submodules recursively.
 
 ---
 
@@ -7415,10 +7407,10 @@ const gitHubOptions: github.GitHubOptions = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#projen.github.GitHubOptions.property.checkoutSubmodules">checkoutSubmodules</a></code> | <code><a href="#projen.github.CheckoutSubmodules">CheckoutSubmodules</a></code> | Whether to checkout Git submodules. |
 | <code><a href="#projen.github.GitHubOptions.property.dependencyReview">dependencyReview</a></code> | <code>boolean</code> | Enable the dependency-review-action workflow on pull requests. |
 | <code><a href="#projen.github.GitHubOptions.property.dependencyReviewOptions">dependencyReviewOptions</a></code> | <code><a href="#projen.github.DependencyReviewOptions">DependencyReviewOptions</a></code> | Options for the dependency review workflow. |
 | <code><a href="#projen.github.GitHubOptions.property.downloadLfs">downloadLfs</a></code> | <code>boolean</code> | Download files in LFS in workflows. |
-| <code><a href="#projen.github.GitHubOptions.property.downloadSubmodules">downloadSubmodules</a></code> | <code>boolean \| string</code> | Whether to checkout Git submodules in workflows. |
 | <code><a href="#projen.github.GitHubOptions.property.mergeQueue">mergeQueue</a></code> | <code>boolean</code> | Whether a merge queue should be used on this repository to merge pull requests. |
 | <code><a href="#projen.github.GitHubOptions.property.mergeQueueOptions">mergeQueueOptions</a></code> | <code><a href="#projen.github.MergeQueueOptions">MergeQueueOptions</a></code> | Options for MergeQueue. |
 | <code><a href="#projen.github.GitHubOptions.property.mergify">mergify</a></code> | <code>boolean</code> | Whether mergify should be enabled on this repository or not. |
@@ -7430,6 +7422,19 @@ const gitHubOptions: github.GitHubOptions = { ... }
 | <code><a href="#projen.github.GitHubOptions.property.pullRequestLint">pullRequestLint</a></code> | <code>boolean</code> | Add a workflow that performs basic checks for pull requests, like validating that PRs follow Conventional Commits. |
 | <code><a href="#projen.github.GitHubOptions.property.pullRequestLintOptions">pullRequestLintOptions</a></code> | <code><a href="#projen.github.PullRequestLintOptions">PullRequestLintOptions</a></code> | Options for configuring a pull request linter. |
 | <code><a href="#projen.github.GitHubOptions.property.workflows">workflows</a></code> | <code>boolean</code> | Enables GitHub workflows. |
+
+---
+
+##### `checkoutSubmodules`<sup>Optional</sup> <a name="checkoutSubmodules" id="projen.github.GitHubOptions.property.checkoutSubmodules"></a>
+
+```typescript
+public readonly checkoutSubmodules: CheckoutSubmodules;
+```
+
+- *Type:* <a href="#projen.github.CheckoutSubmodules">CheckoutSubmodules</a>
+- *Default:* CheckoutSubmodules.DISABLED
+
+Whether to checkout Git submodules.
 
 ---
 
@@ -7475,23 +7480,6 @@ public readonly downloadLfs: boolean;
 - *Default:* true if the associated project has `lfsPatterns`, `false` otherwise
 
 Download files in LFS in workflows.
-
----
-
-##### `downloadSubmodules`<sup>Optional</sup> <a name="downloadSubmodules" id="projen.github.GitHubOptions.property.downloadSubmodules"></a>
-
-```typescript
-public readonly downloadSubmodules: boolean | string;
-```
-
-- *Type:* boolean | string
-- *Default:* false
-
-Whether to checkout Git submodules in workflows.
-
-Pass `true` to clone
-only the top-level submodules, or `"recursive"` to clone submodules
-recursively.
 
 ---
 
@@ -9115,7 +9103,7 @@ const pullRequestPatchSource: github.PullRequestPatchSource = { ... }
 | <code><a href="#projen.github.PullRequestPatchSource.property.path">path</a></code> | <code>string</code> | Relative path under $GITHUB_WORKSPACE to place the repository. |
 | <code><a href="#projen.github.PullRequestPatchSource.property.ref">ref</a></code> | <code>string</code> | Branch or tag name. |
 | <code><a href="#projen.github.PullRequestPatchSource.property.repository">repository</a></code> | <code>string</code> | The repository (owner/repo) to use. |
-| <code><a href="#projen.github.PullRequestPatchSource.property.submodules">submodules</a></code> | <code>boolean \| string</code> | Whether to checkout Git submodules. |
+| <code><a href="#projen.github.PullRequestPatchSource.property.submodules">submodules</a></code> | <code><a href="#projen.github.CheckoutSubmodules">CheckoutSubmodules</a></code> | Whether to checkout Git submodules. |
 | <code><a href="#projen.github.PullRequestPatchSource.property.token">token</a></code> | <code>string</code> | A GitHub token to use when checking out the repository. |
 | <code><a href="#projen.github.PullRequestPatchSource.property.patchFile">patchFile</a></code> | <code>string</code> | The name of the artifact the patch is stored as. |
 | <code><a href="#projen.github.PullRequestPatchSource.property.jobId">jobId</a></code> | <code>string</code> | The id of the job that created the patch file. |
@@ -9193,16 +9181,13 @@ The repository (owner/repo) to use.
 ##### `submodules`<sup>Optional</sup> <a name="submodules" id="projen.github.PullRequestPatchSource.property.submodules"></a>
 
 ```typescript
-public readonly submodules: boolean | string;
+public readonly submodules: CheckoutSubmodules;
 ```
 
-- *Type:* boolean | string
-- *Default:* false
+- *Type:* <a href="#projen.github.CheckoutSubmodules">CheckoutSubmodules</a>
+- *Default:* CheckoutSubmodules.DISABLED
 
 Whether to checkout Git submodules.
-
-Pass `true` to clone only the
-top-level submodules, or `"recursive"` to clone submodules recursively.
 
 ---
 
@@ -9729,11 +9714,11 @@ const taskWorkflowJobOptions: github.TaskWorkflowJobOptions = { ... }
 | --- | --- | --- |
 | <code><a href="#projen.github.TaskWorkflowJobOptions.property.permissions">permissions</a></code> | <code><a href="#projen.github.workflows.JobPermissions">JobPermissions</a></code> | Permissions for the build job. |
 | <code><a href="#projen.github.TaskWorkflowJobOptions.property.artifactsDirectory">artifactsDirectory</a></code> | <code>string</code> | A directory name which contains artifacts to be uploaded (e.g. `dist`). If this is set, the contents of this directory will be uploaded as an artifact at the end of the workflow run, even if other steps fail. |
+| <code><a href="#projen.github.TaskWorkflowJobOptions.property.checkoutSubmodules">checkoutSubmodules</a></code> | <code><a href="#projen.github.CheckoutSubmodules">CheckoutSubmodules</a></code> | Whether to checkout Git submodules. |
 | <code><a href="#projen.github.TaskWorkflowJobOptions.property.checkoutWith">checkoutWith</a></code> | <code><a href="#projen.github.CheckoutWith">CheckoutWith</a></code> | Override for the `with` property of the source code checkout step. |
 | <code><a href="#projen.github.TaskWorkflowJobOptions.property.condition">condition</a></code> | <code>string</code> | Adds an 'if' condition to the workflow. |
 | <code><a href="#projen.github.TaskWorkflowJobOptions.property.container">container</a></code> | <code><a href="#projen.github.workflows.ContainerOptions">ContainerOptions</a></code> | *No description.* |
 | <code><a href="#projen.github.TaskWorkflowJobOptions.property.downloadLfs">downloadLfs</a></code> | <code>boolean</code> | Whether to download files from Git LFS for this workflow. |
-| <code><a href="#projen.github.TaskWorkflowJobOptions.property.downloadSubmodules">downloadSubmodules</a></code> | <code>boolean \| string</code> | Whether to checkout Git submodules for this workflow. |
 | <code><a href="#projen.github.TaskWorkflowJobOptions.property.env">env</a></code> | <code>{[ key: string ]: string}</code> | Workflow environment variables. |
 | <code><a href="#projen.github.TaskWorkflowJobOptions.property.environment">environment</a></code> | <code>string</code> | The GitHub Actions environment used for the job. |
 | <code><a href="#projen.github.TaskWorkflowJobOptions.property.gitIdentity">gitIdentity</a></code> | <code><a href="#projen.github.GitIdentity">GitIdentity</a></code> | The git identity to use in this workflow. |
@@ -9769,6 +9754,19 @@ public readonly artifactsDirectory: string;
 - *Default:* not set
 
 A directory name which contains artifacts to be uploaded (e.g. `dist`). If this is set, the contents of this directory will be uploaded as an artifact at the end of the workflow run, even if other steps fail.
+
+---
+
+##### `checkoutSubmodules`<sup>Optional</sup> <a name="checkoutSubmodules" id="projen.github.TaskWorkflowJobOptions.property.checkoutSubmodules"></a>
+
+```typescript
+public readonly checkoutSubmodules: CheckoutSubmodules;
+```
+
+- *Type:* <a href="#projen.github.CheckoutSubmodules">CheckoutSubmodules</a>
+- *Default:* Use the setting on the corresponding GitHub project
+
+Whether to checkout Git submodules.
 
 ---
 
@@ -9818,23 +9816,6 @@ public readonly downloadLfs: boolean;
 - *Default:* Use the setting on the corresponding GitHub project
 
 Whether to download files from Git LFS for this workflow.
-
----
-
-##### `downloadSubmodules`<sup>Optional</sup> <a name="downloadSubmodules" id="projen.github.TaskWorkflowJobOptions.property.downloadSubmodules"></a>
-
-```typescript
-public readonly downloadSubmodules: boolean | string;
-```
-
-- *Type:* boolean | string
-- *Default:* Use the setting on the corresponding GitHub project
-
-Whether to checkout Git submodules for this workflow.
-
-Pass `true` to
-clone only the top-level submodules, or `"recursive"` for nested
-submodules.
 
 ---
 
@@ -9984,11 +9965,11 @@ const taskWorkflowOptions: github.TaskWorkflowOptions = { ... }
 | --- | --- | --- |
 | <code><a href="#projen.github.TaskWorkflowOptions.property.permissions">permissions</a></code> | <code><a href="#projen.github.workflows.JobPermissions">JobPermissions</a></code> | Permissions for the build job. |
 | <code><a href="#projen.github.TaskWorkflowOptions.property.artifactsDirectory">artifactsDirectory</a></code> | <code>string</code> | A directory name which contains artifacts to be uploaded (e.g. `dist`). If this is set, the contents of this directory will be uploaded as an artifact at the end of the workflow run, even if other steps fail. |
+| <code><a href="#projen.github.TaskWorkflowOptions.property.checkoutSubmodules">checkoutSubmodules</a></code> | <code><a href="#projen.github.CheckoutSubmodules">CheckoutSubmodules</a></code> | Whether to checkout Git submodules. |
 | <code><a href="#projen.github.TaskWorkflowOptions.property.checkoutWith">checkoutWith</a></code> | <code><a href="#projen.github.CheckoutWith">CheckoutWith</a></code> | Override for the `with` property of the source code checkout step. |
 | <code><a href="#projen.github.TaskWorkflowOptions.property.condition">condition</a></code> | <code>string</code> | Adds an 'if' condition to the workflow. |
 | <code><a href="#projen.github.TaskWorkflowOptions.property.container">container</a></code> | <code><a href="#projen.github.workflows.ContainerOptions">ContainerOptions</a></code> | *No description.* |
 | <code><a href="#projen.github.TaskWorkflowOptions.property.downloadLfs">downloadLfs</a></code> | <code>boolean</code> | Whether to download files from Git LFS for this workflow. |
-| <code><a href="#projen.github.TaskWorkflowOptions.property.downloadSubmodules">downloadSubmodules</a></code> | <code>boolean \| string</code> | Whether to checkout Git submodules for this workflow. |
 | <code><a href="#projen.github.TaskWorkflowOptions.property.env">env</a></code> | <code>{[ key: string ]: string}</code> | Workflow environment variables. |
 | <code><a href="#projen.github.TaskWorkflowOptions.property.environment">environment</a></code> | <code>string</code> | The GitHub Actions environment used for the job. |
 | <code><a href="#projen.github.TaskWorkflowOptions.property.gitIdentity">gitIdentity</a></code> | <code><a href="#projen.github.GitIdentity">GitIdentity</a></code> | The git identity to use in this workflow. |
@@ -10028,6 +10009,19 @@ public readonly artifactsDirectory: string;
 - *Default:* not set
 
 A directory name which contains artifacts to be uploaded (e.g. `dist`). If this is set, the contents of this directory will be uploaded as an artifact at the end of the workflow run, even if other steps fail.
+
+---
+
+##### `checkoutSubmodules`<sup>Optional</sup> <a name="checkoutSubmodules" id="projen.github.TaskWorkflowOptions.property.checkoutSubmodules"></a>
+
+```typescript
+public readonly checkoutSubmodules: CheckoutSubmodules;
+```
+
+- *Type:* <a href="#projen.github.CheckoutSubmodules">CheckoutSubmodules</a>
+- *Default:* Use the setting on the corresponding GitHub project
+
+Whether to checkout Git submodules.
 
 ---
 
@@ -10077,23 +10071,6 @@ public readonly downloadLfs: boolean;
 - *Default:* Use the setting on the corresponding GitHub project
 
 Whether to download files from Git LFS for this workflow.
-
----
-
-##### `downloadSubmodules`<sup>Optional</sup> <a name="downloadSubmodules" id="projen.github.TaskWorkflowOptions.property.downloadSubmodules"></a>
-
-```typescript
-public readonly downloadSubmodules: boolean | string;
-```
-
-- *Type:* boolean | string
-- *Default:* Use the setting on the corresponding GitHub project
-
-Whether to checkout Git submodules for this workflow.
-
-Pass `true` to
-clone only the top-level submodules, or `"recursive"` for nested
-submodules.
 
 ---
 
@@ -11142,6 +11119,41 @@ public render(): string[]
 
 
 ## Enums <a name="Enums" id="Enums"></a>
+
+### CheckoutSubmodules <a name="CheckoutSubmodules" id="projen.github.CheckoutSubmodules"></a>
+
+Whether to checkout Git submodules in CI workflows.
+
+#### Members <a name="Members" id="Members"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#projen.github.CheckoutSubmodules.DISABLED">DISABLED</a></code> | Don't checkout submodules. |
+| <code><a href="#projen.github.CheckoutSubmodules.ENABLED">ENABLED</a></code> | Checkout only top-level submodules. |
+| <code><a href="#projen.github.CheckoutSubmodules.RECURSIVE">RECURSIVE</a></code> | Checkout submodules recursively. |
+
+---
+
+##### `DISABLED` <a name="DISABLED" id="projen.github.CheckoutSubmodules.DISABLED"></a>
+
+Don't checkout submodules.
+
+---
+
+
+##### `ENABLED` <a name="ENABLED" id="projen.github.CheckoutSubmodules.ENABLED"></a>
+
+Checkout only top-level submodules.
+
+---
+
+
+##### `RECURSIVE` <a name="RECURSIVE" id="projen.github.CheckoutSubmodules.RECURSIVE"></a>
+
+Checkout submodules recursively.
+
+---
+
 
 ### DependabotGroupAppliesTo <a name="DependabotGroupAppliesTo" id="projen.github.DependabotGroupAppliesTo"></a>
 

--- a/src/build/build-workflow.ts
+++ b/src/build/build-workflow.ts
@@ -352,6 +352,9 @@ export class BuildWorkflow extends Component {
             ref: PULL_REQUEST_REF,
             repository: PULL_REQUEST_REPOSITORY,
             ...(this.github.downloadLfs ? { lfs: true } : {}),
+            ...(this.github.downloadSubmodules
+              ? { submodules: this.github.downloadSubmodules }
+              : {}),
           },
         }),
       );
@@ -425,6 +428,9 @@ export class BuildWorkflow extends Component {
           ref: PULL_REQUEST_REF,
           repository: PULL_REQUEST_REPOSITORY,
           ...(this.github.downloadLfs ? { lfs: true } : {}),
+          ...(this.github.downloadSubmodules
+            ? { submodules: this.github.downloadSubmodules }
+            : {}),
         },
       }),
 

--- a/src/build/build-workflow.ts
+++ b/src/build/build-workflow.ts
@@ -352,8 +352,8 @@ export class BuildWorkflow extends Component {
             ref: PULL_REQUEST_REF,
             repository: PULL_REQUEST_REPOSITORY,
             ...(this.github.downloadLfs ? { lfs: true } : {}),
-            ...(this.github.downloadSubmodules
-              ? { submodules: this.github.downloadSubmodules }
+            ...(this.github.checkoutSubmodules
+              ? { submodules: this.github.checkoutSubmodules }
               : {}),
           },
         }),
@@ -428,8 +428,8 @@ export class BuildWorkflow extends Component {
           ref: PULL_REQUEST_REF,
           repository: PULL_REQUEST_REPOSITORY,
           ...(this.github.downloadLfs ? { lfs: true } : {}),
-          ...(this.github.downloadSubmodules
-            ? { submodules: this.github.downloadSubmodules }
+          ...(this.github.checkoutSubmodules
+            ? { submodules: this.github.checkoutSubmodules }
             : {}),
         },
       }),

--- a/src/build/build-workflow.ts
+++ b/src/build/build-workflow.ts
@@ -2,7 +2,12 @@ import * as posixPath from "node:path/posix";
 import type { Task } from "..";
 import { Component } from "../component";
 import type { GitIdentity, workflows } from "../github";
-import { GitHub, GithubWorkflow, WorkflowSteps } from "../github";
+import {
+  CheckoutSubmodules,
+  GitHub,
+  GithubWorkflow,
+  WorkflowSteps,
+} from "../github";
 import {
   BUILD_ARTIFACT_NAME,
   DEFAULT_GITHUB_ACTIONS_USER,
@@ -352,7 +357,7 @@ export class BuildWorkflow extends Component {
             ref: PULL_REQUEST_REF,
             repository: PULL_REQUEST_REPOSITORY,
             ...(this.github.downloadLfs ? { lfs: true } : {}),
-            ...(this.github.checkoutSubmodules
+            ...(this.github.checkoutSubmodules !== CheckoutSubmodules.DISABLED
               ? { submodules: this.github.checkoutSubmodules }
               : {}),
           },

--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -132,9 +132,8 @@ export interface GitHubOptions {
   readonly dependencyReviewOptions?: DependencyReviewOptions;
 
   /**
-   * Whether to checkout Git submodules in workflows. Pass `true` to clone
-   * only the top-level submodules, or `"recursive"` to clone submodules
-   * recursively.
+   * Whether to checkout Git submodules. Pass `true` to checkout only the
+   * top-level submodules, or `"recursive"` to checkout submodules recursively.
    *
    * @default false
    */

--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -13,6 +13,7 @@ import type { PullRequestBackportOptions } from "./pull-request-backport";
 import { PullRequestBackport } from "./pull-request-backport";
 import type { PullRequestLintOptions } from "./pull-request-lint";
 import { PullRequestLint } from "./pull-request-lint";
+import { CheckoutSubmodules } from "./workflow-steps";
 import { GithubWorkflow } from "./workflows";
 import { Component } from "../component";
 import type { Project } from "../project";
@@ -132,12 +133,11 @@ export interface GitHubOptions {
   readonly dependencyReviewOptions?: DependencyReviewOptions;
 
   /**
-   * Whether to checkout Git submodules. Pass `true` to checkout only the
-   * top-level submodules, or `"recursive"` to checkout submodules recursively.
+   * Whether to checkout Git submodules.
    *
-   * @default false
+   * @default CheckoutSubmodules.DISABLED
    */
-  readonly checkoutSubmodules?: boolean | "recursive";
+  readonly checkoutSubmodules?: CheckoutSubmodules;
 }
 
 export class GitHub extends Component {
@@ -178,7 +178,7 @@ export class GitHub extends Component {
   public readonly actions: GitHubActionsProvider;
 
   private readonly _downloadLfs?: boolean;
-  private readonly _checkoutSubmodules?: boolean | "recursive";
+  private readonly _checkoutSubmodules?: CheckoutSubmodules;
 
   public constructor(project: Project, options: GitHubOptions = {}) {
     super(project);
@@ -282,9 +282,8 @@ export class GitHub extends Component {
 
   /**
    * Whether checking out Git submodules is enabled for this GitHub project.
-   * Returns `false` (default), `true` (top-level submodules), or `"recursive"`.
    */
-  public get checkoutSubmodules(): boolean | "recursive" {
-    return this._checkoutSubmodules ?? false;
+  public get checkoutSubmodules(): CheckoutSubmodules {
+    return this._checkoutSubmodules ?? CheckoutSubmodules.DISABLED;
   }
 }

--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -138,7 +138,7 @@ export interface GitHubOptions {
    *
    * @default false
    */
-  readonly downloadSubmodules?: boolean | "recursive";
+  readonly checkoutSubmodules?: boolean | "recursive";
 }
 
 export class GitHub extends Component {
@@ -179,7 +179,7 @@ export class GitHub extends Component {
   public readonly actions: GitHubActionsProvider;
 
   private readonly _downloadLfs?: boolean;
-  private readonly _downloadSubmodules?: boolean | "recursive";
+  private readonly _checkoutSubmodules?: boolean | "recursive";
 
   public constructor(project: Project, options: GitHubOptions = {}) {
     super(project);
@@ -189,7 +189,7 @@ export class GitHub extends Component {
     this.workflowsEnabled = options.workflows ?? true;
 
     this._downloadLfs = options.downloadLfs;
-    this._downloadSubmodules = options.downloadSubmodules;
+    this._checkoutSubmodules = options.checkoutSubmodules;
 
     if (options.projenCredentials && options.projenTokenSecret) {
       throw new Error(
@@ -285,7 +285,7 @@ export class GitHub extends Component {
    * Whether checking out Git submodules is enabled for this GitHub project.
    * Returns `false` (default), `true` (top-level submodules), or `"recursive"`.
    */
-  public get downloadSubmodules(): boolean | "recursive" {
-    return this._downloadSubmodules ?? false;
+  public get checkoutSubmodules(): boolean | "recursive" {
+    return this._checkoutSubmodules ?? false;
   }
 }

--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -130,6 +130,15 @@ export interface GitHubOptions {
    * @default - default options
    */
   readonly dependencyReviewOptions?: DependencyReviewOptions;
+
+  /**
+   * Whether to checkout Git submodules in workflows. Pass `true` to clone
+   * only the top-level submodules, or `"recursive"` to clone submodules
+   * recursively.
+   *
+   * @default false
+   */
+  readonly downloadSubmodules?: boolean | "recursive";
 }
 
 export class GitHub extends Component {
@@ -170,6 +179,7 @@ export class GitHub extends Component {
   public readonly actions: GitHubActionsProvider;
 
   private readonly _downloadLfs?: boolean;
+  private readonly _downloadSubmodules?: boolean | "recursive";
 
   public constructor(project: Project, options: GitHubOptions = {}) {
     super(project);
@@ -179,6 +189,7 @@ export class GitHub extends Component {
     this.workflowsEnabled = options.workflows ?? true;
 
     this._downloadLfs = options.downloadLfs;
+    this._downloadSubmodules = options.downloadSubmodules;
 
     if (options.projenCredentials && options.projenTokenSecret) {
       throw new Error(
@@ -268,5 +279,13 @@ export class GitHub extends Component {
    */
   public get downloadLfs() {
     return this._downloadLfs ?? this.project.gitattributes.hasLfsPatterns;
+  }
+
+  /**
+   * Whether checking out Git submodules is enabled for this GitHub project.
+   * Returns `false` (default), `true` (top-level submodules), or `"recursive"`.
+   */
+  public get downloadSubmodules(): boolean | "recursive" {
+    return this._downloadSubmodules ?? false;
   }
 }

--- a/src/github/task-workflow-job.ts
+++ b/src/github/task-workflow-job.ts
@@ -123,7 +123,7 @@ export interface TaskWorkflowJobOptions {
    *
    * @default - Use the setting on the corresponding GitHub project
    */
-  readonly downloadSubmodules?: boolean | "recursive";
+  readonly checkoutSubmodules?: boolean | "recursive";
 
   /**
    * Default settings for all steps in the TaskWorkflow Job.
@@ -177,8 +177,8 @@ export class TaskWorkflowJob extends Component {
     if (options.downloadLfs) {
       checkoutWith.lfs = true;
     }
-    if (options.downloadSubmodules) {
-      checkoutWith.submodules = options.downloadSubmodules;
+    if (options.checkoutSubmodules) {
+      checkoutWith.submodules = options.checkoutSubmodules;
     }
     // 'checkoutWith' can override 'lfs' and 'submodules'
     Object.assign(checkoutWith, options.checkoutWith ?? {});

--- a/src/github/task-workflow-job.ts
+++ b/src/github/task-workflow-job.ts
@@ -117,9 +117,8 @@ export interface TaskWorkflowJobOptions {
   readonly downloadLfs?: boolean;
 
   /**
-   * Whether to checkout Git submodules for this workflow. Pass `true` to
-   * clone only the top-level submodules, or `"recursive"` for nested
-   * submodules.
+   * Whether to checkout Git submodules. Pass `true` to checkout only the
+   * top-level submodules, or `"recursive"` to checkout submodules recursively.
    *
    * @default - Use the setting on the corresponding GitHub project
    */

--- a/src/github/task-workflow-job.ts
+++ b/src/github/task-workflow-job.ts
@@ -2,7 +2,7 @@ import type { IConstruct } from "constructs";
 import { DEFAULT_GITHUB_ACTIONS_USER } from "./constants";
 import type { GitIdentity } from "./task-workflow";
 import type { CheckoutWith } from "./workflow-steps";
-import { WorkflowSteps } from "./workflow-steps";
+import { CheckoutSubmodules, WorkflowSteps } from "./workflow-steps";
 import type {
   ContainerOptions,
   Job,
@@ -117,12 +117,11 @@ export interface TaskWorkflowJobOptions {
   readonly downloadLfs?: boolean;
 
   /**
-   * Whether to checkout Git submodules. Pass `true` to checkout only the
-   * top-level submodules, or `"recursive"` to checkout submodules recursively.
+   * Whether to checkout Git submodules.
    *
    * @default - Use the setting on the corresponding GitHub project
    */
-  readonly checkoutSubmodules?: boolean | "recursive";
+  readonly checkoutSubmodules?: CheckoutSubmodules;
 
   /**
    * Default settings for all steps in the TaskWorkflow Job.
@@ -171,12 +170,14 @@ export class TaskWorkflowJob extends Component {
     super(scope, `${new.target.name}#${task.name}`);
     const preCheckoutSteps = options.preCheckoutSteps ?? [];
 
-    const checkoutWith: { lfs?: boolean; submodules?: boolean | "recursive" } =
-      {};
+    const checkoutWith: { lfs?: boolean; submodules?: CheckoutSubmodules } = {};
     if (options.downloadLfs) {
       checkoutWith.lfs = true;
     }
-    if (options.checkoutSubmodules) {
+    if (
+      options.checkoutSubmodules &&
+      options.checkoutSubmodules !== CheckoutSubmodules.DISABLED
+    ) {
       checkoutWith.submodules = options.checkoutSubmodules;
     }
     // 'checkoutWith' can override 'lfs' and 'submodules'

--- a/src/github/task-workflow-job.ts
+++ b/src/github/task-workflow-job.ts
@@ -117,6 +117,15 @@ export interface TaskWorkflowJobOptions {
   readonly downloadLfs?: boolean;
 
   /**
+   * Whether to checkout Git submodules for this workflow. Pass `true` to
+   * clone only the top-level submodules, or `"recursive"` for nested
+   * submodules.
+   *
+   * @default - Use the setting on the corresponding GitHub project
+   */
+  readonly downloadSubmodules?: boolean | "recursive";
+
+  /**
    * Default settings for all steps in the TaskWorkflow Job.
    */
   readonly jobDefaults?: JobDefaults;
@@ -163,11 +172,15 @@ export class TaskWorkflowJob extends Component {
     super(scope, `${new.target.name}#${task.name}`);
     const preCheckoutSteps = options.preCheckoutSteps ?? [];
 
-    const checkoutWith: { lfs?: boolean } = {};
+    const checkoutWith: { lfs?: boolean; submodules?: boolean | "recursive" } =
+      {};
     if (options.downloadLfs) {
       checkoutWith.lfs = true;
     }
-    // 'checkoutWith' can override 'lfs'
+    if (options.downloadSubmodules) {
+      checkoutWith.submodules = options.downloadSubmodules;
+    }
+    // 'checkoutWith' can override 'lfs' and 'submodules'
     Object.assign(checkoutWith, options.checkoutWith ?? {});
 
     const preBuildSteps = options.preBuildSteps ?? [];

--- a/src/github/task-workflow.ts
+++ b/src/github/task-workflow.ts
@@ -65,8 +65,8 @@ export class TaskWorkflow extends GithubWorkflow {
     const job = new TaskWorkflowJob(this, options.task, {
       ...options,
       downloadLfs: options.downloadLfs ?? github.downloadLfs,
-      downloadSubmodules:
-        options.downloadSubmodules ?? github.downloadSubmodules,
+      checkoutSubmodules:
+        options.checkoutSubmodules ?? github.checkoutSubmodules,
     });
 
     this.addJobs({ [this.jobId]: job });

--- a/src/github/task-workflow.ts
+++ b/src/github/task-workflow.ts
@@ -65,6 +65,8 @@ export class TaskWorkflow extends GithubWorkflow {
     const job = new TaskWorkflowJob(this, options.task, {
       ...options,
       downloadLfs: options.downloadLfs ?? github.downloadLfs,
+      downloadSubmodules:
+        options.downloadSubmodules ?? github.downloadSubmodules,
     });
 
     this.addJobs({ [this.jobId]: job });

--- a/src/github/workflow-steps.ts
+++ b/src/github/workflow-steps.ts
@@ -3,6 +3,26 @@ import type { JobStepConfiguration, JobStep } from "./workflows-model";
 import { removeNullOrUndefinedProperties } from "../util/object";
 
 /**
+ * Whether to checkout Git submodules in CI workflows.
+ */
+export enum CheckoutSubmodules {
+  /**
+   * Don't checkout submodules.
+   */
+  DISABLED = "false",
+
+  /**
+   * Checkout only top-level submodules.
+   */
+  ENABLED = "true",
+
+  /**
+   * Checkout submodules recursively.
+   */
+  RECURSIVE = "recursive",
+}
+
+/**
  * A collection of very commonly used, individual, GitHub Workflow Job steps.
  */
 export class WorkflowSteps {
@@ -20,8 +40,14 @@ export class WorkflowSteps {
       repository: options?.with?.repository,
       path: options?.with?.path,
       ...(options?.with?.lfs ? { lfs: true } : {}),
-      ...(options?.with?.submodules
-        ? { submodules: options.with.submodules }
+      ...(options?.with?.submodules &&
+      options.with.submodules !== CheckoutSubmodules.DISABLED
+        ? {
+            submodules:
+              options.with.submodules === CheckoutSubmodules.RECURSIVE
+                ? "recursive"
+                : true,
+          }
         : {}),
     });
 
@@ -189,12 +215,11 @@ export interface CheckoutWith {
   readonly lfs?: boolean;
 
   /**
-   * Whether to checkout Git submodules. Pass `true` to checkout only the
-   * top-level submodules, or `"recursive"` to checkout submodules recursively.
+   * Whether to checkout Git submodules.
    *
-   * @default false
+   * @default CheckoutSubmodules.DISABLED
    */
-  readonly submodules?: boolean | "recursive";
+  readonly submodules?: CheckoutSubmodules;
 
   /**
    * Branch or tag name.

--- a/src/github/workflow-steps.ts
+++ b/src/github/workflow-steps.ts
@@ -189,8 +189,8 @@ export interface CheckoutWith {
   readonly lfs?: boolean;
 
   /**
-   * Whether to checkout Git submodules. Pass `true` to clone only the
-   * top-level submodules, or `"recursive"` to clone submodules recursively.
+   * Whether to checkout Git submodules. Pass `true` to checkout only the
+   * top-level submodules, or `"recursive"` to checkout submodules recursively.
    *
    * @default false
    */

--- a/src/github/workflow-steps.ts
+++ b/src/github/workflow-steps.ts
@@ -20,6 +20,9 @@ export class WorkflowSteps {
       repository: options?.with?.repository,
       path: options?.with?.path,
       ...(options?.with?.lfs ? { lfs: true } : {}),
+      ...(options?.with?.submodules
+        ? { submodules: options.with.submodules }
+        : {}),
     });
 
     return {
@@ -184,6 +187,14 @@ export interface CheckoutWith {
    * @default false
    */
   readonly lfs?: boolean;
+
+  /**
+   * Whether to checkout Git submodules. Pass `true` to clone only the
+   * top-level submodules, or `"recursive"` to clone submodules recursively.
+   *
+   * @default false
+   */
+  readonly submodules?: boolean | "recursive";
 
   /**
    * Branch or tag name.

--- a/src/javascript/upgrade-dependencies.ts
+++ b/src/javascript/upgrade-dependencies.ts
@@ -6,7 +6,12 @@ import type {
   GitIdentity,
   workflows,
 } from "../github";
-import { GitHub, WorkflowJobs, WorkflowSteps } from "../github";
+import {
+  CheckoutSubmodules,
+  GitHub,
+  WorkflowJobs,
+  WorkflowSteps,
+} from "../github";
 import {
   isYarnClassic,
   isYarnBerry,
@@ -577,7 +582,7 @@ export class UpgradeDependencies extends Component {
     const with_ = {
       ...(branch ? { ref: branch } : {}),
       ...(github.downloadLfs ? { lfs: true } : {}),
-      ...(github.checkoutSubmodules
+      ...(github.checkoutSubmodules !== CheckoutSubmodules.DISABLED
         ? { submodules: github.checkoutSubmodules }
         : {}),
     };

--- a/src/javascript/upgrade-dependencies.ts
+++ b/src/javascript/upgrade-dependencies.ts
@@ -577,8 +577,8 @@ export class UpgradeDependencies extends Component {
     const with_ = {
       ...(branch ? { ref: branch } : {}),
       ...(github.downloadLfs ? { lfs: true } : {}),
-      ...(github.downloadSubmodules
-        ? { submodules: github.downloadSubmodules }
+      ...(github.checkoutSubmodules
+        ? { submodules: github.checkoutSubmodules }
         : {}),
     };
 

--- a/src/javascript/upgrade-dependencies.ts
+++ b/src/javascript/upgrade-dependencies.ts
@@ -577,6 +577,9 @@ export class UpgradeDependencies extends Component {
     const with_ = {
       ...(branch ? { ref: branch } : {}),
       ...(github.downloadLfs ? { lfs: true } : {}),
+      ...(github.downloadSubmodules
+        ? { submodules: github.downloadSubmodules }
+        : {}),
     };
 
     const steps: workflows.JobStep[] = [

--- a/test/github/task-workflow.test.ts
+++ b/test/github/task-workflow.test.ts
@@ -118,7 +118,7 @@ describe("task-workflow", () => {
   test("enabling submodule download adds the submodules property to workflows", () => {
     const project = new TestProject({
       githubOptions: {
-        downloadSubmodules: true,
+        checkoutSubmodules: true,
       },
     });
 
@@ -135,10 +135,10 @@ describe("task-workflow", () => {
     );
   });
 
-  test("downloadSubmodules: 'recursive' is preserved in the workflow", () => {
+  test("checkoutSubmodules: 'recursive' is preserved in the workflow", () => {
     const project = new TestProject({
       githubOptions: {
-        downloadSubmodules: "recursive",
+        checkoutSubmodules: "recursive",
       },
     });
 

--- a/test/github/task-workflow.test.ts
+++ b/test/github/task-workflow.test.ts
@@ -115,6 +115,46 @@ describe("task-workflow", () => {
     expect(snapshot[".gitattributes"]).toContain("*.bin filter=lfs");
   });
 
+  test("enabling submodule download adds the submodules property to workflows", () => {
+    const project = new TestProject({
+      githubOptions: {
+        downloadSubmodules: true,
+      },
+    });
+
+    new TaskWorkflow(project.github!, {
+      name: "task-workflow",
+      task,
+      permissions: {},
+    });
+
+    const snapshot = synthSnapshot(project);
+
+    expect(snapshot[".github/workflows/task-workflow.yml"]).toContain(
+      "submodules: true",
+    );
+  });
+
+  test("downloadSubmodules: 'recursive' is preserved in the workflow", () => {
+    const project = new TestProject({
+      githubOptions: {
+        downloadSubmodules: "recursive",
+      },
+    });
+
+    new TaskWorkflow(project.github!, {
+      name: "task-workflow",
+      task,
+      permissions: {},
+    });
+
+    const snapshot = synthSnapshot(project);
+
+    expect(snapshot[".github/workflows/task-workflow.yml"]).toContain(
+      "submodules: recursive",
+    );
+  });
+
   test("with custom runner, multiple labels", () => {
     const project = new TestProject();
 

--- a/test/github/task-workflow.test.ts
+++ b/test/github/task-workflow.test.ts
@@ -1,5 +1,6 @@
 import * as yaml from "yaml";
 import { TaskWorkflow } from "../../src/github/task-workflow";
+import { CheckoutSubmodules } from "../../src/github/workflow-steps";
 import { Task } from "../../src/task";
 import { synthSnapshot, TestProject } from "../util";
 
@@ -118,7 +119,7 @@ describe("task-workflow", () => {
   test("enabling submodule download adds the submodules property to workflows", () => {
     const project = new TestProject({
       githubOptions: {
-        checkoutSubmodules: true,
+        checkoutSubmodules: CheckoutSubmodules.ENABLED,
       },
     });
 
@@ -138,7 +139,7 @@ describe("task-workflow", () => {
   test("checkoutSubmodules: 'recursive' is preserved in the workflow", () => {
     const project = new TestProject({
       githubOptions: {
-        checkoutSubmodules: "recursive",
+        checkoutSubmodules: CheckoutSubmodules.RECURSIVE,
       },
     });
 


### PR DESCRIPTION
Closes #4656.

The issue asked for projen to support checking out Git submodules in CI, with the configuration shape mirroring the existing `downloadLfs` option:

```ts
new GitHubProject({
  // ...
  githubOptions: {
    downloadLfs: true,
    downloadSubmodules: true, // new
  },
});
```

This PR adds that option and threads it through every checkout site that already honors `downloadLfs`, so the default workflows (build, self-mutation, upgrade-deps, task-workflow) all pick it up automatically.

## Changes

- **`workflow-steps.ts`**: `CheckoutWith` gains `submodules?: boolean | "recursive"`. `WorkflowSteps.checkout()` passes it through to `actions/checkout@v6`'s `submodules` input. Matching the upstream action's accepted values keeps `recursive` available without inventing a new shape.
- **`github.ts`**: `GitHubOptions.downloadSubmodules?: boolean | "recursive"` plus a `GitHub.downloadSubmodules` getter (defaults to `false` when not configured).
- **`task-workflow-job.ts`**: new `downloadSubmodules` option that applies to the auto-generated checkout step. Same precedence as `downloadLfs` - the per-job option wins, then the GitHub-level setting, with explicit `checkoutWith` still able to override.
- **`task-workflow.ts`**: when constructing the inner `TaskWorkflowJob`, falls back to `github.downloadSubmodules`.
- **`build-workflow.ts`**: both renderable checkout sites (`renderBuildSteps` and the post-build job's `checkoutRepo` block) now honor `github.downloadSubmodules` next to `downloadLfs`.
- **`upgrade-dependencies.ts`**: same.

`WorkflowActions.checkoutWithPatch` is left alone deliberately - it's a separate API that doesn't currently expose `lfs` either, so I didn't want to expand its surface in this PR.

## Tests

`test/github/task-workflow.test.ts` adds two cases mirroring the existing LFS test:

1. `enabling submodule download adds the submodules property to workflows` - `downloadSubmodules: true` -> renders `submodules: true` in `task-workflow.yml`.
2. `downloadSubmodules: 'recursive' is preserved in the workflow` - `downloadSubmodules: "recursive"` -> renders `submodules: recursive`.

Both pass:

```
$ node ./projen.js test test/github/task-workflow.test.ts
Tests:       9 passed, 9 total
```

`test/github/steps.test.ts` and `test/build/build-workflow.test.ts` also pass with no changes needed (they don't currently exercise submodules, and existing snapshots are unaffected because `downloadSubmodules` defaults to `false`).

`docs/api/github.md` was regenerated by `node ./projen.js docgen` so the new option shows up in the public API docs.

This contribution was developed with AI assistance (Claude Code).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
