### PR TITLE
feat(github): enhance options for reusable workflows

### DIFF
--- a/docs/api/github.workflows.md
+++ b/docs/api/github.workflows.md
@@ -1595,7 +1595,7 @@ const jobCallingReusableWorkflow: github.workflows.JobCallingReusableWorkflow = 
 | <code><a href="#projen.github.workflows.JobCallingReusableWorkflow.property.strategy">strategy</a></code> | <code>projen.github.workflows.JobStrategy</code> | A strategy creates a build matrix for your jobs. |
 | <code><a href="#projen.github.workflows.JobCallingReusableWorkflow.property.uses">uses</a></code> | <code>string</code> | The location and version of a reusable workflow file to run as a job. |
 | <code><a href="#projen.github.workflows.JobCallingReusableWorkflow.property.secrets">secrets</a></code> | <code>string \| {[ key: string ]: string}</code> | When a job is used to call a reusable workflow, you can use secrets to provide a map of secrets that are passed to the called workflow. |
-| <code><a href="#projen.github.workflows.JobCallingReusableWorkflow.property.with">with</a></code> | <code>{[ key: string ]: string \| boolean}</code> | When a job is used to call a reusable workflow, you can use with to provide a map of inputs that are passed to the called workflow. |
+| <code><a href="#projen.github.workflows.JobCallingReusableWorkflow.property.with">with</a></code> | <code>{[ key: string ]: string \| number \| boolean}</code> | When a job is used to call a reusable workflow, you can use with to provide a map of inputs that are passed to the called workflow. |
 
 ---
 
@@ -1722,10 +1722,10 @@ Use the 'inherit' keyword to pass all the calling workflow's secrets to the call
 ##### `with`<sup>Optional</sup> <a name="with" id="projen.github.workflows.JobCallingReusableWorkflow.property.with"></a>
 
 ```typescript
-public readonly with: {[ key: string ]: string | boolean};
+public readonly with: {[ key: string ]: string | number | boolean};
 ```
 
-- *Type:* {[ key: string ]: string | boolean}
+- *Type:* {[ key: string ]: string | number | boolean}
 
 When a job is used to call a reusable workflow, you can use with to provide a map of inputs that are passed to the called workflow.
 
@@ -4420,9 +4420,89 @@ Which activity types to trigger on.
 
 ---
 
+### WorkflowCallInput <a name="WorkflowCallInput" id="projen.github.workflows.WorkflowCallInput"></a>
+
+An input definition for a `workflow_call` trigger.
+
+> [https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callinputs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callinputs)
+
+#### Initializer <a name="Initializer" id="projen.github.workflows.WorkflowCallInput.Initializer"></a>
+
+```typescript
+import { github } from 'projen'
+
+const workflowCallInput: github.workflows.WorkflowCallInput = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen.github.workflows.WorkflowCallInput.property.type">type</a></code> | <code>string</code> | The data type of the input. |
+| <code><a href="#projen.github.workflows.WorkflowCallInput.property.default">default</a></code> | <code>string \| number \| boolean</code> | The default value for the input when it is not provided by the caller. |
+| <code><a href="#projen.github.workflows.WorkflowCallInput.property.description">description</a></code> | <code>string</code> | A description of the input parameter. |
+| <code><a href="#projen.github.workflows.WorkflowCallInput.property.required">required</a></code> | <code>boolean</code> | Whether the input is required. |
+
+---
+
+##### `type`<sup>Required</sup> <a name="type" id="projen.github.workflows.WorkflowCallInput.property.type"></a>
+
+```typescript
+public readonly type: string;
+```
+
+- *Type:* string
+
+The data type of the input.
+
+---
+
+##### `default`<sup>Optional</sup> <a name="default" id="projen.github.workflows.WorkflowCallInput.property.default"></a>
+
+```typescript
+public readonly default: string | number | boolean;
+```
+
+- *Type:* string | number | boolean
+- *Default:* no default
+
+The default value for the input when it is not provided by the caller.
+
+---
+
+##### `description`<sup>Optional</sup> <a name="description" id="projen.github.workflows.WorkflowCallInput.property.description"></a>
+
+```typescript
+public readonly description: string;
+```
+
+- *Type:* string
+
+A description of the input parameter.
+
+---
+
+##### `required`<sup>Optional</sup> <a name="required" id="projen.github.workflows.WorkflowCallInput.property.required"></a>
+
+```typescript
+public readonly required: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Whether the input is required.
+
+If `true`, the caller must supply
+this input when calling the workflow.
+
+---
+
 ### WorkflowCallOptions <a name="WorkflowCallOptions" id="projen.github.workflows.WorkflowCallOptions"></a>
 
