### PR TITLE
fix(awscdk): sample code overwrites existing entrypoint in a subdirectory

### DIFF
--- a/src/awscdk/awscdk-app-ts.ts
+++ b/src/awscdk/awscdk-app-ts.ts
@@ -19,6 +19,7 @@ import { CdkConfig } from "./cdk-config";
 import { CdkTasks } from "./cdk-tasks";
 import { IntegRunner } from "./integ-runner";
 import type { LambdaFunctionCommonOptions } from "./lambda-function";
+import { dirContainsFile } from "../util/fs";
 
 export interface AwsCdkTypeScriptAppOptions
   extends
@@ -337,18 +338,20 @@ class SampleCode extends Component {
   public synthesize() {
     const outdir = this.project.outdir;
     const srcdir = path.join(outdir, this.appProject.srcdir);
-    if (
-      fs.existsSync(srcdir) &&
-      fs.readdirSync(srcdir).some((x) => x.endsWith(".ts"))
-    ) {
-      return;
-    }
 
-    const srcImports = new Array<string>();
-    srcImports.push("import { App, Stack, StackProps } from 'aws-cdk-lib';");
-    srcImports.push("import { Construct } from 'constructs';");
+    // Don't generate the sample app if the user already has TypeScript source
+    // files in the source directory - we don't want to pollute something they
+    // have worked on. We check recursively so that an existing entrypoint
+    // located in a subdirectory (e.g. an `appEntrypoint` of "bin/main.ts") is
+    // also detected. As an extra safeguard, never overwrite an existing
+    // entrypoint file.
+    const entrypointPath = path.join(srcdir, this.appProject.appEntrypoint);
+    if (!dirContainsFile(srcdir, ".ts") && !fs.existsSync(entrypointPath)) {
+      const srcImports = new Array<string>();
+      srcImports.push("import { App, Stack, StackProps } from 'aws-cdk-lib';");
+      srcImports.push("import { Construct } from 'constructs';");
 
-    const srcCode = `${srcImports.join("\n")}
+      const srcCode = `${srcImports.join("\n")}
 
 export class MyStack extends Stack {
   constructor(scope: Construct, id: string, props: StackProps = {}) {
@@ -371,27 +374,35 @@ new MyStack(app, '${this.project.name}-dev', { env: devEnv });
 
 app.synth();`;
 
-    fs.mkdirSync(srcdir, { recursive: true });
-    fs.writeFileSync(path.join(srcdir, this.appProject.appEntrypoint), srcCode);
-
-    const testdir = path.join(outdir, this.appProject.testdir);
-    if (
-      fs.existsSync(testdir) &&
-      fs.readdirSync(testdir).some((x) => x.endsWith(".ts"))
-    ) {
-      return;
+      // create the entrypoint's directory (which may be a subdirectory of `srcdir`) before writing the file.
+      fs.mkdirSync(path.dirname(entrypointPath), { recursive: true });
+      fs.writeFileSync(entrypointPath, srcCode);
     }
 
-    const testImports = new Array<string>();
-    testImports.push("import { App } from 'aws-cdk-lib';");
-    testImports.push("import { Template } from 'aws-cdk-lib/assertions';");
-
+    const testdir = path.join(outdir, this.appProject.testdir);
     const appEntrypointName = path.basename(
       this.appProject.appEntrypoint,
       ".ts",
     );
-    const testCode = `${testImports.join("\n")}
-import { MyStack } from '../${this.appProject.srcdir}/${appEntrypointName}';
+    const testPath = path.join(testdir, `${appEntrypointName}.test.ts`);
+
+    // import path to the stack, preserving any subdirectory in the entrypoint
+    // (e.g. "bin/main.ts" -> "../src/bin/main") and using posix separators.
+    const entrypointImport = this.appProject.appEntrypoint
+      .replace(/\.ts$/, "")
+      .split(path.sep)
+      .join(path.posix.sep);
+
+    // Likewise, don't generate the sample test if the user already has
+    // TypeScript files in the test directory, and never overwrite an existing
+    // test file.
+    if (!dirContainsFile(testdir, ".ts") && !fs.existsSync(testPath)) {
+      const testImports = new Array<string>();
+      testImports.push("import { App } from 'aws-cdk-lib';");
+      testImports.push("import { Template } from 'aws-cdk-lib/assertions';");
+
+      const testCode = `${testImports.join("\n")}
+import { MyStack } from '../${this.appProject.srcdir}/${entrypointImport}';
 
 test('Snapshot', () => {
   const app = new App();
@@ -401,10 +412,8 @@ test('Snapshot', () => {
   expect(template.toJSON()).toMatchSnapshot();
 });`;
 
-    fs.mkdirSync(testdir, { recursive: true });
-    fs.writeFileSync(
-      path.join(testdir, `${appEntrypointName}.test.ts`),
-      testCode,
-    );
+      fs.mkdirSync(path.dirname(testPath), { recursive: true });
+      fs.writeFileSync(testPath, testCode);
+    }
   }
 }

--- a/src/util/fs.ts
+++ b/src/util/fs.ts
@@ -1,0 +1,31 @@
+import { existsSync, readdirSync } from "fs";
+import { join } from "path";
+
+/**
+ * Recursively determines whether a directory contains at least one file,
+ * optionally filtered by file extension.
+ *
+ * @param dir The directory to search. If it does not exist, `false` is
+ * returned.
+ * @param ext Optional file extension (e.g. `".ts"`) used to filter files. When
+ * provided, only files whose name ends with this extension are considered.
+ * @returns `true` if a matching file is found anywhere in the tree, otherwise
+ * `false` (including when the directory only contains empty subdirectories).
+ */
+export function dirContainsFile(dir: string, ext?: string): boolean {
+  if (!existsSync(dir)) {
+    return false;
+  }
+
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (dirContainsFile(join(dir, entry.name), ext)) {
+        return true;
+      }
+    } else if (!ext || entry.name.endsWith(ext)) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/test/awscdk/awscdk-app.test.ts
+++ b/test/awscdk/awscdk-app.test.ts
@@ -1,5 +1,5 @@
 import { mkdirSync, writeFileSync } from "fs";
-import { join } from "path";
+import { dirname, join } from "path";
 import {
   AwsCdkTypeScriptApp,
   CdkFeatureFlags,
@@ -125,6 +125,145 @@ describe("cdk.json", () => {
         appEntrypoint: "my-app.ts",
       });
     }).toThrow("Only one of 'app' or 'appEntrypoint' can be specified");
+  });
+});
+
+describe("sample code", () => {
+  it("generates the app entrypoint and matching test by default", () => {
+    const project = new AwsCdkTypeScriptApp({
+      name: "hello",
+      defaultReleaseBranch: "main",
+      cdkVersion: "2.189.1",
+    });
+
+    const files = synthSnapshot(project);
+
+    expect(files["src/main.ts"]).toContain(
+      "export class MyStack extends Stack",
+    );
+    expect(files["test/main.test.ts"]).toContain(
+      "import { MyStack } from '../src/main';",
+    );
+  });
+
+  it("generates a custom appEntrypoint located in a subdirectory", () => {
+    const project = new AwsCdkTypeScriptApp({
+      name: "hello",
+      defaultReleaseBranch: "main",
+      cdkVersion: "2.189.1",
+      appEntrypoint: "bin/main.ts",
+    });
+
+    const files = synthSnapshot(project);
+
+    // the entrypoint must be created inside the (previously non-existent)
+    // subdirectory - this used to crash because only `src` was created.
+    expect(files["src/bin/main.ts"]).toContain(
+      "export class MyStack extends Stack",
+    );
+    expect(files["test/main.test.ts"]).toContain(
+      "import { MyStack } from '../src/bin/main';",
+    );
+    expect(files["cdk.json"].app).toStrictEqual(
+      "npx ts-node -P tsconfig.json --prefer-ts-exts src/bin/main.ts",
+    );
+  });
+
+  it("does not generate sample code when the source directory already contains a .ts file", () => {
+    // GIVEN an unrelated source file at the top level of `src`
+    const outdir = mkdtemp();
+    mkdirSync(join(outdir, "src"));
+    writeFileSync(join(outdir, "src", "other.ts"), "// pre-existing");
+
+    const project = new AwsCdkTypeScriptApp({
+      name: "hello",
+      outdir,
+      defaultReleaseBranch: "main",
+      cdkVersion: "2.189.1",
+      appEntrypoint: "bin/main.ts",
+    });
+
+    // THEN we don't pollute the user's source dir with sample code, and the
+    // existing file is left untouched.
+    const files = synthSnapshot(project);
+    expect(files["src/bin/main.ts"]).toBeUndefined();
+    expect(files["src/other.ts"]).toStrictEqual("// pre-existing");
+  });
+
+  it("detects existing .ts files in nested subdirectories", () => {
+    // GIVEN a source file nested in a subdirectory of `src`
+    const outdir = mkdtemp();
+    mkdirSync(join(outdir, "src", "nested"), { recursive: true });
+    writeFileSync(join(outdir, "src", "nested", "other.ts"), "// pre-existing");
+
+    const project = new AwsCdkTypeScriptApp({
+      name: "hello",
+      outdir,
+      defaultReleaseBranch: "main",
+      cdkVersion: "2.189.1",
+    });
+
+    // THEN the recursive check finds it and no sample code is generated
+    const files = synthSnapshot(project);
+    expect(files["src/main.ts"]).toBeUndefined();
+  });
+
+  it("ignores non-.ts files when deciding whether to generate sample code", () => {
+    // GIVEN only a non-TypeScript file in `src`
+    const outdir = mkdtemp();
+    mkdirSync(join(outdir, "src"));
+    writeFileSync(join(outdir, "src", "README.md"), "# not source");
+
+    const project = new AwsCdkTypeScriptApp({
+      name: "hello",
+      outdir,
+      defaultReleaseBranch: "main",
+      cdkVersion: "2.189.1",
+    });
+
+    // THEN sample code is still generated
+    const files = synthSnapshot(project);
+    expect(files["src/main.ts"]).toContain(
+      "export class MyStack extends Stack",
+    );
+  });
+
+  it("does not overwrite an existing entrypoint in a subdirectory", () => {
+    // GIVEN a user-authored entrypoint at the configured location
+    const outdir = mkdtemp();
+    const entrypoint = join(outdir, "src", "bin", "main.ts");
+    mkdirSync(dirname(entrypoint), { recursive: true });
+    writeFileSync(entrypoint, "// my own entrypoint");
+
+    const project = new AwsCdkTypeScriptApp({
+      name: "hello",
+      outdir,
+      defaultReleaseBranch: "main",
+      cdkVersion: "2.189.1",
+      appEntrypoint: "bin/main.ts",
+    });
+
+    // THEN the existing file is preserved (not overwritten with the sample)
+    const files = synthSnapshot(project);
+    expect(files["src/bin/main.ts"]).toStrictEqual("// my own entrypoint");
+  });
+
+  it("does not overwrite an existing default entrypoint", () => {
+    // GIVEN a user-authored src/main.ts
+    const outdir = mkdtemp();
+    mkdirSync(join(outdir, "src"));
+    writeFileSync(join(outdir, "src", "main.ts"), "// my own main");
+
+    const project = new AwsCdkTypeScriptApp({
+      name: "hello",
+      outdir,
+      defaultReleaseBranch: "main",
+      cdkVersion: "2.189.1",
+    });
+
+    // THEN it is preserved
+    const files = synthSnapshot(project);
+    expect(files["src/main.ts"]).toStrictEqual("// my own main");
   });
 });
 

