### PR TITLE
fix: reject unsupported new project options

### DIFF
--- a/src/cli/cmds/new.ts
+++ b/src/cli/cmds/new.ts
@@ -75,6 +75,7 @@ class Command implements yargs.CommandModule {
       args.command(type.pjid, type.docs ?? "", {
         builder: (cargs) => {
           cargs.showHelpOnFail(false);
+          cargs.strictOptions();
 
           for (const option of type.options ?? []) {
             // not all types can be represented in the cli

--- a/test/__snapshots__/new.test.ts.snap
+++ b/test/__snapshots__/new.test.ts.snap
@@ -67,21 +67,6 @@ project = PythonProject(
 project.synth()"
 `;
 
-exports[`projen new --from project options projen new with unknown option works 1`] = `
-"const { javascript } = require("projen");
-const project = new javascript.NodeProject({
-  defaultReleaseBranch: "main",
-  name: "my-project",
-  packageManager: javascript.NodePackageManager.NPM,
-
-  // deps: [],                /* Runtime dependencies of this module. */
-  // description: undefined,  /* The description is just a string that helps people understand the purpose of the package. */
-  // devDeps: [],             /* Build dependencies for this module. */
-  // packageName: undefined,  /* The "name" in package.json. */
-});
-project.synth();"
-`;
-
 exports[`projen new --from project options projenrc-json creates external project type 1`] = `
 {
   "cdkVersion": "2.189.1",

--- a/test/new.test.ts
+++ b/test/new.test.ts
@@ -367,18 +367,16 @@ describe("projen new --from", () => {
       });
     });
 
-    test("projen new with unknown option works", () => {
+    test("projen new rejects unsupported project type option", () => {
       withProjectDir((projectdir) => {
-        execProjenCLI(projectdir, [
-          "new",
-          "node",
-          "--DOES_NOT_EXIST",
-          "--no-synth",
-        ]);
-
-        const projenrc = directorySnapshot(projectdir)[".projenrc.js"];
-        expect(projenrc).toBeDefined();
-        expect(projenrc).toMatchSnapshot();
+        expect(() =>
+          execProjenCLI(projectdir, [
+            "new",
+            "jsii",
+            "--projenrc-py",
+            "--no-synth",
+          ]),
+        ).toThrow("Unknown arguments: projenrc-py, projenrcPy");
       });
     });
 


### PR DESCRIPTION
Fixes #4398

Rejects project-type-specific options that are not supported by the selected `projen new` subcommand, so invalid flags fail before synthesis instead of being ignored.

Validation:
- `node ./projen.js compile`
- `npx jest test/new.test.ts -t "projen new rejects unsupported project type option" --runInBand`
- `node ./bin/projen new jsii --projenrc-py --no-git`
- `node ./projen.js eslint`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