-The Workflow Call event accepts no options.
+Options for the `workflow_call` trigger event, used to define a reusable workflow.
+
+> [https://docs.github.com/en/actions/using-workflows/reusing-workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows)
 
 #### Initializer <a name="Initializer" id="projen.github.workflows.WorkflowCallOptions.Initializer"></a>
 
@@ -4432,6 +4512,161 @@ import { github } from 'projen'
 const workflowCallOptions: github.workflows.WorkflowCallOptions = { ... }
 ```
 
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen.github.workflows.WorkflowCallOptions.property.inputs">inputs</a></code> | <code>{[ key: string ]: projen.github.workflows.WorkflowCallInput}</code> | A map of inputs that are passed from the caller workflow. |
+| <code><a href="#projen.github.workflows.WorkflowCallOptions.property.outputs">outputs</a></code> | <code>{[ key: string ]: projen.github.workflows.WorkflowCallOutput}</code> | A map of outputs that the called workflow can set. |
+| <code><a href="#projen.github.workflows.WorkflowCallOptions.property.secrets">secrets</a></code> | <code>{[ key: string ]: projen.github.workflows.WorkflowCallSecret}</code> | A map of secrets that can be used in the called workflow. |
+
+---
+
+##### `inputs`<sup>Optional</sup> <a name="inputs" id="projen.github.workflows.WorkflowCallOptions.property.inputs"></a>
+
+```typescript
+public readonly inputs: {[ key: string ]: WorkflowCallInput};
+```
+
+- *Type:* {[ key: string ]: projen.github.workflows.WorkflowCallInput}
+- *Default:* no inputs
+
+A map of inputs that are passed from the caller workflow.
+
+Inputs are available in the called workflow using the `inputs` context.
+
+---
+
+##### `outputs`<sup>Optional</sup> <a name="outputs" id="projen.github.workflows.WorkflowCallOptions.property.outputs"></a>
+
+```typescript
+public readonly outputs: {[ key: string ]: WorkflowCallOutput};
+```
+
+- *Type:* {[ key: string ]: projen.github.workflows.WorkflowCallOutput}
+- *Default:* no outputs
+
+A map of outputs that the called workflow can set.
+
+Called workflow outputs are available to all downstream jobs in the caller workflow.
+
+---
+
+##### `secrets`<sup>Optional</sup> <a name="secrets" id="projen.github.workflows.WorkflowCallOptions.property.secrets"></a>
+
+```typescript
+public readonly secrets: {[ key: string ]: WorkflowCallSecret};
+```
+
+- *Type:* {[ key: string ]: projen.github.workflows.WorkflowCallSecret}
+- *Default:* no secrets
+
+A map of secrets that can be used in the called workflow.
+
+Secrets are available in the called workflow using the `secrets` context.
+
+---
+
+### WorkflowCallOutput <a name="WorkflowCallOutput" id="projen.github.workflows.WorkflowCallOutput"></a>
+
+An output definition for a `workflow_call` trigger.
+
+> [https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_calloutputs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_calloutputs)
+
+#### Initializer <a name="Initializer" id="projen.github.workflows.WorkflowCallOutput.Initializer"></a>
+
+```typescript
+import { github } from 'projen'
+
+const workflowCallOutput: github.workflows.WorkflowCallOutput = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen.github.workflows.WorkflowCallOutput.property.value">value</a></code> | <code>string</code> | The value of the output. |
+| <code><a href="#projen.github.workflows.WorkflowCallOutput.property.description">description</a></code> | <code>string</code> | A description of the output parameter. |
+
+---
+
+##### `value`<sup>Required</sup> <a name="value" id="projen.github.workflows.WorkflowCallOutput.property.value"></a>
+
+```typescript
+public readonly value: string;
+```
+
+- *Type:* string
+
+The value of the output.
+
+This must reference a job output from within
+the reusable workflow, e.g. `${{ jobs.<job_id>.outputs.<output_name> }}`.
+
+---
+
+##### `description`<sup>Optional</sup> <a name="description" id="projen.github.workflows.WorkflowCallOutput.property.description"></a>
+
+```typescript
+public readonly description: string;
+```
+
+- *Type:* string
+
+A description of the output parameter.
+
+---
+
+### WorkflowCallSecret <a name="WorkflowCallSecret" id="projen.github.workflows.WorkflowCallSecret"></a>
+
+A secret definition for a `workflow_call` trigger.
+
+> [https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callsecrets](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callsecrets)
+
+#### Initializer <a name="Initializer" id="projen.github.workflows.WorkflowCallSecret.Initializer"></a>
+
+```typescript
+import { github } from 'projen'
+
+const workflowCallSecret: github.workflows.WorkflowCallSecret = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen.github.workflows.WorkflowCallSecret.property.description">description</a></code> | <code>string</code> | A description of the secret parameter. |
+| <code><a href="#projen.github.workflows.WorkflowCallSecret.property.required">required</a></code> | <code>boolean</code> | Whether the secret is required. |
+
+---
+
+##### `description`<sup>Optional</sup> <a name="description" id="projen.github.workflows.WorkflowCallSecret.property.description"></a>
+
+```typescript
+public readonly description: string;
+```
+
+- *Type:* string
+
+A description of the secret parameter.
+
+---
+
+##### `required`<sup>Optional</sup> <a name="required" id="projen.github.workflows.WorkflowCallSecret.property.required"></a>
+
+```typescript
+public readonly required: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Whether the secret is required.
+
+If `true`, the caller must supply
+this secret when calling the workflow.
+
+---
 
 ### WorkflowDispatchInput <a name="WorkflowDispatchInput" id="projen.github.workflows.WorkflowDispatchInput"></a>
 

--- a/src/github/workflows-model.ts
+++ b/src/github/workflows-model.ts
@@ -71,7 +71,7 @@ export interface JobCallingReusableWorkflow extends CommonJobDefinition {
    *
    * Allowed expression contexts: `github`, and `needs`.
    */
-  readonly with?: Record<string, string | boolean>;
+  readonly with?: Record<string, string | boolean | number>;
 
   /**
    * When a job is used to call a reusable workflow, you can use secrets to
@@ -1382,9 +1382,105 @@ export interface WorkflowDispatchInput {
 }
 
 /**
- * The Workflow Call event accepts no options.
+ * Options for the `workflow_call` trigger event, used to define a reusable workflow.
+ *
+ * @see https://docs.github.com/en/actions/using-workflows/reusing-workflows
  */
-export interface WorkflowCallOptions {}
+export interface WorkflowCallOptions {
+  /**
+   * A map of inputs that are passed from the caller workflow.
+   * Inputs are available in the called workflow using the `inputs` context.
+   *
+   * @default - no inputs
+   */
+  readonly inputs?: { [name: string]: WorkflowCallInput };
+
+  /**
+   * A map of secrets that can be used in the called workflow.
+   * Secrets are available in the called workflow using the `secrets` context.
+   *
+   * @default - no secrets
+   */
+  readonly secrets?: { [name: string]: WorkflowCallSecret };
+
+  /**
+   * A map of outputs that the called workflow can set.
+   * Called workflow outputs are available to all downstream jobs in the caller workflow.
+   *
+   * @default - no outputs
+   */
+  readonly outputs?: { [name: string]: WorkflowCallOutput };
+}
+
+/**
+ * An input definition for a `workflow_call` trigger.
+ *
+ * @see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callinputs
+ */
+export interface WorkflowCallInput {
+  /**
+   * A description of the input parameter.
+   */
+  readonly description?: string;
+
+  /**
+   * Whether the input is required. If `true`, the caller must supply
+   * this input when calling the workflow.
+   *
+   * @default false
+   */
+  readonly required?: boolean;
+
+  /**
+   * The data type of the input.
+   */
+  readonly type: "string" | "boolean" | "number";
+
+  /**
+   * The default value for the input when it is not provided by the caller.
+   *
+   * @default - no default
+   */
+  readonly default?: string | boolean | number;
+}
+
+/**
+ * A secret definition for a `workflow_call` trigger.
+ *
+ * @see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callsecrets
+ */
+export interface WorkflowCallSecret {
+  /**
+   * A description of the secret parameter.
+   */
+  readonly description?: string;
+
+  /**
+   * Whether the secret is required. If `true`, the caller must supply
+   * this secret when calling the workflow.
+   *
+   * @default false
+   */
+  readonly required?: boolean;
+}
+
+/**
+ * An output definition for a `workflow_call` trigger.
+ *
+ * @see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_calloutputs
+ */
+export interface WorkflowCallOutput {
+  /**
+   * A description of the output parameter.
+   */
+  readonly description?: string;
+
+  /**
+   * The value of the output. This must reference a job output from within
+   * the reusable workflow, e.g. `${{ jobs.<job_id>.outputs.<output_name> }}`.
+   */
+  readonly value: string;
+}
 
 /**
  * The Create event accepts no options.

--- a/test/github/workflows.test.ts
+++ b/test/github/workflows.test.ts
@@ -634,3 +634,163 @@ describe("setupTools", () => {
     expect(content).toContain("distribution: corretto");
   });
 });
+
+describe("reusable workflows", () => {
+  test("calling a reusable workflow job renders uses, with, and secrets", () => {
+    const p = new TestProject();
+    const wf = p.github!.addWorkflow("call-reusable");
+    wf.addJob("deploy", {
+      permissions: {},
+      uses: "octo-org/example-repo/.github/workflows/deployment.yml@main",
+      with: {
+        username: "mona",
+        environment: "production",
+      },
+      secrets: {
+        token: "${{ secrets.GITHUB_TOKEN }}",
+        deploy_key: "${{ secrets.DEPLOY_KEY }}",
+      },
+    });
+
+    const workflows = synthWorkflows(p);
+    const content = YAML.parse(
+      workflows[".github/workflows/call-reusable.yml"],
+    );
+    expect(content.jobs.deploy.uses).toBe(
+      "octo-org/example-repo/.github/workflows/deployment.yml@main",
+    );
+    expect(content.jobs.deploy.with).toEqual({
+      username: "mona",
+      environment: "production",
+    });
+    expect(content.jobs.deploy.secrets).toEqual({
+      token: "${{ secrets.GITHUB_TOKEN }}",
+      deploy_key: "${{ secrets.DEPLOY_KEY }}",
+    });
+    // Should not have runs-on or steps
+    expect(content.jobs.deploy["runs-on"]).toBeUndefined();
+    expect(content.jobs.deploy.steps).toBeUndefined();
+  });
+
+  test("calling a reusable workflow with secrets: inherit", () => {
+    const p = new TestProject();
+    const wf = p.github!.addWorkflow("call-inherit");
+    wf.addJob("deploy", {
+      permissions: {},
+      uses: "octo-org/example-repo/.github/workflows/deployment.yml@main",
+      secrets: "inherit",
+    });
+
+    const workflows = synthWorkflows(p);
+    const content = YAML.parse(workflows[".github/workflows/call-inherit.yml"]);
+    expect(content.jobs.deploy.secrets).toBe("inherit");
+  });
+
+  test("defining a reusable workflow with workflow_call inputs and secrets", () => {
+    const p = new TestProject();
+    const wf = p.github!.addWorkflow("reusable-wf");
+    wf.on({
+      workflowCall: {
+        inputs: {
+          config_path: {
+            description: "Path to the configuration file",
+            required: true,
+            type: "string",
+          },
+          dry_run: {
+            description: "Whether to perform a dry run",
+            required: false,
+            type: "boolean",
+            default: false,
+          },
+        },
+        secrets: {
+          personal_access_token: {
+            description: "A token for authentication",
+            required: true,
+          },
+        },
+      },
+    });
+    wf.addJob("build", {
+      runsOn: ["ubuntu-latest"],
+      permissions: {},
+      steps: [{ run: "echo hello" }],
+    });
+
+    const workflows = synthWorkflows(p);
+    const content = YAML.parse(workflows[".github/workflows/reusable-wf.yml"]);
+    expect(content.on.workflow_call.inputs.config_path).toEqual({
+      description: "Path to the configuration file",
+      required: true,
+      type: "string",
+    });
+    expect(content.on.workflow_call.inputs.dry_run).toEqual({
+      description: "Whether to perform a dry run",
+      required: false,
+      type: "boolean",
+      default: false,
+    });
+    expect(content.on.workflow_call.secrets.personal_access_token).toEqual({
+      description: "A token for authentication",
+      required: true,
+    });
+  });
+
+  test("defining a reusable workflow with workflow_call outputs", () => {
+    const p = new TestProject();
+    const wf = p.github!.addWorkflow("reusable-with-outputs");
+    wf.on({
+      workflowCall: {
+        outputs: {
+          build_id: {
+            description: "The build identifier",
+            value: "${{ jobs.build.outputs.id }}",
+          },
+        },
+      },
+    });
+    wf.addJob("build", {
+      runsOn: ["ubuntu-latest"],
+      permissions: {},
+      steps: [{ run: "echo hello" }],
+    });
+
+    const workflows = synthWorkflows(p);
+    const content = YAML.parse(
+      workflows[".github/workflows/reusable-with-outputs.yml"],
+    );
+    expect(content.on.workflow_call.outputs.build_id).toEqual({
+      description: "The build identifier",
+      value: "${{ jobs.build.outputs.id }}",
+    });
+  });
+
+  test("reusable workflow job with strategy matrix", () => {
+    const p = new TestProject();
+    const wf = p.github!.addWorkflow("matrix-reusable");
+    wf.addJob("deploy", {
+      permissions: {},
+      uses: "octo-org/example-repo/.github/workflows/deployment.yml@main",
+      with: {
+        target: "${{ matrix.target }}",
+      },
+      strategy: {
+        matrix: {
+          domain: { target: ["dev", "stage", "prod"] },
+        },
+      },
+    });
+
+    const workflows = synthWorkflows(p);
+    const content = YAML.parse(
+      workflows[".github/workflows/matrix-reusable.yml"],
+    );
+    expect(content.jobs.deploy.strategy.matrix.target).toEqual([
+      "dev",
+      "stage",
+      "prod",
+    ]);
+    expect(content.jobs.deploy.with.target).toBe("${{ matrix.target }}");
+  });
+});


### PR DESCRIPTION
Closes #1956. Continuation of #1525.

### Changes

* WorkflowCallOptions — populated with inputs, secrets, and outputs to fully model the on.workflow_call trigger per GitHub docs
* WorkflowCallInput — defines input parameters (description, required, type, default)
* WorkflowCallSecret — defines secret parameters (description, required)
* WorkflowCallOutput — defines output parameters (description, value)
* JobCallingReusableWorkflow.with — added number to the value type (was string | boolean), since GitHub supports number-typed inputs

### Tests
Added tests for:

* Calling a reusable workflow with uses, with, and secrets
* Using secrets: inherit
* Defining a reusable workflow with workflow_call inputs and secrets
* Defining workflow-level outputs
* Using a matrix strategy with a reusable workflow call

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
