### PR TITLE
fix(python): uv & poetry environment setup no longer have issues on Windows

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -123,9 +123,37 @@
       }
     ],
     "@typescript-eslint/consistent-type-imports": "error",
-    "@typescript-eslint/consistent-type-exports": "error"
+    "@typescript-eslint/consistent-type-exports": "error",
+    "no-restricted-imports": "off",
+    "@typescript-eslint/no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": "child_process",
+            "message": "Do not import 'child_process' directly. Use the helpers in src/util/exec.ts (e.g. `git.run`).",
+            "allowTypeImports": true
+          },
+          {
+            "name": "node:child_process",
+            "message": "Do not import 'node:child_process' directly. Use the helpers in src/util/exec.ts (e.g. `git.run`).",
+            "allowTypeImports": true
+          }
+        ]
+      }
+    ]
   },
   "overrides": [
+    {
+      "files": [
+        "src/util/exec.ts",
+        "test/cli/run-task.test.ts",
+        "test/tasks/tasks.test.ts"
+      ],
+      "rules": {
+        "@typescript-eslint/no-restricted-imports": "off"
+      }
+    },
     {
       "files": [
         "src/**/*.ts"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -205,9 +205,47 @@ project.with(
   }),
 );
 
-javascript.Eslint.of(project)?.addRules({
+project.eslint?.addRules({
   "@typescript-eslint/consistent-type-imports": "error",
   "@typescript-eslint/consistent-type-exports": "error",
+  // Centralize all OS-command execution in src/util/exec.ts so command
+  // execution goes through a single, consistent set of helpers. Type-only
+  // imports are allowed (they have no runtime effect).
+  "no-restricted-imports": "off",
+  "@typescript-eslint/no-restricted-imports": [
+    "error",
+    {
+      paths: [
+        {
+          name: "child_process",
+          message:
+            "Do not import 'child_process' directly. Use the helpers in src/util/exec.ts (e.g. `git.run`).",
+          allowTypeImports: true,
+        },
+        {
+          name: "node:child_process",
+          message:
+            "Do not import 'node:child_process' directly. Use the helpers in src/util/exec.ts (e.g. `git.run`).",
+          allowTypeImports: true,
+        },
+      ],
+    },
+  ],
+});
+// Files that need direct child_process access:
+// - src/util/exec.ts: the single home for command execution
+// - test/cli/run-task.test.ts: spawns the CLI and spies on the task runtime's
+//   process execution
+// - test/tasks/tasks.test.ts: spies on the task runner's process execution
+project.eslint?.addOverride({
+  files: [
+    "src/util/exec.ts",
+    "test/cli/run-task.test.ts",
+    "test/tasks/tasks.test.ts",
+  ],
+  rules: {
+    "@typescript-eslint/no-restricted-imports": "off",
+  },
 });
 
 // The CLI (src/cli) is the runtime entrypoint of projen. It may depend on the

--- a/src/cli/cmds/new.ts
+++ b/src/cli/cmds/new.ts
@@ -1,4 +1,3 @@
-import type { SpawnSyncReturns } from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 import * as semver from "semver";
@@ -7,20 +6,14 @@ import * as inventory from "../../inventory";
 import * as logging from "../../logging";
 import { InitProjectOptionHints } from "../../option-hints";
 import { Projects } from "../../projects";
-import {
-  exec,
-  execCapture,
-  execOrUndefined,
-  getGitVersion,
-  isTruthy,
-  normalizePersistedPath,
-} from "../../util";
+import { getGitVersion, isTruthy, normalizePersistedPath } from "../../util";
+import { git, npm } from "../../util/exec";
 import { tryProcessMacro } from "../macros";
 import {
   CliError,
   findJsiiFilePath,
   installPackage,
-  renderInstallCommand,
+  renderInstallArgs,
 } from "../util";
 
 class Command implements yargs.CommandModule {
@@ -297,26 +290,29 @@ function commandLineToProps(
  */
 async function initProjectFromModule(baseDir: string, spec: string, args: any) {
   const projenVersion = args.projenVersion ?? "latest";
-  const installCommand = renderInstallCommand(
-    baseDir,
-    `projen@${projenVersion}`,
-  );
+  const installArgs = renderInstallArgs(baseDir, `projen@${projenVersion}`);
   if (args.projenVersion) {
-    exec(installCommand, { cwd: baseDir });
+    await npm.run(installArgs, { cwd: baseDir });
   } else {
-    // do not overwrite existing installation
-    exec(
-      `npm ls --prefix="${baseDir}" --depth=0 --pattern projen || ${installCommand}`,
-      { cwd: baseDir },
-    );
+    // do not overwrite an existing installation: only install if `npm ls` fails
+    try {
+      await npm.run(
+        ["ls", `--prefix=${baseDir}`, "--depth=0", "--pattern", "projen"],
+        { cwd: baseDir },
+      );
+    } catch {
+      await npm.run(installArgs, { cwd: baseDir });
+    }
   }
 
-  const installPackageWithCliError = (b: string, s: string): string => {
+  const installPackageWithCliError = async (
+    b: string,
+    s: string,
+  ): Promise<string> => {
     try {
-      return installPackage(b, s);
+      return await installPackage(b, s);
     } catch (error: unknown) {
-      const stderr =
-        (error as SpawnSyncReturns<Buffer>)?.stderr?.toString() ?? "";
+      const stderr = (error as { stderr?: Buffer })?.stderr?.toString() ?? "";
       const isLocal = stderr.includes("code ENOENT");
       const isRegistry = stderr.includes("code E404");
       if (isLocal || isRegistry) {
@@ -330,7 +326,7 @@ async function initProjectFromModule(baseDir: string, spec: string, args: any) {
     }
   };
 
-  const moduleName = installPackageWithCliError(baseDir, spec);
+  const moduleName = await installPackageWithCliError(baseDir, spec);
   logging.empty();
 
   // Find the just installed package and discover the rest recursively from this package folder
@@ -485,33 +481,38 @@ async function initProject(
   });
 
   if (fs.existsSync(path.join(baseDir, "package.json")) && args.post) {
-    exec("npm run eslint --if-present", { cwd: baseDir });
+    await npm.run(["run", "eslint", "--if-present"], {
+      cwd: baseDir,
+    });
   }
 
   if (args.git) {
-    const git = (cmd: string) => exec(`git ${cmd}`, { cwd: baseDir });
-    const gitversion: string = getGitVersion(
-      execCapture("git --version", { cwd: baseDir }).toString(),
-    );
+    const opts = { cwd: baseDir };
+    const gitversion: string = getGitVersion(git.capture(["--version"], opts));
     logging.debug("system using git version ", gitversion);
     // `git config init.defaultBranch` and `git init -b` are only available since git 2.28.0
     if (gitversion && semver.gte(gitversion, "2.28.0")) {
       const defaultGitInitBranch =
-        execOrUndefined("git config init.defaultBranch", {
-          cwd: baseDir,
-        })?.trim() || "main";
-      git(`init -b ${defaultGitInitBranch}`);
-      git("add .");
-      git('commit --allow-empty -m "chore: project created with projen"');
+        git.tryCapture(["config", "init.defaultBranch"], opts)?.trim() ||
+        "main";
+      git.run(["init", "-b", defaultGitInitBranch], opts);
+      git.run(["add", "."], opts);
+      git.run(
+        ["commit", "--allow-empty", "-m", "chore: project created with projen"],
+        opts,
+      );
       logging.debug(`default branch name set to ${defaultGitInitBranch}`);
     } else {
-      git("init");
-      git("add .");
-      git('commit --allow-empty -m "chore: project created with projen"');
+      git.run(["init"], opts);
+      git.run(["add", "."], opts);
+      git.run(
+        ["commit", "--allow-empty", "-m", "chore: project created with projen"],
+        opts,
+      );
       logging.debug(
         "older version of git detected, changed default branch name to main",
       );
-      git("branch -M main");
+      git.run(["branch", "-M", "main"], opts);
     }
   }
 }

--- a/src/cli/macros.ts
+++ b/src/cli/macros.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
-import { execOrUndefined, formatAsPythonModule } from "../util";
+import { formatAsPythonModule } from "../util";
+import { git } from "../util/exec";
 
 export function tryProcessMacro(cwd: string, macro: string) {
   if (!macro.startsWith("$")) {
@@ -12,7 +13,7 @@ export function tryProcessMacro(cwd: string, macro: string) {
     case "$BASEDIR":
       return basedir;
     case "$GIT_REMOTE":
-      const origin = execOrUndefined("git remote get-url origin", { cwd });
+      const origin = git.tryCapture(["remote", "get-url", "origin"], { cwd });
       if (origin) {
         return origin;
       }
@@ -39,8 +40,8 @@ export function tryProcessMacro(cwd: string, macro: string) {
  */
 function getFromGitConfig(cwd: string, key: string): string | undefined {
   return (
-    execOrUndefined(`git config --get --includes ${key}`, { cwd }) ??
-    execOrUndefined(`git config --get --global --includes ${key}`, { cwd })
+    git.tryCapture(["config", "--get", "--includes", key], { cwd }) ??
+    git.tryCapture(["config", "--get", "--global", "--includes", key], { cwd })
   );
 }
 

--- a/src/cli/task-runtime.ts
+++ b/src/cli/task-runtime.ts
@@ -1,5 +1,4 @@
 import type { SpawnOptions } from "child_process";
-import { spawnSync } from "child_process";
 import { existsSync, readFileSync, statSync } from "fs";
 import { dirname, join, resolve } from "path";
 import * as path from "path";
@@ -9,6 +8,7 @@ import { $ } from "dax";
 import { PROJEN_DIR, TASKS_MANIFEST_VERSION } from "../common";
 import * as logging from "../logging";
 import type { TasksManifest, TaskSpec, TaskStep } from "../task-model";
+import { rawShell } from "../util/exec";
 
 // avoids a (false positive) esbuild warning about incorrect imports.
 // `?.default ?? module` keeps this working both as a plain CommonJS require and
@@ -514,6 +514,10 @@ class RunTask {
       ...options.extraEnv,
     };
 
+    // stdout/stderr are only captured when a caller pipes them (e.g.
+    // `shellEval`); otherwise inherit so output is streamed to the terminal.
+    const capture = Array.isArray(options.spawnOptions?.stdio);
+
     // On Windows the default shell (cmd.exe) does not understand the POSIX-style
     // commands projen tasks are written in (`cat`, `cp`, `mkdir -p`, `rm -rf`,
     // `&&` chains, `$VAR`, ...). Run the command through dax's cross-platform
@@ -521,10 +525,6 @@ class RunTask {
     // commands. Now that the task runtime is asynchronous we can drive dax's
     // `$` API directly instead of spawning a synchronous child node process.
     if (process.platform === "win32") {
-      // stdout/stderr are only captured when a caller pipes them (e.g.
-      // `shellEval`); otherwise inherit so output is streamed to the terminal.
-      const capture = Array.isArray(options.spawnOptions?.stdio);
-
       const result = await $.raw`${options.command}`
         .cwd(cwd)
         .env(env)
@@ -539,14 +539,9 @@ class RunTask {
       };
     }
 
-    return spawnSync(options.command, {
-      ...options,
-      cwd,
-      shell: true,
-      stdio: "inherit",
-      env,
-      ...options.spawnOptions,
-    });
+    // On other platforms, run the command through the system shell via the
+    // centralized `rawShell` helper.
+    return rawShell.exec(options.command, { cwd, env, capture });
   }
 
   private async shellEval(options: ShellOptions): Promise<ShellResult> {

--- a/src/cli/util.ts
+++ b/src/cli/util.ts
@@ -1,28 +1,28 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as logging from "../logging";
-import { exec } from "../util";
+import { npm } from "../util/exec";
 
 /**
  * Installs the npm module (through `npm install`) to node_modules under `projectDir`.
  * @param spec The npm package spec (e.g. `foo@^1.2` or `foo@/var/folders/8k/qcw0ls5pv_ph0000gn/T/projen-RYurCw/pkg.tgz`)
  * @returns The installed package name (e.g. `@foo/bar`)
  */
-export function installPackage(
+export async function installPackage(
   baseDir: string,
   spec: string,
   isProjen = false,
-): string {
+): Promise<string> {
   const packageJsonPath = path.join(baseDir, "package.json");
   const packageJsonExisted = fs.existsSync(packageJsonPath);
 
   if (!packageJsonExisted) {
     // Make sure we have a package.json to read from later
-    exec("npm init --yes", { cwd: baseDir });
+    await npm.run(["init", "--yes"], { cwd: baseDir });
   }
 
   logging.info(`installing module ${spec}...`);
-  exec(renderInstallCommand(baseDir, spec), { cwd: baseDir });
+  await npm.run(renderInstallArgs(baseDir, spec), { cwd: baseDir });
 
   // Get the true installed package name
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
@@ -44,7 +44,7 @@ export function installPackage(
 }
 
 /**
- * Render a command to install an npm package.
+ * Render the arguments to install an npm package (the args following `npm`).
  *
  * Engine checks are ignored at this point so that the module can be installed
  * regardless of the environment. This was needed to unblock the upgrade of the
@@ -53,13 +53,22 @@ export function installPackage(
  *
  * @param dir Base directory
  * @param module The module to install (e.g. foo@^1.2)
- * @returns The string that includes the install command ("npm install ...")
+ * @returns The arguments for `npm` (e.g. ["install", ..., "foo@^1.2"])
  */
-export function renderInstallCommand(dir: string, module: string): string {
+export function renderInstallArgs(dir: string, module: string): string[] {
   // --save is needed to override any global save: false config
   // --save-dev to install as dev dependency
   // --include=dev to force saving the dependencies with NODE_ENV=production
-  return `npm install --save --save-dev -f --no-package-lock --include=dev --prefix="${dir}" ${module}`;
+  return [
+    "install",
+    "--save",
+    "--save-dev",
+    "-f",
+    "--no-package-lock",
+    "--include=dev",
+    `--prefix=${dir}`,
+    module,
+  ];
 }
 
 export function findJsiiFilePath(

--- a/src/python/poetry.ts
+++ b/src/python/poetry.ts
@@ -12,8 +12,9 @@ import { DependencyType } from "../dependencies";
 import type { Project } from "../project";
 import type { Task } from "../task";
 import { TomlFile } from "../toml";
-import { decamelizeKeysRecursively, exec, execOrUndefined } from "../util";
+import { decamelizeKeysRecursively } from "../util";
 import { PyprojectTomlFile } from "./pyproject-toml-file";
+import { poetry } from "../util/exec";
 
 export interface PoetryOptions
   extends PythonPackagingOptions, PythonExecutableOptions {}
@@ -216,7 +217,7 @@ export class Poetry
    * Initializes the virtual environment if it doesn't exist (called during post-synthesis).
    */
   public setupEnvironment() {
-    const result = execOrUndefined("which poetry", {
+    const result = poetry.tryCapture(["--version"], {
       cwd: this.project.outdir,
     });
     if (!result) {
@@ -225,13 +226,15 @@ export class Poetry
       );
     }
 
-    let envPath = execOrUndefined("poetry env info -p", {
+    let envPath = poetry.tryCapture(["env", "info", "-p"], {
       cwd: this.project.outdir,
     });
     if (!envPath) {
       this.project.logger.info("Setting up a virtual environment...");
-      exec(`poetry env use ${this.pythonExec}`, { cwd: this.project.outdir });
-      envPath = execOrUndefined("poetry env info -p", {
+      poetry.run(["env", "use", this.pythonExec], {
+        cwd: this.project.outdir,
+      });
+      envPath = poetry.tryCapture(["env", "info", "-p"], {
         cwd: this.project.outdir,
       });
       this.project.logger.info(

--- a/src/python/uv.ts
+++ b/src/python/uv.ts
@@ -1,17 +1,17 @@
 import type { IConstruct } from "constructs";
+import type { BuildSystem, PyprojectTomlProject } from "./pyproject-toml";
+import { PyprojectTomlFile } from "./pyproject-toml-file";
 import type { IPythonDeps } from "./python-deps";
 import type { IPythonEnv } from "./python-env";
 import type { IPythonPackaging } from "./python-packaging";
 import { Component } from "../component";
+import type { PythonExecutableOptions } from "./python-project";
 import type { UvConfiguration } from "./uv-config";
 import { toJson_UvConfiguration } from "./uv-config";
 import type { Dependency } from "../dependencies";
 import { DependencyType } from "../dependencies";
 import type { Task } from "../task";
-import { exec, execOrUndefined } from "../util";
-import type { BuildSystem, PyprojectTomlProject } from "./pyproject-toml";
-import { PyprojectTomlFile } from "./pyproject-toml-file";
-import type { PythonExecutableOptions } from "./python-project";
+import { uv } from "../util/exec";
 
 /**
  * Options for UV project
@@ -174,7 +174,7 @@ export class Uv
   }
 
   public setupEnvironment(): void {
-    const result = execOrUndefined("which uv", {
+    const result = uv.tryCapture(["--version"], {
       cwd: this.project.outdir,
     });
     if (!result) {
@@ -186,7 +186,7 @@ export class Uv
 
     // Create venv with the specific Python version
     // this will install the requested python version if needed
-    exec(`uv venv --python "${this.venvPython}" --clear .venv`, {
+    uv.run(["venv", "--python", this.venvPython, "--clear", ".venv"], {
       cwd: this.project.outdir,
     });
     this.project.logger.info(

--- a/src/python/venv.ts
+++ b/src/python/venv.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import type { IPythonEnv } from "./python-env";
 import { Component } from "../component";
 import type { Project } from "../project";
-import { exec } from "../util";
+import { tool } from "../util/exec";
 
 /**
  * Options for venv.
@@ -65,7 +65,7 @@ export class Venv extends Component implements IPythonEnv {
     const absoluteEnvdir = path.join(this.project.outdir, this.envdir);
     if (!fs.existsSync(absoluteEnvdir)) {
       this.project.logger.info("Setting up a virtual environment...");
-      exec(`${this.pythonExec} -m venv ${this.envdir}`, {
+      tool(this.pythonExec).run(["-m", "venv", this.envdir], {
         cwd: this.project.outdir,
       });
       this.project.logger.info(

--- a/src/release/bump-version.ts
+++ b/src/release/bump-version.ts
@@ -3,8 +3,6 @@ import { dirname, join } from "path";
 import type { Config } from "conventional-changelog-config-spec";
 import { compare } from "semver";
 import * as logging from "../logging";
-import { execCapture, execOrUndefined } from "../util";
-import { ReleasableCommits } from "../version";
 import type { BumpType } from "./bump-type";
 import {
   parseBumpType,
@@ -12,6 +10,8 @@ import {
   relativeBumpType,
   renderBumpType,
 } from "./bump-type";
+import { git, rawShell } from "../util/exec";
+import { ReleasableCommits } from "../version";
 import { CommitAndTagVersion } from "./commit-tag-version";
 
 export interface BumpOptions {
@@ -199,7 +199,7 @@ export async function bump(cwd: string, options: BumpOptions) {
   // if we even should do nothing at all.
   const shouldRelease = isFirstRelease
     ? true
-    : hasNewInterestingCommits({
+    : await hasNewInterestingCommits({
         cwd,
         latestTag,
         releasableCommits: options.releasableCommits,
@@ -225,16 +225,14 @@ export async function bump(cwd: string, options: BumpOptions) {
 
   logging.info(`Bump from commits: ${renderBumpType(bumpType)}`);
   if (options.nextVersionCommand) {
-    const nextVersion = execCapture(options.nextVersionCommand, {
+    const nextVersion = await rawShell.capture(options.nextVersionCommand, {
       cwd,
-      modEnv: {
+      env: {
         VERSION: latestVersion,
         SUGGESTED_BUMP: renderBumpType(bumpType),
         ...(latestTag ? { LATEST_TAG: latestTag } : {}),
       },
-    })
-      .toString()
-      .trim();
+    });
 
     if (nextVersion) {
       try {
@@ -307,18 +305,20 @@ export async function bump(cwd: string, options: BumpOptions) {
 /**
  * Determine based on releaseable commits whether we should release or not
  */
-function hasNewInterestingCommits(options: {
+async function hasNewInterestingCommits(options: {
   releasableCommits?: string;
   latestTag: string;
   cwd: string;
-}) {
+}): Promise<boolean> {
   const findCommits = (
     options.releasableCommits ?? ReleasableCommits.everyCommit().cmd
   ).replace("$LATEST_TAG", options.latestTag);
 
-  const commitsSinceLastTag = execOrUndefined(findCommits, {
-    cwd: options.cwd,
-  })?.split("\n");
+  const commitsSinceLastTag = (
+    await rawShell.tryCapture(findCommits, {
+      cwd: options.cwd,
+    })
+  )?.split("\n");
   const numCommitsSinceLastTag = commitsSinceLastTag?.length ?? 0;
   logging.info(
     `Number of commits since ${options.latestTag}: ${numCommitsSinceLastTag}`,
@@ -395,16 +395,17 @@ function determineLatestTag(options: LatestTagOptions): {
     prefixFilter = `${prefix}v*`;
   }
 
-  const listGitTags = [
-    "git",
-    '-c "versionsort.suffix=-"', // makes sure pre-release versions are listed after the primary version
-    "tag",
-    '--sort="-version:refname"', // sort as versions and not lexicographically
-    "--list",
-    `"${prefixFilter}"`,
-  ].join(" ");
-
-  const stdout = execCapture(listGitTags, { cwd }).toString("utf8");
+  const stdout = git.capture(
+    [
+      "-c",
+      "versionsort.suffix=-", // makes sure pre-release versions are listed after the primary version
+      "tag",
+      "--sort=-version:refname", // sort as versions and not lexicographically
+      "--list",
+      prefixFilter,
+    ],
+    { cwd },
+  );
 
   let tags = stdout?.split("\n");
 

--- a/src/release/commit-tag-version.ts
+++ b/src/release/commit-tag-version.ts
@@ -5,7 +5,8 @@ import { promises as fs } from "fs";
 import * as path from "node:path";
 import type { Config } from "conventional-changelog-config-spec";
 import * as logging from "../logging";
-import { exec, execCapture } from "../util";
+import { git, node, npx } from "../util/exec";
+import type { AsyncTool, Tool } from "../util/exec";
 
 const DEFAULT_CATV_SPEC = "commit-and-tag-version@^12";
 
@@ -27,25 +28,34 @@ export interface InvokeOptions {
 }
 
 export class CommitAndTagVersion {
-  private readonly cmd: string;
+  private readonly tool: Tool | AsyncTool;
+  private readonly args: string[];
 
   constructor(
     packageSpec: string | undefined,
     private readonly cwd: string,
     private readonly options: CommitAndTagOptions,
   ) {
-    let cmd;
+    let resolvedCli: string | undefined;
     if (!packageSpec) {
       // If no packageSpec is given, try and resolve the CATV binary
       // from devDependencies. This will speed up execution a lot.
       try {
-        cmd = `${process.execPath} ${require.resolve("commit-and-tag-version/bin/cli.js")}`;
+        resolvedCli = require.resolve("commit-and-tag-version/bin/cli.js");
       } catch {
-        // Oh well
+        // not installed locally; fall back to npx below
       }
     }
 
-    this.cmd = cmd ?? `npx ${packageSpec ?? DEFAULT_CATV_SPEC}`;
+    if (resolvedCli) {
+      // Run the resolved CLI directly with node - fully shell-free.
+      this.tool = node;
+      this.args = [resolvedCli];
+    } else {
+      // npx is a Windows `.cmd` shim, so it runs via the cross-platform helper.
+      this.tool = npx;
+      this.args = [packageSpec ?? DEFAULT_CATV_SPEC];
+    }
   }
 
   /**
@@ -93,11 +103,9 @@ export class CommitAndTagVersion {
     try {
       let ret: any;
       if (options.capture) {
-        ret = execCapture(this.cmd, {
-          cwd: this.cwd,
-        }).toString();
+        ret = await this.tool.capture(this.args, { cwd: this.cwd });
       } else {
-        ret = exec(this.cmd, { cwd: this.cwd });
+        await this.tool.run(this.args, { cwd: this.cwd });
       }
       return ret;
     } finally {
@@ -116,20 +124,18 @@ export class CommitAndTagVersion {
    * would be empty).
    */
   public async regeneratePreviousChangeLog(version: string, latestTag: string) {
-    const oldCommit = execCapture(`git rev-parse ${latestTag}`, {
+    const oldCommit = git.capture(["rev-parse", latestTag], {
       cwd: this.cwd,
-    })
-      .toString("utf8")
-      .trim();
+    });
 
-    exec(`git tag --delete ${latestTag}`, { cwd: this.cwd });
+    git.run(["tag", "--delete", latestTag], { cwd: this.cwd });
     try {
       await this.invoke({
         releaseAs: version,
         skipBump: true,
       });
     } finally {
-      exec(`git tag ${latestTag} ${oldCommit}`, { cwd: this.cwd });
+      git.run(["tag", latestTag, oldCommit], { cwd: this.cwd });
     }
   }
 

--- a/src/release/tag-version.ts
+++ b/src/release/tag-version.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "fs";
 import { join } from "path";
 import * as utils from "../util";
+import { git } from "../util/exec";
 
 export interface TagOptions {
   /**
@@ -35,8 +36,6 @@ export interface TagOptions {
  * @param options options
  */
 export async function tag(cwd: string, options: TagOptions) {
-  const git = (cmd: string) => utils.exec(`git ${cmd}`, { cwd: cwd });
-
   const releaseTagFilePath = join(cwd, options.releaseTagFile);
   const changelogFilePath = join(cwd, options.changelog);
 
@@ -54,5 +53,5 @@ export async function tag(cwd: string, options: TagOptions) {
     throw new Error(`No version present in file at ${releaseTagFilePath}`);
   }
 
-  git(`tag ${releaseTag} -a -F ${changelogFilePath}`);
+  git.run(["tag", releaseTag, "-a", "-F", changelogFilePath], { cwd });
 }

--- a/src/release/update-changelog.ts
+++ b/src/release/update-changelog.ts
@@ -2,6 +2,7 @@ import { promises as fs } from "fs";
 import { join } from "path";
 import * as logging from "../logging";
 import * as utils from "../util";
+import { git } from "../util/exec";
 
 export interface UpdateChangelogOptions {
   /**
@@ -85,8 +86,6 @@ export async function updateChangelog(
 
   await fs.writeFile(outputChangelog, newChangelog);
 
-  utils.exec(
-    `git add ${outputChangelog} && git commit -m "chore(release): ${version}"`,
-    { cwd },
-  );
+  git.run(["add", outputChangelog], { cwd });
+  git.run(["commit", "-m", `chore(release): ${version}`], { cwd });
 }

--- a/src/task-runner.ts
+++ b/src/task-runner.ts
@@ -1,4 +1,3 @@
-import { spawnSync } from "node:child_process";
 import * as path from "node:path";
 import type { IConstruct } from "constructs";
 import { resolve } from "./_resolve";
@@ -8,6 +7,7 @@ import type { IResolver } from "./file";
 import { JsonFile } from "./json";
 import type { Task } from "./task";
 import type { TasksManifest } from "./task-model";
+import { node } from "./util/exec";
 
 export interface ITaskRunner {
   /**
@@ -54,19 +54,20 @@ export class ProjenTaskRunner extends Component implements ITaskRunner {
     const moduleRoot = path.dirname(require.resolve("../package.json"));
     const cli = path.join(moduleRoot, "lib", "cli", "index.js");
     const argv = [cli, task.name, ...(args ?? []).map((a) => a.toString())];
-    const result = spawnSync(process.execPath, argv, {
-      cwd: this.project.outdir,
-      stdio: "inherit",
-    });
-
-    if (result.error) {
-      throw result.error;
-    }
-
-    if (result.status !== 0) {
-      throw new Error(
-        `Task "${task.name}" failed (exit code ${result.status ?? "unknown"}).`,
-      );
+    try {
+      node.run(argv, {
+        cwd: this.project.outdir,
+        inheritStdio: true,
+      });
+    } catch (e: any) {
+      // `node.run` (execFileSync) throws on a non-zero exit (with a numeric
+      // `.status`) or on a spawn failure. Translate a non-zero exit into a
+      // task-friendly error; re-throw spawn errors as-is. The child's stderr
+      // was already streamed live (inheritStdio), so it need not be re-surfaced.
+      if (typeof e?.status === "number") {
+        throw new Error(`Task "${task.name}" failed (exit code ${e.status}).`);
+      }
+      throw e;
     }
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,3 @@
-import * as child_process from "child_process";
 import {
   accessSync,
   chmodSync,
@@ -11,78 +10,6 @@ import {
 } from "fs";
 import * as path from "path";
 import * as Case from "case";
-import * as logging from "./logging";
-
-const MAX_BUFFER = 10 * 1024 * 1024;
-
-/**
- * Executes a command with STDOUT > STDERR.
- */
-export function exec(
-  command: string,
-  options: {
-    cwd: string;
-    env?: Record<string, string>;
-    stdio?: child_process.StdioOptions;
-  },
-): void {
-  logging.debug(`${command} (cwd: ${options.cwd})`);
-
-  child_process.execSync(command, {
-    stdio: options.stdio || ["inherit", 2, "pipe"], // "pipe" for STDERR means it appears in exceptions
-    maxBuffer: MAX_BUFFER,
-    cwd: options.cwd,
-    env: options.env,
-  });
-}
-
-/**
- * Executes command and returns STDOUT. If the command fails (non-zero), throws an error.
- */
-export function execCapture(
-  command: string,
-  options: { cwd: string; modEnv?: Record<string, string> },
-) {
-  logging.debug(`${command} (cwd: ${options.cwd})`);
-
-  return child_process.execSync(command, {
-    stdio: ["inherit", "pipe", "pipe"], // "pipe" for STDERR means it appears in exceptions
-    maxBuffer: MAX_BUFFER,
-    cwd: options.cwd,
-    env: {
-      ...process.env,
-      ...options.modEnv,
-    },
-  });
-}
-
-/**
- * Executes `command` and returns its value or undefined if the command failed.
- */
-export function execOrUndefined(
-  command: string,
-  options: { cwd: string },
-): string | undefined {
-  logging.debug(`${command} (cwd: ${options.cwd})`);
-
-  try {
-    const value = child_process
-      .execSync(command, {
-        stdio: ["inherit", "pipe", "pipe"], // "pipe" for STDERR means it appears in exceptions
-        maxBuffer: MAX_BUFFER,
-        cwd: options.cwd,
-      })
-      .toString("utf-8")
-      .trim();
-
-    if (!value) {
-      return undefined;
-    } // an empty string is the same as undefined
-    return value;
-  } catch {
-    return undefined;
-  }
-}
 
 export interface WriteFileOptions {
   /**

--- a/src/util/exec.ts
+++ b/src/util/exec.ts
@@ -1,0 +1,430 @@
+import * as child_process from "child_process";
+import { $ } from "dax";
+import * as logging from "../logging";
+
+const MAX_BUFFER = 10 * 1024 * 1024;
+
+//
+// ---------------------------------------------------------------------------
+// Shell-free execution (execFileSync, shell: false).
+//
+// The program and each argument are passed to the OS directly without going
+// through a shell, so there is no quoting to get right and no differences
+// between platform shells to account for when commands include values derived
+// from files, git output, configuration, etc.
+//
+// Only per-tool helpers are exported (e.g. `git`); the generic primitives are
+// kept private so call sites are explicit about which tool they invoke.
+// ---------------------------------------------------------------------------
+//
+
+/**
+ * Options for shell-free command execution.
+ */
+export interface ExecFileOptions {
+  /**
+   * Working directory for the command.
+   */
+  readonly cwd: string;
+
+  /**
+   * Additional environment variables, merged on top of `process.env`.
+   */
+  readonly env?: Record<string, string>;
+}
+
+/**
+ * Options for {@link Tool.run}.
+ */
+export interface RunOptions extends ExecFileOptions {
+  /**
+   * Stream the child's stdout and stderr straight to the parent's stdout and
+   * stderr (full inheritance), instead of redirecting stdout to stderr and
+   * capturing stderr (the default).
+   *
+   * Use this when launching a child process whose stdout is meaningful and
+   * whose output should stream live to the user (e.g. the projen CLI).
+   *
+   * @default false
+   */
+  readonly inheritStdio?: boolean;
+}
+
+function spawnOpts(options: ExecFileOptions) {
+  return {
+    maxBuffer: MAX_BUFFER,
+    cwd: options.cwd,
+    env: options.env ? { ...process.env, ...options.env } : undefined,
+    // run the program directly, without going through a shell
+    shell: false as const,
+  };
+}
+
+/**
+ * Runs a program with the given arguments, inheriting stdout. Throws if the
+ * command exits with a non-zero status.
+ */
+function run(file: string, args: string[], options: RunOptions): void {
+  logging.debug(`${file} ${args.join(" ")} (cwd: ${options.cwd})`);
+
+  child_process.execFileSync(file, args, {
+    ...spawnOpts(options),
+    // By default the child's stdout is redirected to STDERR (to keep the
+    // parent's STDOUT clean) and its STDERR is piped so it surfaces in
+    // exceptions. `inheritStdio` instead streams both straight to the parent.
+    stdio: options.inheritStdio ? "inherit" : ["inherit", 2, "pipe"],
+  });
+}
+
+/**
+ * Runs a program and returns its trimmed STDOUT. Throws if the command exits
+ * with a non-zero status.
+ */
+function capture(
+  file: string,
+  args: string[],
+  options: ExecFileOptions,
+): string {
+  logging.debug(`${file} ${args.join(" ")} (cwd: ${options.cwd})`);
+
+  return child_process
+    .execFileSync(file, args, {
+      ...spawnOpts(options),
+      stdio: ["inherit", "pipe", "pipe"], // "pipe" for STDERR means it appears in exceptions
+    })
+    .toString("utf-8")
+    .trim();
+}
+
+/**
+ * Runs a program and returns its trimmed STDOUT, or `undefined` if the command
+ * failed or produced no output.
+ */
+function tryCapture(
+  file: string,
+  args: string[],
+  options: ExecFileOptions,
+): string | undefined {
+  logging.debug(`${file} ${args.join(" ")} (cwd: ${options.cwd})`);
+
+  try {
+    const value = child_process
+      .execFileSync(file, args, {
+        ...spawnOpts(options),
+        stdio: ["inherit", "pipe", "pipe"], // "pipe" for STDERR means it appears in exceptions
+      })
+      .toString("utf-8")
+      .trim();
+
+    // an empty string is the same as undefined
+    return value || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * A shell-free handle for invoking a single program by name or path.
+ *
+ * Each argument is passed to the program verbatim (no shell parsing), so there
+ * is no quoting to get right for values such as tags, versions, branch names
+ * or file paths.
+ *
+ * Note: the program is executed directly, without a shell. On Windows this
+ * means it must be a real executable - `.cmd`/`.bat` shims (such as
+ * npm-installed CLIs like npm/npx/yarn/pnpm) cannot be invoked this way.
+ */
+export interface Tool {
+  /**
+   * Runs `<tool> <args>`, inheriting stdout. Throws on non-zero exit.
+   */
+  run(args: string[], options: RunOptions): void;
+
+  /**
+   * Runs `<tool> <args>` and returns its trimmed STDOUT. Throws on non-zero exit.
+   */
+  capture(args: string[], options: ExecFileOptions): string;
+
+  /**
+   * Runs `<tool> <args>` and returns its trimmed STDOUT, or `undefined` if the
+   * command failed or produced no output.
+   */
+  tryCapture(args: string[], options: ExecFileOptions): string | undefined;
+}
+
+/**
+ * Creates a shell-free {@link Tool} for the given program.
+ *
+ * @example const git = tool("git"); git.run(["tag", "--delete", tag], { cwd });
+ */
+export function tool(file: string): Tool {
+  return {
+    run: (args, options) => run(file, args, options),
+    capture: (args, options) => capture(file, args, options),
+    tryCapture: (args, options) => tryCapture(file, args, options),
+  };
+}
+
+/**
+ * Shell-free helper for invoking `git`.
+ *
+ * @example git.run(["tag", "--delete", tag], { cwd });
+ */
+export const git = tool("git");
+
+/**
+ * Shell-free helper for invoking `uv` (ships as a native binary on all
+ * platforms).
+ */
+export const uv = tool("uv");
+
+/**
+ * Shell-free helper for invoking `poetry`.
+ */
+export const poetry = tool("poetry");
+
+/**
+ * Shell-free helper for invoking the current Node.js executable
+ * (`process.execPath`).
+ */
+export const node = tool(process.execPath);
+
+//
+// ---------------------------------------------------------------------------
+// Cross-platform execution via dax (for binaries that may be `.cmd` shims).
+//
+// `tool` above uses `execFileSync` with `shell: false`, which cannot launch
+// Windows `.cmd`/`.bat` shims such as `npx` or `npm`. `shimTool` runs through
+// dax, which resolves those shims cross-platform. Arguments are interpolated
+// through dax's escaping (NOT `$.raw`), so each value is passed as a single
+// literal argument with no quoting to get right. dax is asynchronous, so
+// these helpers are only usable from async call sites.
+// ---------------------------------------------------------------------------
+//
+
+/**
+ * Async, dax-backed equivalent of {@link Tool} for programs that may be a
+ * Windows `.cmd`/`.bat` shim (e.g. `npx`, `npm`).
+ */
+export interface AsyncTool {
+  /**
+   * Runs `<tool> <args>`, inheriting stdout. Rejects on non-zero exit.
+   */
+  run(args: string[], options: ExecFileOptions): Promise<void>;
+
+  /**
+   * Runs `<tool> <args>` and resolves its trimmed STDOUT. Rejects on non-zero
+   * exit.
+   */
+  capture(args: string[], options: ExecFileOptions): Promise<string>;
+}
+
+/**
+ * Creates an {@link AsyncTool} that invokes `file` via dax, resolving Windows
+ * `.cmd`/`.bat` shims and escaping every argument (so each value is passed as
+ * a single literal argument).
+ *
+ * @example await npx.run(["commit-and-tag-version@^12"], { cwd });
+ */
+function shimTool(file: string): AsyncTool {
+  const build = (args: string[], options: ExecFileOptions) => {
+    const cmd = $`${file} ${args}`.cwd(options.cwd).stderr("piped").noThrow();
+    return options.env ? cmd.env(options.env) : cmd;
+  };
+  const ensureOk = (
+    args: string[],
+    result: { code: number; stderr: string },
+  ) => {
+    if (result.code !== 0) {
+      // Mimic the `child_process` error shape (`status`, `stderr`) so callers
+      // can inspect stderr (e.g. to detect ENOENT/E404 from npm).
+      const error: any = new Error(
+        `Command failed (exit code ${result.code}): ${file} ${args.join(" ")}`,
+      );
+      error.status = result.code;
+      error.stderr = Buffer.from(result.stderr);
+      throw error;
+    }
+  };
+  return {
+    run: async (args, options) => {
+      logging.debug(`${file} ${args.join(" ")} (cwd: ${options.cwd})`);
+      ensureOk(args, await build(args, options));
+    },
+    capture: async (args, options) => {
+      logging.debug(`${file} ${args.join(" ")} (cwd: ${options.cwd})`);
+      const result = await build(args, options).stdout("piped");
+      ensureOk(args, result);
+      return result.stdout.trim();
+    },
+  };
+}
+
+/**
+ * Cross-platform helper for `npm` (a Windows `.cmd` shim).
+ */
+export const npm = shimTool("npm");
+
+/**
+ * Cross-platform helper for `npx` (a Windows `.cmd` shim).
+ */
+export const npx = shimTool("npx");
+
+//
+// ---------------------------------------------------------------------------
+// rawShell: arbitrary shell command strings (via the system shell).
+//
+// This runs an opaque command *string* through the operating system's default
+// shell (`/bin/sh` on POSIX, `cmd.exe` on Windows) - the same mechanism the
+// codebase used previously. It is meant for command lines that cannot be
+// expressed as a fixed binary plus a list of arguments, e.g. a release's
+// `nextVersionCommand` or `ReleasableCommits.exec()` (and projen's own
+// generated `ReleasableCommits` queries), as well as task steps on non-Windows
+// platforms. For everything else prefer the structured `tool`/`git` helpers
+// (or `shimTool` for `.cmd` shims), which take an explicit list of arguments.
+// ---------------------------------------------------------------------------
+//
+
+/**
+ * Normalized result of running a command through the system shell. This is a
+ * subset of node's `SpawnSyncReturns` shape.
+ */
+export interface RawShellResult {
+  /**
+   * The exit code, or `null` if the process was terminated by a signal or
+   * never spawned.
+   */
+  readonly status: number | null;
+
+  /**
+   * Captured stdout, or `null` when stdout was inherited (not captured).
+   */
+  readonly stdout: Buffer | null;
+
+  /**
+   * Captured stderr, or `null` when stderr was inherited (not captured).
+   */
+  readonly stderr: Buffer | null;
+
+  /**
+   * An error raised while attempting to spawn the command (not a non-zero
+   * exit, which is reported via `status`).
+   */
+  readonly error?: Error;
+}
+
+/**
+ * Options for {@link rawShell.exec}.
+ */
+export interface RawShellExecOptions {
+  /**
+   * Working directory for the command.
+   */
+  readonly cwd: string;
+
+  /**
+   * The full environment for the command. Passed through to the shell as-is
+   * (it is *not* merged with `process.env`), so callers that want to inherit
+   * the parent environment must include it themselves.
+   */
+  readonly env?: NodeJS.ProcessEnv;
+
+  /**
+   * Capture stdout/stderr (so the caller can read them from the result)
+   * instead of inheriting the parent's streams.
+   *
+   * @default false
+   */
+  readonly capture?: boolean;
+}
+
+/**
+ * Options for {@link rawShell.capture} / {@link rawShell.tryCapture}.
+ */
+export interface RawShellCaptureOptions {
+  /**
+   * Working directory for the command.
+   */
+  readonly cwd: string;
+
+  /**
+   * Additional environment variables, merged on top of `process.env`.
+   */
+  readonly env?: Record<string, string>;
+}
+
+export const rawShell = {
+  /**
+   * Runs a command line through the system shell and returns a normalized
+   * result. Never throws for a non-zero exit (that is reported via `status`);
+   * a spawn failure is reported via `error`.
+   *
+   * The caller is responsible for supplying the full `env`.
+   */
+  exec(command: string, options: RawShellExecOptions): RawShellResult {
+    logging.debug(`${command} (cwd: ${options.cwd})`);
+
+    const result = child_process.spawnSync(command, {
+      cwd: options.cwd,
+      shell: true,
+      maxBuffer: MAX_BUFFER,
+      env: options.env,
+      // "pipe" for STDERR (when capturing) means it appears in exceptions.
+      stdio: options.capture ? ["inherit", "pipe", "pipe"] : "inherit",
+    });
+
+    return {
+      status: result.status,
+      stdout: result.stdout ?? null,
+      stderr: result.stderr ?? null,
+      error: result.error,
+    };
+  },
+
+  /**
+   * Runs a user-supplied shell command line and resolves its trimmed STDOUT.
+   * Rejects if the command exits non-zero.
+   */
+  capture: async (
+    command: string,
+    options: RawShellCaptureOptions,
+  ): Promise<string> => {
+    const result = rawShell.exec(command, {
+      cwd: options.cwd,
+      env: { ...process.env, ...options.env },
+      capture: true,
+    });
+    if (result.error) {
+      throw result.error;
+    }
+    if (result.status !== 0) {
+      const error: any = new Error(
+        `Command failed (exit code ${result.status}): ${command}`,
+      );
+      error.status = result.status;
+      error.stderr = result.stderr;
+      throw error;
+    }
+    return (result.stdout?.toString("utf-8") ?? "").trim();
+  },
+
+  /**
+   * Runs a user-supplied shell command line and resolves its trimmed STDOUT,
+   * or `undefined` if the command failed or produced no output.
+   */
+  tryCapture: async (
+    command: string,
+    options: RawShellCaptureOptions,
+  ): Promise<string | undefined> => {
+    const result = rawShell.exec(command, {
+      cwd: options.cwd,
+      env: { ...process.env, ...options.env },
+      capture: true,
+    });
+    if (result.error || result.status !== 0) {
+      return undefined;
+    }
+    const out = (result.stdout?.toString("utf-8") ?? "").trim();
+    return out || undefined;
+  },
+};

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -3,29 +3,29 @@ import { join } from "path";
 import { directorySnapshot, execProjenCLI, mkdtemp } from "./util";
 import { Project } from "../src/project";
 
-test('running "projen" for projects with a "default" task will execute it', () => {
+test('running "projen" for projects with a "default" task will execute it', async () => {
   const project = new Project({ name: "my-project" });
   project.defaultTask?.exec(
     `node -e "const fs = require('fs'); fs.writeFileSync('bar.txt', 'foo\\n');"`,
   );
   project.synth();
 
-  execProjenCLI(project.outdir);
+  await execProjenCLI(project.outdir);
   expect(directorySnapshot(project.outdir)["bar.txt"]).toStrictEqual("foo\n");
 });
 
-test('running "projen" with task in root of a project will execute task of the project', () => {
+test('running "projen" with task in root of a project will execute task of the project', async () => {
   const project = new Project({ name: "my-project" });
   project.testTask?.exec(
     `node -e "const fs = require('fs'); fs.writeFileSync('bar.txt', 'foo\\n');"`,
   );
   project.synth();
 
-  execProjenCLI(project.outdir, ["test"]);
+  await execProjenCLI(project.outdir, ["test"]);
   expect(directorySnapshot(project.outdir)["bar.txt"]).toStrictEqual("foo\n");
 });
 
-test('running "projen" with task in root of a project that receives args will pass through --help flag', () => {
+test('running "projen" with task in root of a project that receives args will pass through --help flag', async () => {
   const project = new Project({ name: "my-project" });
   project.testTask?.exec(
     `node -e "const fs = require('fs'); fs.writeFileSync('bar.txt', '$@\\n');"`,
@@ -33,13 +33,13 @@ test('running "projen" with task in root of a project that receives args will pa
   );
   project.synth();
 
-  execProjenCLI(project.outdir, ["test", "something", "--help"]);
+  await execProjenCLI(project.outdir, ["test", "something", "--help"]);
   expect(directorySnapshot(project.outdir)["bar.txt"]).toStrictEqual(
     "something --help\n",
   );
 });
 
-test('running "projen" with task in subdirectory of a project will execute task of the project', () => {
+test('running "projen" with task in subdirectory of a project will execute task of the project', async () => {
   const project = new Project({ name: "my-project" });
   project.testTask?.exec(
     `node -e "const fs = require('fs'); fs.writeFileSync('bar.txt', 'foo\\n');"`,
@@ -47,19 +47,19 @@ test('running "projen" with task in subdirectory of a project will execute task 
   project.synth();
   const subdirectory = mkdtemp({ dir: project.outdir });
 
-  execProjenCLI(subdirectory, ["test"]);
+  await execProjenCLI(subdirectory, ["test"]);
   expect(directorySnapshot(project.outdir)["bar.txt"]).toStrictEqual("foo\n");
 });
 
-test('running "projen" without specifying a task it in subdirectory of a project will execute default task of the project', () => {
+test('running "projen" without specifying a task it in subdirectory of a project will execute default task of the project', async () => {
   const project = new Project({ name: "my-project" });
   project.synth();
   const subdirectory = mkdtemp({ dir: project.outdir });
 
-  execProjenCLI(subdirectory, []); // no task specified
+  await execProjenCLI(subdirectory, []); // no task specified
 });
 
-test('running "projen" with task in root of a subproject will execute task of the subproject', () => {
+test('running "projen" with task in root of a subproject will execute task of the subproject', async () => {
   const project = new Project({ name: "my-project" });
   const subProject = new Project({
     name: "my-subproject",
@@ -71,13 +71,13 @@ test('running "projen" with task in root of a subproject will execute task of th
   );
   project.synth();
 
-  execProjenCLI(subProject.outdir, ["test"]);
+  await execProjenCLI(subProject.outdir, ["test"]);
   expect(directorySnapshot(subProject.outdir)["bar.txt"]).toStrictEqual(
     "foo\n",
   );
 });
 
-test('running "projen" with task in subdirectory of a subproject will execute task of the subproject', () => {
+test('running "projen" with task in subdirectory of a subproject will execute task of the subproject', async () => {
   const project = new Project({ name: "my-project" });
   const subProject = new Project({
     name: "my-subproject",
@@ -90,30 +90,29 @@ test('running "projen" with task in subdirectory of a subproject will execute ta
   project.synth();
   const subdirectory = mkdtemp({ dir: subProject.outdir });
 
-  execProjenCLI(subdirectory, ["test"]);
+  await execProjenCLI(subdirectory, ["test"]);
   expect(directorySnapshot(subProject.outdir)["bar.txt"]).toStrictEqual(
     "foo\n",
   );
 });
 
-test('running "projen" with task if there is no tasks.json', () => {
+test('running "projen" with task if there is no tasks.json', async () => {
   const dir = mkdtemp();
 
   const projen = join(dir, ".projen");
   mkdirSync(projen);
 
-  const t = () => {
-    execProjenCLI(dir, ["build"]);
-  };
-  expect(t).toThrow("Unknown command: build");
+  await expect(execProjenCLI(dir, ["build"])).rejects.toThrow(
+    "Unknown command: build",
+  );
 });
 
-test('running "projen" with task in root of a project that receives args will respect whitespaces', () => {
+test('running "projen" with task in root of a project that receives args will respect whitespaces', async () => {
   const project = new Project({ name: "my-project" });
   project.testTask?.exec(`touch "$@"`, { receiveArgs: true });
   project.synth();
 
-  execProjenCLI(project.outdir, ["test", "a b", "c d"]);
+  await execProjenCLI(project.outdir, ["test", "a b", "c d"]);
   expect(directorySnapshot(project.outdir)["a b"]).toStrictEqual("");
   expect(directorySnapshot(project.outdir)["c d"]).toStrictEqual("");
 });

--- a/test/cli/macros.test.ts
+++ b/test/cli/macros.test.ts
@@ -1,0 +1,126 @@
+import { tryProcessMacro } from "../../src/cli/macros";
+import { git } from "../../src/util/exec";
+
+describe("tryProcessMacro", () => {
+  const cwd = "/home/user/My.Project";
+
+  afterEach(() => jest.restoreAllMocks());
+
+  test("returns undefined for a non-macro string", () => {
+    expect(tryProcessMacro(cwd, "not-a-macro")).toBeUndefined();
+  });
+
+  test("returns undefined for an unknown macro", () => {
+    expect(tryProcessMacro(cwd, "$UNKNOWN")).toBeUndefined();
+  });
+
+  test("$BASEDIR returns the basename of the cwd", () => {
+    expect(tryProcessMacro(cwd, "$BASEDIR")).toBe("My.Project");
+  });
+
+  test("$PYTHON_MODULE_NAME formats the basename as a python module", () => {
+    expect(tryProcessMacro(cwd, "$PYTHON_MODULE_NAME")).toBe("My_Project");
+  });
+
+  describe("$GIT_REMOTE", () => {
+    test("returns the origin remote URL when present", () => {
+      jest
+        .spyOn(git, "tryCapture")
+        .mockImplementation((args) =>
+          args[0] === "remote" ? "git@github.com:acme/widget.git" : undefined,
+        );
+      expect(tryProcessMacro(cwd, "$GIT_REMOTE")).toBe(
+        "git@github.com:acme/widget.git",
+      );
+    });
+
+    test("falls back to a github URL from github.user when there is no origin", () => {
+      jest.spyOn(git, "tryCapture").mockImplementation((args) => {
+        if (args[0] === "remote") return undefined;
+        if (args.includes("github.user")) return "octocat";
+        return undefined;
+      });
+      expect(tryProcessMacro(cwd, "$GIT_REMOTE")).toBe(
+        "https://github.com/octocat/My.Project.git",
+      );
+    });
+
+    test("falls back to the email local-part when there is no origin or github.user", () => {
+      jest.spyOn(git, "tryCapture").mockImplementation((args) => {
+        if (args[0] === "remote") return undefined;
+        if (args.includes("github.user")) return undefined;
+        if (args.includes("user.email")) return "jane@example.com";
+        return undefined;
+      });
+      expect(tryProcessMacro(cwd, "$GIT_REMOTE")).toBe(
+        "https://github.com/jane/My.Project.git",
+      );
+    });
+  });
+
+  describe("$GIT_USER_NAME", () => {
+    test("returns the configured user.name", () => {
+      jest.spyOn(git, "tryCapture").mockReturnValue("Jane Doe");
+      expect(tryProcessMacro(cwd, "$GIT_USER_NAME")).toBe("Jane Doe");
+    });
+
+    test("defaults to 'user' when unset", () => {
+      jest.spyOn(git, "tryCapture").mockReturnValue(undefined);
+      expect(tryProcessMacro(cwd, "$GIT_USER_NAME")).toBe("user");
+    });
+  });
+
+  describe("$GIT_USER_EMAIL", () => {
+    test("returns the configured user.email", () => {
+      jest.spyOn(git, "tryCapture").mockReturnValue("jane@example.com");
+      expect(tryProcessMacro(cwd, "$GIT_USER_EMAIL")).toBe("jane@example.com");
+    });
+
+    test("defaults to user@domain.com when unset", () => {
+      jest.spyOn(git, "tryCapture").mockReturnValue(undefined);
+      expect(tryProcessMacro(cwd, "$GIT_USER_EMAIL")).toBe("user@domain.com");
+    });
+  });
+
+  describe("$PACKAGE_MANAGER", () => {
+    const original = {
+      ua: process.env.npm_config_user_agent,
+      execpath: process.env.npm_execpath,
+    };
+
+    afterEach(() => {
+      process.env.npm_config_user_agent = original.ua;
+      process.env.npm_execpath = original.execpath;
+    });
+
+    function detect(ua?: string, execpath?: string): string | undefined {
+      if (ua === undefined) delete process.env.npm_config_user_agent;
+      else process.env.npm_config_user_agent = ua;
+      if (execpath === undefined) delete process.env.npm_execpath;
+      else process.env.npm_execpath = execpath;
+      return tryProcessMacro(cwd, "$PACKAGE_MANAGER");
+    }
+
+    test.each([
+      ["yarn/1.22.0 npm/? node/v20.0.0", "yarn_classic"],
+      ["yarn/4.1.0 npm/? node/v20.0.0", "yarn_berry"],
+      ["pnpm/8.0.0 npm/? node/v20.0.0", "pnpm"],
+      ["bun/1.0.0 npm/? node/v20.0.0", "bun"],
+      ["npm/10.0.0 node/v20.0.0", "npm"],
+    ])("detects %s from the user agent", (ua, expected) => {
+      expect(detect(ua)).toBe(expected);
+    });
+
+    test.each([
+      ["/path/to/yarn.js", "yarn_classic"],
+      ["/path/to/pnpm.cjs", "pnpm"],
+      ["/path/to/bun", "bun"],
+    ])("falls back to npm_execpath %s", (execpath, expected) => {
+      expect(detect(undefined, execpath)).toBe(expected);
+    });
+
+    test("defaults to npm when detection fails", () => {
+      expect(detect("", "")).toBe("npm");
+    });
+  });
+});

--- a/test/cli/run-task.test.ts
+++ b/test/cli/run-task.test.ts
@@ -7,6 +7,7 @@ import { TASKS_MANIFEST_VERSION } from "../../src/common";
 import * as logging from "../../src/logging";
 import type { Project } from "../../src/project";
 import type { TasksManifest } from "../../src/task-model";
+import { node } from "../../src/util/exec";
 import { mkdtemp, TestProject } from "../util";
 
 test("minimal case (just a shell command)", () => {
@@ -751,29 +752,28 @@ function executeTask(
 ) {
   p.synth();
 
-  const args = [require.resolve("../../lib/cli"), taskName].map(
-    (x) => `"${x}"`,
-  );
-
-  const result = spawnSync(
-    `"${process.execPath}"`,
-    [...args, ...additionalArgs],
-    {
-      cwd: p.outdir,
-      shell: true,
-      env: { ...process.env, ...env },
-      timeout: 10_000, // let's try to catch hanging processes sooner than later
-    },
-  );
-  if (result.status !== 0) {
-    throw new Error(`non-zero exit code: ${result.stderr.toString("utf-8")}`);
+  let stdout: string;
+  try {
+    // Run the compiled CLI through the same shell-free `tool` helper the rest
+    // of the codebase uses; `capture` returns its stdout.
+    stdout = node.capture(
+      [require.resolve("../../lib/cli"), taskName, ...additionalArgs],
+      { cwd: p.outdir, env },
+    );
+  } catch (e: any) {
+    // `capture` throws on a non-zero exit; surface the CLI's stderr the way
+    // these tests assert on.
+    if (typeof e?.status === "number") {
+      throw new Error(
+        `non-zero exit code: ${e.stderr?.toString("utf-8") ?? ""}`,
+      );
+    }
+    throw e;
   }
 
-  // Split by any line terminator. The line terminator would depend on the OS, the shell where the command is running and the binary which runs the command called. It could be any of \n, \r\n, or \r.
-  return result.stdout
-    .toString("utf-8")
-    .trim()
-    .split(/\r\n|\n|\r/);
+  // Split by any line terminator: \n, \r\n, or \r depending on the OS and the
+  // binary that produced the output.
+  return stdout.split(/\r\n|\n|\r/);
 }
 
 describe("ejected run-task.cjs bundle", () => {

--- a/test/cli/util.test.ts
+++ b/test/cli/util.test.ts
@@ -1,16 +1,16 @@
 import {
-  renderInstallCommand,
+  renderInstallArgs,
   findJsiiFilePath,
   CliError,
 } from "../../src/cli/util";
 
-describe("renderInstallCommand", () => {
-  test("renders npm install command with dir and module", () => {
-    const cmd = renderInstallCommand("/tmp/test", "my-module");
-    expect(cmd).toContain("npm install");
-    expect(cmd).toContain('--prefix="/tmp/test"');
-    expect(cmd).toContain("my-module");
-    expect(cmd).toContain("--save-dev");
+describe("renderInstallArgs", () => {
+  test("renders npm install args with dir and module", () => {
+    const args = renderInstallArgs("/tmp/test", "my-module");
+    expect(args[0]).toBe("install");
+    expect(args).toContain("--prefix=/tmp/test");
+    expect(args).toContain("my-module");
+    expect(args).toContain("--save-dev");
   });
 });
 

--- a/test/docker-compose/docker-compose.test.ts
+++ b/test/docker-compose/docker-compose.test.ts
@@ -1,8 +1,8 @@
-import * as child_process from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 import { DockerCompose, DockerComposeProtocol, YamlFile } from "../../src/";
 import * as logging from "../../src/logging";
+import { tool } from "../../src/util/exec";
 import { TestProject } from "../util";
 
 logging.disable();
@@ -948,21 +948,21 @@ describe("docker-compose", () => {
 });
 
 const hasDockerCompose =
-  child_process.spawnSync("docker-compose", ["version"]).status === 0;
+  tool("docker-compose").tryCapture(["version"], { cwd: process.cwd() }) !==
+  undefined;
 
 function assertDockerComposeFileValidates(dir: string) {
   const filePath = path.join(dir, "docker-compose.yml");
   expect(fs.existsSync(filePath)).toBeTruthy();
 
   if (hasDockerCompose) {
-    const res = child_process.spawnSync("docker-compose", [
-      "-f",
-      filePath,
-      "config",
-    ]);
-    if (res.status !== 0) {
+    try {
+      tool("docker-compose").capture(["-f", filePath, "config"], { cwd: dir });
+    } catch (e: unknown) {
       throw new Error(
-        `docker-compose file does not validate: ${res.stderr.toString()}`,
+        `docker-compose file does not validate: ${
+          (e as { stderr?: Buffer })?.stderr?.toString() ?? e
+        }`,
       );
     }
   } else {

--- a/test/gitattributes.test.ts
+++ b/test/gitattributes.test.ts
@@ -9,8 +9,8 @@ describe("GitAttributesFile", () => {
       .map((line: string) => line.trim());
   };
 
-  test("should set endOfLine to LF by default", () => {
-    withProjectDir((outdir) => {
+  test("should set endOfLine to LF by default", async () => {
+    await withProjectDir(async (outdir) => {
       // The TestProject already contains a .gitattributes file
       const project = new TestProject({
         outdir,
@@ -23,8 +23,8 @@ describe("GitAttributesFile", () => {
     });
   });
 
-  test("does not at the endOfLine configuration when disabled", () => {
-    withProjectDir((outdir) => {
+  test("does not at the endOfLine configuration when disabled", async () => {
+    await withProjectDir(async (outdir) => {
       // The TestProject already contains a .gitattributes file
       const project = new TestProject({
         outdir,
@@ -40,8 +40,8 @@ describe("GitAttributesFile", () => {
     });
   });
 
-  test("applies the endOfLine option when defined", () => {
-    withProjectDir((outdir) => {
+  test("applies the endOfLine option when defined", async () => {
+    await withProjectDir(async (outdir) => {
       // The TestProject already contains a .gitattributes file
       const project = new TestProject({
         outdir,
@@ -57,8 +57,8 @@ describe("GitAttributesFile", () => {
     });
   });
 
-  test("should add attributes to files", () => {
-    withProjectDir((outdir) => {
+  test("should add attributes to files", async () => {
+    await withProjectDir(async (outdir) => {
       // The TestProject already contains a .gitattributes file
       const project = new TestProject({
         outdir,
@@ -75,8 +75,8 @@ describe("GitAttributesFile", () => {
     });
   });
 
-  test("should remove all attributes when none specified", () => {
-    withProjectDir((outdir) => {
+  test("should remove all attributes when none specified", async () => {
+    await withProjectDir(async (outdir) => {
       const project = new TestProject({
         outdir,
       });
@@ -93,8 +93,8 @@ describe("GitAttributesFile", () => {
     });
   });
 
-  test("should remove a single attribute when specified", () => {
-    withProjectDir((outdir) => {
+  test("should remove a single attribute when specified", async () => {
+    await withProjectDir(async (outdir) => {
       const project = new TestProject({
         outdir,
       });
@@ -110,8 +110,8 @@ describe("GitAttributesFile", () => {
     });
   });
 
-  test("should remove the mapping when no attributes left", () => {
-    withProjectDir((outdir) => {
+  test("should remove the mapping when no attributes left", async () => {
+    await withProjectDir(async (outdir) => {
       const project = new TestProject({
         outdir,
       });
@@ -127,8 +127,8 @@ describe("GitAttributesFile", () => {
     });
   });
 
-  test("should leave mapping unchanged when non-existent attributes are removed", () => {
-    withProjectDir((outdir) => {
+  test("should leave mapping unchanged when non-existent attributes are removed", async () => {
+    await withProjectDir(async (outdir) => {
       const project = new TestProject({
         outdir,
       });
@@ -151,8 +151,8 @@ describe("GitAttributesFile", () => {
     });
   });
 
-  test("should do nothing when trying to remove attributes from a non-existent mapping", () => {
-    withProjectDir((outdir) => {
+  test("should do nothing when trying to remove attributes from a non-existent mapping", async () => {
+    await withProjectDir(async (outdir) => {
       const project = new TestProject({
         outdir,
       });
@@ -166,8 +166,8 @@ describe("GitAttributesFile", () => {
     });
   });
 
-  test("should add a LFS pattern", () => {
-    withProjectDir((outdir) => {
+  test("should add a LFS pattern", async () => {
+    await withProjectDir(async (outdir) => {
       // The TestProject already contains a .gitattributes file
       const project = new TestProject({
         outdir,

--- a/test/integ.test.ts
+++ b/test/integ.test.ts
@@ -1,4 +1,3 @@
-import child_process from "child_process";
 import {
   copyFileSync,
   mkdirSync,
@@ -10,6 +9,7 @@ import * as os from "os";
 import { join, dirname, basename } from "path";
 import * as glob from "fast-glob";
 import { mkdtemp, directorySnapshot, sanitizeOutput } from "./util";
+import { node } from "../src/util/exec";
 
 const samples = join(__dirname, "integration");
 const files = glob.sync("**/*.projenrc.js", { cwd: samples });
@@ -19,7 +19,7 @@ const files = glob.sync("**/*.projenrc.js", { cwd: samples });
 const projenModule = join(__dirname, "..");
 
 for (const projenrc of files) {
-  test(basename(projenrc, ".projenrc.js"), () => {
+  test(basename(projenrc, ".projenrc.js"), async () => {
     const workdir = mkdtemp();
     const base = join(samples, dirname(projenrc));
     if (base !== samples) {
@@ -39,13 +39,9 @@ for (const projenrc of files) {
     );
 
     // synthesize by running the projenrc directly, with post-synth disabled.
-    child_process.execFileSync(process.execPath, [".projenrc.js"], {
-      stdio: ["inherit", 2, "pipe"],
+    node.run([".projenrc.js"], {
       cwd: workdir,
-      env: { ...process.env, PROJEN_DISABLE_POST: "1" } as Record<
-        string,
-        string
-      >,
+      env: { PROJEN_DISABLE_POST: "1" },
     });
 
     // patch the projen version in package.json to match the current version

--- a/test/java/projenrc.test.ts
+++ b/test/java/projenrc.test.ts
@@ -181,8 +181,8 @@ test("assert getJavaImport returns the correct import with no submodules", () =>
   expect(fullName).toEqual("software.aws.sdk.Component");
 });
 
-test("assert generateProjenrc returns the correct projenrc with correct outdir", () => {
-  withProjectDir((projectdir) => {
+test("assert generateProjenrc returns the correct projenrc with correct outdir", async () => {
+  await withProjectDir(async (projectdir) => {
     const newOutDir = path.join(projectdir, "foo");
     const project = new TestProject(
       renderProjenInitOptions("projen.java.JavaProject", {

--- a/test/javascript/eslint.test.ts
+++ b/test/javascript/eslint.test.ts
@@ -7,7 +7,7 @@ import { execProjenCLI, synthSnapshot } from "../util";
 test.each([
   ["prettier is off", false],
   ["prettier is on", true],
-])("eslint task passes with default config: %s", (_, prettier) => {
+])("eslint task passes with default config: %s", async (_, prettier) => {
   const project = new TypeScriptProject({
     name: "test",
     defaultReleaseBranch: "master",
@@ -18,7 +18,7 @@ test.each([
   project.synth();
 
   // THEN
-  execProjenCLI(project.outdir, ["eslint"]);
+  await execProjenCLI(project.outdir, ["eslint"]);
 });
 
 test("can acceess file", () => {

--- a/test/javascript/license-checker.test.ts
+++ b/test/javascript/license-checker.test.ts
@@ -54,7 +54,7 @@ describe("license checker", () => {
     });
   });
 
-  test("will fail task if denied license is found", () => {
+  test("will fail task if denied license is found", async () => {
     // GIVEN
     const project = new NodeProject({
       name: "test",
@@ -70,12 +70,14 @@ describe("license checker", () => {
     project.synth();
 
     // THEN
-    expect(() => execProjenCLI(project.outdir, ["check-licenses"])).toThrow(
+    await expect(
+      execProjenCLI(project.outdir, ["check-licenses"]),
+    ).rejects.toThrow(
       `Found license defined by the --failOn flag: "Apache-2.0"`,
     );
   });
 
-  test("will pass if only allowed licenses are found", () => {
+  test("will pass if only allowed licenses are found", async () => {
     // GIVEN
     const project = new NodeProject({
       name: "test",
@@ -94,6 +96,6 @@ describe("license checker", () => {
     project.synth();
 
     // THEN
-    execProjenCLI(project.outdir, ["check-licenses"]);
+    await execProjenCLI(project.outdir, ["check-licenses"]);
   });
 });

--- a/test/javascript/projenrc.test.ts
+++ b/test/javascript/projenrc.test.ts
@@ -3,8 +3,8 @@ import { Projenrc } from "../../src/javascript";
 import { renderProjenInitOptions } from "../../src/javascript/render-options";
 import { TestProject, withProjectDir } from "../util";
 
-test("assert generateProjenrc returns the correct projenrc with correct outdir", () => {
-  withProjectDir((projectdir) => {
+test("assert generateProjenrc returns the correct projenrc with correct outdir", async () => {
+  await withProjectDir(async (projectdir) => {
     const newOutDir = path.join(projectdir, "foo");
     const project = new TestProject(
       renderProjenInitOptions("projen.javascript.NodeProject", {

--- a/test/javascript/typescript-config.test.ts
+++ b/test/javascript/typescript-config.test.ts
@@ -19,8 +19,8 @@ describe("TypescriptConfig", () => {
     process.env.PROJEN_DISABLE_POST = ENV_PROJEN_DISABLE_POST;
   });
 
-  test("TypeScript should parse generated config without warnings", () => {
-    withProjectDir((outdir) => {
+  test("TypeScript should parse generated config without warnings", async () => {
+    await withProjectDir(async (outdir) => {
       const project = new NodeProject({
         name: "project",
         defaultReleaseBranch: "main",
@@ -44,8 +44,8 @@ describe("TypescriptConfig", () => {
     });
   });
 
-  test("TypeScript should parse generated config with extensions without warnings", () => {
-    withProjectDir((outdir) => {
+  test("TypeScript should parse generated config with extensions without warnings", async () => {
+    await withProjectDir(async (outdir) => {
       const project = new NodeProject({
         name: "project",
         defaultReleaseBranch: "main",
@@ -76,8 +76,8 @@ describe("TypescriptConfig", () => {
     });
   });
 
-  test("TypeScript should allow parse package for extends.", () => {
-    withProjectDir((outdir) => {
+  test("TypeScript should allow parse package for extends.", async () => {
+    await withProjectDir(async (outdir) => {
       const project = new NodeProject({
         name: "project",
         defaultReleaseBranch: "main",
@@ -103,8 +103,8 @@ describe("TypescriptConfig", () => {
     });
   });
 
-  test("TypeScript should allow parse package for extends witout compilerOptions.", () => {
-    withProjectDir((outdir) => {
+  test("TypeScript should allow parse package for extends witout compilerOptions.", async () => {
+    await withProjectDir(async (outdir) => {
       const project = new NodeProject({
         name: "project",
         defaultReleaseBranch: "main",
@@ -143,8 +143,8 @@ describe("TypescriptConfig", () => {
     }).toThrow(/Must provide either `extends` or `compilerOptions`/);
   });
 
-  test("TypeScript should parse generated config with multiple extensions", () => {
-    withProjectDir((outdir) => {
+  test("TypeScript should parse generated config with multiple extensions", async () => {
+    await withProjectDir(async (outdir) => {
       const project = new NodeProject({
         name: "project",
         defaultReleaseBranch: "main",
@@ -282,8 +282,13 @@ describe("TypescriptConfig", () => {
     }),
   ])(
     "Should warn when using extends with %p",
-    ({ tsVersion, manifestVersion, extends: extendsPaths, expectWarn }) => {
-      withProjectDir((outdir) => {
+    async ({
+      tsVersion,
+      manifestVersion,
+      extends: extendsPaths,
+      expectWarn,
+    }) => {
+      await withProjectDir(async (outdir) => {
         const project = new NodeProject({
           name: "project",
           defaultReleaseBranch: "main",

--- a/test/jsii/jsii.test.ts
+++ b/test/jsii/jsii.test.ts
@@ -49,12 +49,12 @@ describe("JsiiProject with default settings", () => {
     });
   });
 
-  it("compiles", () => {
+  it("compiles", async () => {
     const project = new TestJsiiProject();
 
     project.synth();
 
-    execProjenCLI(project.outdir, ["compile"]);
+    await execProjenCLI(project.outdir, ["compile"]);
   });
 });
 
@@ -76,7 +76,7 @@ describe("JsiiProject with modern jsiiVersion", () => {
     expect(output["package.json"].resolutions).toBeUndefined();
   });
 
-  it("compiles", () => {
+  it("compiles", async () => {
     const project = new TestJsiiProject({
       jsiiVersion: "~5.9.0",
       devDeps: ["jsii-pacmak@1.135.0"],
@@ -84,7 +84,7 @@ describe("JsiiProject with modern jsiiVersion", () => {
 
     project.synth();
 
-    execProjenCLI(project.outdir, ["compile"]);
+    await execProjenCLI(project.outdir, ["compile"]);
   });
 });
 
@@ -106,14 +106,14 @@ describe("JsiiProject with jsiiVersion: '*'", () => {
     expect(output["package.json"].resolutions).toBeUndefined();
   });
 
-  it("compiles", () => {
+  it("compiles", async () => {
     const project = new TestJsiiProject({
       jsiiVersion: "*",
     });
 
     project.synth();
 
-    execProjenCLI(project.outdir, ["compile"]);
+    await execProjenCLI(project.outdir, ["compile"]);
   });
 });
 
@@ -132,7 +132,7 @@ describe.each(getSupportedJsiiVersions().map((version) => [`~${version}.0`]))(
         process.env.CI = originalCI;
       });
 
-      it("compiles", () => {
+      it("compiles", async () => {
         const project = new TestJsiiProject({
           minNodeVersion,
           docgen: false,
@@ -141,7 +141,7 @@ describe.each(getSupportedJsiiVersions().map((version) => [`~${version}.0`]))(
 
         project.synth();
 
-        execProjenCLI(project.outdir, ["compile"]);
+        await execProjenCLI(project.outdir, ["compile"]);
       });
     });
   },

--- a/test/json/projenrc.test.ts
+++ b/test/json/projenrc.test.ts
@@ -38,8 +38,8 @@ test("projenrc.json with typed options", () => {
   expect(synthSnapshot(project)).toMatchSnapshot();
 });
 
-test("projenrc.json new project in outdir", () => {
-  withProjectDir((projectdir) => {
+test("projenrc.json new project in outdir", async () => {
+  await withProjectDir(async (projectdir) => {
     const newOutDir = path.join(projectdir, "foo");
     const project = new TestProject(
       renderProjenInitOptions("projen.typescript.TypeScriptProject", {

--- a/test/new.test.ts
+++ b/test/new.test.ts
@@ -1,6 +1,5 @@
 // tests for `projen new`: we run `projen new` for each supported project type
 // and compare against a golden snapshot.
-import { execSync } from "child_process";
 import { mkdirSync, existsSync, writeFileSync, readFileSync } from "fs";
 import { join, resolve } from "path";
 import {
@@ -14,7 +13,8 @@ import {
   withProjectDir,
 } from "./util";
 import * as inventory from "../src/inventory";
-import { execCapture, normalizePersistedPath } from "../src/util";
+import { normalizePersistedPath } from "../src/util";
+import { git, npm } from "../src/util/exec";
 
 const EXCLUDE_FROM_SNAPSHOT = [".git/**", "node_modules/**"];
 const EXCLUDE_FROM_SNAPSHOT_EXTENDED = [
@@ -24,10 +24,10 @@ const EXCLUDE_FROM_SNAPSHOT_EXTENDED = [
 ];
 
 for (const type of inventory.discover()) {
-  test(`projen new ${type.pjid}`, () => {
-    withProjectDir((projectdir) => {
+  test(`projen new ${type.pjid}`, async () => {
+    await withProjectDir(async (projectdir) => {
       // execute `projen new PJID --no-synth` in the project directory
-      execProjenCLI(projectdir, ["new", "--no-synth", type.pjid]);
+      await execProjenCLI(projectdir, ["new", "--no-synth", type.pjid]);
 
       // compare generated snapshot
       const actual = directorySnapshot(projectdir, {
@@ -40,11 +40,15 @@ for (const type of inventory.discover()) {
 }
 
 describe("projen new --from", () => {
+  // These tests download external packages from the npm registry (`npm pack`
+  // and `projen new --from`), which can take a while, especially on Windows CI.
+  jest.setTimeout(20_000);
+
   describe("using registry", () => {
-    test("existing package", () => {
-      withProjectDir((projectdir) => {
+    test("existing package", async () => {
+      await withProjectDir(async (projectdir) => {
         // execute `projen new --from @pepperize/projen-awscdk-app-ts@0.0.333` in the project directory
-        execProjenCLI(projectdir, [
+        await execProjenCLI(projectdir, [
           "new",
           "--from",
           "@pepperize/projen-awscdk-app-ts@0.0.333",
@@ -67,11 +71,11 @@ describe("projen new --from", () => {
       });
     });
 
-    test("non-existing package", () => {
+    test("non-existing package", async () => {
       try {
-        withProjectDir((projectdir) => {
+        await withProjectDir(async (projectdir) => {
           const nonExistentPackage = `@projen/some-non-existent-package`;
-          execProjenCLI(projectdir, [
+          await execProjenCLI(projectdir, [
             "new",
             "--from",
             nonExistentPackage,
@@ -85,10 +89,10 @@ describe("projen new --from", () => {
       }
     });
 
-    test("non-jsii module", () => {
+    test("non-jsii module", async () => {
       try {
-        withProjectDir((projectdir) => {
-          execProjenCLI(projectdir, [
+        await withProjectDir(async (projectdir) => {
+          await execProjenCLI(projectdir, [
             "new",
             "--from",
             "typescript", // valid package, but not a jsii module
@@ -103,9 +107,9 @@ describe("projen new --from", () => {
       }
     });
 
-    test("using dist tag", () => {
-      withProjectDir((projectdir) => {
-        execProjenCLI(projectdir, [
+    test("using dist tag", async () => {
+      await withProjectDir(async (projectdir) => {
+        await execProjenCLI(projectdir, [
           "new",
           "--from",
           "@pepperize/projen-awscdk-app-ts@latest",
@@ -122,10 +126,10 @@ describe("projen new --from", () => {
       });
     });
 
-    test("can choose from one of multiple external project types", () => {
-      withProjectDir((projectdir) => {
+    test("can choose from one of multiple external project types", async () => {
+      await withProjectDir(async (projectdir) => {
         // execute `projen new --from @taimos/projen@0.0.187 taimos-ts-lib` in the project directory
-        execProjenCLI(projectdir, [
+        await execProjenCLI(projectdir, [
           "new",
           "--from",
           "@taimos/projen@0.0.187",
@@ -142,10 +146,10 @@ describe("projen new --from", () => {
       });
     });
 
-    test("with pjid that is similar to a built-in one", () => {
-      withProjectDir((projectdir) => {
+    test("with pjid that is similar to a built-in one", async () => {
+      await withProjectDir(async (projectdir) => {
         try {
-          execProjenCLI(projectdir, [
+          await execProjenCLI(projectdir, [
             "new",
             "--from",
             "cdklabs-projen-project-types@0.1.48",
@@ -169,14 +173,19 @@ describe("projen new --from", () => {
         "@pepperize/projen-awscdk-app-ts@file:./pepperize-projen-awscdk-app-ts-0.0.333.tgz",
       ],
       ["relative path", "./pepperize-projen-awscdk-app-ts-0.0.333.tgz"],
-    ])("projen new --from %s ", (_, external) => {
-      withProjectDir((projectdir) => {
-        const shell = (command: string) =>
-          execSync(command, { cwd: projectdir });
+    ])("projen new --from %s ", async (_, external) => {
+      await withProjectDir(async (projectdir) => {
         // downloads pepperize-projen-awscdk-app-ts-0.0.333.tgz
-        shell("npm pack @pepperize/projen-awscdk-app-ts@0.0.333");
+        await npm.run(["pack", "@pepperize/projen-awscdk-app-ts@0.0.333"], {
+          cwd: projectdir,
+        });
 
-        execProjenCLI(projectdir, ["new", "--from", external, "--no-post"]);
+        await execProjenCLI(projectdir, [
+          "new",
+          "--from",
+          external,
+          "--no-post",
+        ]);
 
         // patch the projen version in package.json to match the current version
         // otherwise, every bump would need to update these snapshots.
@@ -194,19 +203,24 @@ describe("projen new --from", () => {
       });
     });
 
-    test("projen new --from from external tarball (absolute path)", () => {
-      withProjectDir((projectdir) => {
-        const shell = (command: string) =>
-          execSync(command, { cwd: projectdir });
+    test("projen new --from from external tarball (absolute path)", async () => {
+      await withProjectDir(async (projectdir) => {
         // downloads pepperize-projen-awscdk-app-ts-0.0.333.tgz
-        shell("npm pack @pepperize/projen-awscdk-app-ts@0.0.333");
+        await npm.run(["pack", "@pepperize/projen-awscdk-app-ts@0.0.333"], {
+          cwd: projectdir,
+        });
         const tarball = resolve(
           projectdir,
           "pepperize-projen-awscdk-app-ts-0.0.333.tgz",
         );
         const normalizedTarball = normalizePersistedPath(tarball);
 
-        execProjenCLI(projectdir, ["new", "--from", tarball, "--no-post"]);
+        await execProjenCLI(projectdir, [
+          "new",
+          "--from",
+          tarball,
+          "--no-post",
+        ]);
 
         // patch the projen version in package.json to match the current version
         // otherwise, every bump would need to update these snapshots.
@@ -235,10 +249,15 @@ describe("projen new --from", () => {
     test.each([
       ["none-existent-package-0.0.1.tgz"],
       ["@projen/non-existing-package@file:./none-existent-package-0.0.1.tgz"],
-    ])("non-existent tarball %s", (external) => {
-      withProjectDir((projectdir) => {
+    ])("non-existent tarball %s", async (external) => {
+      await withProjectDir(async (projectdir) => {
         try {
-          execProjenCLI(projectdir, ["new", "--from", external, "--no-post"]);
+          await execProjenCLI(projectdir, [
+            "new",
+            "--from",
+            external,
+            "--no-post",
+          ]);
         } catch (error: any) {
           // expect an error since this tarball doesn't exist as it wasn't added via `npm pack`
           expect(error.message).toContain(
@@ -264,10 +283,10 @@ describe("projen new --from", () => {
       });
     });
 
-    test("with enum values", () => {
-      withProjectDir((projectdir) => {
+    test("with enum values", async () => {
+      await withProjectDir(async (projectdir) => {
         // execute `projen new --from @pepperize/projen-awscdk-app-ts@0.0.333` in the project directory
-        execProjenCLI(projectdir, [
+        await execProjenCLI(projectdir, [
           "new",
           "--from",
           "@pepperize/projen-awscdk-app-ts@0.0.333",
@@ -290,10 +309,10 @@ describe("projen new --from", () => {
       });
     });
 
-    test("with array option", () => {
-      withProjectDir((projectdir) => {
+    test("with array option", async () => {
+      await withProjectDir(async (projectdir) => {
         // execute `projen new --from @pepperize/projen-awscdk-app-ts@0.0.333` in the project directory
-        execProjenCLI(projectdir, [
+        await execProjenCLI(projectdir, [
           "new",
           "--from",
           "@pepperize/projen-awscdk-app-ts@0.0.333",
@@ -313,10 +332,10 @@ describe("projen new --from", () => {
       });
     });
 
-    test("options are not overwritten when creating from external project types", () => {
-      withProjectDir((projectdir) => {
+    test("options are not overwritten when creating from external project types", async () => {
+      await withProjectDir(async (projectdir) => {
         // execute `projen new --from @pepperize/projen-awscdk-app-ts@0.0.333` in the project directory
-        execProjenCLI(projectdir, [
+        await execProjenCLI(projectdir, [
           "new",
           "--from",
           "@pepperize/projen-awscdk-app-ts@0.0.333",
@@ -334,10 +353,10 @@ describe("projen new --from", () => {
       });
     });
 
-    test("will fail when a required option without a default is not provided", () => {
-      withProjectDir((projectdir) => {
+    test("will fail when a required option without a default is not provided", async () => {
+      await withProjectDir(async (projectdir) => {
         try {
-          execProjenCLI(projectdir, [
+          await execProjenCLI(projectdir, [
             "new",
             "--from",
             "mrpj@0.0.1",
@@ -352,9 +371,9 @@ describe("projen new --from", () => {
       });
     });
 
-    test("--no-comments", () => {
-      withProjectDir((projectdir) => {
-        execProjenCLI(projectdir, [
+    test("--no-comments", async () => {
+      await withProjectDir(async (projectdir) => {
+        await execProjenCLI(projectdir, [
           "new",
           "node",
           "--no-comments",
@@ -367,22 +386,22 @@ describe("projen new --from", () => {
       });
     });
 
-    test("projen new rejects unsupported project type option", () => {
-      withProjectDir((projectdir) => {
-        expect(() =>
+    test("projen new rejects unsupported project type option", async () => {
+      await withProjectDir(async (projectdir) => {
+        await expect(
           execProjenCLI(projectdir, [
             "new",
             "jsii",
             "--projenrc-py",
             "--no-synth",
           ]),
-        ).toThrow("Unknown arguments: projenrc-py, projenrcPy");
+        ).rejects.toThrow("Unknown arguments: projenrc-py, projenrcPy");
       });
     });
 
-    test("creating node project with enum-typed CLI arg", () => {
-      withProjectDir((projectdir) => {
-        execProjenCLI(projectdir, [
+    test("creating node project with enum-typed CLI arg", async () => {
+      await withProjectDir(async (projectdir) => {
+        await execProjenCLI(projectdir, [
           "new",
           "node",
           "--package-manager",
@@ -395,9 +414,9 @@ describe("projen new --from", () => {
       });
     });
 
-    test("projenrc-json creates node-project", () => {
-      withProjectDir((projectdir) => {
-        execProjenCLI(projectdir, [
+    test("projenrc-json creates node-project", async () => {
+      await withProjectDir(async (projectdir) => {
+        await execProjenCLI(projectdir, [
           "new",
           "node",
           "--projenrc-json",
@@ -409,9 +428,9 @@ describe("projen new --from", () => {
       });
     });
 
-    test("projenrc-json creates java project", () => {
-      withProjectDir((projectdir) => {
-        execProjenCLI(projectdir, [
+    test("projenrc-json creates java project", async () => {
+      await withProjectDir(async (projectdir) => {
+        await execProjenCLI(projectdir, [
           "new",
           "java",
           "--projenrc-json",
@@ -426,9 +445,9 @@ describe("projen new --from", () => {
       });
     });
 
-    test("projenrc-json creates external project type", () => {
-      withProjectDir((projectdir) => {
-        execProjenCLI(projectdir, [
+    test("projenrc-json creates external project type", async () => {
+      await withProjectDir(async (projectdir) => {
+        await execProjenCLI(projectdir, [
           "new",
           "--from",
           "@pepperize/projen-awscdk-app-ts@0.0.333",
@@ -443,15 +462,15 @@ describe("projen new --from", () => {
       });
     });
 
-    test("--outdir path/to/mydir", () => {
-      withProjectDir((projectdir) => {
+    test("--outdir path/to/mydir", async () => {
+      await withProjectDir(async (projectdir) => {
         // GIVEN
-        const shell = (command: string) =>
-          execSync(command, { cwd: projectdir });
-        shell(`mkdir -p ${join("path", "to", "mydir")}`);
+        mkdirSync(join(projectdir, "path", "to", "mydir"), {
+          recursive: true,
+        });
 
         // WHEN
-        execProjenCLI(projectdir, [
+        await execProjenCLI(projectdir, [
           "new",
           "node",
           "--outdir",
@@ -471,9 +490,9 @@ describe("projen new --from", () => {
   });
 
   describe("projen new --from with NODE_ENV=production", () => {
-    test("should install external module successfully", () => {
-      withProjectDir((projectdir) => {
-        execProjenCLI(
+    test("should install external module successfully", async () => {
+      await withProjectDir(async (projectdir) => {
+        await execProjenCLI(
           projectdir,
           [
             "new",
@@ -489,9 +508,9 @@ describe("projen new --from", () => {
 });
 
 describe("typescript project", () => {
-  test("projenrc-ts creates typescript projenrc", () => {
-    withProjectDir((projectdir) => {
-      execProjenCLI(projectdir, [
+  test("projenrc-ts creates typescript projenrc", async () => {
+    await withProjectDir(async (projectdir) => {
+      await execProjenCLI(projectdir, [
         "new",
         "typescript",
         "--no-synth",
@@ -507,18 +526,18 @@ describe("typescript project", () => {
 });
 
 describe("python project", () => {
-  test("includes .projenrc.py by default", () => {
-    withProjectDir((projectdir) => {
-      execProjenCLI(projectdir, ["new", "python", "--no-synth"]);
+  test("includes .projenrc.py by default", async () => {
+    await withProjectDir(async (projectdir) => {
+      await execProjenCLI(projectdir, ["new", "python", "--no-synth"]);
 
       const output = directorySnapshot(projectdir);
       expect(output[".projenrc.py"]).toBeDefined();
     });
   });
 
-  test("can include .projenrc.js", () => {
-    withProjectDir((projectdir) => {
-      execProjenCLI(projectdir, [
+  test("can include .projenrc.js", async () => {
+    await withProjectDir(async (projectdir) => {
+      await execProjenCLI(projectdir, [
         "new",
         "python",
         "--no-synth",
@@ -531,9 +550,9 @@ describe("python project", () => {
     });
   });
 
-  test("can include .projenrc.ts", () => {
-    withProjectDir((projectdir) => {
-      execProjenCLI(projectdir, [
+  test("can include .projenrc.ts", async () => {
+    await withProjectDir(async (projectdir) => {
+      await execProjenCLI(projectdir, [
         "new",
         "python",
         "--no-synth",
@@ -550,9 +569,9 @@ describe("python project", () => {
     });
   });
 
-  test("can define an array option", () => {
-    withProjectDir((projectdir) => {
-      execProjenCLI(projectdir, [
+  test("can define an array option", async () => {
+    await withProjectDir(async (projectdir) => {
+      await execProjenCLI(projectdir, [
         "new",
         "python",
         "--no-synth",
@@ -568,9 +587,9 @@ describe("python project", () => {
 });
 
 describe("initial values", () => {
-  test("cli can override initial values", () => {
-    withProjectDir((projectdir) => {
-      execProjenCLI(projectdir, [
+  test("cli can override initial values", async () => {
+    await withProjectDir(async (projectdir) => {
+      await execProjenCLI(projectdir, [
         "new",
         "typescript",
         "--projenrc-ts",
@@ -587,13 +606,13 @@ describe("initial values", () => {
 });
 
 describe("git", () => {
-  test("--git (default) will initialize a git repo and create a commit", () => {
-    withProjectDir(
-      (projectdir) => {
-        execProjenCLI(projectdir, ["new", "project"]);
+  test("--git (default) will initialize a git repo and create a commit", async () => {
+    await withProjectDir(
+      async (projectdir) => {
+        await execProjenCLI(projectdir, ["new", "project"]);
         expect(
-          execCapture("git log", { cwd: projectdir })
-            .toString("utf8")
+          git
+            .capture(["log"], { cwd: projectdir })
             .includes("chore: project created with projen"),
         ).toBeTruthy();
       },
@@ -601,9 +620,9 @@ describe("git", () => {
     );
   });
 
-  test("--git (default) respects init.defaultBranch setting", () => {
-    withProjectDir(
-      (projectdir) => {
+  test("--git (default) respects init.defaultBranch setting", async () => {
+    await withProjectDir(
+      async (projectdir) => {
         const defaultBranch = "test-default-branch";
 
         // Simulate git config using env variables
@@ -615,21 +634,21 @@ describe("git", () => {
           GIT_CONFIG_VALUE_0: defaultBranch,
         };
 
-        execProjenCLI(projectdir, ["new", "project"], env);
+        await execProjenCLI(projectdir, ["new", "project"], env);
         expect(
-          execCapture("git rev-parse --abbrev-ref HEAD", {
+          git.capture(["rev-parse", "--abbrev-ref", "HEAD"], {
             cwd: projectdir,
-          }).toString(),
+          }),
         ).toContain(defaultBranch);
       },
       { git: false },
     );
   });
 
-  test("--no-git will not create a git repo", () => {
-    withProjectDir(
-      (projectdir) => {
-        execProjenCLI(projectdir, ["new", "project", "--no-git"]);
+  test("--no-git will not create a git repo", async () => {
+    await withProjectDir(
+      async (projectdir) => {
+        await execProjenCLI(projectdir, ["new", "project", "--no-git"]);
         expect(existsSync(join(projectdir, ".git"))).toBeFalsy();
       },
       { git: false },
@@ -639,13 +658,13 @@ describe("git", () => {
 
 describe("regressions", () => {
   // https://github.com/projen/projen/issues/2837
-  test("projen new --from does not fail when save=false in npm config", () => {
-    withProjectDir((projectdir) => {
+  test("projen new --from does not fail when save=false in npm config", async () => {
+    await withProjectDir(async (projectdir) => {
       // Tells Node to not save packages on install. However we must save the external package to determine its name.
       writeFileSync(join(projectdir, ".npmrc"), "save=false\n");
 
       // execute `projen new --from @pepperize/projen-awscdk-app-ts@0.0.333` in the project directory
-      execProjenCLI(
+      await execProjenCLI(
         projectdir,
         [
           "new",
@@ -673,10 +692,10 @@ describe("regressions", () => {
   });
 
   // https://github.com/projen/projen/issues/2649
-  test("projen new without any arguments displays full help", () => {
-    withProjectDir((projectdir) => {
+  test("projen new without any arguments displays full help", async () => {
+    await withProjectDir(async (projectdir) => {
       try {
-        execProjenCLI(projectdir, ["new"]);
+        await execProjenCLI(projectdir, ["new"]);
       } catch (error: any) {
         expect(error.message).toMatch("Creates a new projen project");
         expect(error.message).toMatch("Commands:");
@@ -686,13 +705,13 @@ describe("regressions", () => {
   });
 
   // https://github.com/projen/projen/issues/2443
-  test("can create external project in directory path containing a space", () => {
+  test("can create external project in directory path containing a space", async () => {
     const pathWithSpace = join(mkdtemp(), "path with space");
     mkdirSync(pathWithSpace, { recursive: true });
 
-    withProjectDir(
-      (projectdir) => {
-        execProjenCLI(projectdir, [
+    await withProjectDir(
+      async (projectdir) => {
+        await execProjenCLI(projectdir, [
           "new",
           "--from",
           "@pepperize/projen-awscdk-app-ts@latest",

--- a/test/projects.test.ts
+++ b/test/projects.test.ts
@@ -3,10 +3,13 @@ import { installPackage } from "../src/cli/util";
 import { InitProjectOptionHints } from "../src/option-hints";
 import { Projects } from "../src/projects";
 
+// some tests install packages from the npm registry, which can take a while
+jest.setTimeout(20_000); // 20s
+
 describe("createProject", () => {
-  test("creates a project in a directory", () => {
-    withProjectDir(
-      (projectdir) => {
+  test("creates a project in a directory", async () => {
+    await withProjectDir(
+      async (projectdir) => {
         // GIVEN
         Projects.createProject({
           optionHints: InitProjectOptionHints.FEATURED,
@@ -30,9 +33,9 @@ describe("createProject", () => {
     );
   });
 
-  test("creates a project and passes in JSON-like project options", () => {
-    withProjectDir(
-      (projectdir) => {
+  test("creates a project and passes in JSON-like project options", async () => {
+    await withProjectDir(
+      async (projectdir) => {
         // GIVEN
         Projects.createProject({
           optionHints: InitProjectOptionHints.FEATURED,
@@ -64,11 +67,11 @@ describe("createProject", () => {
     );
   });
 
-  test("creates a project from an external project type, if it's installed", () => {
-    withProjectDir(
-      (projectdir) => {
+  test("creates a project from an external project type, if it's installed", async () => {
+    await withProjectDir(
+      async (projectdir) => {
         // GIVEN
-        installPackage(projectdir, "cdklabs-projen-project-types@0.1.48");
+        await installPackage(projectdir, "cdklabs-projen-project-types@0.1.48");
 
         // WHEN
         Projects.createProject({

--- a/test/python/projenrc.test.ts
+++ b/test/python/projenrc.test.ts
@@ -89,8 +89,8 @@ test("ensure python import is correctly resolved to jsiiFqn when python module i
   expect(resolvedImportName).toEqual(jsiiFqn);
 });
 
-test("generate projenrc in python with a given outdir", () => {
-  withProjectDir((projectdir) => {
+test("generate projenrc in python with a given outdir", async () => {
+  await withProjectDir(async (projectdir) => {
     const newOutDir = path.join(projectdir, "foo");
     const project = new TestProject(
       renderProjenInitOptions("projen.python.PythonProject", {

--- a/test/python/uv.test.ts
+++ b/test/python/uv.test.ts
@@ -1,7 +1,7 @@
 import * as TOML from "@iarna/toml";
 import { TestPythonProject } from "./util";
 import { AnnotationStyle } from "../../src/python/uv-config";
-import * as util from "../../src/util";
+import * as util from "../../src/util/exec";
 import { synthSnapshot } from "../util";
 
 test("uv enabled", () => {
@@ -244,10 +244,8 @@ test("generates correct pyproject.toml content", () => {
 });
 
 test("uv setupEnvironment creates venv with --clear", () => {
-  const whichUv = jest
-    .spyOn(util, "execOrUndefined")
-    .mockReturnValue("/usr/local/bin/uv");
-  const execSpy = jest.spyOn(util, "exec").mockImplementation(() => {});
+  const whichUv = jest.spyOn(util.uv, "tryCapture").mockReturnValue("uv 0.1.0");
+  const execSpy = jest.spyOn(util.uv, "run").mockImplementation(() => {});
 
   const project = new TestPythonProject({
     uv: true,
@@ -259,9 +257,9 @@ test("uv setupEnvironment creates venv with --clear", () => {
 
   project.envManager.setupEnvironment();
 
-  expect(whichUv).toHaveBeenCalledWith("which uv", { cwd: project.outdir });
+  expect(whichUv).toHaveBeenCalledWith(["--version"], { cwd: project.outdir });
   expect(execSpy).toHaveBeenCalledWith(
-    'uv venv --python ">=3.12,<4.0" --clear .venv',
+    ["venv", "--python", ">=3.12,<4.0", "--clear", ".venv"],
     { cwd: project.outdir },
   );
 });

--- a/test/release/bump.test.ts
+++ b/test/release/bump.test.ts
@@ -1,4 +1,3 @@
-import { execSync } from "child_process";
 import { promises as fs, mkdtempSync, readFileSync } from "fs";
 import { tmpdir } from "os";
 import { dirname, join } from "path";
@@ -7,6 +6,7 @@ import * as logging from "../../src/logging";
 import type { BumpOptions } from "../../src/release/bump-version";
 import { bump } from "../../src/release/bump-version";
 import { TypeScriptProject } from "../../src/typescript";
+import { git } from "../../src/util/exec";
 import { execProjenCLI, withProjectDir } from "../util";
 
 logging.disable();
@@ -567,6 +567,45 @@ describe("Releasable Commits Configurations", () => {
 });
 
 //----------------------------------------------------------------------------------------------------------------------------------
+describe("nextVersionCommand", () => {
+  const commits = [
+    { message: "v1", tag: "v1.2.3" },
+    { message: "feat: a feature" },
+  ];
+
+  test("a relative bump from the command overrides the computed bump", async () => {
+    const result = await testBump({
+      commits,
+      options: {
+        nextVersionCommand: `node -e "process.stdout.write('minor')"`,
+      },
+    });
+    expect(result.version).toStrictEqual("1.3.0");
+  });
+
+  test("an absolute version from the command is used as-is", async () => {
+    const result = await testBump({
+      commits,
+      options: {
+        nextVersionCommand: `node -e "process.stdout.write('9.9.9')"`,
+      },
+    });
+    expect(result.version).toStrictEqual("9.9.9");
+  });
+
+  test("invalid command output fails the bump", async () => {
+    await expect(
+      testBump({
+        commits,
+        options: {
+          nextVersionCommand: `node -e "process.stdout.write('not-a-version')"`,
+        },
+      }),
+    ).rejects.toThrow(/returned invalid output/);
+  });
+});
+
+//----------------------------------------------------------------------------------------------------------------------------------
 describe("newline at the end of version file", () => {
   test("created version file ends with a newline", async () => {
     const result = await testBump();
@@ -579,7 +618,7 @@ describe("newline at the end of version file", () => {
   });
 
   test("existing version file keeps newline at the end", async () => {
-    withProjectDir((projectdir) => {
+    await withProjectDir(async (projectdir) => {
       const project = new TypeScriptProject({
         defaultReleaseBranch: "main",
         name: "test",
@@ -590,11 +629,11 @@ describe("newline at the end of version file", () => {
       project.synth();
 
       // Commit files so the bump will work
-      execSync("git add .", { cwd: projectdir });
-      execSync('git commit -m "chore: init"', { cwd: projectdir });
+      git.run(["add", "."], { cwd: projectdir });
+      git.run(["commit", "-m", "chore: init"], { cwd: projectdir });
 
       // Bump the version
-      execProjenCLI(projectdir, ["bump"]);
+      await execProjenCLI(projectdir, ["bump"]);
 
       const file = readFileSync(join(projectdir, "package.json"), "utf-8");
       expect(file.endsWith("\n")).toBe(true);
@@ -612,26 +651,21 @@ async function testBump(
 ) {
   const workdir = mkdtempSync(join(tmpdir(), "bump-test-"));
 
-  const git = (cmd: string) =>
-    execSync(`git ${cmd}`, {
-      cwd: workdir,
-      stdio: "inherit",
-      timeout: 10_000, // let's try to catch hanging processes sooner than later
-    });
+  const run = (args: string[]) => git.run(args, { cwd: workdir });
 
   // init a git repository
-  git("init -b main");
-  git('config user.email "you@example.com"');
-  git('config user.name "Your Name"');
-  git("config commit.gpgsign false");
-  git("config tag.gpgsign false");
+  run(["init", "-b", "main"]);
+  run(["config", "user.email", "you@example.com"]);
+  run(["config", "user.name", "Your Name"]);
+  run(["config", "commit.gpgsign", "false"]);
+  run(["config", "tag.gpgsign", "false"]);
 
   const commit = async (message: string, path: string = "dummy.txt") => {
     const filePath = join(workdir, path);
     await fs.mkdir(dirname(filePath), { recursive: true });
     await fs.writeFile(filePath, message);
-    git("add .");
-    git(`commit -F "${filePath}"`);
+    run(["add", "."]);
+    run(["commit", "-F", filePath]);
   };
 
   await commit("initial commit");
@@ -639,7 +673,7 @@ async function testBump(
   for (const c of opts.commits ?? []) {
     await commit(c.message, c.path);
     if (c.tag) {
-      git(`tag ${c.tag}`);
+      run(["tag", c.tag]);
     }
   }
 

--- a/test/release/tag.test.ts
+++ b/test/release/tag.test.ts
@@ -1,11 +1,10 @@
-import { execSync } from "child_process";
 import { promises as fs, mkdtempSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import * as logging from "../../src/logging";
 import type { TagOptions } from "../../src/release/tag-version";
 import { tag } from "../../src/release/tag-version";
-import { execCapture } from "../../src/util";
+import { git } from "../../src/util/exec";
 
 logging.disable();
 jest.setTimeout(1000 * 60); // 1min
@@ -56,16 +55,16 @@ async function testTag(opts: TestTagOpts = {}) {
   const releaseTagFile =
     opts.tagOptions?.releaseTagFile ?? DEFAULT_RELEASE_TAG_FILE;
 
-  const git = gitFunc(workdir);
+  const run = (args: string[]) => git.run(args, { cwd: workdir });
   const getLatestTag = latestTagFunc(workdir);
   const getTagAnnotation = tagAnnotationFunc(workdir);
 
   // init a git repository
-  git("init -q");
-  git('config user.email "you@example.com"');
-  git('config user.name "Your Name"');
-  git("config commit.gpgsign false");
-  git("config tag.gpgsign false");
+  run(["init", "-q"]);
+  run(["config", "user.email", "you@example.com"]);
+  run(["config", "user.name", "Your Name"]);
+  run(["config", "commit.gpgsign", "false"]);
+  run(["config", "tag.gpgsign", "false"]);
   await fs.writeFile(
     join(workdir, opts.testOptions?.releaseTagPath || "", releaseTagFile),
     releaseTag,
@@ -74,8 +73,8 @@ async function testTag(opts: TestTagOpts = {}) {
     join(workdir, opts.testOptions?.changelogPath || "", changelog),
     changelogContent,
   );
-  git("add .");
-  git('commit -m "chore: foo"');
+  run(["add", "."]);
+  run(["commit", "-m", "chore: foo"]);
 
   await tag(workdir, {
     changelog,
@@ -91,11 +90,9 @@ async function testTag(opts: TestTagOpts = {}) {
   };
 }
 
-const gitFunc = (cwd: string) => (cmd: string) =>
-  execSync(`git ${cmd}`, { cwd: cwd, stdio: "inherit" });
 const latestTagFunc = (cwd: string) => () =>
-  execCapture("git describe --tags --abbrev=0", { cwd: cwd }).toString();
+  git.capture(["describe", "--tags", "--abbrev=0"], { cwd: cwd });
 const tagAnnotationFunc = (cwd: string) => (releaseTag: string) =>
-  execCapture(`git tag -l --format='%(contents)' ${releaseTag}`, {
+  git.capture(["tag", "-l", "--format=%(contents)", releaseTag], {
     cwd: cwd,
-  }).toString();
+  });

--- a/test/release/update-changelog.test.ts
+++ b/test/release/update-changelog.test.ts
@@ -1,11 +1,11 @@
-import { execSync } from "child_process";
 import { promises as fs, mkdtempSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import * as logging from "../../src/logging";
 import type { UpdateChangelogOptions } from "../../src/release/update-changelog";
 import { updateChangelog } from "../../src/release/update-changelog";
-import { execCapture, tryReadFile } from "../../src/util";
+import { tryReadFile } from "../../src/util";
+import { git as gitTool } from "../../src/util/exec";
 
 logging.disable();
 jest.setTimeout(1000 * 60); // 1min
@@ -158,21 +158,21 @@ async function testUpdateChangelog(opts: TestUpdateChangelogOpts = {}) {
   const inputChangelogFullPath = join(workdir, inputChangelog);
   const outputChangelogFullPath = join(workdir, outputChangelog);
 
-  const git = gitFunc(workdir);
+  const run = (args: string[]) => gitTool.run(args, { cwd: workdir });
 
   if (!opts.testOptions?.cwd) {
     // init a git repository and make initial commit
-    git("init -q");
-    git('config user.email "you@example.com"');
-    git('config user.name "Your Name"');
-    git("config commit.gpgsign false");
+    run(["init", "-q"]);
+    run(["config", "user.email", "you@example.com"]);
+    run(["config", "user.name", "Your Name"]);
+    run(["config", "commit.gpgsign", "false"]);
     await fs.mkdir(join(workdir, "dist"));
     await fs.writeFile(join(workdir, versionFile), version);
     await fs.writeFile(inputChangelogFullPath, inputChangelogContent);
     if (!skipOutputChangelog) {
       await fs.writeFile(outputChangelogFullPath, outputChangelogContent);
-      git(`add ${outputChangelogFullPath}`);
-      git('commit -m "chore: setup"');
+      run(["add", outputChangelogFullPath]);
+      run(["commit", "-m", "chore: setup"]);
     }
   }
 
@@ -182,15 +182,13 @@ async function testUpdateChangelog(opts: TestUpdateChangelogOpts = {}) {
     versionFile: versionFile,
   });
 
-  const commits = execCapture("git log --oneline", {
-    cwd: workdir,
-  })
-    .toString()
+  const commits = gitTool
+    .capture(["log", "--oneline"], { cwd: workdir })
     .split("\n");
-  const lastCommitContent = execCapture(
-    "git diff-tree --no-commit-id --name-only -r HEAD",
+  const lastCommitContent = gitTool.capture(
+    ["diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD"],
     { cwd: workdir },
-  ).toString();
+  );
   const projectChangelogContent = await tryReadFile(outputChangelogFullPath);
 
   return {
@@ -200,6 +198,3 @@ async function testUpdateChangelog(opts: TestUpdateChangelogOpts = {}) {
     commits,
   };
 }
-
-const gitFunc = (cwd: string) => (cmd: string) =>
-  execSync(`git ${cmd}`, { cwd: cwd, stdio: "inherit" });

--- a/test/tasks/tasks.test.ts
+++ b/test/tasks/tasks.test.ts
@@ -1,3 +1,4 @@
+import childProcess from "child_process";
 import { readFileSync } from "fs";
 import { join } from "path";
 import type { Project, TasksManifest, TaskStep } from "../../src";
@@ -53,11 +54,11 @@ describe("runTask", () => {
     p.addTask("noop", { exec: "echo hi" });
     p.synth();
 
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const childProcess = require("node:child_process");
     const spy = jest
-      .spyOn(childProcess, "spawnSync")
-      .mockReturnValue({ error: new Error("spawn boom"), status: null } as any);
+      .spyOn(childProcess, "execFileSync")
+      .mockImplementation(() => {
+        throw new Error("spawn boom");
+      });
 
     try {
       expect(() => p.tasks.runTask("noop")).toThrow("spawn boom");

--- a/test/typescript/projenrc.test.ts
+++ b/test/typescript/projenrc.test.ts
@@ -2,8 +2,8 @@ import * as path from "path";
 import { Projenrc, TypeScriptProject } from "../../src/typescript";
 import { withProjectDir, synthSnapshot } from "../util";
 
-test("assert new Typescript project in foo outdir", () => {
-  withProjectDir((projectdir) => {
+test("assert new Typescript project in foo outdir", async () => {
+  await withProjectDir(async (projectdir) => {
     const newOutDir = path.join(projectdir, "foo");
     const project = new TypeScriptProject({
       defaultReleaseBranch: "main",

--- a/test/typescript/typescript.test.ts
+++ b/test/typescript/typescript.test.ts
@@ -23,7 +23,7 @@ describe("TypeScriptProject with default settings", () => {
     expect(output).toMatchSnapshot();
   });
 
-  it("compiles", () => {
+  it("compiles", async () => {
     const project = new TypeScriptProject({
       defaultReleaseBranch: "main",
       packageManager: javascript.NodePackageManager.NPM,
@@ -32,7 +32,7 @@ describe("TypeScriptProject with default settings", () => {
 
     project.synth();
 
-    execProjenCLI(project.outdir, ["compile"]);
+    await execProjenCLI(project.outdir, ["compile"]);
   });
 });
 
@@ -327,7 +327,7 @@ describe("jestConfig", () => {
       expect(jestConfig.transform[JS_PATTERN]).toStrictEqual("babel-jest");
     });
 
-    test("allows overriding of ts-jest transform pattern", () => {
+    test("allows overriding of ts-jest transform pattern", async () => {
       const loggerWarnSpy = jest.spyOn(Logger.prototype, "warn");
       const TS_WITH_JS_PATTERN = "^.+\\.[tj]sx?$";
 
@@ -335,8 +335,8 @@ describe("jestConfig", () => {
       // root to ensure that external projects don't trigger the legacy warning.
       // In order to do that, we need to make the folder ourselves instead of
       // relying on the Project calss making one for us.
-      withProjectDir(
-        (projectdir) => {
+      await withProjectDir(
+        async (projectdir) => {
           fs.writeFileSync(
             path.join(projectdir, "package.json"),
             `{"dependencies": {}}`,

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,4 +1,3 @@
-import * as cp from "child_process";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -8,7 +7,7 @@ import type { GitHubProjectOptions } from "../src/github/github-project";
 import { GitHubProject } from "../src/github/github-project";
 import * as logging from "../src/logging";
 import type { Task } from "../src/task";
-import { exec } from "../src/util";
+import { git, node } from "../src/util/exec";
 import { directorySnapshot } from "../src/util/synth";
 
 const PROJEN_CLI = require.resolve("../lib/cli/index.js");
@@ -39,26 +38,28 @@ interface ProjenCLIExecOptions {
   preInstallProjen?: boolean;
 }
 
-export function execProjenCLI(
+export async function execProjenCLI(
   workdir: string,
   args: string[] = [],
   env?: Record<string, string>,
   { preInstallProjen = true }: ProjenCLIExecOptions = {},
 ) {
-  const command = [process.execPath, PROJEN_CLI, ...args];
-
   // For "projen new" commands we need to pre-install the current library,
   // to ensure the latest code is used in test cases
   // https://github.com/projen/projen/issues/3410
   if (preInstallProjen && args.includes("new")) {
-    installPackage(
+    await installPackage(
       workdir,
       `file:${path.normalize(path.join(__dirname, ".."))}`,
       true,
     );
   }
 
-  return exec(command.map((x) => `"${x}"`).join(" "), { cwd: workdir, env });
+  // run the CLI shell-free via node
+  return node.run([PROJEN_CLI, ...args], {
+    cwd: workdir,
+    env,
+  });
 }
 
 const autoRemove = new Set<string>();
@@ -97,8 +98,8 @@ export function synthSnapshotWithPost(project: Project) {
   }
 }
 
-export function withProjectDir(
-  code: (workdir: string) => void,
+export async function withProjectDir(
+  code: (workdir: string) => void | Promise<void>,
   options: { git?: boolean; chdir?: boolean; tmpdir?: string } = {},
 ) {
   const origDir = process.cwd();
@@ -108,31 +109,36 @@ export function withProjectDir(
     const projectdir = path.join(outdir, "my-project");
     fs.mkdirSync(projectdir);
 
-    const shell = (command: string) =>
-      cp.execSync(command, { cwd: projectdir });
+    const runGit = (args: string[]) => git.run(args, { cwd: projectdir });
     if (options.git ?? true) {
-      shell("git init -b main");
-      shell("git remote add origin git@boom.com:foo/bar.git");
-      shell('git config user.name "My User Name"');
-      shell('git config user.email "my@user.email.com"');
-      shell("git config commit.gpgsign false");
-      shell("git config tag.gpgsign false");
+      runGit(["init", "-b", "main"]);
+      runGit(["remote", "add", "origin", "git@boom.com:foo/bar.git"]);
+      runGit(["config", "user.name", "My User Name"]);
+      runGit(["config", "user.email", "my@user.email.com"]);
+      runGit(["config", "commit.gpgsign", "false"]);
+      runGit(["config", "tag.gpgsign", "false"]);
     } else if (process.env.GITHUB_ACTIONS) {
-      // if "git" is set to "false", we still want to make sure global user is defined
-      // (relevant in our GITHUB_ACTIONS context)
-      shell(
-        'git config user.name || git config --global user.name "My User Name"',
-      );
-      shell(
-        'git config user.email || git config --global user.email "my@user.email.com"',
-      );
+      // if "git" is set to "false", we still want to make sure a global user is
+      // defined (relevant in our GITHUB_ACTIONS context): only set the global
+      // value if none is configured yet (`git config <key>` exits non-zero when
+      // unset).
+      try {
+        runGit(["config", "user.name"]);
+      } catch {
+        runGit(["config", "--global", "user.name", "My User Name"]);
+      }
+      try {
+        runGit(["config", "user.email"]);
+      } catch {
+        runGit(["config", "--global", "user.email", "my@user.email.com"]);
+      }
     }
 
     if (options.chdir ?? false) {
       process.chdir(projectdir);
     }
 
-    code(projectdir);
+    await code(projectdir);
   } finally {
     process.chdir(origDir);
     fs.rmSync(outdir, { force: true, recursive: true });

--- a/test/util/exec.test.ts
+++ b/test/util/exec.test.ts
@@ -1,0 +1,149 @@
+import { git, node, npm, rawShell, tool } from "../../src/util/exec";
+
+// Use the current Node.js executable as a deterministic, cross-platform test
+// binary: it is always present, needs no network, and behaves identically on
+// every OS. Commands run in the current working directory (none of these write
+// files), so no temp dir is needed.
+const cwd = process.cwd();
+
+describe("tool (shell-free)", () => {
+  test("capture returns trimmed stdout", () => {
+    const out = node.capture(["-e", "process.stdout.write('  hello  ')"], {
+      cwd,
+    });
+    expect(out).toBe("hello");
+  });
+
+  test("capture passes each argument verbatim (no shell parsing)", () => {
+    // The value contains characters a shell would otherwise interpret; because
+    // execution is shell-free it must arrive as a single, unmodified argument.
+    const tricky = "a b $HOME && c;'\"";
+    const out = node.capture(
+      ["-e", "process.stdout.write(process.argv[1])", tricky],
+      { cwd },
+    );
+    expect(out).toBe(tricky);
+  });
+
+  test("capture throws with status and stderr on a non-zero exit", () => {
+    let error: any;
+    try {
+      node.capture(["-e", "process.stderr.write('boom'); process.exit(3)"], {
+        cwd,
+      });
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeDefined();
+    expect(error.status).toBe(3);
+    expect(error.stderr.toString("utf-8")).toContain("boom");
+  });
+
+  test("tryCapture returns the trimmed value on success", () => {
+    expect(node.tryCapture(["-e", "process.stdout.write('v1')"], { cwd })).toBe(
+      "v1",
+    );
+  });
+
+  test("tryCapture returns undefined on a non-zero exit", () => {
+    expect(node.tryCapture(["-e", "process.exit(1)"], { cwd })).toBeUndefined();
+  });
+
+  test("tryCapture treats empty output as undefined", () => {
+    expect(node.tryCapture(["-e", ""], { cwd })).toBeUndefined();
+  });
+
+  test("run throws on a non-zero exit", () => {
+    expect(() => node.run(["-e", "process.exit(2)"], { cwd })).toThrow();
+  });
+
+  test("run does not throw on success", () => {
+    expect(() => node.run(["-e", ""], { cwd })).not.toThrow();
+  });
+
+  test("run streams output directly when inheritStdio is set", () => {
+    expect(() =>
+      node.run(["-e", ""], { cwd, inheritStdio: true }),
+    ).not.toThrow();
+  });
+
+  test("additional env is merged over process.env", () => {
+    const out = node.capture(
+      ["-e", "process.stdout.write(process.env.MY_VAR ?? '')"],
+      { cwd, env: { MY_VAR: "xyz" } },
+    );
+    expect(out).toBe("xyz");
+  });
+
+  test("tool() builds a handle for an arbitrary binary", () => {
+    expect(tool(process.execPath).capture(["--version"], { cwd })).toBe(
+      process.version,
+    );
+  });
+
+  test("git helper invokes git", () => {
+    expect(git.capture(["--version"], { cwd })).toMatch(/git version/);
+  });
+});
+
+describe("rawShell (system shell)", () => {
+  test("capture runs a command string and returns trimmed stdout", async () => {
+    const out = await rawShell.capture(
+      `node -e "process.stdout.write('  shell-ok  ')"`,
+      { cwd },
+    );
+    expect(out).toBe("shell-ok");
+  });
+
+  test("capture rejects with status on a non-zero exit", async () => {
+    await expect(
+      rawShell.capture(`node -e "process.exit(4)"`, { cwd }),
+    ).rejects.toMatchObject({ status: 4 });
+  });
+
+  test("tryCapture returns the trimmed value on success", async () => {
+    expect(
+      await rawShell.tryCapture(`node -e "process.stdout.write('ok')"`, {
+        cwd,
+      }),
+    ).toBe("ok");
+  });
+
+  test("tryCapture returns undefined on a non-zero exit", async () => {
+    expect(
+      await rawShell.tryCapture(`node -e "process.exit(1)"`, { cwd }),
+    ).toBeUndefined();
+  });
+
+  test("exec reports the exit status without throwing", () => {
+    const result = rawShell.exec(`node -e "process.exit(5)"`, {
+      cwd,
+      capture: true,
+    });
+    expect(result.status).toBe(5);
+  });
+
+  test("exec inherits streams when not capturing", () => {
+    const result = rawShell.exec(`node -e ""`, { cwd });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBeNull();
+  });
+
+  test("additional env is merged over process.env", async () => {
+    const out = await rawShell.capture(
+      `node -e "process.stdout.write(process.env.RS_VAR ?? '')"`,
+      { cwd, env: { RS_VAR: "yes" } },
+    );
+    expect(out).toBe("yes");
+  });
+});
+
+describe("shimTool helpers (npm/npx)", () => {
+  // npm is a `.cmd` shim on Windows; resolving and spawning it can be slow,
+  // especially on Windows CI.
+  jest.setTimeout(30_000);
+
+  test("npm resolves cross-platform and captures output", async () => {
+    expect(await npm.capture(["--version"], { cwd })).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});

--- a/test/version.test.ts
+++ b/test/version.test.ts
@@ -1,4 +1,3 @@
-import { execSync } from "child_process";
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { dirname, join } from "path";
@@ -9,6 +8,7 @@ import {
   withProjectDir,
 } from "./util";
 import { JavaProject } from "../src/java";
+import { git } from "../src/util/exec";
 import { ReleasableCommits, Version } from "../src/version";
 
 describe("Version", () => {
@@ -67,7 +67,7 @@ describe("with JavaProject", () => {
 
 describe("bump task", () => {
   test("will bump if last commit is not a tag", async () => {
-    withProjectDir((projectdir) => {
+    await withProjectDir(async (projectdir) => {
       const project = new TestProject({
         outdir: projectdir,
       });
@@ -78,7 +78,7 @@ describe("bump task", () => {
 
       project.synth();
 
-      const result = testBumpTask({
+      const result = await testBumpTask({
         workdir: project.outdir,
         commits: [
           { message: "chore(release): v0.1.0", tag: "v0.1.0" },
@@ -91,7 +91,7 @@ describe("bump task", () => {
   });
 
   test("will not bump if last commit is a tag", async () => {
-    withProjectDir((projectdir) => {
+    await withProjectDir(async (projectdir) => {
       const project = new TestProject({
         outdir: projectdir,
       });
@@ -103,7 +103,7 @@ describe("bump task", () => {
       project.synth();
 
       // Bump the first time to generate the initial version
-      let result = testBumpTask({
+      let result = await testBumpTask({
         workdir: project.outdir,
         commits: [
           { message: "chore(release): v0.1.0", tag: "v0.1.0" },
@@ -112,7 +112,7 @@ describe("bump task", () => {
       });
 
       // Bump again to see if the version is the same
-      result = testBumpTask({
+      result = await testBumpTask({
         workdir: project.outdir,
       });
 
@@ -121,7 +121,7 @@ describe("bump task", () => {
   });
 
   test("can invoke a shell command to come up with the next version", async () => {
-    withProjectDir((projectdir) => {
+    await withProjectDir(async (projectdir) => {
       const project = new TestProject({
         outdir: projectdir,
       });
@@ -133,7 +133,7 @@ describe("bump task", () => {
 
       project.synth();
 
-      const result = testBumpTask({
+      const result = await testBumpTask({
         workdir: project.outdir,
         commits: [
           { message: "chore(release): v0.1.0", tag: "v0.1.0" },
@@ -161,7 +161,7 @@ describe("bump task", () => {
       releasable: "all" | "featsFixes",
       expectedBump,
     ) => {
-      withProjectDir((projectdir) => {
+      await withProjectDir(async (projectdir) => {
         const project = new TestProject({
           outdir: projectdir,
         });
@@ -178,7 +178,7 @@ describe("bump task", () => {
 
         project.synth();
 
-        const result = testBumpTask({
+        const result = await testBumpTask({
           workdir: project.outdir,
           commits: [
             {
@@ -195,7 +195,7 @@ describe("bump task", () => {
   );
 
   test("if there are 0 commits but the version script outputs a version, bump anyway", async () => {
-    withProjectDir((projectdir) => {
+    await withProjectDir(async (projectdir) => {
       const project = new TestProject({
         outdir: projectdir,
       });
@@ -208,7 +208,7 @@ describe("bump task", () => {
       project.synth();
 
       // Run with no new commits since last release
-      const result = testBumpTask({
+      const result = await testBumpTask({
         workdir: project.outdir,
         commits: [
           // projen will fully skip the 'bump' task if the most recent commit contains the text "chore(release):",
@@ -222,7 +222,7 @@ describe("bump task", () => {
   });
 
   test("throws an error if the bump command output is not valid", async () => {
-    withProjectDir((projectdir) => {
+    await withProjectDir(async (projectdir) => {
       const project = new TestProject({
         outdir: projectdir,
       });
@@ -236,7 +236,7 @@ describe("bump task", () => {
 
       // The exception tested here does not contain the error message, that
       // gets printed to stderr. We can't assert on it, but users will see it.
-      expect(() =>
+      await expect(
         testBumpTask({
           workdir: project.outdir,
           commits: [
@@ -244,12 +244,12 @@ describe("bump task", () => {
             { message: "new change" },
           ],
         }),
-      ).toThrow(/Command failed/);
+      ).rejects.toThrow(/Command failed/);
     });
   });
 });
 
-function testBumpTask(
+async function testBumpTask(
   opts: {
     workdir?: string;
     commits?: { message: string; tag?: string; path?: string }[];
@@ -257,27 +257,21 @@ function testBumpTask(
 ) {
   const workdir = opts.workdir ?? mkdtempSync(join(tmpdir(), "bump-test-"));
 
-  const git = (cmd: string) =>
-    execSync(`git ${cmd}`, {
-      cwd: workdir,
-      stdio: "inherit",
-      // let's try to catch hanging processes sooner than later
-      timeout: 10_000,
-    });
+  const run = (args: string[]) => git.run(args, { cwd: workdir });
 
   // Initialize a git repository
-  git("init -b main");
-  git('config user.email "you@example.com"');
-  git('config user.name "Your Name"');
-  git("config commit.gpgsign false");
-  git("config tag.gpgsign false");
+  run(["init", "-b", "main"]);
+  run(["config", "user.email", "you@example.com"]);
+  run(["config", "user.name", "Your Name"]);
+  run(["config", "commit.gpgsign", "false"]);
+  run(["config", "tag.gpgsign", "false"]);
 
   const commit = (message: string, path: string = "dummy.txt") => {
     const filePath = join(workdir, path);
     mkdirSync(dirname(filePath), { recursive: true });
     writeFileSync(filePath, message);
-    git("add .");
-    git(`commit -F "${filePath}"`);
+    run(["add", "."]);
+    run(["commit", "-F", filePath]);
   };
 
   commit("initial commit");
@@ -285,12 +279,12 @@ function testBumpTask(
   for (const c of opts.commits ?? []) {
     commit(c.message, c.path);
     if (c.tag) {
-      git(`tag ${c.tag}`);
+      run(["tag", c.tag]);
     }
   }
 
   // Bump the version
-  execProjenCLI(workdir, ["bump"]);
+  await execProjenCLI(workdir, ["bump"]);
 
   return {
     version: JSON.parse(readFileSync(join(workdir, "package.json"), "utf-8"))


### PR DESCRIPTION
## Fixes for users

**uv environment setup no longer fails on Windows.** For uv projects, `setupEnvironment()` checked whether uv was available by running `which uv`. `which` is not a Windows command (cmd.exe provides `where`), so the check always failed on Windows: projen logged "uv is not installed" and skipped creating the `.venv` entirely, even when uv was installed. Detection now runs `uv --version`, so the environment is created on every platform.

**No more false "poetry is not installed" message on Windows.** Poetry detection used `which poetry` the same way and hit the same problem, printing a misleading warning on Windows. It now uses `poetry --version`.

**Interpreter paths with spaces are handled correctly.** Commands such as `poetry env use <python>` now pass their arguments as an explicit list, so a Python path containing spaces (common on Windows) is no longer split into separate arguments.

## Internal changes

This PR centralizes OS command execution behind a single `src/util/exec.ts` module, so the rest of the codebase no longer calls `child_process` directly (enforced by an eslint rule). The helpers are:

- `tool` / `git` / `uv` / `poetry` / `node`: run a fixed binary directly with an explicit argument list, for consistent behavior across platforms
- `npm` / `npx`: cross-platform helpers for binaries that may be Windows `.cmd` shims
- `rawShell`: the system shell, used only for opaque command strings (release queries, and task steps on non-Windows)

This pulls the refactor and non-breaking parts of #4770 out as they are useful on their own, while I am still evaluating the configurable task-shell feature in that PR. Aside from the fixes above, behavior is preserved: task semantics, the shells used to run tasks, and all defaults are unchanged.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
