### PR TITLE
feat(release): support GitHub App credentials for Go publishing

### DIFF
--- a/docs/api/cdk.md
+++ b/docs/api/cdk.md
@@ -7181,6 +7181,7 @@ const jsiiGoTarget: cdk.JsiiGoTarget = { ... }
 | <code><a href="#projen.cdk.JsiiGoTarget.property.publishTools">publishTools</a></code> | <code>projen.github.workflows.Tools</code> | Additional tools to install in the publishing job. |
 | <code><a href="#projen.cdk.JsiiGoTarget.property.gitBranch">gitBranch</a></code> | <code>string</code> | Branch to push to. |
 | <code><a href="#projen.cdk.JsiiGoTarget.property.gitCommitMessage">gitCommitMessage</a></code> | <code>string</code> | The commit message. |
+| <code><a href="#projen.cdk.JsiiGoTarget.property.githubCredentials">githubCredentials</a></code> | <code>projen.github.GithubCredentials</code> | Provide API access to the GitHub repository using `GithubCredentials`, e.g. a GitHub App. |
 | <code><a href="#projen.cdk.JsiiGoTarget.property.githubDeployKeySecret">githubDeployKeySecret</a></code> | <code>string</code> | The name of the secret that includes a GitHub deploy key used to push to the GitHub repository. |
 | <code><a href="#projen.cdk.JsiiGoTarget.property.githubTokenSecret">githubTokenSecret</a></code> | <code>string</code> | The name of the secret that includes a personal GitHub access token used to push to the GitHub repository. |
 | <code><a href="#projen.cdk.JsiiGoTarget.property.githubUseSsh">githubUseSsh</a></code> | <code>boolean</code> | Use SSH to push to GitHub instead of a personal accses token. |
@@ -7284,6 +7285,21 @@ The commit message.
 
 ---
 
+##### `githubCredentials`<sup>Optional</sup> <a name="githubCredentials" id="projen.cdk.JsiiGoTarget.property.githubCredentials"></a>
+
+```typescript
+public readonly githubCredentials: GithubCredentials;
+```
+
+- *Type:* projen.github.GithubCredentials
+- *Default:* no GitHub App credentials used
+
+Provide API access to the GitHub repository using `GithubCredentials`, e.g. a GitHub App.
+
+Cannot be combined with `githubUseSsh`, `githubTokenSecret` or `githubDeployKeySecret`.
+
+---
+
 ##### `githubDeployKeySecret`<sup>Optional</sup> <a name="githubDeployKeySecret" id="projen.cdk.JsiiGoTarget.property.githubDeployKeySecret"></a>
 
 ```typescript
@@ -7295,11 +7311,13 @@ public readonly githubDeployKeySecret: string;
 
 The name of the secret that includes a GitHub deploy key used to push to the GitHub repository.
 
-Ignored if `githubUseSsh` is `false`.
+Ignored if `githubUseSsh` is `false` or `githubCredentials` is set.
 
 ---
 
-##### `githubTokenSecret`<sup>Optional</sup> <a name="githubTokenSecret" id="projen.cdk.JsiiGoTarget.property.githubTokenSecret"></a>
+##### ~~`githubTokenSecret`~~<sup>Optional</sup> <a name="githubTokenSecret" id="projen.cdk.JsiiGoTarget.property.githubTokenSecret"></a>
+
+- *Deprecated:* use `githubCredentials` with `GithubCredentials.fromPersonalAccessToken()` instead.
 
 ```typescript
 public readonly githubTokenSecret: string;
@@ -7310,7 +7328,7 @@ public readonly githubTokenSecret: string;
 
 The name of the secret that includes a personal GitHub access token used to push to the GitHub repository.
 
-Ignored if `githubUseSsh` is `true`.
+Ignored if `githubUseSsh` or `githubCredentials` is set.
 
 ---
 
@@ -7324,6 +7342,8 @@ public readonly githubUseSsh: boolean;
 - *Default:* false
 
 Use SSH to push to GitHub instead of a personal accses token.
+
+Ignored if `githubCredentials` is set.
 
 ---
 

