### PR TITLE
feat(javascript): add dedupe task to remove duplicate dependencies

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -151,6 +151,18 @@
         }
       ]
     },
+    "dedupe": {
+      "name": "dedupe",
+      "description": "Deduplicate project dependencies",
+      "steps": [
+        {
+          "execArgs": [
+            "npm",
+            "dedupe"
+          ]
+        }
+      ]
+    },
     "default": {
       "name": "default",
       "description": "Synthesize project files",
@@ -226,6 +238,9 @@
       "steps": [
         {
           "exec": "npm install"
+        },
+        {
+          "spawn": "dedupe"
         }
       ]
     },
@@ -625,6 +640,9 @@
           ]
         },
         {
+          "spawn": "dedupe"
+        },
+        {
           "exec": "node ./projen.js"
         },
         {
@@ -675,6 +693,9 @@
             "yaml",
             "yargs"
           ]
+        },
+        {
+          "spawn": "dedupe"
         },
         {
           "exec": "node ./projen.js"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -106,6 +106,7 @@ const project = new TypeScriptProject({
 
   peerDeps: ["constructs@^10.5.0"],
 
+  dedupeDeps: true,
   depsUpgrade: false, // configured below
   auditDeps: true,
   auditDepsOptions: {

--- a/docs/api/awscdk.md
+++ b/docs/api/awscdk.md
@@ -9154,6 +9154,7 @@ const awsCdkConstructLibraryOptions: awscdk.AwsCdkConstructLibraryOptions = { ..
 | <code><a href="#projen.awscdk.AwsCdkConstructLibraryOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.awscdk.AwsCdkConstructLibraryOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.awscdk.AwsCdkConstructLibraryOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.javascript.CodeArtifactOptions</code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.awscdk.AwsCdkConstructLibraryOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.awscdk.AwsCdkConstructLibraryOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.awscdk.AwsCdkConstructLibraryOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
 | <code><a href="#projen.awscdk.AwsCdkConstructLibraryOptions.property.description">description</a></code> | <code>string</code> | The description is just a string that helps people understand the purpose of the package. |
@@ -9874,6 +9875,34 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `dedupeDeps`<sup>Optional</sup> <a name="dedupeDeps" id="projen.awscdk.AwsCdkConstructLibraryOptions.property.dedupeDeps"></a>
+
+```typescript
+public readonly dedupeDeps: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false - unless `yarnBerryOptions.dedupePackages` is set
+
+Add a `dedupe` task that deduplicates project dependencies.
+
+Deduplication prevents multiple versions of the same package from being
+installed, if a single version can satisfy all requested version ranges.
+This prevents version proliferation and reduces the size of the dependency
+tree.
+
+The behavior depends on the package manager:
+- npm: runs `npm dedupe` after every mutating install.
+- pnpm: runs `pnpm dedupe` after every mutating install.
+- Yarn Berry: runs `yarn dedupe` after every mutating install. If
+  `yarnBerryOptions.dedupePackages` is set, only the listed packages are
+  deduplicated.
+- Yarn Classic: `yarn install` already deduplicates, so the task only
+  prints an informational message.
+- Bun: not supported, enabling this option throws an error.
 
 ---
 
@@ -14079,6 +14108,7 @@ const awsCdkTypeScriptAppOptions: awscdk.AwsCdkTypeScriptAppOptions = { ... }
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.javascript.CodeArtifactOptions</code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.description">description</a></code> | <code>string</code> | The description is just a string that helps people understand the purpose of the package. |
@@ -14792,6 +14822,34 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `dedupeDeps`<sup>Optional</sup> <a name="dedupeDeps" id="projen.awscdk.AwsCdkTypeScriptAppOptions.property.dedupeDeps"></a>
+
+```typescript
+public readonly dedupeDeps: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false - unless `yarnBerryOptions.dedupePackages` is set
+
+Add a `dedupe` task that deduplicates project dependencies.
+
+Deduplication prevents multiple versions of the same package from being
+installed, if a single version can satisfy all requested version ranges.
+This prevents version proliferation and reduces the size of the dependency
+tree.
+
+The behavior depends on the package manager:
+- npm: runs `npm dedupe` after every mutating install.
+- pnpm: runs `pnpm dedupe` after every mutating install.
+- Yarn Berry: runs `yarn dedupe` after every mutating install. If
+  `yarnBerryOptions.dedupePackages` is set, only the listed packages are
+  deduplicated.
+- Yarn Classic: `yarn install` already deduplicates, so the task only
+  prints an informational message.
+- Bun: not supported, enabling this option throws an error.
 
 ---
 

--- a/docs/api/awscdk.md
+++ b/docs/api/awscdk.md
@@ -9885,7 +9885,7 @@ public readonly dedupeDeps: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* false - unless `yarnBerryOptions.dedupePackages` is set
+- *Default:* false, unless `yarnBerryOptions.dedupePackages` is set
 
 Add a `dedupe` task that deduplicates project dependencies.
 
@@ -14832,7 +14832,7 @@ public readonly dedupeDeps: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* false - unless `yarnBerryOptions.dedupePackages` is set
+- *Default:* false, unless `yarnBerryOptions.dedupePackages` is set
 
 Add a `dedupe` task that deduplicates project dependencies.
 

--- a/docs/api/cdk.md
+++ b/docs/api/cdk.md
@@ -4646,7 +4646,7 @@ public readonly dedupeDeps: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* false - unless `yarnBerryOptions.dedupePackages` is set
+- *Default:* false, unless `yarnBerryOptions.dedupePackages` is set
 
 Add a `dedupe` task that deduplicates project dependencies.
 
@@ -8432,7 +8432,7 @@ public readonly dedupeDeps: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* false - unless `yarnBerryOptions.dedupePackages` is set
+- *Default:* false, unless `yarnBerryOptions.dedupePackages` is set
 
 Add a `dedupe` task that deduplicates project dependencies.
 

--- a/docs/api/cdk.md
+++ b/docs/api/cdk.md
@@ -3926,6 +3926,7 @@ const constructLibraryOptions: cdk.ConstructLibraryOptions = { ... }
 | <code><a href="#projen.cdk.ConstructLibraryOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.cdk.ConstructLibraryOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.cdk.ConstructLibraryOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.javascript.CodeArtifactOptions</code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.cdk.ConstructLibraryOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.cdk.ConstructLibraryOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.cdk.ConstructLibraryOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
 | <code><a href="#projen.cdk.ConstructLibraryOptions.property.description">description</a></code> | <code>string</code> | The description is just a string that helps people understand the purpose of the package. |
@@ -4635,6 +4636,34 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `dedupeDeps`<sup>Optional</sup> <a name="dedupeDeps" id="projen.cdk.ConstructLibraryOptions.property.dedupeDeps"></a>
+
+```typescript
+public readonly dedupeDeps: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false - unless `yarnBerryOptions.dedupePackages` is set
+
+Add a `dedupe` task that deduplicates project dependencies.
+
+Deduplication prevents multiple versions of the same package from being
+installed, if a single version can satisfy all requested version ranges.
+This prevents version proliferation and reduces the size of the dependency
+tree.
+
+The behavior depends on the package manager:
+- npm: runs `npm dedupe` after every mutating install.
+- pnpm: runs `pnpm dedupe` after every mutating install.
+- Yarn Berry: runs `yarn dedupe` after every mutating install. If
+  `yarnBerryOptions.dedupePackages` is set, only the listed packages are
+  deduplicated.
+- Yarn Classic: `yarn install` already deduplicates, so the task only
+  prints an informational message.
+- Bun: not supported, enabling this option throws an error.
 
 ---
 
@@ -7684,6 +7713,7 @@ const jsiiProjectOptions: cdk.JsiiProjectOptions = { ... }
 | <code><a href="#projen.cdk.JsiiProjectOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.cdk.JsiiProjectOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.cdk.JsiiProjectOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.javascript.CodeArtifactOptions</code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.cdk.JsiiProjectOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.cdk.JsiiProjectOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.cdk.JsiiProjectOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
 | <code><a href="#projen.cdk.JsiiProjectOptions.property.description">description</a></code> | <code>string</code> | The description is just a string that helps people understand the purpose of the package. |
@@ -8392,6 +8422,34 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `dedupeDeps`<sup>Optional</sup> <a name="dedupeDeps" id="projen.cdk.JsiiProjectOptions.property.dedupeDeps"></a>
+
+```typescript
+public readonly dedupeDeps: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false - unless `yarnBerryOptions.dedupePackages` is set
+
+Add a `dedupe` task that deduplicates project dependencies.
+
+Deduplication prevents multiple versions of the same package from being
+installed, if a single version can satisfy all requested version ranges.
+This prevents version proliferation and reduces the size of the dependency
+tree.
+
+The behavior depends on the package manager:
+- npm: runs `npm dedupe` after every mutating install.
+- pnpm: runs `pnpm dedupe` after every mutating install.
+- Yarn Berry: runs `yarn dedupe` after every mutating install. If
+  `yarnBerryOptions.dedupePackages` is set, only the listed packages are
+  deduplicated.
+- Yarn Classic: `yarn install` already deduplicates, so the task only
+  prints an informational message.
+- Bun: not supported, enabling this option throws an error.
 
 ---
 

--- a/docs/api/cdk8s.md
+++ b/docs/api/cdk8s.md
@@ -6681,6 +6681,7 @@ const cdk8sTypeScriptAppOptions: cdk8s.Cdk8sTypeScriptAppOptions = { ... }
 | <code><a href="#projen.cdk8s.Cdk8sTypeScriptAppOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.cdk8s.Cdk8sTypeScriptAppOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.cdk8s.Cdk8sTypeScriptAppOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.javascript.CodeArtifactOptions</code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.cdk8s.Cdk8sTypeScriptAppOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.cdk8s.Cdk8sTypeScriptAppOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.cdk8s.Cdk8sTypeScriptAppOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
 | <code><a href="#projen.cdk8s.Cdk8sTypeScriptAppOptions.property.description">description</a></code> | <code>string</code> | The description is just a string that helps people understand the purpose of the package. |
@@ -7388,6 +7389,34 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `dedupeDeps`<sup>Optional</sup> <a name="dedupeDeps" id="projen.cdk8s.Cdk8sTypeScriptAppOptions.property.dedupeDeps"></a>
+
+```typescript
+public readonly dedupeDeps: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false - unless `yarnBerryOptions.dedupePackages` is set
+
+Add a `dedupe` task that deduplicates project dependencies.
+
+Deduplication prevents multiple versions of the same package from being
+installed, if a single version can satisfy all requested version ranges.
+This prevents version proliferation and reduces the size of the dependency
+tree.
+
+The behavior depends on the package manager:
+- npm: runs `npm dedupe` after every mutating install.
+- pnpm: runs `pnpm dedupe` after every mutating install.
+- Yarn Berry: runs `yarn dedupe` after every mutating install. If
+  `yarnBerryOptions.dedupePackages` is set, only the listed packages are
+  deduplicated.
+- Yarn Classic: `yarn install` already deduplicates, so the task only
+  prints an informational message.
+- Bun: not supported, enabling this option throws an error.
 
 ---
 
@@ -9240,6 +9269,7 @@ const constructLibraryCdk8sOptions: cdk8s.ConstructLibraryCdk8sOptions = { ... }
 | <code><a href="#projen.cdk8s.ConstructLibraryCdk8sOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.cdk8s.ConstructLibraryCdk8sOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.cdk8s.ConstructLibraryCdk8sOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.javascript.CodeArtifactOptions</code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.cdk8s.ConstructLibraryCdk8sOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.cdk8s.ConstructLibraryCdk8sOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.cdk8s.ConstructLibraryCdk8sOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
 | <code><a href="#projen.cdk8s.ConstructLibraryCdk8sOptions.property.description">description</a></code> | <code>string</code> | The description is just a string that helps people understand the purpose of the package. |
@@ -9955,6 +9985,34 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `dedupeDeps`<sup>Optional</sup> <a name="dedupeDeps" id="projen.cdk8s.ConstructLibraryCdk8sOptions.property.dedupeDeps"></a>
+
+```typescript
+public readonly dedupeDeps: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false - unless `yarnBerryOptions.dedupePackages` is set
+
+Add a `dedupe` task that deduplicates project dependencies.
+
+Deduplication prevents multiple versions of the same package from being
+installed, if a single version can satisfy all requested version ranges.
+This prevents version proliferation and reduces the size of the dependency
+tree.
+
+The behavior depends on the package manager:
+- npm: runs `npm dedupe` after every mutating install.
+- pnpm: runs `pnpm dedupe` after every mutating install.
+- Yarn Berry: runs `yarn dedupe` after every mutating install. If
+  `yarnBerryOptions.dedupePackages` is set, only the listed packages are
+  deduplicated.
+- Yarn Classic: `yarn install` already deduplicates, so the task only
+  prints an informational message.
+- Bun: not supported, enabling this option throws an error.
 
 ---
 

--- a/docs/api/cdk8s.md
+++ b/docs/api/cdk8s.md
@@ -7399,7 +7399,7 @@ public readonly dedupeDeps: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* false - unless `yarnBerryOptions.dedupePackages` is set
+- *Default:* false, unless `yarnBerryOptions.dedupePackages` is set
 
 Add a `dedupe` task that deduplicates project dependencies.
 
@@ -9995,7 +9995,7 @@ public readonly dedupeDeps: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* false - unless `yarnBerryOptions.dedupePackages` is set
+- *Default:* false, unless `yarnBerryOptions.dedupePackages` is set
 
 Add a `dedupe` task that deduplicates project dependencies.
 

--- a/docs/api/cdktf.md
+++ b/docs/api/cdktf.md
@@ -2177,7 +2177,7 @@ public readonly dedupeDeps: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* false - unless `yarnBerryOptions.dedupePackages` is set
+- *Default:* false, unless `yarnBerryOptions.dedupePackages` is set
 
 Add a `dedupe` task that deduplicates project dependencies.
 

--- a/docs/api/cdktf.md
+++ b/docs/api/cdktf.md
@@ -1455,6 +1455,7 @@ const constructLibraryCdktfOptions: cdktf.ConstructLibraryCdktfOptions = { ... }
 | <code><a href="#projen.cdktf.ConstructLibraryCdktfOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.cdktf.ConstructLibraryCdktfOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.cdktf.ConstructLibraryCdktfOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.javascript.CodeArtifactOptions</code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.cdktf.ConstructLibraryCdktfOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.cdktf.ConstructLibraryCdktfOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.cdktf.ConstructLibraryCdktfOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
 | <code><a href="#projen.cdktf.ConstructLibraryCdktfOptions.property.description">description</a></code> | <code>string</code> | The description is just a string that helps people understand the purpose of the package. |
@@ -2166,6 +2167,34 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `dedupeDeps`<sup>Optional</sup> <a name="dedupeDeps" id="projen.cdktf.ConstructLibraryCdktfOptions.property.dedupeDeps"></a>
+
+```typescript
+public readonly dedupeDeps: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false - unless `yarnBerryOptions.dedupePackages` is set
+
+Add a `dedupe` task that deduplicates project dependencies.
+
+Deduplication prevents multiple versions of the same package from being
+installed, if a single version can satisfy all requested version ranges.
+This prevents version proliferation and reduces the size of the dependency
+tree.
+
+The behavior depends on the package manager:
+- npm: runs `npm dedupe` after every mutating install.
+- pnpm: runs `pnpm dedupe` after every mutating install.
+- Yarn Berry: runs `yarn dedupe` after every mutating install. If
+  `yarnBerryOptions.dedupePackages` is set, only the listed packages are
+  deduplicated.
+- Yarn Classic: `yarn install` already deduplicates, so the task only
+  prints an informational message.
+- Bun: not supported, enabling this option throws an error.
 
 ---
 

--- a/docs/api/javascript.md
+++ b/docs/api/javascript.md
@@ -2381,9 +2381,9 @@ The project.
 | <code><a href="#projen.javascript.NodePackage.property.entrypoint">entrypoint</a></code> | <code>string</code> | The module's entrypoint (e.g. `lib/index.js`). |
 | <code><a href="#projen.javascript.NodePackage.property.execCommand">execCommand</a></code> | <code>string</code> | The command prefix to use when executing binary commands for this package manager (e.g. `npx`, `pnpm exec`, `yarn`, `bunx`). |
 | <code><a href="#projen.javascript.NodePackage.property.file">file</a></code> | <code>projen.JsonFile</code> | The package.json file. |
-| <code><a href="#projen.javascript.NodePackage.property.installAndUpdateLockfileCommand">installAndUpdateLockfileCommand</a></code> | <code>string</code> | Renders `pnpm install` or `npm install` with lockfile update (not frozen). |
+| <code><a href="#projen.javascript.NodePackage.property.installAndUpdateLockfileCommand">installAndUpdateLockfileCommand</a></code> | <code>string</code> | Returns the package manager's mutable install command with lockfile update, e.g. `npm install` or `pnpm install`. |
 | <code><a href="#projen.javascript.NodePackage.property.installCiTask">installCiTask</a></code> | <code>projen.Task</code> | The task for installing project dependencies (frozen). |
-| <code><a href="#projen.javascript.NodePackage.property.installCommand">installCommand</a></code> | <code>string</code> | Returns the command to execute in order to install all dependencies (always frozen). |
+| <code><a href="#projen.javascript.NodePackage.property.installCommand">installCommand</a></code> | <code>string</code> | Returns the package manager's immutable install command with a frozen lockfile, e.g. `npm ci` or `pnpm ci`. |
 | <code><a href="#projen.javascript.NodePackage.property.installTask">installTask</a></code> | <code>projen.Task</code> | The task for installing project dependencies (non-frozen). |
 | <code><a href="#projen.javascript.NodePackage.property.lockFile">lockFile</a></code> | <code>string</code> | The name of the lock file. |
 | <code><a href="#projen.javascript.NodePackage.property.manifest">manifest</a></code> | <code>any</code> | *No description.* |
@@ -2395,6 +2395,7 @@ The project.
 | <code><a href="#projen.javascript.NodePackage.property.packageName">packageName</a></code> | <code>string</code> | The name of the npm package. |
 | <code><a href="#projen.javascript.NodePackage.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.javascript.NodePackage.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code><a href="#projen.javascript.CodeArtifactOptions">CodeArtifactOptions</a></code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.javascript.NodePackage.property.dedupeTask">dedupeTask</a></code> | <code>projen.Task</code> | The task for deduplicating project dependencies, if configured. |
 | <code><a href="#projen.javascript.NodePackage.property.license">license</a></code> | <code>string</code> | The SPDX license of this module. |
 | <code><a href="#projen.javascript.NodePackage.property.maxNodeVersion">maxNodeVersion</a></code> | <code>string</code> | Maximum node version supported by this package. |
 | <code><a href="#projen.javascript.NodePackage.property.minNodeVersion">minNodeVersion</a></code> | <code>string</code> | The minimum node version required by this package to function. |
@@ -2483,7 +2484,9 @@ public readonly installAndUpdateLockfileCommand: string;
 
 - *Type:* string
 
-Renders `pnpm install` or `npm install` with lockfile update (not frozen).
+Returns the package manager's mutable install command with lockfile update, e.g. `npm install` or `pnpm install`.
+
+Prefer using `NodePackage.installTask`. The raw command string is intended for bootstrapping.
 
 ---
 
@@ -2507,7 +2510,9 @@ public readonly installCommand: string;
 
 - *Type:* string
 
-Returns the command to execute in order to install all dependencies (always frozen).
+Returns the package manager's immutable install command with a frozen lockfile, e.g. `npm ci` or `pnpm ci`.
+
+Prefer using `NodePackage.installCiTask`. The raw command string is intended for bootstrapping.
 
 ---
 
@@ -2643,6 +2648,18 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `dedupeTask`<sup>Optional</sup> <a name="dedupeTask" id="projen.javascript.NodePackage.property.dedupeTask"></a>
+
+```typescript
+public readonly dedupeTask: Task;
+```
+
+- *Type:* projen.Task
+
+The task for deduplicating project dependencies, if configured.
 
 ---
 
@@ -9503,6 +9520,7 @@ const nodePackageOptions: javascript.NodePackageOptions = { ... }
 | <code><a href="#projen.javascript.NodePackageOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.javascript.NodePackageOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.javascript.NodePackageOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code><a href="#projen.javascript.CodeArtifactOptions">CodeArtifactOptions</a></code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.javascript.NodePackageOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.javascript.NodePackageOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.javascript.NodePackageOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
 | <code><a href="#projen.javascript.NodePackageOptions.property.description">description</a></code> | <code>string</code> | The description is just a string that helps people understand the purpose of the package. |
@@ -9750,6 +9768,34 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `dedupeDeps`<sup>Optional</sup> <a name="dedupeDeps" id="projen.javascript.NodePackageOptions.property.dedupeDeps"></a>
+
+```typescript
+public readonly dedupeDeps: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false - unless `yarnBerryOptions.dedupePackages` is set
+
+Add a `dedupe` task that deduplicates project dependencies.
+
+Deduplication prevents multiple versions of the same package from being
+installed, if a single version can satisfy all requested version ranges.
+This prevents version proliferation and reduces the size of the dependency
+tree.
+
+The behavior depends on the package manager:
+- npm: runs `npm dedupe` after every mutating install.
+- pnpm: runs `pnpm dedupe` after every mutating install.
+- Yarn Berry: runs `yarn dedupe` after every mutating install. If
+  `yarnBerryOptions.dedupePackages` is set, only the listed packages are
+  deduplicated.
+- Yarn Classic: `yarn install` already deduplicates, so the task only
+  prints an informational message.
+- Bun: not supported, enabling this option throws an error.
 
 ---
 
@@ -10256,6 +10302,7 @@ const nodeProjectOptions: javascript.NodeProjectOptions = { ... }
 | <code><a href="#projen.javascript.NodeProjectOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.javascript.NodeProjectOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.javascript.NodeProjectOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code><a href="#projen.javascript.CodeArtifactOptions">CodeArtifactOptions</a></code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.javascript.NodeProjectOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.javascript.NodeProjectOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.javascript.NodeProjectOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
 | <code><a href="#projen.javascript.NodeProjectOptions.property.description">description</a></code> | <code>string</code> | The description is just a string that helps people understand the purpose of the package. |
@@ -10930,6 +10977,34 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `dedupeDeps`<sup>Optional</sup> <a name="dedupeDeps" id="projen.javascript.NodeProjectOptions.property.dedupeDeps"></a>
+
+```typescript
+public readonly dedupeDeps: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false - unless `yarnBerryOptions.dedupePackages` is set
+
+Add a `dedupe` task that deduplicates project dependencies.
+
+Deduplication prevents multiple versions of the same package from being
+installed, if a single version can satisfy all requested version ranges.
+This prevents version proliferation and reduces the size of the dependency
+tree.
+
+The behavior depends on the package manager:
+- npm: runs `npm dedupe` after every mutating install.
+- pnpm: runs `pnpm dedupe` after every mutating install.
+- Yarn Berry: runs `yarn dedupe` after every mutating install. If
+  `yarnBerryOptions.dedupePackages` is set, only the listed packages are
+  deduplicated.
+- Yarn Classic: `yarn install` already deduplicates, so the task only
+  prints an informational message.
+- Bun: not supported, enabling this option throws an error.
 
 ---
 
@@ -19433,7 +19508,7 @@ const yarnBerryOptions: javascript.YarnBerryOptions = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#projen.javascript.YarnBerryOptions.property.dedupePackages">dedupePackages</a></code> | <code>string[]</code> | Packages to deduplicate. |
+| <code><a href="#projen.javascript.YarnBerryOptions.property.dedupePackages">dedupePackages</a></code> | <code>string[]</code> | Packages to deduplicate when the `dedupe` task runs. |
 | <code><a href="#projen.javascript.YarnBerryOptions.property.version">version</a></code> | <code>string</code> | A fully specified version to use for yarn (e.g., x.x.x). |
 | <code><a href="#projen.javascript.YarnBerryOptions.property.yarnRcOptions">yarnRcOptions</a></code> | <code><a href="#projen.javascript.YarnrcOptions">YarnrcOptions</a></code> | The yarnrc configuration. |
 | <code><a href="#projen.javascript.YarnBerryOptions.property.zeroInstalls">zeroInstalls</a></code> | <code>boolean</code> | Should zero-installs be enabled? |
@@ -19447,15 +19522,18 @@ public readonly dedupePackages: string[];
 ```
 
 - *Type:* string[]
+- *Default:* all packages are deduplicated
 
-Packages to deduplicate.
+Packages to deduplicate when the `dedupe` task runs.
 
 This will prevent multiple versions of the same package from being
 installed in the lock file, if a single version could satisfy all requested
 version ranges. This will prevent version proliferation and reduce the size
-of the depdendency tree.
+of the dependency tree.
 
-Setting this will run `yarn dedupe` after dependency upgrades.
+Setting this implies `dedupeDeps: true` on the project, which will run
+`yarn dedupe` after every mutating install. Set `dedupeDeps: false`
+explicitly to disable the task.
 
 Supports glob patterns, e.g. `@aws-sdk/*`.
 
@@ -19874,8 +19952,11 @@ const yarnrcOptions: javascript.YarnrcOptions = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#projen.javascript.YarnrcOptions.property.approvedGitRepositories">approvedGitRepositories</a></code> | <code>string[]</code> | https://yarnpkg.com/configuration/yarnrc#approvedGitRepositories. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.cacheFolder">cacheFolder</a></code> | <code>string</code> | https://yarnpkg.com/configuration/yarnrc#cacheFolder. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.cacheMigrationMode">cacheMigrationMode</a></code> | <code><a href="#projen.javascript.YarnCacheMigrationMode">YarnCacheMigrationMode</a></code> | https://yarnpkg.com/configuration/yarnrc#cacheMigrationMode. |
+| <code><a href="#projen.javascript.YarnrcOptions.property.catalog">catalog</a></code> | <code>{[ key: string ]: string}</code> | https://yarnpkg.com/configuration/yarnrc#catalog. |
+| <code><a href="#projen.javascript.YarnrcOptions.property.catalogs">catalogs</a></code> | <code>{[ key: string ]: {[ key: string ]: string}}</code> | https://yarnpkg.com/configuration/yarnrc#catalogs. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.changesetBaseRefs">changesetBaseRefs</a></code> | <code>string[]</code> | https://yarnpkg.com/configuration/yarnrc#changesetBaseRefs. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.changesetIgnorePatterns">changesetIgnorePatterns</a></code> | <code>string[]</code> | https://yarnpkg.com/configuration/yarnrc#changesetIgnorePatterns. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.checksumBehavior">checksumBehavior</a></code> | <code><a href="#projen.javascript.YarnChecksumBehavior">YarnChecksumBehavior</a></code> | https://yarnpkg.com/configuration/yarnrc#checksumBehavior. |
@@ -19887,7 +19968,8 @@ const yarnrcOptions: javascript.YarnrcOptions = { ... }
 | <code><a href="#projen.javascript.YarnrcOptions.property.defaultSemverRangePrefix">defaultSemverRangePrefix</a></code> | <code><a href="#projen.javascript.YarnDefaultSemverRangePrefix">YarnDefaultSemverRangePrefix</a></code> | https://yarnpkg.com/configuration/yarnrc#defaultSemverRangePrefix. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.deferredVersionFolder">deferredVersionFolder</a></code> | <code>string</code> | https://yarnpkg.com/configuration/yarnrc#deferredVersionFolder. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.enableColors">enableColors</a></code> | <code>boolean</code> | https://yarnpkg.com/configuration/yarnrc#enableColors. |
-| <code><a href="#projen.javascript.YarnrcOptions.property.enableConstraintsCheck">enableConstraintsCheck</a></code> | <code>boolean</code> | https://yarnpkg.com/configuration/yarnrc#enableConstraintsCheck. |
+| <code><a href="#projen.javascript.YarnrcOptions.property.enableConstraintsCheck">enableConstraintsCheck</a></code> | <code>boolean</code> | https://yarnpkg.com/configuration/yarnrc#enableConstraintsChecks. |
+| <code><a href="#projen.javascript.YarnrcOptions.property.enableConstraintsChecks">enableConstraintsChecks</a></code> | <code>boolean</code> | https://yarnpkg.com/configuration/yarnrc#enableConstraintsChecks. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.enableGlobalCache">enableGlobalCache</a></code> | <code>boolean</code> | https://yarnpkg.com/configuration/yarnrc#enableGlobalCache. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.enableHardenedMode">enableHardenedMode</a></code> | <code>boolean</code> | https://yarnpkg.com/configuration/yarnrc#enableHardenedMode. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.enableHyperlinks">enableHyperlinks</a></code> | <code>boolean</code> | https://yarnpkg.com/configuration/yarnrc#enableHyperlinks. |
@@ -19925,14 +20007,19 @@ const yarnrcOptions: javascript.YarnrcOptions = { ... }
 | <code><a href="#projen.javascript.YarnrcOptions.property.nmHoistingLimits">nmHoistingLimits</a></code> | <code><a href="#projen.javascript.YarnNmHoistingLimit">YarnNmHoistingLimit</a></code> | https://yarnpkg.com/configuration/yarnrc#nmHoistingLimits. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.nmMode">nmMode</a></code> | <code><a href="#projen.javascript.YarnNmMode">YarnNmMode</a></code> | https://yarnpkg.com/configuration/yarnrc#nmMode. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.nmSelfReferences">nmSelfReferences</a></code> | <code>boolean</code> | https://yarnpkg.com/configuration/yarnrc#nmSelfReferences. |
+| <code><a href="#projen.javascript.YarnrcOptions.property.nodeExperimentalPackageMap">nodeExperimentalPackageMap</a></code> | <code>boolean</code> | https://yarnpkg.com/configuration/yarnrc#nodeExperimentalPackageMap. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.nodeLinker">nodeLinker</a></code> | <code><a href="#projen.javascript.YarnNodeLinker">YarnNodeLinker</a></code> | https://yarnpkg.com/configuration/yarnrc#nodeLinker. |
+| <code><a href="#projen.javascript.YarnrcOptions.property.nodePackageMapType">nodePackageMapType</a></code> | <code><a href="#projen.javascript.YarnNodePackageMapType">YarnNodePackageMapType</a></code> | https://yarnpkg.com/configuration/yarnrc#nodePackageMapType. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.npmAlwaysAuth">npmAlwaysAuth</a></code> | <code>boolean</code> | https://yarnpkg.com/configuration/yarnrc#npmAlwaysAuth. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.npmAuditExcludePackages">npmAuditExcludePackages</a></code> | <code>string[]</code> | https://yarnpkg.com/configuration/yarnrc#npmAuditExcludePackages. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.npmAuditIgnoreAdvisories">npmAuditIgnoreAdvisories</a></code> | <code>string[]</code> | https://yarnpkg.com/configuration/yarnrc#npmAuditIgnoreAdvisories. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.npmAuditRegistry">npmAuditRegistry</a></code> | <code>string</code> | https://yarnpkg.com/configuration/yarnrc#npmAuditRegistry. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.npmAuthIdent">npmAuthIdent</a></code> | <code>string</code> | https://yarnpkg.com/configuration/yarnrc#npmAuthIdent. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.npmAuthToken">npmAuthToken</a></code> | <code>string</code> | https://yarnpkg.com/configuration/yarnrc#npmAuthToken. |
+| <code><a href="#projen.javascript.YarnrcOptions.property.npmMinimalAgeGate">npmMinimalAgeGate</a></code> | <code>string</code> | https://yarnpkg.com/configuration/yarnrc#npmMinimalAgeGate. |
+| <code><a href="#projen.javascript.YarnrcOptions.property.npmPreapprovedPackages">npmPreapprovedPackages</a></code> | <code>string[]</code> | https://yarnpkg.com/configuration/yarnrc#npmPreapprovedPackages. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.npmPublishAccess">npmPublishAccess</a></code> | <code><a href="#projen.javascript.YarnNpmPublishAccess">YarnNpmPublishAccess</a></code> | https://yarnpkg.com/configuration/yarnrc#npmPublishAccess. |
+| <code><a href="#projen.javascript.YarnrcOptions.property.npmPublishProvenance">npmPublishProvenance</a></code> | <code>boolean</code> | https://yarnpkg.com/configuration/yarnrc#npmPublishProvenance. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.npmPublishRegistry">npmPublishRegistry</a></code> | <code>string</code> | https://yarnpkg.com/configuration/yarnrc#npmPublishRegistry. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.npmRegistries">npmRegistries</a></code> | <code>{[ key: string ]: <a href="#projen.javascript.YarnNpmRegistry">YarnNpmRegistry</a>}</code> | https://yarnpkg.com/configuration/yarnrc#npmRegistries. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.npmRegistryServer">npmRegistryServer</a></code> | <code>string</code> | https://yarnpkg.com/configuration/yarnrc#npmRegistryServer. |
@@ -19944,6 +20031,7 @@ const yarnrcOptions: javascript.YarnrcOptions = { ... }
 | <code><a href="#projen.javascript.YarnrcOptions.property.pnpFallbackMode">pnpFallbackMode</a></code> | <code><a href="#projen.javascript.YarnPnpFallbackMode">YarnPnpFallbackMode</a></code> | https://yarnpkg.com/configuration/yarnrc#pnpFallbackMode. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.pnpIgnorePatterns">pnpIgnorePatterns</a></code> | <code>string[]</code> | https://yarnpkg.com/configuration/yarnrc#pnpIgnorePatterns. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.pnpMode">pnpMode</a></code> | <code><a href="#projen.javascript.YarnPnpMode">YarnPnpMode</a></code> | https://yarnpkg.com/configuration/yarnrc#pnpMode. |
+| <code><a href="#projen.javascript.YarnrcOptions.property.pnpmStoreFolder">pnpmStoreFolder</a></code> | <code>string</code> | https://yarnpkg.com/configuration/yarnrc#pnpmStoreFolder. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.pnpShebang">pnpShebang</a></code> | <code>string</code> | https://yarnpkg.com/configuration/yarnrc#pnpShebang. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.pnpUnpluggedFolder">pnpUnpluggedFolder</a></code> | <code>string</code> | https://yarnpkg.com/configuration/yarnrc#pnpUnpluggedFolder. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.preferDeferredVersions">preferDeferredVersions</a></code> | <code>boolean</code> | https://yarnpkg.com/configuration/yarnrc#preferDeferredVersions. |
@@ -19954,14 +20042,27 @@ const yarnrcOptions: javascript.YarnrcOptions = { ... }
 | <code><a href="#projen.javascript.YarnrcOptions.property.rcFilename">rcFilename</a></code> | <code>string</code> | https://yarnpkg.com/configuration/yarnrc#rcFilename. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.supportedArchitectures">supportedArchitectures</a></code> | <code><a href="#projen.javascript.YarnSupportedArchitectures">YarnSupportedArchitectures</a></code> | https://yarnpkg.com/configuration/yarnrc#supportedArchitectures. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.taskPoolConcurrency">taskPoolConcurrency</a></code> | <code>string</code> | https://yarnpkg.com/configuration/yarnrc#taskPoolConcurrency. |
+| <code><a href="#projen.javascript.YarnrcOptions.property.taskPoolMode">taskPoolMode</a></code> | <code><a href="#projen.javascript.YarnTaskPoolMode">YarnTaskPoolMode</a></code> | https://yarnpkg.com/configuration/yarnrc#taskPoolMode. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.telemetryInterval">telemetryInterval</a></code> | <code>number</code> | https://yarnpkg.com/configuration/yarnrc#telemetryInterval. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.telemetryUserId">telemetryUserId</a></code> | <code>string</code> | https://yarnpkg.com/configuration/yarnrc#telemetryUserId. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.tsEnableAutoTypes">tsEnableAutoTypes</a></code> | <code>boolean</code> | https://yarnpkg.com/configuration/yarnrc#tsEnableAutoTypes. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.unsafeHttpWhitelist">unsafeHttpWhitelist</a></code> | <code>string[]</code> | https://yarnpkg.com/configuration/yarnrc#unsafeHttpWhitelist. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.virtualFolder">virtualFolder</a></code> | <code>string</code> | https://yarnpkg.com/configuration/yarnrc#virtualFolder. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.winLinkType">winLinkType</a></code> | <code><a href="#projen.javascript.YarnWinLinkType">YarnWinLinkType</a></code> | https://yarnpkg.com/configuration/yarnrc#winLinkType. |
-| <code><a href="#projen.javascript.YarnrcOptions.property.workerPoolMode">workerPoolMode</a></code> | <code><a href="#projen.javascript.YarnWorkerPoolMode">YarnWorkerPoolMode</a></code> | https://yarnpkg.com/configuration/yarnrc#workerPoolMode. |
+| <code><a href="#projen.javascript.YarnrcOptions.property.workerPoolMode">workerPoolMode</a></code> | <code><a href="#projen.javascript.YarnWorkerPoolMode">YarnWorkerPoolMode</a></code> | https://yarnpkg.com/configuration/yarnrc#taskPoolMode. |
 | <code><a href="#projen.javascript.YarnrcOptions.property.yarnPath">yarnPath</a></code> | <code>string</code> | https://yarnpkg.com/configuration/yarnrc#yarnPath. |
+
+---
+
+##### `approvedGitRepositories`<sup>Optional</sup> <a name="approvedGitRepositories" id="projen.javascript.YarnrcOptions.property.approvedGitRepositories"></a>
+
+```typescript
+public readonly approvedGitRepositories: string[];
+```
+
+- *Type:* string[]
+
+https://yarnpkg.com/configuration/yarnrc#approvedGitRepositories.
 
 ---
 
@@ -19986,6 +20087,30 @@ public readonly cacheMigrationMode: YarnCacheMigrationMode;
 - *Type:* <a href="#projen.javascript.YarnCacheMigrationMode">YarnCacheMigrationMode</a>
 
 https://yarnpkg.com/configuration/yarnrc#cacheMigrationMode.
+
+---
+
+##### `catalog`<sup>Optional</sup> <a name="catalog" id="projen.javascript.YarnrcOptions.property.catalog"></a>
+
+```typescript
+public readonly catalog: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
+
+https://yarnpkg.com/configuration/yarnrc#catalog.
+
+---
+
+##### `catalogs`<sup>Optional</sup> <a name="catalogs" id="projen.javascript.YarnrcOptions.property.catalogs"></a>
+
+```typescript
+public readonly catalogs: {[ key: string ]: {[ key: string ]: string}};
+```
+
+- *Type:* {[ key: string ]: {[ key: string ]: string}}
+
+https://yarnpkg.com/configuration/yarnrc#catalogs.
 
 ---
 
@@ -20121,7 +20246,10 @@ https://yarnpkg.com/configuration/yarnrc#enableColors.
 
 ---
 
-##### `enableConstraintsCheck`<sup>Optional</sup> <a name="enableConstraintsCheck" id="projen.javascript.YarnrcOptions.property.enableConstraintsCheck"></a>
+##### ~~`enableConstraintsCheck`~~<sup>Optional</sup> <a name="enableConstraintsCheck" id="projen.javascript.YarnrcOptions.property.enableConstraintsCheck"></a>
+
+- *Deprecated:* use {@link YarnrcOptions.enableConstraintsChecks } instead. Yarn
+calls this setting `enableConstraintsChecks` (note the trailing `s`).
 
 ```typescript
 public readonly enableConstraintsCheck: boolean;
@@ -20129,7 +20257,19 @@ public readonly enableConstraintsCheck: boolean;
 
 - *Type:* boolean
 
-https://yarnpkg.com/configuration/yarnrc#enableConstraintsCheck.
+https://yarnpkg.com/configuration/yarnrc#enableConstraintsChecks.
+
+---
+
+##### `enableConstraintsChecks`<sup>Optional</sup> <a name="enableConstraintsChecks" id="projen.javascript.YarnrcOptions.property.enableConstraintsChecks"></a>
+
+```typescript
+public readonly enableConstraintsChecks: boolean;
+```
+
+- *Type:* boolean
+
+https://yarnpkg.com/configuration/yarnrc#enableConstraintsChecks.
 
 ---
 
@@ -20577,6 +20717,18 @@ https://yarnpkg.com/configuration/yarnrc#nmSelfReferences.
 
 ---
 
+##### `nodeExperimentalPackageMap`<sup>Optional</sup> <a name="nodeExperimentalPackageMap" id="projen.javascript.YarnrcOptions.property.nodeExperimentalPackageMap"></a>
+
+```typescript
+public readonly nodeExperimentalPackageMap: boolean;
+```
+
+- *Type:* boolean
+
+https://yarnpkg.com/configuration/yarnrc#nodeExperimentalPackageMap.
+
+---
+
 ##### `nodeLinker`<sup>Optional</sup> <a name="nodeLinker" id="projen.javascript.YarnrcOptions.property.nodeLinker"></a>
 
 ```typescript
@@ -20586,6 +20738,18 @@ public readonly nodeLinker: YarnNodeLinker;
 - *Type:* <a href="#projen.javascript.YarnNodeLinker">YarnNodeLinker</a>
 
 https://yarnpkg.com/configuration/yarnrc#nodeLinker.
+
+---
+
+##### `nodePackageMapType`<sup>Optional</sup> <a name="nodePackageMapType" id="projen.javascript.YarnrcOptions.property.nodePackageMapType"></a>
+
+```typescript
+public readonly nodePackageMapType: YarnNodePackageMapType;
+```
+
+- *Type:* <a href="#projen.javascript.YarnNodePackageMapType">YarnNodePackageMapType</a>
+
+https://yarnpkg.com/configuration/yarnrc#nodePackageMapType.
 
 ---
 
@@ -20661,6 +20825,30 @@ https://yarnpkg.com/configuration/yarnrc#npmAuthToken.
 
 ---
 
+##### `npmMinimalAgeGate`<sup>Optional</sup> <a name="npmMinimalAgeGate" id="projen.javascript.YarnrcOptions.property.npmMinimalAgeGate"></a>
+
+```typescript
+public readonly npmMinimalAgeGate: string;
+```
+
+- *Type:* string
+
+https://yarnpkg.com/configuration/yarnrc#npmMinimalAgeGate.
+
+---
+
+##### `npmPreapprovedPackages`<sup>Optional</sup> <a name="npmPreapprovedPackages" id="projen.javascript.YarnrcOptions.property.npmPreapprovedPackages"></a>
+
+```typescript
+public readonly npmPreapprovedPackages: string[];
+```
+
+- *Type:* string[]
+
+https://yarnpkg.com/configuration/yarnrc#npmPreapprovedPackages.
+
+---
+
 ##### `npmPublishAccess`<sup>Optional</sup> <a name="npmPublishAccess" id="projen.javascript.YarnrcOptions.property.npmPublishAccess"></a>
 
 ```typescript
@@ -20670,6 +20858,18 @@ public readonly npmPublishAccess: YarnNpmPublishAccess;
 - *Type:* <a href="#projen.javascript.YarnNpmPublishAccess">YarnNpmPublishAccess</a>
 
 https://yarnpkg.com/configuration/yarnrc#npmPublishAccess.
+
+---
+
+##### `npmPublishProvenance`<sup>Optional</sup> <a name="npmPublishProvenance" id="projen.javascript.YarnrcOptions.property.npmPublishProvenance"></a>
+
+```typescript
+public readonly npmPublishProvenance: boolean;
+```
+
+- *Type:* boolean
+
+https://yarnpkg.com/configuration/yarnrc#npmPublishProvenance.
 
 ---
 
@@ -20805,6 +21005,18 @@ https://yarnpkg.com/configuration/yarnrc#pnpMode.
 
 ---
 
+##### `pnpmStoreFolder`<sup>Optional</sup> <a name="pnpmStoreFolder" id="projen.javascript.YarnrcOptions.property.pnpmStoreFolder"></a>
+
+```typescript
+public readonly pnpmStoreFolder: string;
+```
+
+- *Type:* string
+
+https://yarnpkg.com/configuration/yarnrc#pnpmStoreFolder.
+
+---
+
 ##### `pnpShebang`<sup>Optional</sup> <a name="pnpShebang" id="projen.javascript.YarnrcOptions.property.pnpShebang"></a>
 
 ```typescript
@@ -20925,6 +21137,18 @@ https://yarnpkg.com/configuration/yarnrc#taskPoolConcurrency.
 
 ---
 
+##### `taskPoolMode`<sup>Optional</sup> <a name="taskPoolMode" id="projen.javascript.YarnrcOptions.property.taskPoolMode"></a>
+
+```typescript
+public readonly taskPoolMode: YarnTaskPoolMode;
+```
+
+- *Type:* <a href="#projen.javascript.YarnTaskPoolMode">YarnTaskPoolMode</a>
+
+https://yarnpkg.com/configuration/yarnrc#taskPoolMode.
+
+---
+
 ##### `telemetryInterval`<sup>Optional</sup> <a name="telemetryInterval" id="projen.javascript.YarnrcOptions.property.telemetryInterval"></a>
 
 ```typescript
@@ -20997,7 +21221,10 @@ https://yarnpkg.com/configuration/yarnrc#winLinkType.
 
 ---
 
-##### `workerPoolMode`<sup>Optional</sup> <a name="workerPoolMode" id="projen.javascript.YarnrcOptions.property.workerPoolMode"></a>
+##### ~~`workerPoolMode`~~<sup>Optional</sup> <a name="workerPoolMode" id="projen.javascript.YarnrcOptions.property.workerPoolMode"></a>
+
+- *Deprecated:* use {@link YarnrcOptions.taskPoolMode } instead. Yarn calls this
+setting `taskPoolMode`; there is no `workerPoolMode` setting.
 
 ```typescript
 public readonly workerPoolMode: YarnWorkerPoolMode;
@@ -21005,7 +21232,7 @@ public readonly workerPoolMode: YarnWorkerPoolMode;
 
 - *Type:* <a href="#projen.javascript.YarnWorkerPoolMode">YarnWorkerPoolMode</a>
 
-https://yarnpkg.com/configuration/yarnrc#workerPoolMode.
+https://yarnpkg.com/configuration/yarnrc#taskPoolMode.
 
 ---
 
@@ -23130,6 +23357,29 @@ https://yarnpkg.com/configuration/yarnrc#nodeLinker.
 ---
 
 
+### YarnNodePackageMapType <a name="YarnNodePackageMapType" id="projen.javascript.YarnNodePackageMapType"></a>
+
+https://yarnpkg.com/configuration/yarnrc#nodePackageMapType.
+
+#### Members <a name="Members" id="Members"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#projen.javascript.YarnNodePackageMapType.STANDARD">STANDARD</a></code> | *No description.* |
+| <code><a href="#projen.javascript.YarnNodePackageMapType.LOOSE">LOOSE</a></code> | *No description.* |
+
+---
+
+##### `STANDARD` <a name="STANDARD" id="projen.javascript.YarnNodePackageMapType.STANDARD"></a>
+
+---
+
+
+##### `LOOSE` <a name="LOOSE" id="projen.javascript.YarnNodePackageMapType.LOOSE"></a>
+
+---
+
+
 ### YarnNpmPublishAccess <a name="YarnNpmPublishAccess" id="projen.javascript.YarnNpmPublishAccess"></a>
 
 https://yarnpkg.com/configuration/yarnrc#npmPublishAccess.
@@ -23246,6 +23496,29 @@ https://yarnpkg.com/configuration/yarnrc#progressBarStyle.
 ---
 
 
+### YarnTaskPoolMode <a name="YarnTaskPoolMode" id="projen.javascript.YarnTaskPoolMode"></a>
+
+https://yarnpkg.com/configuration/yarnrc#taskPoolMode.
+
+#### Members <a name="Members" id="Members"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#projen.javascript.YarnTaskPoolMode.ASYNC">ASYNC</a></code> | *No description.* |
+| <code><a href="#projen.javascript.YarnTaskPoolMode.WORKERS">WORKERS</a></code> | *No description.* |
+
+---
+
+##### `ASYNC` <a name="ASYNC" id="projen.javascript.YarnTaskPoolMode.ASYNC"></a>
+
+---
+
+
+##### `WORKERS` <a name="WORKERS" id="projen.javascript.YarnTaskPoolMode.WORKERS"></a>
+
+---
+
+
 ### YarnWinLinkType <a name="YarnWinLinkType" id="projen.javascript.YarnWinLinkType"></a>
 
 https://yarnpkg.com/configuration/yarnrc#winLinkType.
@@ -23271,6 +23544,8 @@ https://yarnpkg.com/configuration/yarnrc#winLinkType.
 
 ### YarnWorkerPoolMode <a name="YarnWorkerPoolMode" id="projen.javascript.YarnWorkerPoolMode"></a>
 
+https://yarnpkg.com/configuration/yarnrc#taskPoolMode.
+
 #### Members <a name="Members" id="Members"></a>
 
 | **Name** | **Description** |
@@ -23280,12 +23555,18 @@ https://yarnpkg.com/configuration/yarnrc#winLinkType.
 
 ---
 
-##### `ASYNC` <a name="ASYNC" id="projen.javascript.YarnWorkerPoolMode.ASYNC"></a>
+##### ~~`ASYNC`~~ <a name="ASYNC" id="projen.javascript.YarnWorkerPoolMode.ASYNC"></a>
+
+- *Deprecated:* use {@link YarnTaskPoolMode } instead. Yarn calls this setting
+`taskPoolMode`; there is no `workerPoolMode` setting.
 
 ---
 
 
-##### `WORKERS` <a name="WORKERS" id="projen.javascript.YarnWorkerPoolMode.WORKERS"></a>
+##### ~~`WORKERS`~~ <a name="WORKERS" id="projen.javascript.YarnWorkerPoolMode.WORKERS"></a>
+
+- *Deprecated:* use {@link YarnTaskPoolMode } instead. Yarn calls this setting
+`taskPoolMode`; there is no `workerPoolMode` setting.
 
 ---
 

--- a/docs/api/javascript.md
+++ b/docs/api/javascript.md
@@ -19433,9 +19433,31 @@ const yarnBerryOptions: javascript.YarnBerryOptions = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#projen.javascript.YarnBerryOptions.property.dedupePackages">dedupePackages</a></code> | <code>string[]</code> | Packages to deduplicate. |
 | <code><a href="#projen.javascript.YarnBerryOptions.property.version">version</a></code> | <code>string</code> | A fully specified version to use for yarn (e.g., x.x.x). |
 | <code><a href="#projen.javascript.YarnBerryOptions.property.yarnRcOptions">yarnRcOptions</a></code> | <code><a href="#projen.javascript.YarnrcOptions">YarnrcOptions</a></code> | The yarnrc configuration. |
 | <code><a href="#projen.javascript.YarnBerryOptions.property.zeroInstalls">zeroInstalls</a></code> | <code>boolean</code> | Should zero-installs be enabled? |
+
+---
+
+##### `dedupePackages`<sup>Optional</sup> <a name="dedupePackages" id="projen.javascript.YarnBerryOptions.property.dedupePackages"></a>
+
+```typescript
+public readonly dedupePackages: string[];
+```
+
+- *Type:* string[]
+
+Packages to deduplicate.
+
+This will prevent multiple versions of the same package from being
+installed in the lock file, if a single version could satisfy all requested
+version ranges. This will prevent version proliferation and reduce the size
+of the depdendency tree.
+
+Setting this will run `yarn dedupe` after dependency upgrades.
+
+Supports glob patterns, e.g. `@aws-sdk/*`.
 
 ---
 

--- a/docs/api/javascript.md
+++ b/docs/api/javascript.md
@@ -9778,7 +9778,7 @@ public readonly dedupeDeps: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* false - unless `yarnBerryOptions.dedupePackages` is set
+- *Default:* false, unless `yarnBerryOptions.dedupePackages` is set
 
 Add a `dedupe` task that deduplicates project dependencies.
 
@@ -10987,7 +10987,7 @@ public readonly dedupeDeps: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* false - unless `yarnBerryOptions.dedupePackages` is set
+- *Default:* false, unless `yarnBerryOptions.dedupePackages` is set
 
 Add a `dedupe` task that deduplicates project dependencies.
 

--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -4275,6 +4275,7 @@ const typeScriptProjectOptions: typescript.TypeScriptProjectOptions = { ... }
 | <code><a href="#projen.typescript.TypeScriptProjectOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.typescript.TypeScriptProjectOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.typescript.TypeScriptProjectOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.javascript.CodeArtifactOptions</code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.typescript.TypeScriptProjectOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.typescript.TypeScriptProjectOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.typescript.TypeScriptProjectOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
 | <code><a href="#projen.typescript.TypeScriptProjectOptions.property.description">description</a></code> | <code>string</code> | The description is just a string that helps people understand the purpose of the package. |
@@ -4968,6 +4969,34 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `dedupeDeps`<sup>Optional</sup> <a name="dedupeDeps" id="projen.typescript.TypeScriptProjectOptions.property.dedupeDeps"></a>
+
+```typescript
+public readonly dedupeDeps: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false - unless `yarnBerryOptions.dedupePackages` is set
+
+Add a `dedupe` task that deduplicates project dependencies.
+
+Deduplication prevents multiple versions of the same package from being
+installed, if a single version can satisfy all requested version ranges.
+This prevents version proliferation and reduces the size of the dependency
+tree.
+
+The behavior depends on the package manager:
+- npm: runs `npm dedupe` after every mutating install.
+- pnpm: runs `pnpm dedupe` after every mutating install.
+- Yarn Berry: runs `yarn dedupe` after every mutating install. If
+  `yarnBerryOptions.dedupePackages` is set, only the listed packages are
+  deduplicated.
+- Yarn Classic: `yarn install` already deduplicates, so the task only
+  prints an informational message.
+- Bun: not supported, enabling this option throws an error.
 
 ---
 

--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -4979,7 +4979,7 @@ public readonly dedupeDeps: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* false - unless `yarnBerryOptions.dedupePackages` is set
+- *Default:* false, unless `yarnBerryOptions.dedupePackages` is set
 
 Add a `dedupe` task that deduplicates project dependencies.
 

--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -5975,6 +5975,7 @@ const nextJsProjectOptions: web.NextJsProjectOptions = { ... }
 | <code><a href="#projen.web.NextJsProjectOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.web.NextJsProjectOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.web.NextJsProjectOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.javascript.CodeArtifactOptions</code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.web.NextJsProjectOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.web.NextJsProjectOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.web.NextJsProjectOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
 | <code><a href="#projen.web.NextJsProjectOptions.property.description">description</a></code> | <code>string</code> | The description is just a string that helps people understand the purpose of the package. |
@@ -6679,6 +6680,34 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `dedupeDeps`<sup>Optional</sup> <a name="dedupeDeps" id="projen.web.NextJsProjectOptions.property.dedupeDeps"></a>
+
+```typescript
+public readonly dedupeDeps: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false - unless `yarnBerryOptions.dedupePackages` is set
+
+Add a `dedupe` task that deduplicates project dependencies.
+
+Deduplication prevents multiple versions of the same package from being
+installed, if a single version can satisfy all requested version ranges.
+This prevents version proliferation and reduces the size of the dependency
+tree.
+
+The behavior depends on the package manager:
+- npm: runs `npm dedupe` after every mutating install.
+- pnpm: runs `pnpm dedupe` after every mutating install.
+- Yarn Berry: runs `yarn dedupe` after every mutating install. If
+  `yarnBerryOptions.dedupePackages` is set, only the listed packages are
+  deduplicated.
+- Yarn Classic: `yarn install` already deduplicates, so the task only
+  prints an informational message.
+- Bun: not supported, enabling this option throws an error.
 
 ---
 
@@ -8105,6 +8134,7 @@ const nextJsTypeScriptProjectOptions: web.NextJsTypeScriptProjectOptions = { ...
 | <code><a href="#projen.web.NextJsTypeScriptProjectOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.web.NextJsTypeScriptProjectOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.web.NextJsTypeScriptProjectOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.javascript.CodeArtifactOptions</code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.web.NextJsTypeScriptProjectOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.web.NextJsTypeScriptProjectOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.web.NextJsTypeScriptProjectOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
 | <code><a href="#projen.web.NextJsTypeScriptProjectOptions.property.description">description</a></code> | <code>string</code> | The description is just a string that helps people understand the purpose of the package. |
@@ -8826,6 +8856,34 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `dedupeDeps`<sup>Optional</sup> <a name="dedupeDeps" id="projen.web.NextJsTypeScriptProjectOptions.property.dedupeDeps"></a>
+
+```typescript
+public readonly dedupeDeps: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false - unless `yarnBerryOptions.dedupePackages` is set
+
+Add a `dedupe` task that deduplicates project dependencies.
+
+Deduplication prevents multiple versions of the same package from being
+installed, if a single version can satisfy all requested version ranges.
+This prevents version proliferation and reduces the size of the dependency
+tree.
+
+The behavior depends on the package manager:
+- npm: runs `npm dedupe` after every mutating install.
+- pnpm: runs `pnpm dedupe` after every mutating install.
+- Yarn Berry: runs `yarn dedupe` after every mutating install. If
+  `yarnBerryOptions.dedupePackages` is set, only the listed packages are
+  deduplicated.
+- Yarn Classic: `yarn install` already deduplicates, so the task only
+  prints an informational message.
+- Bun: not supported, enabling this option throws an error.
 
 ---
 
@@ -10611,6 +10669,7 @@ const reactProjectOptions: web.ReactProjectOptions = { ... }
 | <code><a href="#projen.web.ReactProjectOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.web.ReactProjectOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.web.ReactProjectOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.javascript.CodeArtifactOptions</code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.web.ReactProjectOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.web.ReactProjectOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.web.ReactProjectOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
 | <code><a href="#projen.web.ReactProjectOptions.property.description">description</a></code> | <code>string</code> | The description is just a string that helps people understand the purpose of the package. |
@@ -11288,6 +11347,34 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `dedupeDeps`<sup>Optional</sup> <a name="dedupeDeps" id="projen.web.ReactProjectOptions.property.dedupeDeps"></a>
+
+```typescript
+public readonly dedupeDeps: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false - unless `yarnBerryOptions.dedupePackages` is set
+
+Add a `dedupe` task that deduplicates project dependencies.
+
+Deduplication prevents multiple versions of the same package from being
+installed, if a single version can satisfy all requested version ranges.
+This prevents version proliferation and reduces the size of the dependency
+tree.
+
+The behavior depends on the package manager:
+- npm: runs `npm dedupe` after every mutating install.
+- pnpm: runs `pnpm dedupe` after every mutating install.
+- Yarn Berry: runs `yarn dedupe` after every mutating install. If
+  `yarnBerryOptions.dedupePackages` is set, only the listed packages are
+  deduplicated.
+- Yarn Classic: `yarn install` already deduplicates, so the task only
+  prints an informational message.
+- Bun: not supported, enabling this option throws an error.
 
 ---
 
@@ -12808,6 +12895,7 @@ const reactTypeScriptProjectOptions: web.ReactTypeScriptProjectOptions = { ... }
 | <code><a href="#projen.web.ReactTypeScriptProjectOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.web.ReactTypeScriptProjectOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.web.ReactTypeScriptProjectOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.javascript.CodeArtifactOptions</code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.web.ReactTypeScriptProjectOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.web.ReactTypeScriptProjectOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.web.ReactTypeScriptProjectOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
 | <code><a href="#projen.web.ReactTypeScriptProjectOptions.property.description">description</a></code> | <code>string</code> | The description is just a string that helps people understand the purpose of the package. |
@@ -13502,6 +13590,34 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `dedupeDeps`<sup>Optional</sup> <a name="dedupeDeps" id="projen.web.ReactTypeScriptProjectOptions.property.dedupeDeps"></a>
+
+```typescript
+public readonly dedupeDeps: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false - unless `yarnBerryOptions.dedupePackages` is set
+
+Add a `dedupe` task that deduplicates project dependencies.
+
+Deduplication prevents multiple versions of the same package from being
+installed, if a single version can satisfy all requested version ranges.
+This prevents version proliferation and reduces the size of the dependency
+tree.
+
+The behavior depends on the package manager:
+- npm: runs `npm dedupe` after every mutating install.
+- pnpm: runs `pnpm dedupe` after every mutating install.
+- Yarn Berry: runs `yarn dedupe` after every mutating install. If
+  `yarnBerryOptions.dedupePackages` is set, only the listed packages are
+  deduplicated.
+- Yarn Classic: `yarn install` already deduplicates, so the task only
+  prints an informational message.
+- Bun: not supported, enabling this option throws an error.
 
 ---
 

--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -6690,7 +6690,7 @@ public readonly dedupeDeps: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* false - unless `yarnBerryOptions.dedupePackages` is set
+- *Default:* false, unless `yarnBerryOptions.dedupePackages` is set
 
 Add a `dedupe` task that deduplicates project dependencies.
 
@@ -8866,7 +8866,7 @@ public readonly dedupeDeps: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* false - unless `yarnBerryOptions.dedupePackages` is set
+- *Default:* false, unless `yarnBerryOptions.dedupePackages` is set
 
 Add a `dedupe` task that deduplicates project dependencies.
 
@@ -11357,7 +11357,7 @@ public readonly dedupeDeps: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* false - unless `yarnBerryOptions.dedupePackages` is set
+- *Default:* false, unless `yarnBerryOptions.dedupePackages` is set
 
 Add a `dedupe` task that deduplicates project dependencies.
 
@@ -13600,7 +13600,7 @@ public readonly dedupeDeps: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* false - unless `yarnBerryOptions.dedupePackages` is set
+- *Default:* false, unless `yarnBerryOptions.dedupePackages` is set
 
 Add a `dedupe` task that deduplicates project dependencies.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1363,9 +1363,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1444,9 +1444,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1742,9 +1742,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2045,9 +2045,9 @@
       "license": "MIT"
     },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5050,9 +5050,9 @@
       "license": "MIT"
     },
     "node_modules/dotgitignore/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5638,9 +5638,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5750,9 +5750,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6567,9 +6567,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6807,9 +6807,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7649,9 +7649,9 @@
       "license": "MIT"
     },
     "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8007,9 +8007,9 @@
       "license": "MIT"
     },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8197,9 +8197,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -9851,9 +9851,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10548,24 +10548,10 @@
       }
     },
     "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
       "license": "MIT"
     },
     "node_modules/safe-push-apply": {
@@ -11093,13 +11079,13 @@
       }
     },
     "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "safe-buffer": "~5.2.0"
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string-length": {
@@ -11361,9 +11347,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11433,23 +11419,6 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/through2/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/through2/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/tinyglobby": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "clobber": "node ./projen.js clobber",
     "compat": "node ./projen.js compat",
     "compile": "node ./projen.js compile",
+    "dedupe": "node ./projen.js dedupe",
     "default": "node ./projen.js default",
     "devenv:setup": "node ./projen.js devenv:setup",
     "docgen": "node ./projen.js docgen",

--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -909,6 +909,11 @@ export class NodePackage extends Component {
       description: "Install project dependencies using frozen lockfile",
       exec: this.installCommand,
     });
+
+    if (isYarnBerry(this.packageManager)) {
+      // Needs to happen after the install tasks have been added
+      this.configureYarnBerryDedupe(options.yarnBerryOptions?.dedupePackages);
+    }
   }
 
   /**
@@ -2137,6 +2142,22 @@ export class NodePackage extends Component {
     });
   }
 
+  /**
+   * Configure package deduping
+   */
+  private configureYarnBerryDedupe(dedupePackages: string[] | undefined) {
+    if (!dedupePackages || dedupePackages.length === 0) {
+      return;
+    }
+
+    const dedupeTask = this.project.addTask("yarn:dedupe", {
+      execArgs: ["yarn", "dedupe", ...dedupePackages],
+    });
+
+    // Add dedupe to non-CI install command
+    this.project.tasks.tryFind("install")?.spawn(dedupeTask);
+  }
+
   private checkForConflictingYarnOptions(yarnRcOptions: YarnrcOptions) {
     if (
       this.npmAccess &&
@@ -2273,6 +2294,20 @@ export interface YarnBerryOptions {
    * @default false
    */
   readonly zeroInstalls?: boolean;
+
+  /**
+   * Packages to deduplicate.
+   *
+   * This will prevent multiple versions of the same package from being
+   * installed in the lock file, if a single version could satisfy all requested
+   * version ranges. This will prevent version proliferation and reduce the size
+   * of the depdendency tree.
+   *
+   * Setting this will run `yarn dedupe` after dependency upgrades.
+   *
+   * Supports glob patterns, e.g. `@aws-sdk/*`.
+   */
+  readonly dedupePackages?: string[];
 }
 
 /**

--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -174,6 +174,28 @@ export interface NodePackageOptions {
   readonly packageManager?: NodePackageManager;
 
   /**
+   * Add a `dedupe` task that deduplicates project dependencies.
+   *
+   * Deduplication prevents multiple versions of the same package from being
+   * installed, if a single version can satisfy all requested version ranges.
+   * This prevents version proliferation and reduces the size of the dependency
+   * tree.
+   *
+   * The behavior depends on the package manager:
+   * - npm: runs `npm dedupe` after every mutating install.
+   * - pnpm: runs `pnpm dedupe` after every mutating install.
+   * - Yarn Berry: runs `yarn dedupe` after every mutating install. If
+   *   `yarnBerryOptions.dedupePackages` is set, only the listed packages are
+   *   deduplicated.
+   * - Yarn Classic: `yarn install` already deduplicates, so the task only
+   *   prints an informational message.
+   * - Bun: not supported, enabling this option throws an error.
+   *
+   * @default - false, unless `yarnBerryOptions.dedupePackages` is set
+   */
+  readonly dedupeDeps?: boolean;
+
+  /**
    * The repository is the location where the actual code for your package lives.
    * See https://classic.yarnpkg.com/en/docs/package-json/#toc-repository
    */
@@ -712,14 +734,19 @@ export class NodePackage extends Component {
   public readonly lockFile: string;
 
   /**
-   * The task for installing project dependencies (non-frozen)
+   * The task for installing project dependencies (non-frozen).
    */
   public readonly installTask: Task;
 
   /**
-   * The task for installing project dependencies (frozen)
+   * The task for installing project dependencies (frozen).
    */
   public readonly installCiTask: Task;
+
+  /**
+   * The task for deduplicating project dependencies, if configured.
+   */
+  public readonly dedupeTask?: Task;
 
   /**
    * The package.json file.
@@ -910,10 +937,49 @@ export class NodePackage extends Component {
       exec: this.installCommand,
     });
 
-    if (isYarnBerry(this.packageManager)) {
-      // Needs to happen after the install tasks have been added
-      this.configureYarnBerryDedupe(options.yarnBerryOptions?.dedupePackages);
+    // Needs to happen after the install tasks have been added
+    this.dedupeTask = this.maybeAddDedupeTask(options);
+  }
+
+  /**
+   * Adds a `dedupe` task if enabled via `dedupeDeps` or implied by
+   * `yarnBerryOptions.dedupePackages`.
+   *
+   * @returns the dedupe task, or `undefined` if not enabled.
+   */
+  private maybeAddDedupeTask(options: NodePackageOptions): Task | undefined {
+    const yarnBerryDedupePackages = options.yarnBerryOptions?.dedupePackages;
+    if (!(options.dedupeDeps ?? yarnBerryDedupePackages !== undefined)) {
+      return undefined;
     }
+
+    if (this.packageManager === NodePackageManager.BUN) {
+      throw new Error(
+        "The 'dedupeDeps' option is not supported for Bun: bun does not provide a dedupe command.",
+      );
+    }
+
+    const dedupeTask = this.project.addTask("dedupe", {
+      description: "Deduplicate project dependencies",
+    });
+
+    if (isYarnClassic(this.packageManager)) {
+      // Yarn Classic always deduplicates as part of `yarn install`
+      dedupeTask.say(
+        "The dedupe command isn't necessary. `yarn install` will already dedupe.",
+      );
+    } else {
+      dedupeTask.execArgs(
+        isYarnBerry(this.packageManager)
+          ? ["yarn", "dedupe", ...(yarnBerryDedupePackages ?? [])]
+          : [this.packageManager, "dedupe"],
+      );
+
+      // Add dedupe to mutable install task
+      this.installTask.spawn(dedupeTask);
+    }
+
+    return dedupeTask;
   }
 
   /**
@@ -1107,14 +1173,18 @@ export class NodePackage extends Component {
   }
 
   /**
-   * Returns the command to execute in order to install all dependencies (always frozen).
+   * Returns the package manager's immutable install command with a frozen lockfile, e.g. `npm ci` or `pnpm ci`.
+   *
+   * Prefer using `NodePackage.installCiTask`. The raw command string is intended for bootstrapping.
    */
   public get installCommand() {
     return this.renderInstallCommand(true);
   }
 
   /**
-   * Renders `pnpm install` or `npm install` with lockfile update (not frozen)
+   * Returns the package manager's mutable install command with lockfile update, e.g. `npm install` or `pnpm install`.
+   *
+   * Prefer using `NodePackage.installTask`. The raw command string is intended for bootstrapping.
    */
   public get installAndUpdateLockfileCommand() {
     return this.renderInstallCommand(false);
@@ -2142,22 +2212,6 @@ export class NodePackage extends Component {
     });
   }
 
-  /**
-   * Configure package deduping
-   */
-  private configureYarnBerryDedupe(dedupePackages: string[] | undefined) {
-    if (!dedupePackages || dedupePackages.length === 0) {
-      return;
-    }
-
-    const dedupeTask = this.project.addTask("yarn:dedupe", {
-      execArgs: ["yarn", "dedupe", ...dedupePackages],
-    });
-
-    // Add dedupe to non-CI install command
-    this.project.tasks.tryFind("install")?.spawn(dedupeTask);
-  }
-
   private checkForConflictingYarnOptions(yarnRcOptions: YarnrcOptions) {
     if (
       this.npmAccess &&
@@ -2296,16 +2350,20 @@ export interface YarnBerryOptions {
   readonly zeroInstalls?: boolean;
 
   /**
-   * Packages to deduplicate.
+   * Packages to deduplicate when the `dedupe` task runs.
    *
    * This will prevent multiple versions of the same package from being
    * installed in the lock file, if a single version could satisfy all requested
    * version ranges. This will prevent version proliferation and reduce the size
-   * of the depdendency tree.
+   * of the dependency tree.
    *
-   * Setting this will run `yarn dedupe` after dependency upgrades.
+   * Setting this implies `dedupeDeps: true` on the project, which will run
+   * `yarn dedupe` after every mutating install. Set `dedupeDeps: false`
+   * explicitly to disable the task.
    *
    * Supports glob patterns, e.g. `@aws-sdk/*`.
+   *
+   * @default - all packages are deduplicated
    */
   readonly dedupePackages?: string[];
 }

--- a/src/javascript/upgrade-dependencies.ts
+++ b/src/javascript/upgrade-dependencies.ts
@@ -313,6 +313,12 @@ export class UpgradeDependencies extends Component {
         );
       }
     }
+
+    // If we can find the yarn:dedupe task, add it to the post-upgrade task. This is only relevant for yarn berry.
+    const dedupeCommand = this.project.tasks.tryFind("yarn:dedupe");
+    if (dedupeCommand) {
+      this.postUpgradeTask.spawn(dedupeCommand);
+    }
   }
 
   /**

--- a/src/javascript/upgrade-dependencies.ts
+++ b/src/javascript/upgrade-dependencies.ts
@@ -313,12 +313,6 @@ export class UpgradeDependencies extends Component {
         );
       }
     }
-
-    // If we can find the yarn:dedupe task, add it to the post-upgrade task. This is only relevant for yarn berry.
-    const dedupeCommand = this.project.tasks.tryFind("yarn:dedupe");
-    if (dedupeCommand) {
-      this.postUpgradeTask.spawn(dedupeCommand);
-    }
   }
 
   /**
@@ -361,6 +355,11 @@ export class UpgradeDependencies extends Component {
         includeForPackageManagerUpgrade,
       ),
     });
+
+    // If we have a packages deduplication task, run it now.
+    if (this.project.package.dedupeTask) {
+      steps.push({ spawn: this.project.package.dedupeTask.name });
+    }
 
     // run "projen" to give projen a chance to update dependencies (it will also run "yarn install")
     steps.push({ exec: this.project.projenCommand });

--- a/src/javascript/yarnrc.ts
+++ b/src/javascript/yarnrc.ts
@@ -64,6 +64,12 @@ export enum YarnNodeLinker {
   NODE_MODULES = "node-modules",
 }
 
+/** https://yarnpkg.com/configuration/yarnrc#nodePackageMapType */
+export enum YarnNodePackageMapType {
+  STANDARD = "standard",
+  LOOSE = "loose",
+}
+
 /** https://yarnpkg.com/configuration/yarnrc#npmPublishAccess */
 export enum YarnNpmPublishAccess {
   PUBLIC = "public",
@@ -132,7 +138,7 @@ export interface YarnSupportedArchitectures {
 
 /** https://yarnpkg.com/configuration/yarnrc#cacheMigrationMode */
 export enum YarnCacheMigrationMode {
-  REQUIRED_ONLY = "requied-only",
+  REQUIRED_ONLY = "required-only",
   MATCH_SPEC = "match-spec",
   ALWAYS = "always",
 }
@@ -143,7 +149,19 @@ export enum YarnWinLinkType {
   SYMLINKS = "symlinks",
 }
 
+/**
+ * https://yarnpkg.com/configuration/yarnrc#taskPoolMode
+ *
+ * @deprecated use {@link YarnTaskPoolMode} instead. Yarn calls this setting
+ * `taskPoolMode`; there is no `workerPoolMode` setting.
+ */
 export enum YarnWorkerPoolMode {
+  ASYNC = "async",
+  WORKERS = "workers",
+}
+
+/** https://yarnpkg.com/configuration/yarnrc#taskPoolMode */
+export enum YarnTaskPoolMode {
   ASYNC = "async",
   WORKERS = "workers",
 }
@@ -154,6 +172,12 @@ export interface YarnrcOptions {
   readonly cacheFolder?: string;
   /** https://yarnpkg.com/configuration/yarnrc#cacheMigrationMode */
   readonly cacheMigrationMode?: YarnCacheMigrationMode;
+  /** https://yarnpkg.com/configuration/yarnrc#catalog */
+  readonly catalog?: Record<string, string>;
+  /** https://yarnpkg.com/configuration/yarnrc#catalogs */
+  readonly catalogs?: Record<string, Record<string, string>>;
+  /** https://yarnpkg.com/configuration/yarnrc#approvedGitRepositories */
+  readonly approvedGitRepositories?: string[];
   /** https://yarnpkg.com/configuration/yarnrc#httpsCaFilePath */
   readonly httpsCaFilePath?: string;
   /** https://yarnpkg.com/configuration/yarnrc#changesetBaseRefs */
@@ -178,8 +202,15 @@ export interface YarnrcOptions {
   readonly deferredVersionFolder?: string;
   /** https://yarnpkg.com/configuration/yarnrc#enableColors */
   readonly enableColors?: boolean;
-  /** https://yarnpkg.com/configuration/yarnrc#enableConstraintsCheck */
+  /**
+   * https://yarnpkg.com/configuration/yarnrc#enableConstraintsChecks
+   *
+   * @deprecated use {@link YarnrcOptions.enableConstraintsChecks} instead. Yarn
+   * calls this setting `enableConstraintsChecks` (note the trailing `s`).
+   */
   readonly enableConstraintsCheck?: boolean;
+  /** https://yarnpkg.com/configuration/yarnrc#enableConstraintsChecks */
+  readonly enableConstraintsChecks?: boolean;
   /** https://yarnpkg.com/configuration/yarnrc#enableGlobalCache */
   readonly enableGlobalCache?: boolean;
   /** https://yarnpkg.com/configuration/yarnrc#enableHardenedMode */
@@ -254,6 +285,16 @@ export interface YarnrcOptions {
   readonly nmMode?: YarnNmMode;
   /** https://yarnpkg.com/configuration/yarnrc#nodeLinker */
   readonly nodeLinker?: YarnNodeLinker;
+  /** https://yarnpkg.com/configuration/yarnrc#nodeExperimentalPackageMap */
+  readonly nodeExperimentalPackageMap?: boolean;
+  /** https://yarnpkg.com/configuration/yarnrc#nodePackageMapType */
+  readonly nodePackageMapType?: YarnNodePackageMapType;
+  /** https://yarnpkg.com/configuration/yarnrc#npmMinimalAgeGate */
+  readonly npmMinimalAgeGate?: string;
+  /** https://yarnpkg.com/configuration/yarnrc#npmPreapprovedPackages */
+  readonly npmPreapprovedPackages?: string[];
+  /** https://yarnpkg.com/configuration/yarnrc#pnpmStoreFolder */
+  readonly pnpmStoreFolder?: string;
   /** https://yarnpkg.com/configuration/yarnrc#winLinkType */
   readonly winLinkType?: YarnWinLinkType;
   /** https://yarnpkg.com/configuration/yarnrc#npmAlwaysAuth */
@@ -266,6 +307,8 @@ export interface YarnrcOptions {
   readonly npmAuthToken?: string;
   /** https://yarnpkg.com/configuration/yarnrc#npmPublishAccess */
   readonly npmPublishAccess?: YarnNpmPublishAccess;
+  /** https://yarnpkg.com/configuration/yarnrc#npmPublishProvenance */
+  readonly npmPublishProvenance?: boolean;
   /** https://yarnpkg.com/configuration/yarnrc#npmAuditExcludePackages */
   readonly npmAuditExcludePackages?: string[];
   /** https://yarnpkg.com/configuration/yarnrc#npmAuditIgnoreAdvisories */
@@ -312,7 +355,14 @@ export interface YarnrcOptions {
   readonly supportedArchitectures?: YarnSupportedArchitectures;
   /** https://yarnpkg.com/configuration/yarnrc#taskPoolConcurrency */
   readonly taskPoolConcurrency?: string;
-  /** https://yarnpkg.com/configuration/yarnrc#workerPoolMode */
+  /** https://yarnpkg.com/configuration/yarnrc#taskPoolMode */
+  readonly taskPoolMode?: YarnTaskPoolMode;
+  /**
+   * https://yarnpkg.com/configuration/yarnrc#taskPoolMode
+   *
+   * @deprecated use {@link YarnrcOptions.taskPoolMode} instead. Yarn calls this
+   * setting `taskPoolMode`; there is no `workerPoolMode` setting.
+   */
   readonly workerPoolMode?: YarnWorkerPoolMode;
   /** https://yarnpkg.com/configuration/yarnrc#telemetryInterval */
   readonly telemetryInterval?: number;

--- a/test/__snapshots__/inventory.test.ts.snap
+++ b/test/__snapshots__/inventory.test.ts.snap
@@ -3033,6 +3033,23 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "default": "- false, unless \`yarnBerryOptions.dedupePackages\` is set",
+        "docs": "Add a \`dedupe\` task that deduplicates project dependencies.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "dedupeDeps",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "dedupeDeps",
+        ],
+        "simpleType": "boolean",
+        "switch": "dedupe-deps",
+        "type": {
+          "primitive": "boolean",
+        },
+      },
+      {
         "default": ""main"",
         "docs": "The name of the main release branch.",
         "featured": true,
@@ -6108,6 +6125,23 @@ exports[`inventory 1`] = `
         "switch": "copyright-period",
         "type": {
           "primitive": "string",
+        },
+      },
+      {
+        "default": "- false, unless \`yarnBerryOptions.dedupePackages\` is set",
+        "docs": "Add a \`dedupe\` task that deduplicates project dependencies.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "dedupeDeps",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "dedupeDeps",
+        ],
+        "simpleType": "boolean",
+        "switch": "dedupe-deps",
+        "type": {
+          "primitive": "boolean",
         },
       },
       {
@@ -10563,6 +10597,23 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "default": "- false, unless \`yarnBerryOptions.dedupePackages\` is set",
+        "docs": "Add a \`dedupe\` task that deduplicates project dependencies.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "dedupeDeps",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "dedupeDeps",
+        ],
+        "simpleType": "boolean",
+        "switch": "dedupe-deps",
+        "type": {
+          "primitive": "boolean",
+        },
+      },
+      {
         "default": ""main"",
         "docs": "The name of the main release branch.",
         "featured": true,
@@ -13503,6 +13554,23 @@ exports[`inventory 1`] = `
         "switch": "copyright-period",
         "type": {
           "primitive": "string",
+        },
+      },
+      {
+        "default": "- false, unless \`yarnBerryOptions.dedupePackages\` is set",
+        "docs": "Add a \`dedupe\` task that deduplicates project dependencies.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "dedupeDeps",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "dedupeDeps",
+        ],
+        "simpleType": "boolean",
+        "switch": "dedupe-deps",
+        "type": {
+          "primitive": "boolean",
         },
       },
       {
@@ -16545,6 +16613,23 @@ exports[`inventory 1`] = `
         "switch": "copyright-period",
         "type": {
           "primitive": "string",
+        },
+      },
+      {
+        "default": "- false, unless \`yarnBerryOptions.dedupePackages\` is set",
+        "docs": "Add a \`dedupe\` task that deduplicates project dependencies.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "dedupeDeps",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "dedupeDeps",
+        ],
+        "simpleType": "boolean",
+        "switch": "dedupe-deps",
+        "type": {
+          "primitive": "boolean",
         },
       },
       {
@@ -20316,6 +20401,23 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "default": "- false, unless \`yarnBerryOptions.dedupePackages\` is set",
+        "docs": "Add a \`dedupe\` task that deduplicates project dependencies.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "dedupeDeps",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "dedupeDeps",
+        ],
+        "simpleType": "boolean",
+        "switch": "dedupe-deps",
+        "type": {
+          "primitive": "boolean",
+        },
+      },
+      {
         "default": ""main"",
         "docs": "The name of the main release branch.",
         "featured": true,
@@ -23220,6 +23322,23 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "default": "- false, unless \`yarnBerryOptions.dedupePackages\` is set",
+        "docs": "Add a \`dedupe\` task that deduplicates project dependencies.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "dedupeDeps",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "dedupeDeps",
+        ],
+        "simpleType": "boolean",
+        "switch": "dedupe-deps",
+        "type": {
+          "primitive": "boolean",
+        },
+      },
+      {
         "default": ""main"",
         "docs": "The name of the main release branch.",
         "featured": true,
@@ -25654,6 +25773,23 @@ exports[`inventory 1`] = `
         "switch": "copyright-period",
         "type": {
           "primitive": "string",
+        },
+      },
+      {
+        "default": "- false, unless \`yarnBerryOptions.dedupePackages\` is set",
+        "docs": "Add a \`dedupe\` task that deduplicates project dependencies.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "dedupeDeps",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "dedupeDeps",
+        ],
+        "simpleType": "boolean",
+        "switch": "dedupe-deps",
+        "type": {
+          "primitive": "boolean",
         },
       },
       {
@@ -28374,6 +28510,23 @@ exports[`inventory 1`] = `
         "switch": "copyright-period",
         "type": {
           "primitive": "string",
+        },
+      },
+      {
+        "default": "- false, unless \`yarnBerryOptions.dedupePackages\` is set",
+        "docs": "Add a \`dedupe\` task that deduplicates project dependencies.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "dedupeDeps",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "dedupeDeps",
+        ],
+        "simpleType": "boolean",
+        "switch": "dedupe-deps",
+        "type": {
+          "primitive": "boolean",
         },
       },
       {
@@ -32012,6 +32165,23 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "default": "- false, unless \`yarnBerryOptions.dedupePackages\` is set",
+        "docs": "Add a \`dedupe\` task that deduplicates project dependencies.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "dedupeDeps",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "dedupeDeps",
+        ],
+        "simpleType": "boolean",
+        "switch": "dedupe-deps",
+        "type": {
+          "primitive": "boolean",
+        },
+      },
+      {
         "default": ""main"",
         "docs": "The name of the main release branch.",
         "featured": true,
@@ -34434,6 +34604,23 @@ exports[`inventory 1`] = `
         "switch": "copyright-period",
         "type": {
           "primitive": "string",
+        },
+      },
+      {
+        "default": "- false, unless \`yarnBerryOptions.dedupePackages\` is set",
+        "docs": "Add a \`dedupe\` task that deduplicates project dependencies.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "dedupeDeps",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "dedupeDeps",
+        ],
+        "simpleType": "boolean",
+        "switch": "dedupe-deps",
+        "type": {
+          "primitive": "boolean",
         },
       },
       {
@@ -37162,6 +37349,23 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "default": "- false, unless \`yarnBerryOptions.dedupePackages\` is set",
+        "docs": "Add a \`dedupe\` task that deduplicates project dependencies.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "dedupeDeps",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "dedupeDeps",
+        ],
+        "simpleType": "boolean",
+        "switch": "dedupe-deps",
+        "type": {
+          "primitive": "boolean",
+        },
+      },
+      {
         "default": ""main"",
         "docs": "The name of the main release branch.",
         "featured": true,
@@ -39862,6 +40066,23 @@ exports[`inventory 1`] = `
         "switch": "copyright-period",
         "type": {
           "primitive": "string",
+        },
+      },
+      {
+        "default": "- false, unless \`yarnBerryOptions.dedupePackages\` is set",
+        "docs": "Add a \`dedupe\` task that deduplicates project dependencies.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "dedupeDeps",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "dedupeDeps",
+        ],
+        "simpleType": "boolean",
+        "switch": "dedupe-deps",
+        "type": {
+          "primitive": "boolean",
         },
       },
       {

--- a/test/javascript/node-package.test.ts
+++ b/test/javascript/node-package.test.ts
@@ -3,7 +3,11 @@ import { dirname, join } from "path";
 import * as semver from "semver";
 import * as YAML from "yaml";
 import { Project, DependencyType, Component } from "../../src";
-import { YarnNodeLinker, YarnNpmPublishAccess } from "../../src/javascript";
+import {
+  NodeProject,
+  YarnNodeLinker,
+  YarnNpmPublishAccess,
+} from "../../src/javascript";
 import {
   NodePackage,
   NodePackageManager,
@@ -1185,6 +1189,62 @@ describe("yarn berry", () => {
           }),
       ).toThrow(
         "Cannot set npmAccess (public) and yarnRcOptions.npmPublishAccess (restricted) to different values.",
+      );
+    });
+  });
+
+  describe("Package deduplication", () => {
+    test("without dependency upgrades", () => {
+      const project = new TestProject();
+      new NodePackage(project, {
+        packageManager: NodePackageManager.YARN_BERRY,
+        yarnBerryOptions: {
+          dedupePackages: ["@aws-sdk/*", "some-package"],
+        },
+      });
+
+      const snps = synthSnapshot(project);
+
+      expect(snps[".projen/tasks.json"]).toEqual(
+        expect.objectContaining({
+          tasks: expect.objectContaining({
+            "yarn:dedupe": expect.objectContaining({
+              steps: expect.arrayContaining([
+                expect.objectContaining({
+                  execArgs: ["yarn", "dedupe", "@aws-sdk/*", "some-package"],
+                }),
+              ]),
+            }),
+          }),
+        }),
+      );
+    });
+
+    test("with dependency upgrades", () => {
+      const project = new NodeProject({
+        name: "test",
+        clobber: false,
+        packageManager: NodePackageManager.YARN_BERRY,
+        yarnBerryOptions: {
+          dedupePackages: ["@aws-sdk/*", "some-package"],
+        },
+        depsUpgrade: true,
+      });
+
+      const snps = synthSnapshot(project);
+
+      expect(snps[".projen/tasks.json"]).toEqual(
+        expect.objectContaining({
+          tasks: expect.objectContaining({
+            "post-upgrade": expect.objectContaining({
+              steps: expect.arrayContaining([
+                expect.objectContaining({
+                  spawn: "yarn:dedupe",
+                }),
+              ]),
+            }),
+          }),
+        }),
       );
     });
   });

--- a/test/javascript/node-package.test.ts
+++ b/test/javascript/node-package.test.ts
@@ -1194,7 +1194,69 @@ describe("yarn berry", () => {
   });
 
   describe("Package deduplication", () => {
-    test("without dependency upgrades", () => {
+    test("no dedupe task by default", () => {
+      const project = new TestProject();
+      new NodePackage(project, {
+        packageManager: NodePackageManager.NPM,
+      });
+
+      const snps = synthSnapshot(project);
+
+      expect(snps[".projen/tasks.json"].tasks.dedupe).toBeUndefined();
+    });
+
+    test("adds a npm dedupe task", () => {
+      const project = new TestProject();
+      new NodePackage(project, {
+        packageManager: NodePackageManager.NPM,
+        dedupeDeps: true,
+      });
+
+      const snps = synthSnapshot(project);
+
+      expect(snps[".projen/tasks.json"].tasks.dedupe.steps).toEqual([
+        { execArgs: ["npm", "dedupe"] },
+      ]);
+      expect(snps[".projen/tasks.json"].tasks.install.steps).toContainEqual({
+        spawn: "dedupe",
+      });
+    });
+
+    test("adds a pnpm dedupe task", () => {
+      const project = new TestProject();
+      new NodePackage(project, {
+        packageManager: NodePackageManager.PNPM,
+        dedupeDeps: true,
+      });
+
+      const snps = synthSnapshot(project);
+
+      expect(snps[".projen/tasks.json"].tasks.dedupe.steps).toEqual([
+        { execArgs: ["pnpm", "dedupe"] },
+      ]);
+      expect(snps[".projen/tasks.json"].tasks.install.steps).toContainEqual({
+        spawn: "dedupe",
+      });
+    });
+
+    test("adds a yarn berry dedupe task for all packages", () => {
+      const project = new TestProject();
+      new NodePackage(project, {
+        packageManager: NodePackageManager.YARN_BERRY,
+        dedupeDeps: true,
+      });
+
+      const snps = synthSnapshot(project);
+
+      expect(snps[".projen/tasks.json"].tasks.dedupe.steps).toEqual([
+        { execArgs: ["yarn", "dedupe"] },
+      ]);
+      expect(snps[".projen/tasks.json"].tasks.install.steps).toContainEqual({
+        spawn: "dedupe",
+      });
+    });
+
+    test("yarn berry dedupe task honors yarnBerryOptions.dedupePackages", () => {
       const project = new TestProject();
       new NodePackage(project, {
         packageManager: NodePackageManager.YARN_BERRY,
@@ -1205,18 +1267,60 @@ describe("yarn berry", () => {
 
       const snps = synthSnapshot(project);
 
-      expect(snps[".projen/tasks.json"]).toEqual(
-        expect.objectContaining({
-          tasks: expect.objectContaining({
-            "yarn:dedupe": expect.objectContaining({
-              steps: expect.arrayContaining([
-                expect.objectContaining({
-                  execArgs: ["yarn", "dedupe", "@aws-sdk/*", "some-package"],
-                }),
-              ]),
-            }),
+      expect(snps[".projen/tasks.json"].tasks.dedupe.steps).toEqual([
+        { execArgs: ["yarn", "dedupe", "@aws-sdk/*", "some-package"] },
+      ]);
+      expect(snps[".projen/tasks.json"].tasks.install.steps).toContainEqual({
+        spawn: "dedupe",
+      });
+    });
+
+    test("explicitly disabled dedupeDeps wins over yarnBerryOptions.dedupePackages", () => {
+      const project = new TestProject();
+      new NodePackage(project, {
+        packageManager: NodePackageManager.YARN_BERRY,
+        dedupeDeps: false,
+        yarnBerryOptions: {
+          dedupePackages: ["@aws-sdk/*", "some-package"],
+        },
+      });
+
+      const snps = synthSnapshot(project);
+
+      expect(snps[".projen/tasks.json"].tasks.dedupe).toBeUndefined();
+    });
+
+    test("yarn classic dedupe task only prints a message", () => {
+      const project = new TestProject();
+      new NodePackage(project, {
+        packageManager: NodePackageManager.YARN_CLASSIC,
+        dedupeDeps: true,
+      });
+
+      const snps = synthSnapshot(project);
+
+      expect(snps[".projen/tasks.json"].tasks.dedupe.steps).toEqual([
+        {
+          say: "The dedupe command isn't necessary. `yarn install` will already dedupe.",
+        },
+      ]);
+      expect(snps[".projen/tasks.json"].tasks.install.steps).not.toContainEqual(
+        {
+          spawn: "dedupe",
+        },
+      );
+    });
+
+    test("throws for bun", () => {
+      const project = new TestProject();
+      expect(
+        () =>
+          new NodePackage(project, {
+            packageManager: NodePackageManager.BUN,
+            dedupeDeps: true,
           }),
-        }),
+      ).toThrow(
+        "The 'dedupeDeps' option is not supported for Bun: bun does not provide a dedupe command.",
       );
     });
 
@@ -1236,10 +1340,10 @@ describe("yarn berry", () => {
       expect(snps[".projen/tasks.json"]).toEqual(
         expect.objectContaining({
           tasks: expect.objectContaining({
-            "post-upgrade": expect.objectContaining({
+            upgrade: expect.objectContaining({
               steps: expect.arrayContaining([
                 expect.objectContaining({
-                  spawn: "yarn:dedupe",
+                  spawn: "dedupe",
                 }),
               ]),
             }),


### PR DESCRIPTION
Over multiple upgrade cycles, lock files tend to accumulate several versions of the same package, even when a single version could satisfy all requested ranges — think, *as a purely hypothetical example*, 5 copies of the AWS SDK in one dependency tree. Package managers ship a `dedupe` command to clean this up, but nothing was running it.

This PR adds a new `dedupeDeps` option (default: `false`) to Node.js projects. When enabled, projen adds a `dedupe` task that keeps the dependency tree lean:

- **npm** runs `npm dedupe`
- **pnpm** runs `pnpm dedupe`
- **Yarn Berry** runs `yarn dedupe`. If `yarnBerryOptions.dedupePackages` is set, only the listed packages are deduplicated (glob patterns like `@aws-sdk/*` are supported). Setting that list also implies `dedupeDeps: true`, so it works out of the box.
- **Yarn Classic** already dedupes as part of `yarn install`, so the task just prints a note saying the command isn't necessary.
- **Bun** has no dedupe command, so enabling the option throws an error.

The `dedupe` task is spawned as part of the mutable `install` task and during the `upgrade` task. The reasoning: even projects without automatic upgrades should keep the deduping behavior when dependencies are changed by hand, though in practice the upgrade workflow is where it matters most.

Projen itself now dogfoods the feature with `dedupeDeps: true`.

Incidentally, this also refreshes the Yarn Berry `.yarnrc.yml` options with settings added in recent Yarn releases (catalogs, `npmMinimalAgeGate`, `taskPoolMode`, and friends), and deprecates a couple of misspelled options (`workerPoolMode`, `enableConstraintsCheck`) in favor of correctly named ones.

 _PR body rewritten by an AI Agent on behalf of @mrgrain_

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
