### PR TITLE
fix(tasks): unclear error when the built-in shell can't run a command

### DIFF
--- a/src/cli/task-runtime.ts
+++ b/src/cli/task-runtime.ts
@@ -33,6 +33,30 @@ function quoteArg(arg: string): string {
 }
 
 /**
+ * dax's built-in cross-platform shell only implements a subset of POSIX shell
+ * syntax and throws a terse `Not implemented: ...` for the rest. Rewrite those
+ * into a short, actionable error that points at the system-shell escape hatch;
+ * pass every other error through unchanged.
+ */
+function enrichBuiltinShellError(
+  error: unknown,
+  command: string | string[],
+): unknown {
+  const message = error instanceof Error ? error.message : String(error);
+  if (!/Not implemented:/.test(message)) {
+    /* v8 ignore next */
+    return error;
+  }
+
+  const commandLine = Array.isArray(command) ? command.join(" ") : command;
+  return new Error(
+    "projen's built-in shell can't run this command:\n" +
+      `  ${commandLine}\n` +
+      "To use your system's shell instead, set this task to TaskShell.system().",
+  );
+}
+
+/**
  * Normalized result of `shell()` (a subset of node's `SpawnSyncReturns`).
  */
 interface ShellResult {
@@ -603,12 +627,21 @@ class RunTask {
     // Otherwise run through dax: the "projen" shell or an explicit invocation.
     const builder = this.buildDaxCommand(command, shell);
 
-    const result = await builder
-      .cwd(cwd)
-      .env(env)
-      .stdout(capture ? "piped" : "inherit")
-      .stderr(capture ? "piped" : "inherit")
-      .noThrow();
+    let result;
+    try {
+      result = await builder
+        .cwd(cwd)
+        .env(env)
+        .stdout(capture ? "piped" : "inherit")
+        .stderr(capture ? "piped" : "inherit")
+        .noThrow();
+    } catch (e) {
+      // dax's in-process shell throws a terse `Not implemented: ...` for shell
+      // syntax it does not support (e.g. `$(...)` command substitution); turn
+      // that into an actionable error that points at the system-shell escape
+      // hatch. Other errors pass through unchanged.
+      throw enrichBuiltinShellError(e, command);
+    }
 
     return {
       status: result.code,

--- a/test/cli/run-task.test.ts
+++ b/test/cli/run-task.test.ts
@@ -304,6 +304,36 @@ describe("environment variables", () => {
   });
 });
 
+describe("built-in shell unsupported syntax", () => {
+  test("command substitution produces an actionable error", async () => {
+    // GIVEN a task that uses `$(...)`, which the built-in cross-platform shell
+    // does not implement
+    const p = new TestProject();
+    p.addTask("subst", { exec: 'echo "dir is $(pwd)"' });
+    p.synth();
+
+    // THEN the error explains the limitation and how to opt into the system shell
+    await expect(new TaskRuntime(p.outdir).runTask("subst")).rejects.toThrow(
+      /projen's built-in shell[\s\S]*TaskShell\.system\(\)/,
+    );
+  });
+
+  test("running the same command through the system shell works", async () => {
+    // GIVEN the same command, but opted into the system shell
+    const p = new TestProject();
+    p.addTask("subst", {
+      exec: 'echo "dir is $(pwd)"',
+      shell: TaskShell.system(),
+    });
+    p.synth();
+
+    // THEN it runs without the built-in-shell error
+    await expect(
+      new TaskRuntime(p.outdir).runTask("subst"),
+    ).resolves.toBeUndefined();
+  });
+});
+
 describe("task condition", () => {
   test("zero exit code means that steps should be executed", () => {
     // GIVEN


### PR DESCRIPTION
Tasks run through projen's built-in cross-platform shell by default, but that shell only implements a subset of POSIX syntax. When a task command relies on something it doesn't implement — most commonly `$(...)` command substitution — execution failed with a bare `Not implemented: command`. That error names neither the command that failed nor a way forward, so it reads like an internal projen bug rather than an unsupported-syntax problem the user can resolve.

This wraps the built-in shell invocation so that such failures are rethrown with a message that shows the offending command and points at the escape hatch: running the command through the system shell with `TaskShell.system()`. Only the built-in shell's `Not implemented: ...` failures are rewritten; every other error is passed through unchanged so we don't mask unrelated failures.

The resulting message looks like:

```
projen's built-in shell can't run this command:
  echo "dir is $(pwd)"
To use your system's shell instead, set this task to TaskShell.system().
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