--- a/docs/api/release.md
+++ b/docs/api/release.md
@@ -1436,6 +1436,7 @@ const goPublishOptions: release.GoPublishOptions = { ... }
 | <code><a href="#projen.release.GoPublishOptions.property.publishTools">publishTools</a></code> | <code>projen.github.workflows.Tools</code> | Additional tools to install in the publishing job. |
 | <code><a href="#projen.release.GoPublishOptions.property.gitBranch">gitBranch</a></code> | <code>string</code> | Branch to push to. |
 | <code><a href="#projen.release.GoPublishOptions.property.gitCommitMessage">gitCommitMessage</a></code> | <code>string</code> | The commit message. |
+| <code><a href="#projen.release.GoPublishOptions.property.githubCredentials">githubCredentials</a></code> | <code>projen.github.GithubCredentials</code> | Provide API access to the GitHub repository using `GithubCredentials`, e.g. a GitHub App. |
 | <code><a href="#projen.release.GoPublishOptions.property.githubDeployKeySecret">githubDeployKeySecret</a></code> | <code>string</code> | The name of the secret that includes a GitHub deploy key used to push to the GitHub repository. |
 | <code><a href="#projen.release.GoPublishOptions.property.githubTokenSecret">githubTokenSecret</a></code> | <code>string</code> | The name of the secret that includes a personal GitHub access token used to push to the GitHub repository. |
 | <code><a href="#projen.release.GoPublishOptions.property.githubUseSsh">githubUseSsh</a></code> | <code>boolean</code> | Use SSH to push to GitHub instead of a personal accses token. |
@@ -1536,6 +1537,21 @@ The commit message.
 
 ---
 
+##### `githubCredentials`<sup>Optional</sup> <a name="githubCredentials" id="projen.release.GoPublishOptions.property.githubCredentials"></a>
+
+```typescript
+public readonly githubCredentials: GithubCredentials;
+```
+
+- *Type:* projen.github.GithubCredentials
+- *Default:* no GitHub App credentials used
+
+Provide API access to the GitHub repository using `GithubCredentials`, e.g. a GitHub App.
+
+Cannot be combined with `githubUseSsh`, `githubTokenSecret` or `githubDeployKeySecret`.
+
+---
+
 ##### `githubDeployKeySecret`<sup>Optional</sup> <a name="githubDeployKeySecret" id="projen.release.GoPublishOptions.property.githubDeployKeySecret"></a>
 
 ```typescript
@@ -1547,11 +1563,13 @@ public readonly githubDeployKeySecret: string;
 
 The name of the secret that includes a GitHub deploy key used to push to the GitHub repository.
 
-Ignored if `githubUseSsh` is `false`.
+Ignored if `githubUseSsh` is `false` or `githubCredentials` is set.
 
 ---
 
-##### `githubTokenSecret`<sup>Optional</sup> <a name="githubTokenSecret" id="projen.release.GoPublishOptions.property.githubTokenSecret"></a>
+##### ~~`githubTokenSecret`~~<sup>Optional</sup> <a name="githubTokenSecret" id="projen.release.GoPublishOptions.property.githubTokenSecret"></a>
+
+- *Deprecated:* use `githubCredentials` with `GithubCredentials.fromPersonalAccessToken()` instead.
 
 ```typescript
 public readonly githubTokenSecret: string;
@@ -1562,7 +1580,7 @@ public readonly githubTokenSecret: string;
 
 The name of the secret that includes a personal GitHub access token used to push to the GitHub repository.
 
-Ignored if `githubUseSsh` is `true`.
+Ignored if `githubUseSsh` or `githubCredentials` is set.
 
 ---
 
@@ -1576,6 +1594,8 @@ public readonly githubUseSsh: boolean;
 - *Default:* false
 
 Use SSH to push to GitHub instead of a personal accses token.
+
+Ignored if `githubCredentials` is set.
 
 ---
 

--- a/src/release/publisher.ts
+++ b/src/release/publisher.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_GITHUB_ACTIONS_USER,
   PERMISSION_BACKUP_FILE,
 } from "../github/constants";
