### PR TITLE
fix(tasks): every command fails with "command not found" on Node < 22.3 / < 20.16

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -139,6 +139,11 @@
             "name": "node:child_process",
             "message": "Do not import 'node:child_process' directly. Use the helpers in src/util/exec.ts (e.g. `git.run`).",
             "allowTypeImports": true
+          },
+          {
+            "name": "dax",
+            "message": "Do not import 'dax' directly. Import from src/util/dax.ts instead, which installs required Node compat shims (see projen#4846).",
+            "allowTypeImports": true
           }
         ]
       }
@@ -153,7 +158,18 @@
         "test/tasks/tasks.test.ts"
       ],
       "rules": {
-        "@typescript-eslint/no-restricted-imports": "off"
+        "@typescript-eslint/no-restricted-imports": [
+          "error",
+          {
+            "paths": [
+              {
+                "name": "dax",
+                "message": "Do not import 'dax' directly. Import from src/util/dax.ts instead, which installs required Node compat shims (see projen#4846).",
+                "allowTypeImports": true
+              }
+            ]
+          }
+        ]
       }
     },
     {

--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -19,7 +19,7 @@ jobs:
       - id: auto_4ca7ae43
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: lts/*
           package-manager-cache: false
       - name: Install dependencies
         id: install_dependencies
@@ -33,6 +33,11 @@ jobs:
       - name: Package
         id: package
         run: node ./projen.js package:js
+      - id: auto_4ca7ae43_2
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          package-manager-cache: false
       - name: Run Node integration test
         id: run_node_integration_test
         run: node ./projen.js integ:node
@@ -46,8 +51,12 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 18.18.0
+          - 20.9.0
           - lts/-2
+          - 22.0.0
           - lts/-1
+          - 24.0.0
           - lts/*
         os:
           - ubuntu-latest

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -207,6 +207,15 @@ project.with(
   }),
 );
 
+// Import of "dax" is only allowed through the src/util/dax.ts wrapper, which
+// installs a required Node compat shim before dax runs (see projen#4846).
+const restrictedDaxImport = {
+  name: "dax",
+  message:
+    "Do not import 'dax' directly. Import from src/util/dax.ts instead, which installs required Node compat shims (see projen#4846).",
+  allowTypeImports: true,
+};
+
 project.eslint?.addRules({
   "@typescript-eslint/consistent-type-imports": "error",
   "@typescript-eslint/consistent-type-exports": "error",
@@ -230,11 +239,12 @@ project.eslint?.addRules({
             "Do not import 'node:child_process' directly. Use the helpers in src/util/exec.ts (e.g. `git.run`).",
           allowTypeImports: true,
         },
+        restrictedDaxImport,
       ],
     },
   ],
 });
-// Files that need direct child_process access
+// Files that need direct child_process access (dax stays restricted)
 project.eslint?.addOverride({
   files: [
     "src/util/exec.ts", // the single home for command execution
@@ -243,7 +253,10 @@ project.eslint?.addOverride({
     "test/tasks/tasks.test.ts", // spies on the task runner's process execution
   ],
   rules: {
-    "@typescript-eslint/no-restricted-imports": "off",
+    "@typescript-eslint/no-restricted-imports": [
+      "error",
+      { paths: [restrictedDaxImport] },
+    ],
   },
 });
 

--- a/projenrc/integ-test.ts
+++ b/projenrc/integ-test.ts
@@ -351,13 +351,18 @@ export class IntegrationTests extends Component {
       },
       steps: [
         ...this.createCommonSteps(),
-        this.setupNodeStep("${{ matrix.node-version }}"),
+        // Build and package with a modern Node
+        // The matrix version is only the *consumer* runtime - installed right before the integ test below.
+        this.setupNodeStep("lts/*"),
         this.installDepsStep(project),
         this.compileStep(project),
         // Build the run-task.cjs bundle (normally a post-compile step) so the
         // packaged tarball includes it - the eject test below depends on it.
         this.runTaskStep(project, "Bundle task runner", "bundle:task-runner"),
         this.runTaskStep(project, "Package", config.packageTask),
+        // Switch to the matrix Node version: everything from here on runs the
+        // *packaged* projen the way a user would, on the runtime under test.
+        this.setupNodeStep("${{ matrix.node-version }}"),
         this.runTaskStep(
           project,
           `Run Node integration test`,

--- a/projenrc/integ-versions.ts
+++ b/projenrc/integ-versions.ts
@@ -30,7 +30,12 @@ export interface LanguageVersions {
  * to modify the version matrix for CI workflows.
  */
 export const INTEG_TEST_VERSIONS: LanguageVersions = {
-  node: ["lts/-2", "lts/-1", "lts/*"],
+  // Latest patch of each LTS line (`lts/-N`) plus the oldest viable patch as
+  // canaries for APIs added in later patches, e.g. `process.getBuiltinModule`
+  // (20.16 / 22.3, never in 18.x) whose absence broke all task commands (#4846).
+  // 18.18.0/20.9.0 are the oldest patches the generated project's toolchain
+  // supports (eslint 9); node 16 can't run the toolchain at all.
+  node: ["18.18.0", "20.9.0", "lts/-2", "22.0.0", "lts/-1", "24.0.0", "lts/*"],
   python: ["3.10", "3.11", "3.12", "3.13", "3.14"],
   go: ["1.25.x", "1.26.x"],
   java: [

--- a/src/cli/task-runtime.ts
+++ b/src/cli/task-runtime.ts
@@ -1,3 +1,6 @@
+// Must come first: polyfills `process.getBuiltinModule` for Node < 22.3 /
+// < 20.16, which dax needs to resolve any command (see projen#4846).
+import "../util/node-compat";
 import * as child_process from "child_process";
 import { existsSync, readFileSync, statSync } from "fs";
 import { dirname, join, resolve } from "path";

--- a/src/cli/task-runtime.ts
+++ b/src/cli/task-runtime.ts
@@ -1,16 +1,13 @@
-// Must come first: polyfills `process.getBuiltinModule` for Node < 22.3 /
-// < 20.16, which dax needs to resolve any command (see projen#4846).
-import "../util/node-compat";
 import * as child_process from "child_process";
 import { existsSync, readFileSync, statSync } from "fs";
 import { dirname, join, resolve } from "path";
 import * as path from "path";
 import { format } from "util";
 import { gray, underline } from "chalk";
-import { $ } from "dax";
 import { PROJEN_DIR, TASKS_MANIFEST_VERSION } from "../common";
 import * as logging from "../logging";
 import type { TasksManifest, TaskSpec, TaskStep } from "../task-model";
+import { $ } from "../util/dax";
 import { MAX_BUFFER, tool } from "../util/exec";
 
 // avoids a (false positive) esbuild warning about incorrect imports.

--- a/src/util/dax.ts
+++ b/src/util/dax.ts
@@ -1,0 +1,18 @@
+/**
+ * The only module allowed to import "dax" (enforced via eslint's
+ * no-restricted-imports): it guarantees the Node compat shim is installed
+ * before dax resolves any command.
+ *
+ * dax's bundled `which` loads `node:fs` through `process.getBuiltinModule()`,
+ * which only exists since Node 22.3.0 / 20.16.0. Without the shim, every task
+ * command fails with `dax: <cmd>: command not found` on older runtimes
+ * (https://github.com/projen/projen/issues/4846). dax reads the API lazily on
+ * first command resolution, so installing the shim at module load - even
+ * though the re-export below makes dax itself load first - is early enough.
+ */
+import { polyfillGetBuiltinModule } from "./node-compat";
+
+polyfillGetBuiltinModule();
+
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+export { $ } from "dax";

--- a/src/util/exec.ts
+++ b/src/util/exec.ts
@@ -1,3 +1,6 @@
+// Must come first: polyfills `process.getBuiltinModule` for Node < 22.3 /
+// < 20.16, which dax needs to resolve any command (see projen#4846).
+import "./node-compat";
 import * as child_process from "child_process";
 import * as fs from "fs";
 import * as os from "os";

--- a/src/util/exec.ts
+++ b/src/util/exec.ts
@@ -1,11 +1,8 @@
-// Must come first: polyfills `process.getBuiltinModule` for Node < 22.3 /
-// < 20.16, which dax needs to resolve any command (see projen#4846).
-import "./node-compat";
 import * as child_process from "child_process";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { $ } from "dax";
+import { $ } from "./dax";
 import * as logging from "../logging";
 
 export const MAX_BUFFER = 10 * 1024 * 1024;

--- a/src/util/node-compat.ts
+++ b/src/util/node-compat.ts
@@ -9,8 +9,8 @@
  * regardless of PATH (https://github.com/projen/projen/issues/4846).
  *
  * projen declares `engines: node >= 16`, so polyfill the API with `require()`
- * on runtimes that lack it. dax reads it lazily on first command resolution,
- * so installing the polyfill at module load (before any task runs) is enough.
+ * on runtimes that lack it. `src/util/dax.ts` - the only module allowed to
+ * import dax - installs the polyfill before dax can resolve any command.
  */
 
 import { builtinModules } from "module";
@@ -36,5 +36,3 @@ export function polyfillGetBuiltinModule(proc: NodeJS.Process = process): void {
     return require(`node:${bare}`);
   };
 }
-
-polyfillGetBuiltinModule();

--- a/src/util/node-compat.ts
+++ b/src/util/node-compat.ts
@@ -1,0 +1,40 @@
+/**
+ * Compatibility shims for older Node.js runtimes.
+ *
+ * dax's bundled `which` resolves executables by loading `node:fs` through
+ * `process.getBuiltinModule()`, an API that only exists since Node 22.3.0 /
+ * 20.16.0 (and in no 18.x or older release). On older runtimes every stat
+ * call inside `which` throws, the error is treated as "file does not exist",
+ * and every task command fails with `dax: <cmd>: command not found`
+ * regardless of PATH (https://github.com/projen/projen/issues/4846).
+ *
+ * projen declares `engines: node >= 16`, so polyfill the API with `require()`
+ * on runtimes that lack it. dax reads it lazily on first command resolution,
+ * so installing the polyfill at module load (before any task runs) is enough.
+ */
+
+import { builtinModules } from "module";
+
+/**
+ * Installs a `process.getBuiltinModule()` polyfill on the given process
+ * object if it does not already provide one.
+ *
+ * Mirrors the real API: returns the builtin module for both `"fs"` and
+ * `"node:fs"` style ids, and `undefined` for anything that is not a builtin
+ * (the real API never resolves userland modules).
+ */
+export function polyfillGetBuiltinModule(proc: NodeJS.Process = process): void {
+  if (typeof (proc as any).getBuiltinModule === "function") {
+    return;
+  }
+  (proc as any).getBuiltinModule = (id: string) => {
+    const bare = id.startsWith("node:") ? id.slice("node:".length) : id;
+    if (!builtinModules.includes(bare)) {
+      return undefined;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require(`node:${bare}`);
+  };
+}
+
+polyfillGetBuiltinModule();

--- a/test/util/node-compat.test.ts
+++ b/test/util/node-compat.test.ts
@@ -1,0 +1,47 @@
+import { polyfillGetBuiltinModule } from "../../src/util/node-compat";
+
+// Regression tests for https://github.com/projen/projen/issues/4846:
+// dax resolves every command through `process.getBuiltinModule("node:fs")`,
+// which only exists on Node >= 22.3 / >= 20.16. On older runtimes projen must
+// provide it, otherwise every task fails with "command not found".
+// (End-to-end coverage runs in the integ workflow on old Node patch releases;
+// these tests verify the shim itself.)
+describe("polyfillGetBuiltinModule", () => {
+  test("installs a working polyfill when the API is missing", () => {
+    const proc = {} as NodeJS.Process;
+
+    polyfillGetBuiltinModule(proc);
+
+    const getBuiltinModule = (proc as any).getBuiltinModule;
+    expect(typeof getBuiltinModule).toBe("function");
+    // dax's exact call: must return a usable node:fs
+    const fsModule = getBuiltinModule("node:fs");
+    expect(typeof fsModule.statSync).toBe("function");
+    expect(typeof fsModule.promises.stat).toBe("function");
+    // bare ids resolve to the same module
+    expect(getBuiltinModule("fs")).toBe(fsModule);
+    // non-builtins are not resolved (matches the real API)
+    expect(getBuiltinModule("jest")).toBeUndefined();
+    expect(getBuiltinModule("./some/file")).toBeUndefined();
+  });
+
+  test("leaves an existing implementation untouched", () => {
+    const original = jest.fn();
+    const proc = { getBuiltinModule: original } as unknown as NodeJS.Process;
+
+    polyfillGetBuiltinModule(proc);
+
+    expect((proc as any).getBuiltinModule).toBe(original);
+  });
+
+  test("the real process object provides getBuiltinModule after module load", () => {
+    // Importing the module (done at the top of this file) installs the
+    // polyfill on the real `process` when needed. Either way - native or
+    // polyfilled - dax's call must work now.
+    const getBuiltinModule = (process as any).getBuiltinModule;
+    expect(typeof getBuiltinModule).toBe("function");
+    expect(typeof getBuiltinModule.call(process, "node:fs").statSync).toBe(
+      "function",
+    );
+  });
+});

--- a/test/util/node-compat.test.ts
+++ b/test/util/node-compat.test.ts
@@ -34,10 +34,11 @@ describe("polyfillGetBuiltinModule", () => {
     expect((proc as any).getBuiltinModule).toBe(original);
   });
 
-  test("the real process object provides getBuiltinModule after module load", () => {
-    // Importing the module (done at the top of this file) installs the
-    // polyfill on the real `process` when needed. Either way - native or
-    // polyfilled - dax's call must work now.
+  test("the real process object provides getBuiltinModule after loading the dax wrapper", async () => {
+    // src/util/dax.ts is the only module allowed to import dax; loading it
+    // must install the polyfill on the real `process`. Either way - native or
+    // polyfilled - dax's call must work afterwards.
+    await import("../../src/util/dax");
     const getBuiltinModule = (process as any).getBuiltinModule;
     expect(typeof getBuiltinModule).toBe("function");
     expect(typeof getBuiltinModule.call(process, "node:fs").statSync).toBe(

--- a/test/util/node-compat.test.ts
+++ b/test/util/node-compat.test.ts
@@ -34,11 +34,12 @@ describe("polyfillGetBuiltinModule", () => {
     expect((proc as any).getBuiltinModule).toBe(original);
   });
 
-  test("the real process object provides getBuiltinModule after loading the dax wrapper", async () => {
+  test("the real process object provides getBuiltinModule after loading the dax wrapper", () => {
     // src/util/dax.ts is the only module allowed to import dax; loading it
     // must install the polyfill on the real `process`. Either way - native or
     // polyfilled - dax's call must work afterwards.
-    await import("../../src/util/dax");
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require("../../src/util/dax");
     const getBuiltinModule = (process as any).getBuiltinModule;
     expect(typeof getBuiltinModule).toBe("function");
     expect(typeof getBuiltinModule.call(process, "node:fs").statSync).toBe(


### PR DESCRIPTION
Fixes #4846

Since projen 0.101.0, running any task on Node older than 22.3.0 / 20.16.0 (including every 18.x release) fails with `dax: <cmd>: command not found` — for every command, no matter what is on your PATH. If your CI pins an older Node (for example `node-version: 22.0.0` in setup-node, as in DataDog/datadog-cdk-constructs#646), `npx projen`, upgrade workflows and builds all break with what looks like a broken PATH.

The PATH is fine. The task runner's new built-in shell resolves executables through a helper that relies on `process.getBuiltinModule`, a Node API that only exists from 22.3.0 / 20.16.0 onwards. On older runtimes the lookup fails internally for every candidate, and the error surfaces as "command not found". Full analysis and reproduction in the issue.

After this PR, projen tasks work again on all Node versions projen declares support for (`engines: >= 16.0.0`) — no workaround like `TaskShell.system()` needed.

To make sure this stays true, the integration test matrix now also runs on the oldest patch release of each supported Node line (18.18.0, 20.9.0, 22.0.0, 24.0.0) instead of only the newest — the newest patches are exactly why this regression was invisible to CI. These new matrix legs reproduce the bug and are expected to stay red until the fix commit lands in this PR.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
