### PR TITLE
feat(cdk): a `JsiiBuild` mixin to turn any `TypeScriptProject` into a `jsii` project

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -203,12 +203,12 @@
     },
     {
       "name": "constructs",
-      "version": "^10.0.0",
+      "version": "^10.5.0",
       "type": "peer"
     },
     {
       "name": "constructs",
-      "version": "^10.0.0",
+      "version": "^10.5.0",
       "type": "runtime"
     }
   ],

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -68,7 +68,7 @@ const project = new JsiiProject({
 
   packageManager: javascript.NodePackageManager.NPM,
 
-  deps: ["constructs@^10.0.0"],
+  deps: ["constructs@^10.5.0"],
 
   bundledDeps: [
     "conventional-changelog-config-spec",
@@ -104,7 +104,7 @@ const project = new JsiiProject({
     "aws-cdk-lib",
   ],
 
-  peerDeps: ["constructs@^10.0.0"],
+  peerDeps: ["constructs@^10.5.0"],
 
   depsUpgrade: false, // configured below
   auditDeps: true,

--- a/docs/api/cdk.md
+++ b/docs/api/cdk.md
@@ -6832,6 +6832,295 @@ Name of the integration test.
 
 ---
 
+### JsiiBuildOptions <a name="JsiiBuildOptions" id="projen.cdk.JsiiBuildOptions"></a>
+
+Options for `JsiiBuild`.
+
+#### Initializer <a name="Initializer" id="projen.cdk.JsiiBuildOptions.Initializer"></a>
+
+```typescript
+import { cdk } from 'projen'
+
+const jsiiBuildOptions: cdk.JsiiBuildOptions = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen.cdk.JsiiBuildOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.release.CodeArtifactOptions</code> | Options for publishing npm package to AWS CodeArtifact. |
+| <code><a href="#projen.cdk.JsiiBuildOptions.property.compat">compat</a></code> | <code>boolean</code> | Automatically run API compatibility test against the latest version published to npm after compilation. |
+| <code><a href="#projen.cdk.JsiiBuildOptions.property.compatIgnore">compatIgnore</a></code> | <code>string</code> | Name of the ignore file for API compatibility tests. |
+| <code><a href="#projen.cdk.JsiiBuildOptions.property.compressAssembly">compressAssembly</a></code> | <code>boolean</code> | Emit a compressed version of the assembly. |
+| <code><a href="#projen.cdk.JsiiBuildOptions.property.docgen">docgen</a></code> | <code>boolean</code> | Generate a MarkDown file describing the jsii API. |
+| <code><a href="#projen.cdk.JsiiBuildOptions.property.docgenFilePath">docgenFilePath</a></code> | <code>string</code> | File path for generated docs. |
+| <code><a href="#projen.cdk.JsiiBuildOptions.property.excludeTypescript">excludeTypescript</a></code> | <code>string[]</code> | Accepts a list of glob patterns. |
+| <code><a href="#projen.cdk.JsiiBuildOptions.property.jsiiVersion">jsiiVersion</a></code> | <code>string</code> | Version of the jsii compiler to use. |
+| <code><a href="#projen.cdk.JsiiBuildOptions.property.npmTrustedPublishing">npmTrustedPublishing</a></code> | <code>boolean</code> | Whether to use trusted publishing for npm. |
+| <code><a href="#projen.cdk.JsiiBuildOptions.property.publishToGo">publishToGo</a></code> | <code><a href="#projen.cdk.JsiiGoTarget">JsiiGoTarget</a></code> | Publish Go bindings to a git repository. |
+| <code><a href="#projen.cdk.JsiiBuildOptions.property.publishToMaven">publishToMaven</a></code> | <code><a href="#projen.cdk.JsiiJavaTarget">JsiiJavaTarget</a></code> | Publish to maven. |
+| <code><a href="#projen.cdk.JsiiBuildOptions.property.publishToNuget">publishToNuget</a></code> | <code><a href="#projen.cdk.JsiiDotNetTarget">JsiiDotNetTarget</a></code> | Publish to NuGet. |
+| <code><a href="#projen.cdk.JsiiBuildOptions.property.publishToPypi">publishToPypi</a></code> | <code><a href="#projen.cdk.JsiiPythonTarget">JsiiPythonTarget</a></code> | Publish to pypi. |
+| <code><a href="#projen.cdk.JsiiBuildOptions.property.releaseToNpm">releaseToNpm</a></code> | <code>boolean</code> | Whether to publish to npm. |
+| <code><a href="#projen.cdk.JsiiBuildOptions.property.stability">stability</a></code> | <code>string</code> | The stability of the package. |
+| <code><a href="#projen.cdk.JsiiBuildOptions.property.workflowBootstrapSteps">workflowBootstrapSteps</a></code> | <code>projen.github.workflows.Step[]</code> | Additional steps to run before packaging in workflows. |
+| <code><a href="#projen.cdk.JsiiBuildOptions.property.workflowNodeVersion">workflowNodeVersion</a></code> | <code>string</code> | The node version to use in packaging workflows. |
+| <code><a href="#projen.cdk.JsiiBuildOptions.property.workspaceDirectory">workspaceDirectory</a></code> | <code>string</code> | Relative path of the package within the repository. |
+
+---
+
+##### `codeArtifactOptions`<sup>Optional</sup> <a name="codeArtifactOptions" id="projen.cdk.JsiiBuildOptions.property.codeArtifactOptions"></a>
+
+```typescript
+public readonly codeArtifactOptions: CodeArtifactOptions;
+```
+
+- *Type:* projen.release.CodeArtifactOptions
+- *Default:* undefined
+
+Options for publishing npm package to AWS CodeArtifact.
+
+---
+
+##### `compat`<sup>Optional</sup> <a name="compat" id="projen.cdk.JsiiBuildOptions.property.compat"></a>
+
+```typescript
+public readonly compat: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Automatically run API compatibility test against the latest version published to npm after compilation.
+
+You can manually run compatibility tests using `yarn compat` if this feature is disabled.
+- You can ignore compatibility failures by adding lines to a ".compatignore" file.
+
+---
+
+##### `compatIgnore`<sup>Optional</sup> <a name="compatIgnore" id="projen.cdk.JsiiBuildOptions.property.compatIgnore"></a>
+
+```typescript
+public readonly compatIgnore: string;
+```
+
+- *Type:* string
+- *Default:* ".compatignore"
+
+Name of the ignore file for API compatibility tests.
+
+---
+
+##### `compressAssembly`<sup>Optional</sup> <a name="compressAssembly" id="projen.cdk.JsiiBuildOptions.property.compressAssembly"></a>
+
+```typescript
+public readonly compressAssembly: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Emit a compressed version of the assembly.
+
+---
+
+##### `docgen`<sup>Optional</sup> <a name="docgen" id="projen.cdk.JsiiBuildOptions.property.docgen"></a>
+
+```typescript
+public readonly docgen: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Generate a MarkDown file describing the jsii API.
+
+---
+
+##### `docgenFilePath`<sup>Optional</sup> <a name="docgenFilePath" id="projen.cdk.JsiiBuildOptions.property.docgenFilePath"></a>
+
+```typescript
+public readonly docgenFilePath: string;
+```
+
+- *Type:* string
+- *Default:* "API.md"
+
+File path for generated docs.
+
+---
+
+##### `excludeTypescript`<sup>Optional</sup> <a name="excludeTypescript" id="projen.cdk.JsiiBuildOptions.property.excludeTypescript"></a>
+
+```typescript
+public readonly excludeTypescript: string[];
+```
+
+- *Type:* string[]
+
+Accepts a list of glob patterns.
+
+Files matching any of those patterns will be excluded from the TypeScript compiler input.
+
+By default, jsii will include all *.ts files (except .d.ts files) in the TypeScript compiler input.
+This can be problematic for example when the package's build or test procedure generates .ts files
+that cannot be compiled with jsii's compiler settings.
+
+---
+
+##### `jsiiVersion`<sup>Optional</sup> <a name="jsiiVersion" id="projen.cdk.JsiiBuildOptions.property.jsiiVersion"></a>
+
+```typescript
+public readonly jsiiVersion: string;
+```
+
+- *Type:* string
+- *Default:* "~5.9.0"
+
+Version of the jsii compiler to use.
+
+Set to "*" if you want to manually manage the version of jsii in your
+project by managing updates to `package.json` on your own.
+
+NOTE: The jsii compiler releases since 5.0.0 are not semantically versioned
+and should remain on the same minor, so we recommend using a `~` dependency
+(e.g. `~5.0.0`).
+
+---
+
+##### `npmTrustedPublishing`<sup>Optional</sup> <a name="npmTrustedPublishing" id="projen.cdk.JsiiBuildOptions.property.npmTrustedPublishing"></a>
+
+```typescript
+public readonly npmTrustedPublishing: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Whether to use trusted publishing for npm.
+
+---
+
+##### `publishToGo`<sup>Optional</sup> <a name="publishToGo" id="projen.cdk.JsiiBuildOptions.property.publishToGo"></a>
+
+```typescript
+public readonly publishToGo: JsiiGoTarget;
+```
+
+- *Type:* <a href="#projen.cdk.JsiiGoTarget">JsiiGoTarget</a>
+- *Default:* no publishing
+
+Publish Go bindings to a git repository.
+
+---
+
+##### `publishToMaven`<sup>Optional</sup> <a name="publishToMaven" id="projen.cdk.JsiiBuildOptions.property.publishToMaven"></a>
+
+```typescript
+public readonly publishToMaven: JsiiJavaTarget;
+```
+
+- *Type:* <a href="#projen.cdk.JsiiJavaTarget">JsiiJavaTarget</a>
+- *Default:* no publishing
+
+Publish to maven.
+
+---
+
+##### `publishToNuget`<sup>Optional</sup> <a name="publishToNuget" id="projen.cdk.JsiiBuildOptions.property.publishToNuget"></a>
+
+```typescript
+public readonly publishToNuget: JsiiDotNetTarget;
+```
+
+- *Type:* <a href="#projen.cdk.JsiiDotNetTarget">JsiiDotNetTarget</a>
+- *Default:* no publishing
+
+Publish to NuGet.
+
+---
+
+##### `publishToPypi`<sup>Optional</sup> <a name="publishToPypi" id="projen.cdk.JsiiBuildOptions.property.publishToPypi"></a>
+
+```typescript
+public readonly publishToPypi: JsiiPythonTarget;
+```
+
+- *Type:* <a href="#projen.cdk.JsiiPythonTarget">JsiiPythonTarget</a>
+- *Default:* no publishing
+
+Publish to pypi.
+
+---
+
+##### `releaseToNpm`<sup>Optional</sup> <a name="releaseToNpm" id="projen.cdk.JsiiBuildOptions.property.releaseToNpm"></a>
+
+```typescript
+public readonly releaseToNpm: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Whether to publish to npm.
+
+---
+
+##### `stability`<sup>Optional</sup> <a name="stability" id="projen.cdk.JsiiBuildOptions.property.stability"></a>
+
+```typescript
+public readonly stability: string;
+```
+
+- *Type:* string
+- *Default:* "stable"
+
+The stability of the package.
+
+---
+
+##### `workflowBootstrapSteps`<sup>Optional</sup> <a name="workflowBootstrapSteps" id="projen.cdk.JsiiBuildOptions.property.workflowBootstrapSteps"></a>
+
+```typescript
+public readonly workflowBootstrapSteps: Step[];
+```
+
+- *Type:* projen.github.workflows.Step[]
+- *Default:* []
+
+Additional steps to run before packaging in workflows.
+
+---
+
+##### `workflowNodeVersion`<sup>Optional</sup> <a name="workflowNodeVersion" id="projen.cdk.JsiiBuildOptions.property.workflowNodeVersion"></a>
+
+```typescript
+public readonly workflowNodeVersion: string;
+```
+
+- *Type:* string
+- *Default:* "lts/*"
+
+The node version to use in packaging workflows.
+
+---
+
+##### `workspaceDirectory`<sup>Optional</sup> <a name="workspaceDirectory" id="projen.cdk.JsiiBuildOptions.property.workspaceDirectory"></a>
+
+```typescript
+public readonly workspaceDirectory: string;
+```
+
+- *Type:* string
+- *Default:* "." - root of the repository
+
+Relative path of the package within the repository.
+
+This is used in monorepo setups where the package is not at the root.
+Packaging steps will extract build artifacts into this subdirectory.
+
+---
+
 ### JsiiDocgenOptions <a name="JsiiDocgenOptions" id="projen.cdk.JsiiDocgenOptions"></a>
 
 Options for `JsiiDocgen`.
@@ -10468,6 +10757,94 @@ public readonly module: string;
 - *Type:* string
 
 ---
+
+## Classes <a name="Classes" id="Classes"></a>
+
+### JsiiBuild <a name="JsiiBuild" id="projen.cdk.JsiiBuild"></a>
+
+- *Implements:* constructs.IMixin
+
+A mixin that adds jsii compilation, multi-language packaging, and publishing capabilities to any TypeScript project.
+
+This implements the constructs `IMixin` interface and is applied using the
+`.with()` method on any construct.
+
+*Example*
+
+```typescript
+const project = new TypeScriptProject({ disableTsconfig: true, ... });
+project.with(new JsiiBuild({
+  jsiiVersion: '~5.9.0',
+  publishToMaven: { ... },
+}));
+```
+
+
+#### Initializers <a name="Initializers" id="projen.cdk.JsiiBuild.Initializer"></a>
+
+```typescript
+import { cdk } from 'projen'
+
+new cdk.JsiiBuild(options?: JsiiBuildOptions, extraJobOptions?: {[ key: string ]: any})
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen.cdk.JsiiBuild.Initializer.parameter.options">options</a></code> | <code><a href="#projen.cdk.JsiiBuildOptions">JsiiBuildOptions</a></code> | *No description.* |
+| <code><a href="#projen.cdk.JsiiBuild.Initializer.parameter.extraJobOptions">extraJobOptions</a></code> | <code>{[ key: string ]: any}</code> | *No description.* |
+
+---
+
+##### `options`<sup>Optional</sup> <a name="options" id="projen.cdk.JsiiBuild.Initializer.parameter.options"></a>
+
+- *Type:* <a href="#projen.cdk.JsiiBuildOptions">JsiiBuildOptions</a>
+
+---
+
+##### `extraJobOptions`<sup>Optional</sup> <a name="extraJobOptions" id="projen.cdk.JsiiBuild.Initializer.parameter.extraJobOptions"></a>
+
+- *Type:* {[ key: string ]: any}
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#projen.cdk.JsiiBuild.applyTo">applyTo</a></code> | Applies jsii configuration to the target TypeScriptProject. |
+| <code><a href="#projen.cdk.JsiiBuild.supports">supports</a></code> | Returns true if the construct is a TypeScriptProject. |
+
+---
+
+##### `applyTo` <a name="applyTo" id="projen.cdk.JsiiBuild.applyTo"></a>
+
+```typescript
+public applyTo(project: IConstruct): void
+```
+
+Applies jsii configuration to the target TypeScriptProject.
+
+###### `project`<sup>Required</sup> <a name="project" id="projen.cdk.JsiiBuild.applyTo.parameter.project"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+##### `supports` <a name="supports" id="projen.cdk.JsiiBuild.supports"></a>
+
+```typescript
+public supports(construct: IConstruct): boolean
+```
+
+Returns true if the construct is a TypeScriptProject.
+
+###### `construct`<sup>Required</sup> <a name="construct" id="projen.cdk.JsiiBuild.supports.parameter.construct"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+
 
 
 

--- a/docs/concepts/components.md
+++ b/docs/concepts/components.md
@@ -15,7 +15,7 @@ In projen, constructs are used to represent the desired state of project configu
 The lowest-level constructs represent a configuration file.
 Files are composed to represent higher-level logical units of configurations, etc.
 
-Projen uses two types of constructs as basic building blocks: Projects & Components.
+Projen uses three primitives to build project configurations: Projects, Components, and [Mixins](./mixins.md).
 
 ## Composition
 
@@ -60,3 +60,20 @@ Project
 └── MyComponent
     └── YourComponent
 ```
+
+## Mixins
+
+While components require you to own the class hierarchy (you compose them *into* a project), mixins let you add capabilities *onto* any existing project without changing its type.
+
+Mixins implement the `IMixin` interface from `constructs` and are applied using the `.with()` method:
+
+```ts
+const project = new TypeScriptProject({ ... });
+project.with(new JsiiBuild({ jsiiVersion: '~5.9.0' }));
+```
+
+This is particularly powerful in monorepo scenarios where workspace projects aren't `JsiiProject` instances but still need jsii capabilities.
+Instead of maintaining hundreds of lines of custom configuration code, you apply a mixin.
+
+Mixins are not part of the construct tree — they modify constructs in place and are then discarded.
+For a full guide on creating and using mixins, see [Mixins](./mixins.md).

--- a/docs/concepts/mixins.md
+++ b/docs/concepts/mixins.md
@@ -1,0 +1,84 @@
+---
+sidebar_position: 2
+---
+
+# Mixins
+
+## What are mixins?
+
+Mixins are reusable pieces of functionality that can be applied to constructs without inheritance.
+They implement the `IMixin` interface from [constructs](https://github.com/aws/constructs) and are applied using the `.with()` method available on all constructs.
+
+While [components](./components.md) are constructs that live in the construct tree and participate in the synthesis lifecycle, mixins are standalone objects that modify existing constructs in place.
+This makes them ideal for adding capabilities to projects you don't control the class hierarchy of.
+
+## When to use mixins vs components
+
+Use a **component** when you need to:
+
+- Add new files to a project
+- Participate in the synthesis lifecycle (preSynthesize, synthesize, postSynthesize)
+- Be discoverable in the construct tree
+
+Use a **mixin** when you need to:
+
+- Add capabilities to any compatible project without requiring inheritance
+- Compose features that work across different project types
+- Apply the same functionality in both standalone and monorepo contexts
+
+## The IMixin interface
+
+A mixin implements two methods:
+
+```ts
+import { IMixin } from 'constructs';
+
+class MyMixin implements IMixin {
+  // Determines which constructs this mixin can be applied to
+  supports(construct: IConstruct): boolean { ... }
+
+  // Modifies the construct in place
+  applyTo(construct: IConstruct): void { ... }
+}
+```
+
+## Applying mixins
+
+Use the `.with()` method to apply one or more mixins to a construct:
+
+```ts
+project.with(new MyMixin());
+```
+
+The `.with()` method walks the construct tree rooted at the target and applies the mixin to every construct where `supports()` returns true.
+This means you can apply a mixin to a project and it will also be applied to any child constructs that support it.
+
+Mixins that don't support a construct are silently skipped.
+
+## Creating custom mixins
+
+Here's an example mixin that adds a standard linting configuration to any Node.js project:
+
+```ts
+import type { IConstruct } from 'constructs';
+import type { IMixin } from 'constructs';
+import { NodeProject } from 'projen/lib/javascript';
+
+class StandardLinting implements IMixin {
+  supports(construct: IConstruct): boolean {
+    return construct instanceof NodeProject;
+  }
+
+  applyTo(construct: IConstruct): void {
+    const project = construct as NodeProject;
+    project.addDevDeps('eslint@^9', 'prettier');
+    project.addTask('lint', { exec: 'eslint .' });
+  }
+}
+```
+
+Apply it to any Node.js project:
+
+```ts
+project.with(new StandardLinting());
+```

--- a/docs/project-types/aws-cdk-construct-library.md
+++ b/docs/project-types/aws-cdk-construct-library.md
@@ -181,3 +181,35 @@ you can add the following to export it:
 ```typescript
 export * from './our-s3-bucket'
 ```
+
+## Adding jsii support to TypeScript projects
+
+If you have an existing `TypeScriptProject` and want to add jsii capabilities without switching to `JsiiProject`, you can use the `JsiiBuild`.
+This is particularly useful in monorepo setups where workspace projects have their own project type.
+
+```typescript
+import { TypeScriptProject } from 'projen/lib/typescript';
+import { JsiiBuild } from 'projen/lib/cdk';
+
+const project = new TypeScriptProject({
+  name: 'my-construct-lib',
+  defaultReleaseBranch: 'main',
+  disableTsconfig: true, // jsii manages tsconfig
+});
+
+project.with(new JsiiBuild({
+  jsiiVersion: '~5.9.0',
+  workspaceDirectory: 'packages/my-construct-lib',
+  publishToMaven: {
+    javaPackage: 'com.example.mylib',
+    mavenGroupId: 'com.example',
+    mavenArtifactId: 'my-construct-lib',
+  },
+  publishToPypi: {
+    distName: 'my-construct-lib',
+    module: 'my_construct_lib',
+  },
+}));
+```
+
+See [Mixins](../concepts/mixins.md) for more information on the mixin pattern.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "case": "^1.6.3",
         "chalk": "^4.1.2",
         "comment-json": "4.2.2",
-        "constructs": "^10.0.0",
+        "constructs": "^10.5.0",
         "conventional-changelog-config-spec": "^2.1.0",
         "fast-glob": "^3.3.3",
         "fast-json-patch": "^3.1.1",
@@ -83,7 +83,7 @@
         "node": ">= 16.0.0"
       },
       "peerDependencies": {
-        "constructs": "^10.0.0"
+        "constructs": "^10.5.0"
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {

--- a/package.json
+++ b/package.json
@@ -87,14 +87,14 @@
     "typescript": "5.9.x"
   },
   "peerDependencies": {
-    "constructs": "^10.0.0"
+    "constructs": "^10.5.0"
   },
   "dependencies": {
     "@iarna/toml": "^2.2.5",
     "case": "^1.6.3",
     "chalk": "^4.1.2",
     "comment-json": "4.2.2",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "conventional-changelog-config-spec": "^2.1.0",
     "fast-glob": "^3.3.3",
     "fast-json-patch": "^3.1.1",

--- a/src/cdk/index.ts
+++ b/src/cdk/index.ts
@@ -1,5 +1,6 @@
 export * from "./construct-lib";
 export * from "./jsii-docgen";
+export * from "./jsii-build";
 export * from "./jsii-project";
 export * from "./integration-test-base";
 export * from "./auto-discover-base";

--- a/src/cdk/jsii-build.ts
+++ b/src/cdk/jsii-build.ts
@@ -1,0 +1,575 @@
+import type { IConstruct, IMixin } from "constructs";
+import type { Task } from "..";
+import type { JsiiPacmakTarget } from "./consts";
+import { JSII_TOOLCHAIN } from "./consts";
+import { JsiiDocgen } from "./jsii-docgen";
+import type {
+  JsiiDotNetTarget,
+  JsiiGoTarget,
+  JsiiJavaTarget,
+  JsiiPythonTarget,
+} from "./jsii-project";
+import {
+  PULL_REQUEST_REF,
+  PULL_REQUEST_REPOSITORY,
+} from "../build/private/consts";
+import { WorkflowSteps } from "../github/workflow-steps";
+import type { Job, Step, Tools } from "../github/workflows-model";
+import { JobPermission } from "../github/workflows-model";
+import { NodePackageManager } from "../javascript";
+import { isYarnBerry } from "../javascript/util";
+import type {
+  CommonPublishOptions,
+  NpmPublishOptions,
+  Publisher,
+} from "../release";
+import { filteredRunsOnOptions } from "../runner-options";
+import { TypeScriptProject } from "../typescript";
+
+const REPO_TEMP_DIRECTORY = ".repo";
+const BUILD_ARTIFACT_OLD_DIR = "dist.old";
+
+/**
+ * Options for `JsiiBuild`.
+ */
+export interface JsiiBuildOptions {
+  /**
+   * Publish to maven
+   * @default - no publishing
+   */
+  readonly publishToMaven?: JsiiJavaTarget;
+
+  /**
+   * Publish to pypi
+   * @default - no publishing
+   */
+  readonly publishToPypi?: JsiiPythonTarget;
+
+  /**
+   * Publish Go bindings to a git repository.
+   * @default - no publishing
+   */
+  readonly publishToGo?: JsiiGoTarget;
+
+  /**
+   * Publish to NuGet
+   * @default - no publishing
+   */
+  readonly publishToNuget?: JsiiDotNetTarget;
+
+  /**
+   * Automatically run API compatibility test against the latest version published to npm after compilation.
+   *
+   * - You can manually run compatibility tests using `yarn compat` if this feature is disabled.
+   * - You can ignore compatibility failures by adding lines to a ".compatignore" file.
+   *
+   * @default false
+   */
+  readonly compat?: boolean;
+
+  /**
+   * Name of the ignore file for API compatibility tests.
+   *
+   * @default ".compatignore"
+   */
+  readonly compatIgnore?: string;
+
+  /**
+   * Accepts a list of glob patterns. Files matching any of those patterns will be excluded from the TypeScript compiler input.
+   *
+   * By default, jsii will include all *.ts files (except .d.ts files) in the TypeScript compiler input.
+   * This can be problematic for example when the package's build or test procedure generates .ts files
+   * that cannot be compiled with jsii's compiler settings.
+   */
+  readonly excludeTypescript?: string[];
+
+  /**
+   * File path for generated docs.
+   * @default "API.md"
+   */
+  readonly docgenFilePath?: string;
+
+  /**
+   * Emit a compressed version of the assembly
+   * @default false
+   */
+  readonly compressAssembly?: boolean;
+
+  /**
+   * Version of the jsii compiler to use.
+   *
+   * Set to "*" if you want to manually manage the version of jsii in your
+   * project by managing updates to `package.json` on your own.
+   *
+   * NOTE: The jsii compiler releases since 5.0.0 are not semantically versioned
+   * and should remain on the same minor, so we recommend using a `~` dependency
+   * (e.g. `~5.0.0`).
+   *
+   * @default "~5.9.0"
+   * @pjnew "~5.9.0"
+   */
+  readonly jsiiVersion?: string;
+
+  /**
+   * The stability of the package.
+   *
+   * @default "stable"
+   */
+  readonly stability?: string;
+
+  /**
+   * Generate a MarkDown file describing the jsii API.
+   *
+   * @default true
+   */
+  readonly docgen?: boolean;
+
+  /**
+   * Whether to publish to npm.
+   *
+   * @default true
+   */
+  readonly releaseToNpm?: boolean;
+
+  /**
+   * Whether to use trusted publishing for npm.
+   *
+   * @default false
+   */
+  readonly npmTrustedPublishing?: boolean;
+
+  /**
+   * Options for publishing npm package to AWS CodeArtifact.
+   *
+   * @default - undefined
+   */
+  readonly codeArtifactOptions?: NpmPublishOptions["codeArtifactOptions"];
+
+  /**
+   * Relative path of the package within the repository.
+   *
+   * This is used in monorepo setups where the package is not at the root.
+   * Packaging steps will extract build artifacts into this subdirectory.
+   *
+   * @default "." - root of the repository
+   */
+  readonly workspaceDirectory?: string;
+
+  /**
+   * The node version to use in packaging workflows.
+   *
+   * @default "lts/*"
+   */
+  readonly workflowNodeVersion?: string;
+
+  /**
+   * Additional steps to run before packaging in workflows.
+   *
+   * @default []
+   */
+  readonly workflowBootstrapSteps?: Array<Step>;
+}
+
+/**
+ * A mixin that adds jsii compilation, multi-language packaging, and publishing
+ * capabilities to any TypeScript project.
+ *
+ * This implements the constructs `IMixin` interface and is applied using the
+ * `.with()` method on any construct.
+ *
+ * @example
+ * const project = new TypeScriptProject({ disableTsconfig: true, ... });
+ * project.with(new JsiiBuild({
+ *   jsiiVersion: '~5.9.0',
+ *   publishToMaven: { ... },
+ * }));
+ */
+export class JsiiBuild implements IMixin {
+  private readonly options: JsiiBuildOptions;
+  private readonly extraJobOptions: Partial<Job>;
+
+  constructor(
+    options: JsiiBuildOptions = {},
+    extraJobOptions?: Record<string, unknown>,
+  ) {
+    this.options = options;
+    this.extraJobOptions = (extraJobOptions ?? {}) as Partial<Job>;
+  }
+
+  /**
+   * Returns true if the construct is a TypeScriptProject.
+   */
+  public supports(construct: IConstruct): construct is TypeScriptProject {
+    return construct instanceof TypeScriptProject;
+  }
+
+  /**
+   * Applies jsii configuration to the target TypeScriptProject.
+   */
+  public applyTo(project: IConstruct): void {
+    if (!this.supports(project)) {
+      return;
+    }
+
+    const options = { ...this.options };
+    const srcdir = project.srcdir;
+    const libdir = project.libdir;
+
+    project.addFields({ types: `${libdir}/index.d.ts` });
+
+    const compressAssembly = options.compressAssembly ?? false;
+
+    // this is an unhelpful warning
+    const jsiiFlags = ["--silence-warnings=reserved-word"];
+    if (compressAssembly) {
+      jsiiFlags.push("--compress-assembly");
+    }
+
+    const compatIgnore = options.compatIgnore ?? ".compatignore";
+
+    project.addFields({ stability: options.stability ?? "stable" });
+
+    if (options.stability === "deprecated") {
+      project.addFields({ deprecated: true });
+    }
+
+    project.compileTask.reset(["jsii", ...jsiiFlags].join(" "));
+    project.watchTask.reset(["jsii", "-w", ...jsiiFlags].join(" "));
+
+    const compatTask = project.addTask("compat", {
+      description: "Perform API compatibility check against latest version",
+      exec: `jsii-diff npm:$(node -p "require(\'./package.json\').name") -k --ignore-file ${compatIgnore} || (echo "\nUNEXPECTED BREAKING CHANGES: add keys such as \'removed:constructs.Node.of\' to ${compatIgnore} to skip.\n" && exit 1)`,
+    });
+
+    if (options.compat ?? false) {
+      project.compileTask.spawn(compatTask);
+    }
+
+    // Create a new package:all task, it will be filled with language targets later
+    const packageAllTask = project.addTask("package-all", {
+      description: "Packages artifacts for all target languages",
+    });
+
+    // in jsii we consider the entire repo (post build) as the build artifact
+    // which is then used to create the language bindings in separate jobs.
+    const packageJsTask = this.addPackagingTask(project, packageAllTask, "js");
+
+    // When running inside CI we initially only package js. Other targets are packaged in separate jobs.
+    // Outside of CI (i.e locally) we simply package all targets.
+    project.packageTask.reset();
+    project.packageTask.spawn(packageJsTask, {
+      // Only run in CI
+      condition: `node -e "if (!process.env.CI) process.exit(1)"`,
+    });
+    project.packageTask.spawn(packageAllTask, {
+      // Don't run in CI
+      condition: `node -e "if (process.env.CI) process.exit(1)"`,
+    });
+
+    const targets: Record<string, any> = {};
+
+    const jsii: any = {
+      outdir: project.artifactsDirectory,
+      targets,
+      tsc: {
+        outDir: libdir,
+        rootDir: srcdir,
+      },
+    };
+
+    if (options.excludeTypescript) {
+      jsii.excludeTypescript = options.excludeTypescript;
+    }
+
+    project.addFields({ jsii });
+
+    const extraJobOptions: Partial<Job> = this.extraJobOptions;
+
+    if (options.releaseToNpm !== false) {
+      const npmjs: NpmPublishOptions = {
+        registry: project.package.npmRegistry,
+        npmTokenSecret: project.package.npmTokenSecret,
+        npmProvenance: project.package.npmProvenance,
+        codeArtifactOptions: options.codeArtifactOptions,
+        trustedPublishing: options.npmTrustedPublishing ?? false,
+      };
+      this.addTargetToBuild(project, packageJsTask, "js", extraJobOptions);
+      this.addTargetToRelease(project, packageJsTask, "js", npmjs);
+    }
+
+    const maven = options.publishToMaven;
+    if (maven) {
+      targets.java = {
+        package: maven.javaPackage,
+        maven: {
+          groupId: maven.mavenGroupId,
+          artifactId: maven.mavenArtifactId,
+        },
+      };
+
+      const task = this.addPackagingTask(project, packageAllTask, "java");
+      this.addTargetToBuild(project, task, "java", extraJobOptions);
+      this.addTargetToRelease(project, task, "java", maven);
+    }
+
+    const pypi = options.publishToPypi;
+    if (pypi) {
+      targets.python = {
+        distName: pypi.distName,
+        module: pypi.module,
+      };
+
+      const task = this.addPackagingTask(project, packageAllTask, "python");
+      this.addTargetToBuild(project, task, "python", extraJobOptions);
+      this.addTargetToRelease(project, task, "python", pypi);
+    }
+
+    const nuget = options.publishToNuget;
+    if (nuget) {
+      targets.dotnet = {
+        namespace: nuget.dotNetNamespace,
+        packageId: nuget.packageId,
+        iconUrl: nuget.iconUrl,
+      };
+
+      const task = this.addPackagingTask(project, packageAllTask, "dotnet");
+      this.addTargetToBuild(project, task, "dotnet", extraJobOptions);
+      this.addTargetToRelease(project, task, "dotnet", nuget);
+    }
+
+    const golang = options.publishToGo;
+    if (golang) {
+      targets.go = {
+        moduleName: golang.moduleName,
+        packageName: golang.packageName,
+        versionSuffix: golang.versionSuffix,
+      };
+
+      const task = this.addPackagingTask(project, packageAllTask, "go");
+      this.addTargetToBuild(project, task, "go", extraJobOptions);
+      this.addTargetToRelease(project, task, "go", golang);
+    }
+
+    // If jsiiVersion is "*", don't specify anything so the user can manage.
+    // Otherwise, use `jsiiVersion`
+    const jsiiVersion = options.jsiiVersion ?? "~5.9.0";
+    const jsiiSuffix = jsiiVersion === "*" ? "" : `@${jsiiVersion}`;
+    project.addDevDeps(
+      `jsii${jsiiSuffix}`,
+      `jsii-rosetta${jsiiSuffix}`,
+      "jsii-diff",
+      "jsii-pacmak",
+    );
+
+    project.gitignore.exclude(".jsii", "tsconfig.json");
+    project.npmignore?.include(".jsii");
+
+    if (options.docgen ?? true) {
+      // If jsiiVersion is "*", don't specify anything so the user can manage.
+      // Otherwise use a version that is compatible with all supported jsii releases.
+      const docgenVersion = options.jsiiVersion === "*" ? "*" : "^10.5.0";
+      new JsiiDocgen(project, {
+        version: docgenVersion,
+        filePath: options.docgenFilePath,
+      });
+    }
+
+    // jsii updates .npmignore, so we make it writable
+    if (project.npmignore) {
+      project.npmignore.readonly = false;
+    }
+  }
+
+  /**
+   * Adds a target language to the release workflow.
+   */
+  private addTargetToRelease(
+    project: TypeScriptProject,
+    packTask: Task,
+    language: JsiiPacmakTarget,
+    target:
+      | JsiiPythonTarget
+      | JsiiDotNetTarget
+      | JsiiGoTarget
+      | JsiiJavaTarget
+      | NpmPublishOptions,
+  ) {
+    if (!project.release) {
+      return;
+    }
+
+    const pacmak = this.pacmakForLanguage(project, language, packTask);
+    const prePublishSteps = [
+      ...pacmak.bootstrapSteps,
+      WorkflowSteps.checkout({
+        with: {
+          path: REPO_TEMP_DIRECTORY,
+          ...(project.github?.downloadLfs ? { lfs: true } : {}),
+        },
+      }),
+      ...pacmak.packagingSteps,
+    ];
+    const commonPublishOptions: CommonPublishOptions = {
+      publishTools: pacmak.publishTools,
+      prePublishSteps,
+    };
+
+    const handler: PublishTo = publishTo[language];
+    project.release?.publisher[handler]({
+      ...commonPublishOptions,
+      ...target,
+    });
+  }
+
+  /**
+   * Adds a target language to the build workflow.
+   */
+  private addTargetToBuild(
+    project: TypeScriptProject,
+    packTask: Task,
+    language: JsiiPacmakTarget,
+    extraJobOptions: Partial<Job>,
+  ) {
+    if (!project.buildWorkflow) {
+      return;
+    }
+    const pacmak = this.pacmakForLanguage(project, language, packTask);
+
+    project.buildWorkflow.addPostBuildJob(`package-${language}`, {
+      ...filteredRunsOnOptions(
+        extraJobOptions.runsOn,
+        extraJobOptions.runsOnGroup,
+      ),
+      permissions: {
+        contents: JobPermission.READ,
+      },
+      tools: {
+        node: {
+          version: this.options.workflowNodeVersion ?? "lts/*",
+        },
+        ...pacmak.publishTools,
+      },
+      steps: [
+        ...pacmak.bootstrapSteps,
+        WorkflowSteps.checkout({
+          with: {
+            path: REPO_TEMP_DIRECTORY,
+            ref: PULL_REQUEST_REF,
+            repository: PULL_REQUEST_REPOSITORY,
+            ...(project.github?.downloadLfs ? { lfs: true } : {}),
+          },
+        }),
+        ...pacmak.packagingSteps,
+      ],
+      ...extraJobOptions,
+    });
+  }
+
+  private addPackagingTask(
+    project: TypeScriptProject,
+    packageAllTask: Task,
+    language: JsiiPacmakTarget,
+  ): Task {
+    const packageTargetTask = project.tasks.addTask(`package:${language}`, {
+      description: `Create ${language} language bindings`,
+    });
+    const commandParts = ["jsii-pacmak", "-v"];
+
+    if (project.package.packageManager === NodePackageManager.PNPM) {
+      commandParts.push('--pack-command "pnpm pack"');
+    }
+
+    commandParts.push(`--target ${language}`);
+
+    packageTargetTask.exec(commandParts.join(" "));
+
+    packageAllTask.spawn(packageTargetTask);
+    return packageTargetTask;
+  }
+
+  private pacmakForLanguage(
+    project: TypeScriptProject,
+    target: JsiiPacmakTarget,
+    packTask: Task,
+  ): {
+    publishTools: Tools;
+    bootstrapSteps: Array<Step>;
+    packagingSteps: Array<Step>;
+  } {
+    const bootstrapSteps: Array<Step> = [];
+    const packagingSteps: Array<Step> = [];
+
+    // Generic bootstrapping for all target languages
+    bootstrapSteps.push(...(this.options.workflowBootstrapSteps ?? []));
+    if (project.package.packageManager === NodePackageManager.PNPM) {
+      bootstrapSteps.push({
+        name: "Setup pnpm",
+        uses: "pnpm/action-setup@v5",
+        with: { version: project.package.pnpmVersion },
+      });
+    } else if (project.package.packageManager === NodePackageManager.BUN) {
+      bootstrapSteps.push({
+        name: "Setup bun",
+        uses: "oven-sh/setup-bun@v2",
+        with: { "bun-version": project.package.bunVersion },
+      });
+    } else if (isYarnBerry(project.package.packageManager)) {
+      bootstrapSteps.push({
+        name: "Enable corepack",
+        run: "corepack enable",
+      });
+    }
+
+    const workDir = this.options.workspaceDirectory
+      ? `${REPO_TEMP_DIRECTORY}/${this.options.workspaceDirectory}`
+      : REPO_TEMP_DIRECTORY;
+
+    // Installation steps before packaging, but after checkout
+    packagingSteps.push(
+      {
+        name: "Install Dependencies",
+        run: `cd ${REPO_TEMP_DIRECTORY} && ${project.package.installCommand}`,
+      },
+      {
+        name: "Extract build artifact",
+        run: `tar --strip-components=1 -xzvf ${project.artifactsDirectory}/js/*.tgz -C ${workDir}`,
+      },
+      {
+        name: `Move build artifact out of the way`,
+        run: `mv ${project.artifactsDirectory} ${BUILD_ARTIFACT_OLD_DIR}`,
+      },
+      {
+        name: `Create ${target} artifact`,
+        run: `cd ${workDir} && ${project.runTaskCommand(packTask)}`,
+      },
+      {
+        name: `Collect ${target} artifact`,
+        run: `mv ${workDir}/${project.artifactsDirectory} ${project.artifactsDirectory}`,
+      },
+    );
+
+    return {
+      publishTools: JSII_TOOLCHAIN[target],
+      bootstrapSteps,
+      packagingSteps,
+    };
+  }
+}
+
+type PublishTo = keyof Publisher &
+  (
+    | "publishToNpm"
+    | "publishToMaven"
+    | "publishToPyPi"
+    | "publishToNuget"
+    | "publishToGo"
+  );
+
+type PublishToTarget = { [K in JsiiPacmakTarget]: PublishTo };
+const publishTo: PublishToTarget = {
+  js: "publishToNpm",
+  java: "publishToMaven",
+  python: "publishToPyPi",
+  dotnet: "publishToNuget",
+  go: "publishToGo",
+};

--- a/src/cdk/jsii-project.ts
+++ b/src/cdk/jsii-project.ts
@@ -1,26 +1,10 @@
-import type { Task } from "..";
-import type { JsiiPacmakTarget } from "./consts";
-import { JSII_TOOLCHAIN } from "./consts";
-import { JsiiDocgen } from "./jsii-docgen";
-import {
-  PULL_REQUEST_REF,
-  PULL_REQUEST_REPOSITORY,
-} from "../build/private/consts";
-import { WorkflowSteps } from "../github/workflow-steps";
-import type { Job, Step, Tools } from "../github/workflows-model";
-import { JobPermission } from "../github/workflows-model";
-import { NodePackageManager } from "../javascript";
-import { isYarnBerry } from "../javascript/util";
+import { JsiiBuild } from "./jsii-build";
 import type {
-  CommonPublishOptions,
   GoPublishOptions,
   MavenPublishOptions,
-  NpmPublishOptions,
   NugetPublishOptions,
-  Publisher,
   PyPiPublishOptions,
 } from "../release";
-import { filteredRunsOnOptions } from "../runner-options";
 import type { TypeScriptProjectOptions } from "../typescript";
 import { TypeScriptProject } from "../typescript";
 import { deepMerge } from "../util";
@@ -28,9 +12,6 @@ import { deepMerge } from "../util";
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+$/;
 const URL_REGEX =
   /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/;
-
-const REPO_TEMP_DIRECTORY = ".repo";
-const BUILD_ARTIFACT_OLD_DIR = "dist.old";
 
 export interface JsiiProjectOptions extends TypeScriptProjectOptions {
   /**
@@ -205,13 +186,8 @@ export interface JsiiGoTarget extends GoPublishOptions {
  * @pjid jsii
  */
 export class JsiiProject extends TypeScriptProject {
-  private readonly packageAllTask: Task;
-  private readonly packageJsTask: Task;
-
   constructor(options: JsiiProjectOptions) {
     const { authorEmail, authorUrl } = parseAuthorAddress(options);
-
-    const jsiiVersion = options.jsiiVersion ?? "~5.9.0";
 
     const defaultOptions: Partial<TypeScriptProjectOptions> = {
       repository: options.repositoryUrl,
@@ -234,351 +210,36 @@ export class JsiiProject extends TypeScriptProject {
 
     super(mergedOptions);
 
-    const srcdir = this.srcdir;
-    const libdir = this.libdir;
-
-    this.addFields({ types: `${libdir}/index.d.ts` });
-
-    const compressAssembly = options.compressAssembly ?? false;
-
-    // this is an unhelpful warning
-    const jsiiFlags = ["--silence-warnings=reserved-word"];
-    if (compressAssembly) {
-      jsiiFlags.push("--compress-assembly");
-    }
-
-    const compatIgnore = options.compatIgnore ?? ".compatignore";
-
-    this.addFields({ stability: options.stability ?? Stability.STABLE });
-
-    if (options.stability === Stability.DEPRECATED) {
-      this.addFields({ deprecated: true });
-    }
-
-    const compatTask = this.addTask("compat", {
-      description: "Perform API compatibility check against latest version",
-      exec: `jsii-diff npm:$(node -p "require(\'./package.json\').name") -k --ignore-file ${compatIgnore} || (echo "\nUNEXPECTED BREAKING CHANGES: add keys such as \'removed:constructs.Node.of\' to ${compatIgnore} to skip.\n" && exit 1)`,
-    });
-
-    const compat = options.compat ?? false;
-    if (compat) {
-      this.compileTask.spawn(compatTask);
-    }
-
-    this.compileTask.reset(["jsii", ...jsiiFlags].join(" "));
-    this.watchTask.reset(["jsii", "-w", ...jsiiFlags].join(" "));
-
-    // Create a new package:all task, it will be filled with language targets later
-    this.packageAllTask = this.addTask("package-all", {
-      description: "Packages artifacts for all target languages",
-    });
-
-    // in jsii we consider the entire repo (post build) as the build artifact
-    // which is then used to create the language bindings in separate jobs.
-    // we achieve this by doing a checkout and overwrite with the files from the js package.
-    this.packageJsTask = this.addPackagingTask("js");
-
-    // When running inside CI we initially only package js. Other targets are packaged in separate jobs.
-    // Outside of CI (i.e locally) we simply package all targets.
-    this.packageTask.reset();
-    this.packageTask.spawn(this.packageJsTask, {
-      // Only run in CI
-      condition: `node -e "if (!process.env.CI) process.exit(1)"`,
-    });
-    this.packageTask.spawn(this.packageAllTask, {
-      // Don't run in CI
-      condition: `node -e "if (process.env.CI) process.exit(1)"`,
-    });
-
-    const targets: Record<string, any> = {};
-
-    const jsii: any = {
-      outdir: this.artifactsDirectory,
-      targets,
-      tsc: {
-        outDir: libdir,
-        rootDir: srcdir,
-      },
-    };
-
-    if (options.excludeTypescript) {
-      jsii.excludeTypescript = options.excludeTypescript;
-    }
-
-    this.addFields({ jsii });
-
-    const extraJobOptions: Partial<Job> = {
-      ...this.getJobRunsOnConfig(options),
-      ...(options.workflowContainerImage
-        ? { container: { image: options.workflowContainerImage } }
-        : {}),
-    };
-
-    if (options.releaseToNpm != false) {
-      const npmjs: NpmPublishOptions = {
-        registry: this.package.npmRegistry,
-        npmTokenSecret: this.package.npmTokenSecret,
-        npmProvenance: this.package.npmProvenance,
-        codeArtifactOptions: options.codeArtifactOptions,
-        trustedPublishing: options.npmTrustedPublishing ?? false,
-      };
-      this.addTargetToBuild("js", this.packageJsTask, extraJobOptions);
-      this.addTargetToRelease("js", this.packageJsTask, npmjs);
-    }
-
-    // we cannot call an option `java` because the java code generated by jsii
-    // does not compile due to a conflict between this option name and the `java`
-    // package (e.g. when `java.util.Objects` is referenced).
-    if ("java" in options) {
-      throw new Error('the "java" option is now called "publishToMaven"');
-    }
-
-    const maven = options.publishToMaven;
-    if (maven) {
-      targets.java = {
-        package: maven.javaPackage,
-        maven: {
-          groupId: maven.mavenGroupId,
-          artifactId: maven.mavenArtifactId,
+    // Apply the jsii mixin using the constructs .with() pattern
+    this.with(
+      new JsiiBuild(
+        {
+          publishToMaven: options.publishToMaven,
+          publishToPypi: options.publishToPypi ?? options.python,
+          publishToGo: options.publishToGo,
+          publishToNuget: options.publishToNuget ?? options.dotnet,
+          compat: options.compat,
+          compatIgnore: options.compatIgnore,
+          excludeTypescript: options.excludeTypescript,
+          docgenFilePath: options.docgenFilePath,
+          compressAssembly: options.compressAssembly,
+          jsiiVersion: options.jsiiVersion,
+          stability: options.stability,
+          docgen: options.docgen,
+          releaseToNpm: options.releaseToNpm,
+          npmTrustedPublishing: options.npmTrustedPublishing,
+          codeArtifactOptions: options.codeArtifactOptions,
+          workflowNodeVersion: this.nodeVersion,
+          workflowBootstrapSteps: this.workflowBootstrapSteps,
         },
-      };
-
-      const task = this.addPackagingTask("java");
-      this.addTargetToBuild("java", task, extraJobOptions);
-      this.addTargetToRelease("java", task, maven);
-    }
-
-    const pypi = options.publishToPypi ?? options.python;
-    if (pypi) {
-      targets.python = {
-        distName: pypi.distName,
-        module: pypi.module,
-      };
-
-      const task = this.addPackagingTask("python");
-      this.addTargetToBuild("python", task, extraJobOptions);
-      this.addTargetToRelease("python", task, pypi);
-    }
-
-    const nuget = options.publishToNuget ?? options.dotnet;
-    if (nuget) {
-      targets.dotnet = {
-        namespace: nuget.dotNetNamespace,
-        packageId: nuget.packageId,
-        iconUrl: nuget.iconUrl,
-      };
-
-      const task = this.addPackagingTask("dotnet");
-      this.addTargetToBuild("dotnet", task, extraJobOptions);
-      this.addTargetToRelease("dotnet", task, nuget);
-    }
-
-    const golang = options.publishToGo;
-    if (golang) {
-      targets.go = {
-        moduleName: golang.moduleName,
-        packageName: golang.packageName,
-        versionSuffix: golang.versionSuffix,
-      };
-
-      const task = this.addPackagingTask("go");
-      this.addTargetToBuild("go", task, extraJobOptions);
-      this.addTargetToRelease("go", task, golang);
-    }
-
-    // If jsiiVersion is "*", don't specify anything so the user can manage.
-    // Otherwise, use `jsiiVersion`
-    const jsiiSuffix = jsiiVersion === "*" ? "" : `@${jsiiVersion}`;
-    this.addDevDeps(
-      `jsii${jsiiSuffix}`,
-      `jsii-rosetta${jsiiSuffix}`,
-      "jsii-diff",
-      "jsii-pacmak",
-    );
-
-    this.gitignore.exclude(".jsii", "tsconfig.json");
-    this.npmignore?.include(".jsii");
-
-    if (options.docgen ?? true) {
-      // If jsiiVersion is "*", don't specify anything so the user can manage.
-      // Otherwise use a version that is compatible with all supported jsii releases.
-      const docgenVersion = options.jsiiVersion === "*" ? "*" : "^10.5.0";
-      new JsiiDocgen(this, {
-        version: docgenVersion,
-        filePath: options.docgenFilePath,
-      });
-    }
-
-    // jsii updates .npmignore, so we make it writable
-    if (this.npmignore) {
-      this.npmignore.readonly = false;
-    }
-  }
-
-  /**
-   * Adds a target language to the release workflow.
-   * @param language
-   * @returns
-   */
-  private addTargetToRelease(
-    language: JsiiPacmakTarget,
-    packTask: Task,
-    target:
-      | JsiiPythonTarget
-      | JsiiDotNetTarget
-      | JsiiGoTarget
-      | JsiiJavaTarget
-      | NpmPublishOptions,
-  ) {
-    if (!this.release) {
-      return;
-    }
-
-    const pacmak = this.pacmakForLanguage(language, packTask);
-    const prePublishSteps = [
-      ...pacmak.bootstrapSteps,
-      WorkflowSteps.checkout({
-        with: {
-          path: REPO_TEMP_DIRECTORY,
-          ...(this.github?.downloadLfs ? { lfs: true } : {}),
+        {
+          ...this.getJobRunsOnConfig(options),
+          ...(options.workflowContainerImage
+            ? { container: { image: options.workflowContainerImage } }
+            : {}),
         },
-      }),
-      ...pacmak.packagingSteps,
-    ];
-    const commonPublishOptions: CommonPublishOptions = {
-      publishTools: pacmak.publishTools,
-      prePublishSteps,
-    };
-
-    const handler: PublishTo = publishTo[language];
-    this.release?.publisher[handler]({
-      ...commonPublishOptions,
-      ...target,
-    });
-  }
-
-  /**
-   * Adds a target language to the build workflow
-   * @param language
-   * @returns
-   */
-  private addTargetToBuild(
-    language: JsiiPacmakTarget,
-    packTask: Task,
-    extraJobOptions: Partial<Job>,
-  ) {
-    if (!this.buildWorkflow) {
-      return;
-    }
-    const pacmak = this.pacmakForLanguage(language, packTask);
-
-    this.buildWorkflow.addPostBuildJob(`package-${language}`, {
-      ...filteredRunsOnOptions(
-        extraJobOptions.runsOn,
-        extraJobOptions.runsOnGroup,
       ),
-      permissions: {
-        contents: JobPermission.READ,
-      },
-      tools: {
-        node: { version: this.nodeVersion ?? "lts/*" },
-        ...pacmak.publishTools,
-      },
-      steps: [
-        ...pacmak.bootstrapSteps,
-        WorkflowSteps.checkout({
-          with: {
-            path: REPO_TEMP_DIRECTORY,
-            ref: PULL_REQUEST_REF,
-            repository: PULL_REQUEST_REPOSITORY,
-            ...(this.github?.downloadLfs ? { lfs: true } : {}),
-          },
-        }),
-        ...pacmak.packagingSteps,
-      ],
-      ...extraJobOptions,
-    });
-  }
-
-  private addPackagingTask(language: JsiiPacmakTarget): Task {
-    const packageTargetTask = this.tasks.addTask(`package:${language}`, {
-      description: `Create ${language} language bindings`,
-    });
-    const commandParts = ["jsii-pacmak", "-v"];
-
-    if (this.package.packageManager === NodePackageManager.PNPM) {
-      commandParts.push('--pack-command "pnpm pack"');
-    }
-
-    commandParts.push(`--target ${language}`);
-
-    packageTargetTask.exec(commandParts.join(" "));
-
-    this.packageAllTask.spawn(packageTargetTask);
-    return packageTargetTask;
-  }
-
-  private pacmakForLanguage(
-    target: JsiiPacmakTarget,
-    packTask: Task,
-  ): {
-    publishTools: Tools;
-    bootstrapSteps: Array<Step>;
-    packagingSteps: Array<Step>;
-  } {
-    const bootstrapSteps: Array<Step> = [];
-    const packagingSteps: Array<Step> = [];
-
-    // Generic bootstrapping for all target languages
-    bootstrapSteps.push(...this.workflowBootstrapSteps);
-    if (this.package.packageManager === NodePackageManager.PNPM) {
-      bootstrapSteps.push({
-        name: "Setup pnpm",
-        uses: "pnpm/action-setup@v5",
-        with: { version: this.package.pnpmVersion },
-      });
-    } else if (this.package.packageManager === NodePackageManager.BUN) {
-      bootstrapSteps.push({
-        name: "Setup bun",
-        uses: "oven-sh/setup-bun@v2",
-        with: { "bun-version": this.package.bunVersion },
-      });
-    } else if (isYarnBerry(this.package.packageManager)) {
-      bootstrapSteps.push({
-        name: "Enable corepack",
-        run: "corepack enable",
-      });
-    }
-
-    // Installation steps before packaging, but after checkout
-    packagingSteps.push(
-      {
-        name: "Install Dependencies",
-        run: `cd ${REPO_TEMP_DIRECTORY} && ${this.package.installCommand}`,
-      },
-      {
-        name: "Extract build artifact",
-        run: `tar --strip-components=1 -xzvf ${this.artifactsDirectory}/js/*.tgz -C ${REPO_TEMP_DIRECTORY}`,
-      },
-      {
-        name: `Move build artifact out of the way`,
-        run: `mv ${this.artifactsDirectory} ${BUILD_ARTIFACT_OLD_DIR}`,
-      },
-      {
-        name: `Create ${target} artifact`,
-        run: `cd ${REPO_TEMP_DIRECTORY} && ${this.runTaskCommand(packTask)}`,
-      },
-      {
-        name: `Collect ${target} artifact`,
-        run: `mv ${REPO_TEMP_DIRECTORY}/${this.artifactsDirectory} ${this.artifactsDirectory}`,
-      },
     );
-
-    return {
-      publishTools: JSII_TOOLCHAIN[target],
-      bootstrapSteps,
-      packagingSteps,
-    };
   }
 
   /**
@@ -595,24 +256,6 @@ export class JsiiProject extends TypeScriptProject {
         : {};
   }
 }
-
-type PublishTo = keyof Publisher &
-  (
-    | "publishToNpm"
-    | "publishToMaven"
-    | "publishToPyPi"
-    | "publishToNuget"
-    | "publishToGo"
-  );
-
-type PublishToTarget = { [K in JsiiPacmakTarget]: PublishTo };
-const publishTo: PublishToTarget = {
-  js: "publishToNpm",
-  java: "publishToMaven",
-  python: "publishToPyPi",
-  dotnet: "publishToNuget",
-  go: "publishToGo",
-};
 
 function parseAuthorAddress(options: JsiiProjectOptions) {
   let authorEmail = options.authorEmail;

--- a/test/cdk/jsii-build.test.ts
+++ b/test/cdk/jsii-build.test.ts
@@ -1,0 +1,148 @@
+import { javascript, Project } from "../../src";
+import { JsiiBuild } from "../../src/cdk";
+import { TypeScriptProject } from "../../src/typescript";
+import { synthSnapshot } from "../util";
+
+function createTypeScriptProject(
+  options: Partial<javascript.NodeProjectOptions> = {},
+) {
+  return new TypeScriptProject({
+    name: "test-project",
+    defaultReleaseBranch: "main",
+    disableTsconfig: true,
+    ...options,
+  });
+}
+
+describe("JsiiBuild", () => {
+  describe("supports()", () => {
+    it("returns true for TypeScriptProject", () => {
+      const mixin = new JsiiBuild();
+      const project = createTypeScriptProject();
+      expect(mixin.supports(project)).toBe(true);
+    });
+
+    it("applyTo is a no-op for unsupported constructs", () => {
+      const mixin = new JsiiBuild();
+      const project = new Project({ name: "plain" });
+      mixin.applyTo(project);
+      expect(project.tasks.tryFind("package-all")).toBeUndefined();
+    });
+  });
+
+  describe("applyTo()", () => {
+    it("applies jsii configuration to a TypeScriptProject", () => {
+      const project = createTypeScriptProject();
+      project.with(new JsiiBuild());
+
+      const output = synthSnapshot(project);
+      const pkgjson = output["package.json"];
+      expect(pkgjson.jsii).toBeDefined();
+      expect(pkgjson.jsii.tsc.outDir).toBe("lib");
+      expect(pkgjson.jsii.tsc.rootDir).toBe("src");
+    });
+
+    it("sets stability to deprecated", () => {
+      const project = createTypeScriptProject();
+      project.with(new JsiiBuild({ stability: "deprecated" }));
+
+      const output = synthSnapshot(project);
+      const pkgjson = output["package.json"];
+      expect(pkgjson.stability).toBe("deprecated");
+      expect(pkgjson.deprecated).toBe(true);
+    });
+
+    it("enables compat check", () => {
+      const project = createTypeScriptProject();
+      project.with(new JsiiBuild({ compat: true }));
+
+      const output = synthSnapshot(project);
+      const tasks = output[".projen/tasks.json"].tasks;
+      expect(tasks.compat).toBeDefined();
+      // compat should be spawned by compile
+      expect(tasks.compile.steps.some((s: any) => s.spawn === "compat")).toBe(
+        true,
+      );
+    });
+
+    it("skips npm release when releaseToNpm is false", () => {
+      const project = createTypeScriptProject();
+      project.with(new JsiiBuild({ releaseToNpm: false }));
+
+      const output = synthSnapshot(project);
+      const buildWorkflow = output[".github/workflows/build.yml"];
+      expect(buildWorkflow).not.toContain("package-js");
+    });
+
+    it("works without release component", () => {
+      const project = createTypeScriptProject({ release: false });
+      project.with(
+        new JsiiBuild({
+          publishToMaven: {
+            javaPackage: "com.example",
+            mavenGroupId: "com.example",
+            mavenArtifactId: "test",
+          },
+        }),
+      );
+
+      // Should not throw
+      const output = synthSnapshot(project);
+      expect(output["package.json"].jsii.targets.java).toBeDefined();
+    });
+
+    it("works without build workflow", () => {
+      const project = createTypeScriptProject({ buildWorkflow: false });
+      project.with(
+        new JsiiBuild({
+          publishToMaven: {
+            javaPackage: "com.example",
+            mavenGroupId: "com.example",
+            mavenArtifactId: "test",
+          },
+        }),
+      );
+
+      // Should not throw
+      const output = synthSnapshot(project);
+      expect(output["package.json"].jsii.targets.java).toBeDefined();
+    });
+
+    it("uses bun package manager bootstrap steps", () => {
+      const project = createTypeScriptProject({
+        packageManager: javascript.NodePackageManager.BUN,
+      });
+      project.with(
+        new JsiiBuild({
+          publishToMaven: {
+            javaPackage: "com.example",
+            mavenGroupId: "com.example",
+            mavenArtifactId: "test",
+          },
+        }),
+      );
+
+      const output = synthSnapshot(project);
+      const buildWorkflow = output[".github/workflows/build.yml"];
+      expect(buildWorkflow).toContain("setup-bun");
+    });
+
+    it("uses workspaceDirectory in packaging steps", () => {
+      const project = createTypeScriptProject();
+      project.with(
+        new JsiiBuild({
+          workspaceDirectory: "packages/my-lib",
+          publishToMaven: {
+            javaPackage: "com.example",
+            mavenGroupId: "com.example",
+            mavenArtifactId: "test",
+          },
+        }),
+      );
+
+      const output = synthSnapshot(project);
+      const releaseWorkflow = output[".github/workflows/release.yml"];
+      expect(releaseWorkflow).toContain(".repo/packages/my-lib");
+    });
+  });
+});


### PR DESCRIPTION
This PR introduces `JsiiBuild`, a mixin implementing the constructs 10.x `IMixin` interface that decouples jsii functionality from project inheritance.

Today, getting jsii compilation and multi-language publishing requires either extending `JsiiProject` or maintaining hundreds of lines of custom code (as in [aws-cdk-cli's projenrc/jsii.ts](https://github.com/aws/aws-cdk-cli/blob/main/projenrc/jsii.ts)). With this change, the same capabilities can be applied to any `TypeScriptProject` using the `.with()` pattern:

```ts
const project = new TypeScriptProject({ disableTsconfig: true, ... });
project.with(new JsiiBuild({
  jsiiVersion: '~5.9.0',
  publishToMaven: { ... },
  publishToPypi: { ... },
  workspaceDirectory: 'packages/my-lib', // for monorepos
}));
```

`JsiiProject` is refactored to use the mixin internally via `this.with(new JsiiBuild(...))`, maintaining full backward compatibility — all existing tests pass with no snapshot changes.

Also fixes a latent bug where `compat: true` had no effect because the compat task was spawned on compile before `compileTask.reset()` wiped it.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