+import type { GithubCredentials } from "../github/github-credentials";
 import type {
   Job,
   JobPermissions,
@@ -650,9 +651,30 @@ export class Publisher extends Component {
    * @param options Options
    */
   public publishToGo(options: GoPublishOptions = {}) {
+    if (
+      options.githubCredentials &&
+      (options.githubUseSsh ||
+        options.githubTokenSecret ||
+        options.githubDeployKeySecret)
+    ) {
+      throw new Error(
+        "Only one of 'githubCredentials' or 'githubUseSsh'/'githubTokenSecret'/'githubDeployKeySecret' may be specified, not both.",
+      );
+    }
+
+    if (options.githubUseSsh && options.githubTokenSecret) {
+      throw new Error(
+        "'githubTokenSecret' cannot be used together with 'githubUseSsh'. Use 'githubDeployKeySecret' instead.",
+      );
+    }
+
     const prePublishSteps = options.prePublishSteps ?? [];
     const workflowEnv: { [name: string]: string | undefined } = {};
-    if (options.githubUseSsh) {
+    if (options.githubCredentials) {
+      const credentials = options.githubCredentials;
+      prePublishSteps.push(...credentials.setupSteps);
+      workflowEnv.GITHUB_TOKEN = credentials.tokenRef;
+    } else if (options.githubUseSsh) {
       workflowEnv.GITHUB_USE_SSH = "true";
       workflowEnv.SSH_AUTH_SOCK = "/tmp/ssh_agent.sock";
       prePublishSteps.push({
@@ -677,7 +699,10 @@ export class Publisher extends Component {
         publishTools: PUBLIB_TOOLCHAIN.go,
         prePublishSteps: prePublishSteps,
         postPublishSteps: options.postPublishSteps ?? [],
-        environment: options.githubEnvironment ?? branchOptions.environment,
+        environment:
+          options.githubEnvironment ??
+          options.githubCredentials?.environment ??
+          branchOptions.environment,
         run: this.publibCommand("publib-golang"),
         registryName: "GitHub Go Module Repository",
         env: {
@@ -1286,8 +1311,9 @@ export interface GoPublishOptions extends CommonPublishOptions {
    * The name of the secret that includes a personal GitHub access token used to
    * push to the GitHub repository.
    *
-   * Ignored if `githubUseSsh` is `true`.
+   * Ignored if `githubUseSsh` or `githubCredentials` is set.
    *
+   * @deprecated use `githubCredentials` with `GithubCredentials.fromPersonalAccessToken()` instead.
    * @default "GO_GITHUB_TOKEN"
    */
   readonly githubTokenSecret?: string;
@@ -1296,7 +1322,7 @@ export interface GoPublishOptions extends CommonPublishOptions {
    * The name of the secret that includes a GitHub deploy key used to push to the
    * GitHub repository.
    *
-   * Ignored if `githubUseSsh` is `false`.
+   * Ignored if `githubUseSsh` is `false` or `githubCredentials` is set.
    *
    * @default "GO_GITHUB_DEPLOY_KEY"
    */
@@ -1305,9 +1331,24 @@ export interface GoPublishOptions extends CommonPublishOptions {
   /**
    * Use SSH to push to GitHub instead of a personal accses token.
    *
+   * Ignored if `githubCredentials` is set.
+   *
    * @default false
    */
   readonly githubUseSsh?: boolean;
+
+  /**
+   * Provide API access to the GitHub repository the Go module is pushed to
+   * through a `GithubCredentials` instance, e.g. a GitHub App
+   * (`GithubCredentials.fromApp`).
+   *
+   * Cannot be combined with `githubUseSsh`, `githubTokenSecret` or
+   * `githubDeployKeySecret`. When a GitHub App credential specifies an
+   * `environment`, it is used unless `githubEnvironment` is also set.
+   *
+   * @default - no GitHub App credentials used
+   */
+  readonly githubCredentials?: GithubCredentials;
 
   /**
    * Branch to push to.

--- a/src/release/publisher.ts
+++ b/src/release/publisher.ts
@@ -1338,13 +1338,9 @@ export interface GoPublishOptions extends CommonPublishOptions {
   readonly githubUseSsh?: boolean;
 
   /**
-   * Provide API access to the GitHub repository the Go module is pushed to
-   * through a `GithubCredentials` instance, e.g. a GitHub App
-   * (`GithubCredentials.fromApp`).
+   * Provide API access to the GitHub repository using `GithubCredentials`, e.g. a GitHub App.
    *
-   * Cannot be combined with `githubUseSsh`, `githubTokenSecret` or
-   * `githubDeployKeySecret`. When a GitHub App credential specifies an
-   * `environment`, it is used unless `githubEnvironment` is also set.
+   * Cannot be combined with `githubUseSsh`, `githubTokenSecret` or `githubDeployKeySecret`.
    *
    * @default - no GitHub App credentials used
    */

--- a/test/release/publisher-go-github-credentials.test.ts
+++ b/test/release/publisher-go-github-credentials.test.ts
@@ -1,0 +1,171 @@
+import * as YAML from "yaml";
+import { GithubCredentials } from "../../src/github";
+import { AppPermission } from "../../src/github/workflows-model";
+import { Release } from "../../src/release";
+import { synthSnapshot, TestProject } from "../util";
+
+describe("publishToGo with githubCredentials", () => {
+  test("uses a GitHub App token instead of a secret-based token", () => {
+    // GIVEN
+    const project = new TestProject();
+    const release = new Release(project, {
+      tasks: [project.buildTask],
+      versionFile: "version.json",
+      branch: "main",
+      artifactsDirectory: "dist",
+    });
+
+    // WHEN
+    release.publisher.publishToGo({
+      githubCredentials: GithubCredentials.fromApp({
+        owner: "${{ github.repository_owner }}",
+        repositories: ["my-go-repo"],
+        permissions: { contents: AppPermission.WRITE },
+      }),
+    });
+
+    // THEN
+    const outdir = synthSnapshot(project);
+    const workflow = YAML.parse(outdir[".github/workflows/release.yml"]);
+    const job = workflow.jobs.release_golang;
+    const releaseStep = job.steps.find((s: any) => s.name === "Release");
+    const tokenStep = job.steps.find((s: any) => s.name === "Generate token");
+
+    expect(tokenStep).toBeDefined();
+    expect(tokenStep.uses).toContain("actions/create-github-app-token");
+    expect(tokenStep.with["app-id"]).toBe("${{ secrets.PROJEN_APP_ID }}");
+    expect(tokenStep.with["private-key"]).toBe(
+      "${{ secrets.PROJEN_APP_PRIVATE_KEY }}",
+    );
+    expect(tokenStep.with.owner).toBe("${{ github.repository_owner }}");
+    expect(tokenStep.with.repositories).toBe("my-go-repo");
+    expect(tokenStep.with["permission-contents"]).toBe("write");
+
+    expect(releaseStep.env.GITHUB_TOKEN).toBe(
+      "${{ steps.generate_token.outputs.token }}",
+    );
+    // should not fall back to the secret-based token or SSH deploy key
+    expect(releaseStep.env.GITHUB_TOKEN).not.toBe(
+      "${{ secrets.GO_GITHUB_TOKEN }}",
+    );
+    expect(
+      job.steps.some((s: any) => s.name === "Setup GitHub deploy key"),
+    ).toBe(false);
+  });
+
+  test("uses the credentials' environment when githubEnvironment is not set", () => {
+    // GIVEN
+    const project = new TestProject();
+    const release = new Release(project, {
+      tasks: [project.buildTask],
+      versionFile: "version.json",
+      branch: "main",
+      artifactsDirectory: "dist",
+    });
+
+    // WHEN
+    release.publisher.publishToGo({
+      githubCredentials: GithubCredentials.fromApp({
+        environment: "go-app-env",
+      }),
+    });
+
+    // THEN
+    const outdir = synthSnapshot(project);
+    const workflow = YAML.parse(outdir[".github/workflows/release.yml"]);
+    expect(workflow.jobs.release_golang.environment).toBe("go-app-env");
+  });
+
+  test("githubEnvironment takes precedence over the credentials' environment", () => {
+    // GIVEN
+    const project = new TestProject();
+    const release = new Release(project, {
+      tasks: [project.buildTask],
+      versionFile: "version.json",
+      branch: "main",
+      artifactsDirectory: "dist",
+    });
+
+    // WHEN
+    release.publisher.publishToGo({
+      githubEnvironment: "explicit-env",
+      githubCredentials: GithubCredentials.fromApp({
+        environment: "go-app-env",
+      }),
+    });
+
+    // THEN
+    const outdir = synthSnapshot(project);
+    const workflow = YAML.parse(outdir[".github/workflows/release.yml"]);
+    expect(workflow.jobs.release_golang.environment).toBe("explicit-env");
+  });
+
+  test("throws when combined with githubUseSsh", () => {
+    // GIVEN
+    const project = new TestProject();
+    const release = new Release(project, {
+      tasks: [project.buildTask],
+      versionFile: "version.json",
+      branch: "main",
+      artifactsDirectory: "dist",
+    });
+
+    // THEN
+    expect(() =>
+      release.publisher.publishToGo({
+        githubUseSsh: true,
+        githubCredentials: GithubCredentials.fromApp(),
+      }),
+    ).toThrow(/Only one of 'githubCredentials' or/);
+  });
+});
+
+describe("publishToGo with conflicting githubCredentials options", () => {
+  test.each([
+    ["githubUseSsh", { githubUseSsh: true }],
+    ["githubTokenSecret", { githubTokenSecret: "MY_TOKEN" }],
+    ["githubDeployKeySecret", { githubDeployKeySecret: "MY_DEPLOY_KEY" }],
+  ])("throws when combined with %s", (_name, conflictingOption) => {
+    // GIVEN
+    const project = new TestProject();
+    const release = new Release(project, {
+      tasks: [project.buildTask],
+      versionFile: "version.json",
+      branch: "main",
+      artifactsDirectory: "dist",
+    });
+
+    // THEN
+    expect(() =>
+      release.publisher.publishToGo({
+        ...conflictingOption,
+        githubCredentials: GithubCredentials.fromApp(),
+      }),
+    ).toThrow(
+      /Only one of 'githubCredentials' or 'githubUseSsh'\/'githubTokenSecret'\/'githubDeployKeySecret' may be specified/,
+    );
+  });
+});
+
+describe("publishToGo with githubUseSsh and githubTokenSecret", () => {
+  test("throws because the two are incompatible auth methods", () => {
+    // GIVEN
+    const project = new TestProject();
+    const release = new Release(project, {
+      tasks: [project.buildTask],
+      versionFile: "version.json",
+      branch: "main",
+      artifactsDirectory: "dist",
+    });
+
+    // THEN
+    expect(() =>
+      release.publisher.publishToGo({
+        githubUseSsh: true,
+        githubTokenSecret: "MY_TOKEN",
+      }),
+    ).toThrow(
+      /'githubTokenSecret' cannot be used together with 'githubUseSsh'/,
+    );
+  });
+});


### PR DESCRIPTION
Fixes #4498

Adds a `githubCredentials` option to `publishToGo`, so Go module releases can authenticate with a GitHub App token instead of a personal access token secret or SSH deploy key — avoiding a long-lived credential that has to be rotated by hand. Two projects already worked around this by patching the generated release job after synthesis ([1](https://github.com/mrgrain/cdk-esbuild/pull/1674), [2](https://github.com/cdktn-io/cdktn-provider-project/pull/21)); this makes it a first-class option.

`githubTokenSecret` is now deprecated in favor of `githubCredentials` (a PAT can be modeled via `GithubCredentials.fromPersonalAccessToken()`). `githubUseSsh` and `githubDeployKeySecret` stay as-is for now, since `GithubCredentials` has no SSH/deploy-key equivalent yet. Combining `githubCredentials` with any of the three legacy options throws, as does combining `githubUseSsh` with `githubTokenSecret` (they're incompatible auth methods).

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
