### PR TITLE
chore(docs): clarify license placeholder options

### DIFF
--- a/docs/api/awscdk.md
+++ b/docs/api/awscdk.md
@@ -10866,6 +10866,10 @@ public readonly copyrightOwner: string;
 
 License copyright owner.
 
+This value is only used if the selected license text contains the
+`$copyright_owner` placeholder. For example, it has no effect on the
+MPL-2.0 license text.
+
 ---
 
 ##### `copyrightPeriod`<sup>Optional</sup> <a name="copyrightPeriod" id="projen.awscdk.AwsCdkConstructLibraryOptions.property.copyrightPeriod"></a>
@@ -10878,6 +10882,10 @@ public readonly copyrightPeriod: string;
 - *Default:* current year
 
 The copyright years to put in the LICENSE file.
+
+This value is only used if the selected license text contains the
+`$copyright_period` placeholder. For example, it has no effect on the
+MPL-2.0 license text.
 
 ---
 
@@ -15776,6 +15784,10 @@ public readonly copyrightOwner: string;
 
 License copyright owner.
 
+This value is only used if the selected license text contains the
+`$copyright_owner` placeholder. For example, it has no effect on the
+MPL-2.0 license text.
+
 ---
 
 ##### `copyrightPeriod`<sup>Optional</sup> <a name="copyrightPeriod" id="projen.awscdk.AwsCdkTypeScriptAppOptions.property.copyrightPeriod"></a>
@@ -15788,6 +15800,10 @@ public readonly copyrightPeriod: string;
 - *Default:* current year
 
 The copyright years to put in the LICENSE file.
+
+This value is only used if the selected license text contains the
+`$copyright_period` placeholder. For example, it has no effect on the
+MPL-2.0 license text.
 
 ---
 

--- a/docs/api/cdk.md
+++ b/docs/api/cdk.md
@@ -5627,6 +5627,10 @@ public readonly copyrightOwner: string;
 
 License copyright owner.
 
+This value is only used if the selected license text contains the
+`$copyright_owner` placeholder. For example, it has no effect on the
+MPL-2.0 license text.
+
 ---
 
 ##### `copyrightPeriod`<sup>Optional</sup> <a name="copyrightPeriod" id="projen.cdk.ConstructLibraryOptions.property.copyrightPeriod"></a>
@@ -5639,6 +5643,10 @@ public readonly copyrightPeriod: string;
 - *Default:* current year
 
 The copyright years to put in the LICENSE file.
+
+This value is only used if the selected license text contains the
+`$copyright_period` placeholder. For example, it has no effect on the
+MPL-2.0 license text.
 
 ---
 
@@ -9376,6 +9384,10 @@ public readonly copyrightOwner: string;
 
 License copyright owner.
 
+This value is only used if the selected license text contains the
+`$copyright_owner` placeholder. For example, it has no effect on the
+MPL-2.0 license text.
+
 ---
 
 ##### `copyrightPeriod`<sup>Optional</sup> <a name="copyrightPeriod" id="projen.cdk.JsiiProjectOptions.property.copyrightPeriod"></a>
@@ -9388,6 +9400,10 @@ public readonly copyrightPeriod: string;
 - *Default:* current year
 
 The copyright years to put in the LICENSE file.
+
+This value is only used if the selected license text contains the
+`$copyright_period` placeholder. For example, it has no effect on the
+MPL-2.0 license text.
 
 ---
 

--- a/docs/api/cdk8s.md
+++ b/docs/api/cdk8s.md
@@ -8380,6 +8380,10 @@ public readonly copyrightOwner: string;
 
 License copyright owner.
 
+This value is only used if the selected license text contains the
+`$copyright_owner` placeholder. For example, it has no effect on the
+MPL-2.0 license text.
+
 ---
 
 ##### `copyrightPeriod`<sup>Optional</sup> <a name="copyrightPeriod" id="projen.cdk8s.Cdk8sTypeScriptAppOptions.property.copyrightPeriod"></a>
