### PR TITLE
fix(cdk): jsii projects fail to run jest tests with TypeScript v6

### DIFF
--- a/src/cdk/jsii-project.ts
+++ b/src/cdk/jsii-project.ts
@@ -211,6 +211,7 @@ export class JsiiProject extends TypeScriptProject {
       tsconfigDev: {
         compilerOptions: {
           stripInternal: true,
+          isolatedModules: true,
         },
       },
     };

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -1604,7 +1604,8 @@ project.synth();
   "compilerOptions": {
     "noEmit": true,
     "rootDir": "..",
-    "stripInternal": true
+    "stripInternal": true,
+    "isolatedModules": true
   },
   "include": [
     "**/*.ts"
@@ -2889,7 +2890,8 @@ project.synth();
   "compilerOptions": {
     "noEmit": true,
     "rootDir": "..",
-    "stripInternal": true
+    "stripInternal": true,
+    "isolatedModules": true
   },
   "include": [
     "**/*.ts"

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -1530,6 +1530,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
 }",
   "test/tsconfig.json": {
     "compilerOptions": {
+      "isolatedModules": true,
       "noEmit": true,
       "rootDir": "..",
       "stripInternal": true,

--- a/test/jsii/__snapshots__/jsii.test.ts.snap
+++ b/test/jsii/__snapshots__/jsii.test.ts.snap
@@ -1531,6 +1531,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
 }",
   "test/tsconfig.json": {
     "compilerOptions": {
+      "isolatedModules": true,
       "noEmit": true,
       "rootDir": "..",
       "stripInternal": true,
@@ -3116,6 +3117,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
 }",
   "test/tsconfig.json": {
     "compilerOptions": {
+      "isolatedModules": true,
       "noEmit": true,
       "rootDir": "..",
       "stripInternal": true,
@@ -4703,6 +4705,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
 }",
   "test/tsconfig.json": {
     "compilerOptions": {
+      "isolatedModules": true,
       "noEmit": true,
       "rootDir": "..",
       "stripInternal": true,

--- a/test/jsii/jsii.test.ts
+++ b/test/jsii/jsii.test.ts
@@ -56,6 +56,21 @@ describe("JsiiProject with default settings", () => {
 
     await execProjenCLI(project.outdir, ["compile"]);
   });
+
+  // https://github.com/projen/projen/issues/4806
+  it("supports running jest tests", async () => {
+    const project = new TestJsiiProject();
+
+    project.synth();
+
+    // Add a trivial test file, mirroring the issue's reproduction steps.
+    fs.writeFileSync(
+      path.join(project.outdir, project.testdir, "dummy.test.ts"),
+      "test('dummy', () => { expect(true).toBe(true); });\n",
+    );
+
+    await execProjenCLI(project.outdir, ["test"]);
+  });
 });
 
 describe("JsiiProject with modern jsiiVersion", () => {


### PR DESCRIPTION
## Summary

Fixes #4806.

`JsiiProject`'s `tsconfigDev` (the config ts-jest actually consumes) inherits `module: "node16"` and `noEmitOnError: true` from the jsii-strict base `tsconfig`. With ts-jest 29+, hybrid module kinds (Node16/18/Next) require `isolatedModules: true`; without it, `noEmitOnError` causes `emitSkipped`, which ts-jest surfaces as a misleading `outDir` error instead of the real diagnostic.

This only adds `isolatedModules: true` to `tsconfigDev`, leaving the jsii build's actual `tsconfig` (and therefore the shipped artifact's type-checking/emit) untouched.

## What was tested

- Added a regression test in `test/jsii/jsii.test.ts` (`supports running jest tests`) that synthesizes a `JsiiProject`, writes a dummy test file, and runs `projen test` end-to-end via the CLI.
- Confirmed the test fails with the exact reported `outDir` error before the fix, and passes after.
- Ran the full `test/jsii/jsii.test.ts` suite (13 tests) — all pass; 3 snapshots updated to reflect `isolatedModules: true` in the generated `test/tsconfig.json`.
