### PR TITLE
fix(node): replace codeartifact auth token command substitution with environment variable evaluation

### DIFF
--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -1305,13 +1305,15 @@ export class NodePackage extends Component {
           // reference: https://docs.aws.amazon.com/codeartifact/latest/ug/npm-auth.html
           const commands = [
             `npm config set ${scope}:registry ${registryUrl}`,
-            `CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${domain} --region ${region} --domain-owner ${accountId} --query authorizationToken --output text)`,
             `npm config set //${registry}:_authToken=$CODEARTIFACT_AUTH_TOKEN`,
           ];
           if (!this.minNodeVersion || semver.major(this.minNodeVersion) <= 16) {
             commands.push(`npm config set //${registry}:always-auth=true`);
           }
           return {
+            env: {
+              CODEARTIFACT_AUTH_TOKEN: `$(aws codeartifact get-authorization-token --domain ${domain} --region ${region} --domain-owner ${accountId} --query authorizationToken --output text)`,
+            },
             exec: commands.join("; "),
           };
         }),

--- a/test/javascript/node-project.test.ts
+++ b/test/javascript/node-project.test.ts
@@ -1885,7 +1885,10 @@ describe("scoped private packages", () => {
           exec: "which aws",
         },
         {
-          exec: `npm config set ${scope}:registry ${registryUrl}; CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${domain} --region ${region} --domain-owner ${accountId} --query authorizationToken --output text); npm config set //${registry}:_authToken=$CODEARTIFACT_AUTH_TOKEN; npm config set //${registry}:always-auth=true`,
+          env: {
+            CODEARTIFACT_AUTH_TOKEN: `$(aws codeartifact get-authorization-token --domain ${domain} --region ${region} --domain-owner ${accountId} --query authorizationToken --output text)`,
+          },
+          exec: `npm config set ${scope}:registry ${registryUrl}; npm config set //${registry}:_authToken=$CODEARTIFACT_AUTH_TOKEN; npm config set //${registry}:always-auth=true`,
         },
       ],
     });
@@ -1911,13 +1914,16 @@ describe("scoped private packages", () => {
           exec: "which aws",
         },
         {
-          exec: `npm config set ${scope}:registry ${registryUrl}; CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${domain} --region ${region} --domain-owner ${accountId} --query authorizationToken --output text); npm config set //${registry}:_authToken=$CODEARTIFACT_AUTH_TOKEN`,
+          env: {
+            CODEARTIFACT_AUTH_TOKEN: `$(aws codeartifact get-authorization-token --domain ${domain} --region ${region} --domain-owner ${accountId} --query authorizationToken --output text)`,
+          },
+          exec: `npm config set ${scope}:registry ${registryUrl}; npm config set //${registry}:_authToken=$CODEARTIFACT_AUTH_TOKEN`,
         },
       ],
     });
   });
 
-  test("adds ca:login script when multiple scoped packages defined", () => {
+  test.only("adds ca:login script when multiple scoped packages defined", () => {
     const accountId2 = "123456789013";
     const domain2 = "my-domain-2";
     const region2 = "my-region-2";
@@ -1947,10 +1953,16 @@ describe("scoped private packages", () => {
           exec: "which aws",
         },
         {
-          exec: `npm config set ${scope}:registry ${registryUrl}; CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${domain} --region ${region} --domain-owner ${accountId} --query authorizationToken --output text); npm config set //${registry}:_authToken=$CODEARTIFACT_AUTH_TOKEN; npm config set //${registry}:always-auth=true`,
+          env: {
+            CODEARTIFACT_AUTH_TOKEN: `$(aws codeartifact get-authorization-token --domain ${domain} --region ${region} --domain-owner ${accountId} --query authorizationToken --output text)`,
+          },
+          exec: `npm config set ${scope}:registry ${registryUrl}; npm config set //${registry}:_authToken=$CODEARTIFACT_AUTH_TOKEN; npm config set //${registry}:always-auth=true`,
         },
         {
-          exec: `npm config set ${scope2}:registry ${registryUrl2}; CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${domain2} --region ${region2} --domain-owner ${accountId2} --query authorizationToken --output text); npm config set //${registry2}:_authToken=$CODEARTIFACT_AUTH_TOKEN; npm config set //${registry2}:always-auth=true`,
+          env: {
+            CODEARTIFACT_AUTH_TOKEN: `$(aws codeartifact get-authorization-token --domain ${domain2} --region ${region2} --domain-owner ${accountId2} --query authorizationToken --output text)`,
+          },
+          exec: `npm config set ${scope2}:registry ${registryUrl2}; npm config set //${registry2}:_authToken=$CODEARTIFACT_AUTH_TOKEN; npm config set //${registry2}:always-auth=true`,
         },
       ],
     });

--- a/test/javascript/node-project.test.ts
+++ b/test/javascript/node-project.test.ts
@@ -1923,7 +1923,7 @@ describe("scoped private packages", () => {
     });
   });
 
-  test.only("adds ca:login script when multiple scoped packages defined", () => {
+  test("adds ca:login script when multiple scoped packages defined", () => {
     const accountId2 = "123456789013";
     const domain2 = "my-domain-2";
     const region2 = "my-region-2";


### PR DESCRIPTION
Fixes #4784 

### Summary

The changes introduced by #4770 caused command substitution within the `ca:login` task to throw with error `Not implemented: command` (https://github.com/dsherret/dax/issues/401).  By replacing command substitution with task environment variable evaluation, we ensure compatibility with the default built-in cross-platform shell. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