@@ -8392,6 +8396,10 @@ public readonly copyrightPeriod: string;
 - *Default:* current year
 
 The copyright years to put in the LICENSE file.
+
+This value is only used if the selected license text contains the
+`$copyright_period` placeholder. For example, it has no effect on the
+MPL-2.0 license text.
 
 ---
 
@@ -10939,6 +10947,10 @@ public readonly copyrightOwner: string;
 
 License copyright owner.
 
+This value is only used if the selected license text contains the
+`$copyright_owner` placeholder. For example, it has no effect on the
+MPL-2.0 license text.
+
 ---
 
 ##### `copyrightPeriod`<sup>Optional</sup> <a name="copyrightPeriod" id="projen.cdk8s.ConstructLibraryCdk8sOptions.property.copyrightPeriod"></a>
@@ -10951,6 +10963,10 @@ public readonly copyrightPeriod: string;
 - *Default:* current year
 
 The copyright years to put in the LICENSE file.
+
+This value is only used if the selected license text contains the
+`$copyright_period` placeholder. For example, it has no effect on the
+MPL-2.0 license text.
 
 ---
 

--- a/docs/api/cdktf.md
+++ b/docs/api/cdktf.md
@@ -3158,6 +3158,10 @@ public readonly copyrightOwner: string;
 
 License copyright owner.
 
+This value is only used if the selected license text contains the
+`$copyright_owner` placeholder. For example, it has no effect on the
+MPL-2.0 license text.
+
 ---
 
 ##### `copyrightPeriod`<sup>Optional</sup> <a name="copyrightPeriod" id="projen.cdktf.ConstructLibraryCdktfOptions.property.copyrightPeriod"></a>
@@ -3170,6 +3174,10 @@ public readonly copyrightPeriod: string;
 - *Default:* current year
 
 The copyright years to put in the LICENSE file.
+
+This value is only used if the selected license text contains the
+`$copyright_period` placeholder. For example, it has no effect on the
+MPL-2.0 license text.
 
 ---
 

--- a/docs/api/javascript.md
+++ b/docs/api/javascript.md
@@ -11922,6 +11922,10 @@ public readonly copyrightOwner: string;
 
 License copyright owner.
 
+This value is only used if the selected license text contains the
+`$copyright_owner` placeholder. For example, it has no effect on the
+MPL-2.0 license text.
+
 ---
 
 ##### `copyrightPeriod`<sup>Optional</sup> <a name="copyrightPeriod" id="projen.javascript.NodeProjectOptions.property.copyrightPeriod"></a>
@@ -11934,6 +11938,10 @@ public readonly copyrightPeriod: string;
 - *Default:* current year
 
 The copyright years to put in the LICENSE file.
+
+This value is only used if the selected license text contains the
+`$copyright_period` placeholder. For example, it has no effect on the
+MPL-2.0 license text.
 
 ---
 

--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -5960,6 +5960,10 @@ public readonly copyrightOwner: string;
 
 License copyright owner.
 
+This value is only used if the selected license text contains the
+`$copyright_owner` placeholder. For example, it has no effect on the
+MPL-2.0 license text.
+
 ---
 
 ##### `copyrightPeriod`<sup>Optional</sup> <a name="copyrightPeriod" id="projen.typescript.TypeScriptProjectOptions.property.copyrightPeriod"></a>
@@ -5972,6 +5976,10 @@ public readonly copyrightPeriod: string;
 - *Default:* current year
 
 The copyright years to put in the LICENSE file.
+
+This value is only used if the selected license text contains the
+`$copyright_period` placeholder. For example, it has no effect on the
+MPL-2.0 license text.
 
 ---
 

--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -7671,6 +7671,10 @@ public readonly copyrightOwner: string;
 
 License copyright owner.
 
+This value is only used if the selected license text contains the
+`$copyright_owner` placeholder. For example, it has no effect on the
+MPL-2.0 license text.
+
 ---
 
 ##### `copyrightPeriod`<sup>Optional</sup> <a name="copyrightPeriod" id="projen.web.NextJsProjectOptions.property.copyrightPeriod"></a>
