### PR TITLE
fix(cdk): jsii projects fail to run jest tests with TypeScript v6

### DIFF
--- a/src/cdk/jsii-project.ts
+++ b/src/cdk/jsii-project.ts
@@ -211,6 +211,7 @@ export class JsiiProject extends TypeScriptProject {
       tsconfigDev: {
         compilerOptions: {
           stripInternal: true,
+          isolatedModules: true,
         },
       },
     };

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -1604,7 +1604,8 @@ project.synth();
   "compilerOptions": {
     "noEmit": true,
     "rootDir": "..",
-    "stripInternal": true
+    "stripInternal": true,
+    "isolatedModules": true
   },
   "include": [
     "**/*.ts"
@@ -2889,7 +2890,8 @@ project.synth();
   "compilerOptions": {
     "noEmit": true,
     "rootDir": "..",
-    "stripInternal": true
+    "stripInternal": true,
+    "isolatedModules": true
   },
   "include": [
     "**/*.ts"

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -1530,6 +1530,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
 }",
   "test/tsconfig.json": {
     "compilerOptions": {
+      "isolatedModules": true,
       "noEmit": true,
       "rootDir": "..",
       "stripInternal": true,

--- a/test/jsii/__snapshots__/jsii.test.ts.snap
+++ b/test/jsii/__snapshots__/jsii.test.ts.snap
@@ -1531,6 +1531,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
 }",
   "test/tsconfig.json": {
     "compilerOptions": {
+      "isolatedModules": true,
       "noEmit": true,
       "rootDir": "..",
       "stripInternal": true,
@@ -3116,6 +3117,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
 }",
   "test/tsconfig.json": {
     "compilerOptions": {
+      "isolatedModules": true,
       "noEmit": true,
       "rootDir": "..",
       "stripInternal": true,
@@ -4703,6 +4705,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
 }",
   "test/tsconfig.json": {
     "compilerOptions": {
+      "isolatedModules": true,
       "noEmit": true,
       "rootDir": "..",
       "stripInternal": true,

--- a/test/jsii/jsii.test.ts
+++ b/test/jsii/jsii.test.ts
@@ -56,6 +56,21 @@ describe("JsiiProject with default settings", () => {
 
     await execProjenCLI(project.outdir, ["compile"]);
   });
+
+  // https://github.com/projen/projen/issues/4806
+  it("supports running jest tests", async () => {
+    const project = new TestJsiiProject();
+
+    project.synth();
+
+    // Add a trivial test file, mirroring the issue's reproduction steps.
+    fs.writeFileSync(
+      path.join(project.outdir, project.testdir, "dummy.test.ts"),
+      "test('dummy', () => { expect(true).toBe(true); });\n",
+    );
+
+    await execProjenCLI(project.outdir, ["test"]);
+  });
 });
 
 describe("JsiiProject with modern jsiiVersion", () => {


### PR DESCRIPTION
Fixes #4806

With TypeScript v6 and ts-jest 29, a freshly generated `JsiiProject` (e.g. `awscdk-construct`) fails to run any jest test with a misleading error claiming `outDir` in the tsconfig is `''` or `'.'`, even though `outDir` is set correctly. `awscdk-app-ts` and other non-jsii TypeScript projects are unaffected.

The real cause is unrelated to `outDir`. `tsconfigDev`, which is the config ts-jest actually type-checks against, inherits `module: "node16"` and `noEmitOnError: true` from the jsii-strict base `tsconfig`. ts-jest 29 requires `isolatedModules: true` whenever the effective module kind is a hybrid one (Node16/18/Next) — without it, the `TS151002` diagnostic combines with the inherited `noEmitOnError: true` to make TypeScript report `emitSkipped`, and ts-jest surfaces that as the confusing `outDir` message instead of the real diagnostic.

The fix only sets `isolatedModules: true` on `tsconfigDev`. The jsii build's actual `tsconfig` is untouched, so the shipped artifact's type-checking and emit behavior does not change — this only affects how tests are type-checked while running under jest.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
