### PR TITLE
fix(javascript): yarn berry upgrade ignores package manifest version ranges

### DIFF
--- a/src/javascript/upgrade-dependencies.ts
+++ b/src/javascript/upgrade-dependencies.ts
@@ -457,7 +457,7 @@ export class UpgradeDependencies extends Component {
       case NodePackageManager.YARN2:
       case NodePackageManager.YARN_BERRY:
         // Yarn Berry cooldown set via task env
-        lazy = upgradePackages("yarn up");
+        lazy = upgradePackages("yarn up -R");
         break;
       case NodePackageManager.NPM:
         // npm cooldown set via NPM_CONFIG_BEFORE env

--- a/test/javascript/upgrade-dependencies.test.ts
+++ b/test/javascript/upgrade-dependencies.test.ts
@@ -548,6 +548,10 @@ test("uses the proper yarn berry upgrade command", () => {
     CI: "0",
     YARN_ENABLE_IMMUTABLE_INSTALLS: "false",
   });
+  // yarn berry must use -R flag, otherwise packages will be updated to latest regardless of what's in the package manifest
+  expect(tasks.upgrade.steps[2].exec).toStrictEqual(
+    "yarn up -R commit-and-tag-version constructs jest jest-junit projen",
+  );
   expect(tasks.upgrade.steps).toMatchInlineSnapshot(`
    [
      {
@@ -557,7 +561,7 @@ test("uses the proper yarn berry upgrade command", () => {
        "exec": "yarn install --no-immutable",
      },
      {
-       "exec": "yarn up commit-and-tag-version constructs jest jest-junit projen",
+       "exec": "yarn up -R commit-and-tag-version constructs jest jest-junit projen",
      },
      {
        "exec": "yarn projen",


### PR DESCRIPTION
When using Yarn Berry, `yarn up` without the `-R` flag resolves packages to the latest version available on the registry. This means it completely ignores the version ranges declared in the package manifest, which can lead to unexpected major version bumps during automated dependency upgrades.

Adding the `-R` flag ensures that `yarn up` respects the version ranges specified in `package.json`, matching the behavior users expect from the upgrade workflow.

Relates to #2980

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