@@ -7683,6 +7687,10 @@ public readonly copyrightPeriod: string;
 - *Default:* current year
 
 The copyright years to put in the LICENSE file.
+
+This value is only used if the selected license text contains the
+`$copyright_period` placeholder. For example, it has no effect on the
+MPL-2.0 license text.
 
 ---
 
@@ -9810,6 +9818,10 @@ public readonly copyrightOwner: string;
 
 License copyright owner.
 
+This value is only used if the selected license text contains the
+`$copyright_owner` placeholder. For example, it has no effect on the
+MPL-2.0 license text.
+
 ---
 
 ##### `copyrightPeriod`<sup>Optional</sup> <a name="copyrightPeriod" id="projen.web.NextJsTypeScriptProjectOptions.property.copyrightPeriod"></a>
@@ -9822,6 +9834,10 @@ public readonly copyrightPeriod: string;
 - *Default:* current year
 
 The copyright years to put in the LICENSE file.
+
+This value is only used if the selected license text contains the
+`$copyright_period` placeholder. For example, it has no effect on the
+MPL-2.0 license text.
 
 ---
 
@@ -12264,6 +12280,10 @@ public readonly copyrightOwner: string;
 
 License copyright owner.
 
+This value is only used if the selected license text contains the
+`$copyright_owner` placeholder. For example, it has no effect on the
+MPL-2.0 license text.
+
 ---
 
 ##### `copyrightPeriod`<sup>Optional</sup> <a name="copyrightPeriod" id="projen.web.ReactProjectOptions.property.copyrightPeriod"></a>
@@ -12276,6 +12296,10 @@ public readonly copyrightPeriod: string;
 - *Default:* current year
 
 The copyright years to put in the LICENSE file.
+
+This value is only used if the selected license text contains the
+`$copyright_period` placeholder. For example, it has no effect on the
+MPL-2.0 license text.
 
 ---
 
@@ -14470,6 +14494,10 @@ public readonly copyrightOwner: string;
 
 License copyright owner.
 
+This value is only used if the selected license text contains the
+`$copyright_owner` placeholder. For example, it has no effect on the
+MPL-2.0 license text.
+
 ---
 
 ##### `copyrightPeriod`<sup>Optional</sup> <a name="copyrightPeriod" id="projen.web.ReactTypeScriptProjectOptions.property.copyrightPeriod"></a>
@@ -14482,6 +14510,10 @@ public readonly copyrightPeriod: string;
 - *Default:* current year
 
 The copyright years to put in the LICENSE file.
+
+This value is only used if the selected license text contains the
+`$copyright_period` placeholder. For example, it has no effect on the
+MPL-2.0 license text.
 
 ---
 

--- a/src/javascript/node-project.ts
+++ b/src/javascript/node-project.ts
@@ -102,12 +102,20 @@ export interface NodeProjectOptions
   /**
    * License copyright owner.
    *
+   * This value is only used if the selected license text contains the
+   * `$copyright_owner` placeholder. For example, it has no effect on the
+   * MPL-2.0 license text.
+   *
    * @default - defaults to the value of authorName or "" if `authorName` is undefined.
    */
   readonly copyrightOwner?: string;
 
   /**
    * The copyright years to put in the LICENSE file.
+   *
+   * This value is only used if the selected license text contains the
+   * `$copyright_period` placeholder. For example, it has no effect on the
+   * MPL-2.0 license text.
    *
    * @default - current year
    */


### PR DESCRIPTION
Fixes #2512

## Summary

- clarify that `copyrightOwner` and `copyrightPeriod` only affect license texts containing the corresponding placeholders
- call out MPL-2.0 as an example where these options have no effect
- regenerate the affected API reference pages

## Validation

- `node ./projen.js eslint`
- `node ./projen.js compile`
- `node ./projen.js docgen`
- `git diff --check`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
