### PR TITLE
fix(release): make CHANGES_SINCE_LAST_RELEASE robust to the dax pipe race

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -54,7 +54,7 @@
           "builtin": "release/bump-version"
         }
       ],
-      "condition": "git log --oneline -1 | grep -qv \"chore(release):\""
+      "condition": "git log --oneline -1 | grep -v \"chore(release):\" > /dev/null"
     },
     "bundle:task-runner": {
       "name": "bundle:task-runner",

--- a/src/version.ts
+++ b/src/version.ts
@@ -6,19 +6,35 @@ import { NodePackage } from "./javascript/node-package";
 import type { Task } from "./task";
 
 /**
- * This command determines if there were any changes since the last release in a cross-platform compatible way.
- * It is used as a condition for both the `bump` and the `release` tasks.
+ * This command determines if there were any changes since the last release in a
+ * cross-platform compatible way. It is used as a condition for both the `bump`
+ * and the `release` tasks: it exits 0 (proceed) when the most recent commit is
+ * not a release commit, and non-zero (skip) when the most recent commit is a
+ * `chore(release):` commit.
  *
  * Explanation:
- *  - log commits                                               | git log
- *  - limit log output to a single line per commit              | --oneline
- *  - looks only at the most recent commit                      | -1
- *  - silent grep output                                        | grep -q
- *  - exits with code 0 if a match is found                     | grep -q "chore(release):"
- *  - exits with code 1 if a match is found (reverse-match)     | grep -qv "chore(release):"
+ *  - `git log --oneline -1`          the most recent commit, one line
+ *  - `| grep -v "chore(release):"`   pass the line through only if it is NOT a release commit
+ *  - `> /dev/null`                   discard grep's output; only its exit code matters
+ *
+ * grep exits 0 when it prints at least one non-matching line (a normal commit,
+ * so proceed) and 1 when every line matches (a release commit, so skip).
+ *
+ * IMPORTANT: do NOT reintroduce `grep -q` here (i.e. do not "optimize" this back
+ * to `grep -qv`). `grep -q` exits as soon as it has an answer and closes the read
+ * end of the pipe. When this condition runs through projen's built-in (dax)
+ * shell, that early close races with `git log` still writing to the pipe, and dax
+ * surfaces the failed write as a spurious non-zero exit ("stdin pipe broken.
+ * Invalid state: WritableStream is closed"). The task runtime cannot distinguish
+ * that from a legitimate skip (dax reports it as a plain non-zero code under
+ * `.noThrow()`, not as an error), so the bump/release task is silently skipped: a
+ * release is missed, or a dependent publishes a broken `^0.0.0` version range.
+ * Plain `grep -v ... > /dev/null` reads to EOF instead of short-circuiting, so it
+ * never closes the pipe while the writer is active and the race cannot occur. The
+ * exit semantics are identical to the previous `grep -qv`.
  */
 export const CHANGES_SINCE_LAST_RELEASE =
-  'git log --oneline -1 | grep -qv "chore(release):"';
+  'git log --oneline -1 | grep -v "chore(release):" > /dev/null';
 
 /**
  * The default package to be used for commit-and-tag-version

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -999,7 +999,7 @@ tsconfig.tsbuildinfo
           "builtin": "release/bump-version"
         }
       ],
-      "condition": "git log --oneline -1 | grep -qv \\"chore(release):\\""
+      "condition": "git log --oneline -1 | grep -v \\"chore(release):\\" > /dev/null"
     },
     "clobber": {
       "name": "clobber",
@@ -4600,7 +4600,7 @@ permissions-backup.acl
           "builtin": "release/bump-version"
         }
       ],
-      "condition": "git log --oneline -1 | grep -qv \\"chore(release):\\""
+      "condition": "git log --oneline -1 | grep -v \\"chore(release):\\" > /dev/null"
     },
     "clobber": {
       "name": "clobber",

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -883,7 +883,7 @@ tsconfig.tsbuildinfo
         ],
       },
       "bump": {
-        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
+        "condition": "git log --oneline -1 | grep -v "chore(release):" > /dev/null",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",

--- a/test/changes-since-last-release.test.ts
+++ b/test/changes-since-last-release.test.ts
@@ -1,0 +1,67 @@
+import { existsSync, rmSync } from "fs";
+import { join } from "path";
+import { TestProject } from "./util";
+import { TaskRuntime } from "../src/cli/task-runtime";
+import { TaskShell } from "../src/task-shell";
+import { git } from "../src/util/exec";
+import { CHANGES_SINCE_LAST_RELEASE } from "../src/version";
+
+// The condition shells out to `git` and `grep`, which are POSIX tools; skip the
+// execution assertions on Windows. The value pin below always runs.
+const posixOnly = process.platform === "win32" ? describe.skip : describe;
+
+describe("CHANGES_SINCE_LAST_RELEASE value", () => {
+  test("is the race-free drop-`-q` form and must never reintroduce `grep -q`", () => {
+    // Pins the exact value so a future change is deliberate. Reintroducing
+    // `grep -q` brings back the dax pipe-close race (see the comment on the
+    // constant in src/version.ts); assert it stays out.
+    expect(CHANGES_SINCE_LAST_RELEASE).toEqual(
+      'git log --oneline -1 | grep -v "chore(release):" > /dev/null',
+    );
+    expect(CHANGES_SINCE_LAST_RELEASE).not.toContain("grep -q");
+  });
+});
+
+posixOnly("CHANGES_SINCE_LAST_RELEASE execution", () => {
+  // Build a project whose outdir is a git repo whose HEAD subject is `subject`,
+  // with one task per shell gated by the release condition. Each task's step
+  // drops a marker file, so a created marker means the condition proceeded and a
+  // missing marker means it was skipped.
+  function setup(subject: string) {
+    const p = new TestProject();
+    for (const shell of ["projen", "system"] as const) {
+      p.addTask(`cond-${shell}`, {
+        condition: CHANGES_SINCE_LAST_RELEASE,
+        shell: shell === "system" ? TaskShell.system() : undefined,
+        exec: `node -e "require('fs').writeFileSync('ran-${shell}.txt','1')"`,
+      });
+    }
+    p.synth();
+
+    const cwd = p.outdir;
+    git.run(["init", "-q"], { cwd });
+    git.run(["config", "user.email", "t@example.com"], { cwd });
+    git.run(["config", "user.name", "t"], { cwd });
+    git.run(["commit", "-q", "--allow-empty", "-m", subject], { cwd });
+    return p;
+  }
+
+  async function proceeded(p: TestProject, shell: "projen" | "system") {
+    const marker = join(p.outdir, `ran-${shell}.txt`);
+    if (existsSync(marker)) rmSync(marker);
+    await new TaskRuntime(p.outdir).runTask(`cond-${shell}`);
+    return existsSync(marker);
+  }
+
+  test("a normal HEAD proceeds (exit 0) under the built-in and system shells", async () => {
+    const p = setup("feat: a normal change");
+    expect(await proceeded(p, "projen")).toBe(true);
+    expect(await proceeded(p, "system")).toBe(true);
+  });
+
+  test("a chore(release) HEAD skips (non-zero) under the built-in and system shells", async () => {
+    const p = setup("chore(release): 1.2.3");
+    expect(await proceeded(p, "projen")).toBe(false);
+    expect(await proceeded(p, "system")).toBe(false);
+  });
+});

--- a/test/jsii/__snapshots__/jsii.test.ts.snap
+++ b/test/jsii/__snapshots__/jsii.test.ts.snap
@@ -881,7 +881,7 @@ tsconfig.tsbuildinfo
         ],
       },
       "bump": {
-        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
+        "condition": "git log --oneline -1 | grep -v "chore(release):" > /dev/null",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -2469,7 +2469,7 @@ tsconfig.tsbuildinfo
         ],
       },
       "bump": {
-        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
+        "condition": "git log --oneline -1 | grep -v "chore(release):" > /dev/null",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -4059,7 +4059,7 @@ tsconfig.tsbuildinfo
         ],
       },
       "bump": {
-        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
+        "condition": "git log --oneline -1 | grep -v "chore(release):" > /dev/null",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",

--- a/test/release/__snapshots__/release.test.ts.snap
+++ b/test/release/__snapshots__/release.test.ts.snap
@@ -252,7 +252,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
+        "condition": "git log --oneline -1 | grep -v "chore(release):" > /dev/null",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -657,7 +657,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
+        "condition": "git log --oneline -1 | grep -v "chore(release):" > /dev/null",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -1069,7 +1069,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
+        "condition": "git log --oneline -1 | grep -v "chore(release):" > /dev/null",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -1436,7 +1436,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
+        "condition": "git log --oneline -1 | grep -v "chore(release):" > /dev/null",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -1947,7 +1947,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
+        "condition": "git log --oneline -1 | grep -v "chore(release):" > /dev/null",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -2496,7 +2496,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
+        "condition": "git log --oneline -1 | grep -v "chore(release):" > /dev/null",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -2874,7 +2874,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
+        "condition": "git log --oneline -1 | grep -v "chore(release):" > /dev/null",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -3422,7 +3422,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
+        "condition": "git log --oneline -1 | grep -v "chore(release):" > /dev/null",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -3716,7 +3716,7 @@ exports[`Single Project majorVersion can be 0 2`] = `
       ],
     },
     "bump": {
-      "condition": "git log --oneline -1 | grep -qv "chore(release):"",
+      "condition": "git log --oneline -1 | grep -v "chore(release):" > /dev/null",
       "description": "Bumps version based on latest git tag and generates a changelog entry",
       "env": {
         "BUMPFILE": "dist/version.txt",
@@ -3860,7 +3860,7 @@ exports[`Single Project minMajorVersion can be 1 1`] = `
       ],
     },
     "bump": {
-      "condition": "git log --oneline -1 | grep -qv "chore(release):"",
+      "condition": "git log --oneline -1 | grep -v "chore(release):" > /dev/null",
       "description": "Bumps version based on latest git tag and generates a changelog entry",
       "env": {
         "BUMPFILE": "dist/version.txt",
@@ -4161,7 +4161,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
+        "condition": "git log --oneline -1 | grep -v "chore(release):" > /dev/null",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -4402,7 +4402,7 @@ exports[`Single Project prerelease can be specified per branch 3`] = `
       ],
     },
     "bump": {
-      "condition": "git log --oneline -1 | grep -qv "chore(release):"",
+      "condition": "git log --oneline -1 | grep -v "chore(release):" > /dev/null",
       "description": "Bumps version based on latest git tag and generates a changelog entry",
       "env": {
         "BUMPFILE": "dist/version.txt",
@@ -4836,7 +4836,7 @@ exports[`Single Project publisher (defaults) 2`] = `
       ],
     },
     "bump": {
-      "condition": "git log --oneline -1 | grep -qv "chore(release):"",
+      "condition": "git log --oneline -1 | grep -v "chore(release):" > /dev/null",
       "description": "Bumps version based on latest git tag and generates a changelog entry",
       "env": {
         "BUMPFILE": "dist/version.txt",
@@ -5320,7 +5320,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
+        "condition": "git log --oneline -1 | grep -v "chore(release):" > /dev/null",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -5853,7 +5853,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
+        "condition": "git log --oneline -1 | grep -v "chore(release):" > /dev/null",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -6237,7 +6237,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
+        "condition": "git log --oneline -1 | grep -v "chore(release):" > /dev/null",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",
@@ -6540,7 +6540,7 @@ node_modules/
         ],
       },
       "bump": {
-        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
+        "condition": "git log --oneline -1 | grep -v "chore(release):" > /dev/null",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",

--- a/test/typescript/__snapshots__/typescript.test.ts.snap
+++ b/test/typescript/__snapshots__/typescript.test.ts.snap
@@ -764,7 +764,7 @@ tsconfig.tsbuildinfo
         ],
       },
       "bump": {
-        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
+        "condition": "git log --oneline -1 | grep -v "chore(release):" > /dev/null",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",

--- a/test/web/__snapshots__/nextjs-project.test.ts.snap
+++ b/test/web/__snapshots__/nextjs-project.test.ts.snap
@@ -506,7 +506,7 @@ permissions-backup.acl
         ],
       },
       "bump": {
-        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
+        "condition": "git log --oneline -1 | grep -v "chore(release):" > /dev/null",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",

--- a/test/web/__snapshots__/react-project.test.ts.snap
+++ b/test/web/__snapshots__/react-project.test.ts.snap
@@ -492,7 +492,7 @@ permissions-backup.acl
         ],
       },
       "bump": {
-        "condition": "git log --oneline -1 | grep -qv "chore(release):"",
+        "condition": "git log --oneline -1 | grep -v "chore(release):" > /dev/null",
         "description": "Bumps version based on latest git tag and generates a changelog entry",
         "env": {
           "BUMPFILE": "dist/version.txt",


### PR DESCRIPTION
### What broke

`CHANGES_SINCE_LAST_RELEASE` (the condition on the generated `bump` and `release` tasks) is `git log --oneline -1 | grep -qv "chore(release):"`. `grep -q` closes the read end of the pipe as soon as it has an answer. When the condition runs through projen's built-in dax shell, that early close races with `git log` still writing, and dax surfaces the failed write as a spurious non-zero exit (`stdin pipe broken. Invalid state: WritableStream is closed`). The task runtime treats that as "skip", so a `bump`/`release` task is silently skipped even on a normal commit: a release is missed, or (in a monorepo) a dependent publishes a broken `^0.0.0` dependency range.

Real-world impact: `@aws-cdk/service-spec-importers@0.0.133` shipped `@aws-cdk/service-spec-types: "^0.0.0"` (`npm view @aws-cdk/service-spec-importers@0.0.133 dependencies`; the prior `0.0.132` was `^0.0.251`). Release log: https://github.com/cdklabs/awscdk-service-spec/actions/runs/28693317594 shows two `stdin pipe broken` errors matched 1:1 with two skipped bump tasks on a non-release HEAD, versus zero in the clean runs https://github.com/cdklabs/awscdk-service-spec/actions/runs/27250884136 and https://github.com/cdklabs/awscdk-service-spec/actions/runs/28980091973.

### Why fix the condition, not `evalCondition`

On dax 0.49 (bundled by projen), an early-closing pipe under `.noThrow()` returns a plain non-zero exit code rather than throwing (verified: `seq 1 500000 | grep -qv "chore(release):"` returns code 1 with the pipe-broken error on stderr). `evalCondition` inspects only the exit status, so the infrastructure failure is indistinguishable from a legitimate condition-false without brittle stderr string-matching. The robust fix is therefore to remove the trigger in the condition itself.

### The fix

Drop `-q`:

```
git log --oneline -1 | grep -v "chore(release):" > /dev/null
```

`grep -v` reads to EOF instead of short-circuiting, so it never closes the pipe while the writer is active and the race cannot occur. Exit semantics are identical (proceed when the last commit line does not contain `chore(release):`, skip when it does). A comment on the constant explains why `-q` must not be reintroduced.

A pipe-free form was considered and rejected: dax's shell subset does not support `case`, `if`, or `${var#pattern}` (verified on 0.49), and `expr` is not guaranteed on Windows. Dropping `-q` removes the defect with the least change and stays cross-platform.

### Validation

- Same-stress A/B (`seq 1 500000`, 10 runs each): under dax the old `grep -qv` fails 10/10 (code 1 + pipe-broken) while the new form passes 10/10 (code 0, no pipe error); under `/bin/sh` both pass, confirming the defect is specific to dax's in-process pipe.
- New tests pin the exact constant value and execute the condition under both the built-in (dax) and system shells for a normal HEAD (proceeds) and a `chore(release)` HEAD (skips).
- The only piped `grep -q` in the repo is this condition; `src/release/publisher.ts` uses `grep -q` on a file (not a pipe) and is unaffected. Snapshots updated for the new condition string.

### Related PRs

Downstream consumers (cdklabs/cdklabs-projen-project-types) currently carry interim mitigations for this defect; once this fix is released they can be removed:
- Fail-loud guard: https://github.com/cdklabs/cdklabs-projen-project-types/pull/960
- Release-shell hardening + retry: https://github.com/cdklabs/cdklabs-projen-project-types/pull/961

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.