--- a/test/util/fs.test.ts
+++ b/test/util/fs.test.ts
@@ -1,0 +1,53 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { dirContainsFile } from "../../src/util/fs";
+
+describe("dirContainsFile", () => {
+  function tempDir(): string {
+    return mkdtempSync(join(tmpdir(), "projen-fs-test-"));
+  }
+
+  test("returns false for a non-existent directory", () => {
+    expect(dirContainsFile(join(tempDir(), "does-not-exist"))).toBe(false);
+  });
+
+  test("returns false for an empty directory", () => {
+    expect(dirContainsFile(tempDir())).toBe(false);
+  });
+
+  test("returns false when only empty (nested) subdirectories exist", () => {
+    const dir = tempDir();
+    mkdirSync(join(dir, "a", "b"), { recursive: true });
+    expect(dirContainsFile(dir)).toBe(false);
+  });
+
+  test("returns true when a file exists at the top level", () => {
+    const dir = tempDir();
+    writeFileSync(join(dir, "file.txt"), "x");
+    expect(dirContainsFile(dir)).toBe(true);
+  });
+
+  test("returns true when a file exists in a nested subdirectory", () => {
+    const dir = tempDir();
+    mkdirSync(join(dir, "a", "b"), { recursive: true });
+    writeFileSync(join(dir, "a", "b", "file.txt"), "x");
+    expect(dirContainsFile(dir)).toBe(true);
+  });
+
+  describe("with an extension filter", () => {
+    test("returns true when a matching file exists (recursively)", () => {
+      const dir = tempDir();
+      mkdirSync(join(dir, "nested"), { recursive: true });
+      writeFileSync(join(dir, "nested", "main.ts"), "x");
+      expect(dirContainsFile(dir, ".ts")).toBe(true);
+    });
+
+    test("returns false when only non-matching files exist", () => {
+      const dir = tempDir();
+      writeFileSync(join(dir, "README.md"), "x");
+      writeFileSync(join(dir, "data.json"), "{}");
+      expect(dirContainsFile(dir, ".ts")).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
When an `AwsCdkTypeScriptApp` is configured with an `appEntrypoint` that lives in a subdirectory, such as `bin/main.ts`, the sample code generator could overwrite a user's existing entrypoint. The generator only looked at the top level of the source directory to decide whether to emit sample code, so a file at `src/bin/main.ts` went undetected and was clobbered on synth. Conversely, an unrelated top-level file could suppress generation entirely. This was surfaced by the change in #4762 which made the existing guard actually take effect.

The guard now scans the source directory recursively and only considers `.ts` files, which restores the original intent of not polluting a source tree the user has already worked on while correctly detecting entrypoints in subdirectories. As an additional safeguard the generator never overwrites an existing entrypoint or test file, so user code is preserved even in edge cases.

While fixing this I also addressed two latent issues in the same code path that only manifested with subdirectory entrypoints. Generation now creates the entrypoint's nested directory before writing, which previously would have thrown because only `src` was created, and the generated test imports the stack from its real location (`../src/bin/main`) instead of dropping the subdirectory, so the sample test actually compiles.

The recursive directory check is extracted into a reusable `dirContainsFile` helper in `src/util/fs.ts` and covered by its own unit tests, alongside new test cases for the subdirectory generation, no-overwrite, and `.ts`-only behaviours.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
