### PR TITLE
fix(build): artifact_id output references non-existent step without post-build jobs

### DIFF
--- a/src/build/build-workflow.ts
+++ b/src/build/build-workflow.ts
@@ -250,10 +250,6 @@ export class BuildWorkflow extends Component {
           stepId: SELF_MUTATION_STEP,
           outputName: SELF_MUTATION_HAPPENED_OUTPUT,
         },
-        [ARTIFACT_ID_OUTPUT]: {
-          stepId: UPLOAD_ARTIFACT_STEP,
-          outputName: "artifact-id",
-        },
       },
     };
 
@@ -320,6 +316,15 @@ export class BuildWorkflow extends Component {
 
     // add to the list of build job IDs
     this._postBuildJobs.push(id);
+
+    // add artifact_id output to the build job (only needed when post-build jobs exist)
+    const buildJob = this.workflow.getJob(BUILD_JOBID) as Job;
+    if (buildJob.outputs && !buildJob.outputs[ARTIFACT_ID_OUTPUT]) {
+      (buildJob.outputs as Record<string, unknown>)[ARTIFACT_ID_OUTPUT] = {
+        stepId: UPLOAD_ARTIFACT_STEP,
+        outputName: "artifact-id",
+      };
+    }
   }
 
   /**

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -3996,7 +3996,6 @@ jobs:
       contents: write
     outputs:
       self_mutation_happened: \${{ steps.self_mutation.outputs.self_mutation_happened }}
-      artifact_id: \${{ steps.upload_artifact.outputs.artifact-id }}
     env:
       CI: "true"
     steps:

--- a/test/build/__snapshots__/build-workflow.test.ts.snap
+++ b/test/build/__snapshots__/build-workflow.test.ts.snap
@@ -14,7 +14,6 @@ jobs:
       contents: write
     outputs:
       self_mutation_happened: \${{ steps.self_mutation.outputs.self_mutation_happened }}
-      artifact_id: \${{ steps.upload_artifact.outputs.artifact-id }}
     env:
       CI: "true"
     steps:
@@ -93,7 +92,6 @@ jobs:
       contents: write
     outputs:
       self_mutation_happened: \${{ steps.self_mutation.outputs.self_mutation_happened }}
-      artifact_id: \${{ steps.upload_artifact.outputs.artifact-id }}
     env:
       CI: "true"
     steps:
@@ -172,7 +170,6 @@ jobs:
       contents: write
     outputs:
       self_mutation_happened: \${{ steps.self_mutation.outputs.self_mutation_happened }}
-      artifact_id: \${{ steps.upload_artifact.outputs.artifact-id }}
     env:
       CI: "true"
     defaults:

--- a/test/build/build-workflow.test.ts
+++ b/test/build/build-workflow.test.ts
@@ -107,6 +107,38 @@ describe("addPostBuildJob", () => {
     );
     expect(downloadStep.with.name).toBeUndefined();
   });
+
+  test("artifact_id output is not present without post-build jobs", () => {
+    const p = new TestProject();
+    new BuildWorkflow(p, {
+      buildTask: p.buildTask,
+      artifactsDirectory: "dist",
+    });
+
+    const workflows = synthWorkflows(p);
+    const build = yaml.parse(workflows[".github/workflows/build.yml"]);
+    expect(build.jobs.build.outputs.artifact_id).toBeUndefined();
+  });
+
+  test("artifact_id output is present with post-build jobs", () => {
+    const p = new TestProject();
+    const bw = new BuildWorkflow(p, {
+      buildTask: p.buildTask,
+      artifactsDirectory: "dist",
+    });
+
+    bw.addPostBuildJob("post-job", {
+      runsOn: ["ubuntu-latest"],
+      permissions: {},
+      steps: [{ run: "echo hello" }],
+    });
+
+    const workflows = synthWorkflows(p);
+    const build = yaml.parse(workflows[".github/workflows/build.yml"]);
+    expect(build.jobs.build.outputs.artifact_id).toBe(
+      "${{ steps.upload_artifact.outputs.artifact-id }}",
+    );
+  });
 });
 
 function synthWorkflows(p: Project): any {

--- a/test/typescript/__snapshots__/typescript.test.ts.snap
+++ b/test/typescript/__snapshots__/typescript.test.ts.snap
@@ -260,7 +260,6 @@ jobs:
       contents: write
     outputs:
       self_mutation_happened: \${{ steps.self_mutation.outputs.self_mutation_happened }}
-      artifact_id: \${{ steps.upload_artifact.outputs.artifact-id }}
     env:
       CI: "true"
     steps:

--- a/test/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-project.test.ts.snap
@@ -37,7 +37,6 @@ jobs:
       contents: write
     outputs:
       self_mutation_happened: \${{ steps.self_mutation.outputs.self_mutation_happened }}
-      artifact_id: \${{ steps.upload_artifact.outputs.artifact-id }}
     env:
       CI: "true"
     steps:

--- a/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-ts-project.test.ts.snap
@@ -38,7 +38,6 @@ jobs:
       contents: write
     outputs:
       self_mutation_happened: \${{ steps.self_mutation.outputs.self_mutation_happened }}
-      artifact_id: \${{ steps.upload_artifact.outputs.artifact-id }}
     env:
       CI: "true"
     steps:

--- a/test/web/__snapshots__/react-project.test.ts.snap
+++ b/test/web/__snapshots__/react-project.test.ts.snap
@@ -35,7 +35,6 @@ jobs:
       contents: write
     outputs:
       self_mutation_happened: \${{ steps.self_mutation.outputs.self_mutation_happened }}
-      artifact_id: \${{ steps.upload_artifact.outputs.artifact-id }}
     env:
       CI: "true"
     steps:

--- a/test/web/__snapshots__/react-ts-project.test.ts.snap
+++ b/test/web/__snapshots__/react-ts-project.test.ts.snap
@@ -258,7 +258,6 @@ jobs:
       contents: write
     outputs:
       self_mutation_happened: \${{ steps.self_mutation.outputs.self_mutation_happened }}
-      artifact_id: \${{ steps.upload_artifact.outputs.artifact-id }}
     env:
       CI: "true"
     steps:


### PR DESCRIPTION
After #4719, the build workflow job unconditionally adds an `artifact_id` output referencing the `upload_artifact` step. However, this step is only rendered when there are post-build jobs. Without post-build jobs, the output references a non-existent step, causing a GitHub Actions warning.

This moves the `artifact_id` output registration into `addPostBuildJob`, so it is only added to the build job when the upload step will actually be present.

Fixes #4721

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
