### PR TITLE
feat(github): global runs-on for workflows

### DIFF
--- a/docs/api/awscdk.md
+++ b/docs/api/awscdk.md
@@ -10701,7 +10701,9 @@ Container image to use for GitHub workflows.
 
 ---
 
-##### `workflowRunsOn`<sup>Optional</sup> <a name="workflowRunsOn" id="projen.awscdk.AwsCdkConstructLibraryOptions.property.workflowRunsOn"></a>
+##### ~~`workflowRunsOn`~~<sup>Optional</sup> <a name="workflowRunsOn" id="projen.awscdk.AwsCdkConstructLibraryOptions.property.workflowRunsOn"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOn` on the project, or `runsOn` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOn: string[];
@@ -10714,7 +10716,9 @@ Github Runner selection labels.
 
 ---
 
-##### `workflowRunsOnGroup`<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.awscdk.AwsCdkConstructLibraryOptions.property.workflowRunsOnGroup"></a>
+##### ~~`workflowRunsOnGroup`~~<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.awscdk.AwsCdkConstructLibraryOptions.property.workflowRunsOnGroup"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOnGroup` on the project, or `runsOnGroup` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOnGroup: GroupRunnerOptions;
@@ -15671,7 +15675,9 @@ Container image to use for GitHub workflows.
 
 ---
 
-##### `workflowRunsOn`<sup>Optional</sup> <a name="workflowRunsOn" id="projen.awscdk.AwsCdkTypeScriptAppOptions.property.workflowRunsOn"></a>
+##### ~~`workflowRunsOn`~~<sup>Optional</sup> <a name="workflowRunsOn" id="projen.awscdk.AwsCdkTypeScriptAppOptions.property.workflowRunsOn"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOn` on the project, or `runsOn` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOn: string[];
@@ -15684,7 +15690,9 @@ Github Runner selection labels.
 
 ---
 
-##### `workflowRunsOnGroup`<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.awscdk.AwsCdkTypeScriptAppOptions.property.workflowRunsOnGroup"></a>
+##### ~~`workflowRunsOnGroup`~~<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.awscdk.AwsCdkTypeScriptAppOptions.property.workflowRunsOnGroup"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOnGroup` on the project, or `runsOnGroup` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOnGroup: GroupRunnerOptions;

--- a/docs/api/cdk.md
+++ b/docs/api/cdk.md
@@ -5462,7 +5462,9 @@ Container image to use for GitHub workflows.
 
 ---
 
-##### `workflowRunsOn`<sup>Optional</sup> <a name="workflowRunsOn" id="projen.cdk.ConstructLibraryOptions.property.workflowRunsOn"></a>
+##### ~~`workflowRunsOn`~~<sup>Optional</sup> <a name="workflowRunsOn" id="projen.cdk.ConstructLibraryOptions.property.workflowRunsOn"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOn` on the project, or `runsOn` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOn: string[];
@@ -5475,7 +5477,9 @@ Github Runner selection labels.
 
 ---
 
-##### `workflowRunsOnGroup`<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.cdk.ConstructLibraryOptions.property.workflowRunsOnGroup"></a>
+##### ~~`workflowRunsOnGroup`~~<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.cdk.ConstructLibraryOptions.property.workflowRunsOnGroup"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOnGroup` on the project, or `runsOnGroup` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOnGroup: GroupRunnerOptions;
@@ -9275,7 +9279,9 @@ Container image to use for GitHub workflows.
 
 ---
 
-##### `workflowRunsOn`<sup>Optional</sup> <a name="workflowRunsOn" id="projen.cdk.JsiiProjectOptions.property.workflowRunsOn"></a>
+##### ~~`workflowRunsOn`~~<sup>Optional</sup> <a name="workflowRunsOn" id="projen.cdk.JsiiProjectOptions.property.workflowRunsOn"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOn` on the project, or `runsOn` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOn: string[];
@@ -9288,7 +9294,9 @@ Github Runner selection labels.
 
 ---
 
-##### `workflowRunsOnGroup`<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.cdk.JsiiProjectOptions.property.workflowRunsOnGroup"></a>
+##### ~~`workflowRunsOnGroup`~~<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.cdk.JsiiProjectOptions.property.workflowRunsOnGroup"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOnGroup` on the project, or `runsOnGroup` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOnGroup: GroupRunnerOptions;

--- a/docs/api/cdk8s.md
+++ b/docs/api/cdk8s.md
@@ -8219,7 +8219,9 @@ Container image to use for GitHub workflows.
 
 ---
 
-##### `workflowRunsOn`<sup>Optional</sup> <a name="workflowRunsOn" id="projen.cdk8s.Cdk8sTypeScriptAppOptions.property.workflowRunsOn"></a>
+##### ~~`workflowRunsOn`~~<sup>Optional</sup> <a name="workflowRunsOn" id="projen.cdk8s.Cdk8sTypeScriptAppOptions.property.workflowRunsOn"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOn` on the project, or `runsOn` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOn: string[];
@@ -8232,7 +8234,9 @@ Github Runner selection labels.
 
 ---
 
-##### `workflowRunsOnGroup`<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.cdk8s.Cdk8sTypeScriptAppOptions.property.workflowRunsOnGroup"></a>
+##### ~~`workflowRunsOnGroup`~~<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.cdk8s.Cdk8sTypeScriptAppOptions.property.workflowRunsOnGroup"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOnGroup` on the project, or `runsOnGroup` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOnGroup: GroupRunnerOptions;
@@ -10822,7 +10826,9 @@ Container image to use for GitHub workflows.
 
 ---
 
-##### `workflowRunsOn`<sup>Optional</sup> <a name="workflowRunsOn" id="projen.cdk8s.ConstructLibraryCdk8sOptions.property.workflowRunsOn"></a>
+##### ~~`workflowRunsOn`~~<sup>Optional</sup> <a name="workflowRunsOn" id="projen.cdk8s.ConstructLibraryCdk8sOptions.property.workflowRunsOn"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOn` on the project, or `runsOn` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOn: string[];
@@ -10835,7 +10841,9 @@ Github Runner selection labels.
 
 ---
 
-##### `workflowRunsOnGroup`<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.cdk8s.ConstructLibraryCdk8sOptions.property.workflowRunsOnGroup"></a>
+##### ~~`workflowRunsOnGroup`~~<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.cdk8s.ConstructLibraryCdk8sOptions.property.workflowRunsOnGroup"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOnGroup` on the project, or `runsOnGroup` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOnGroup: GroupRunnerOptions;

--- a/docs/api/cdktf.md
+++ b/docs/api/cdktf.md
@@ -3170,7 +3170,9 @@ Container image to use for GitHub workflows.
 
 ---
 
-##### `workflowRunsOn`<sup>Optional</sup> <a name="workflowRunsOn" id="projen.cdktf.ConstructLibraryCdktfOptions.property.workflowRunsOn"></a>
+##### ~~`workflowRunsOn`~~<sup>Optional</sup> <a name="workflowRunsOn" id="projen.cdktf.ConstructLibraryCdktfOptions.property.workflowRunsOn"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOn` on the project, or `runsOn` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOn: string[];
@@ -3183,7 +3185,9 @@ Github Runner selection labels.
 
 ---
 
-##### `workflowRunsOnGroup`<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.cdktf.ConstructLibraryCdktfOptions.property.workflowRunsOnGroup"></a>
+##### ~~`workflowRunsOnGroup`~~<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.cdktf.ConstructLibraryCdktfOptions.property.workflowRunsOnGroup"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOnGroup` on the project, or `runsOnGroup` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOnGroup: GroupRunnerOptions;

--- a/docs/api/cdktn.md
+++ b/docs/api/cdktn.md
@@ -5755,7 +5755,9 @@ Container image to use for GitHub workflows.
 
 ---
 
-##### `workflowRunsOn`<sup>Optional</sup> <a name="workflowRunsOn" id="projen.cdktn.CdktnTypeScriptAppOptions.property.workflowRunsOn"></a>
+##### ~~`workflowRunsOn`~~<sup>Optional</sup> <a name="workflowRunsOn" id="projen.cdktn.CdktnTypeScriptAppOptions.property.workflowRunsOn"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOn` on the project, or `runsOn` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOn: string[];
@@ -5768,7 +5770,9 @@ Github Runner selection labels.
 
 ---
 
-##### `workflowRunsOnGroup`<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.cdktn.CdktnTypeScriptAppOptions.property.workflowRunsOnGroup"></a>
+##### ~~`workflowRunsOnGroup`~~<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.cdktn.CdktnTypeScriptAppOptions.property.workflowRunsOnGroup"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOnGroup` on the project, or `runsOnGroup` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOnGroup: GroupRunnerOptions;
@@ -8326,7 +8330,9 @@ Container image to use for GitHub workflows.
 
 ---
 
-##### `workflowRunsOn`<sup>Optional</sup> <a name="workflowRunsOn" id="projen.cdktn.ConstructLibraryCdktnOptions.property.workflowRunsOn"></a>
+##### ~~`workflowRunsOn`~~<sup>Optional</sup> <a name="workflowRunsOn" id="projen.cdktn.ConstructLibraryCdktnOptions.property.workflowRunsOn"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOn` on the project, or `runsOn` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOn: string[];
@@ -8339,7 +8345,9 @@ Github Runner selection labels.
 
 ---
 
-##### `workflowRunsOnGroup`<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.cdktn.ConstructLibraryCdktnOptions.property.workflowRunsOnGroup"></a>
+##### ~~`workflowRunsOnGroup`~~<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.cdktn.ConstructLibraryCdktnOptions.property.workflowRunsOnGroup"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOnGroup` on the project, or `runsOnGroup` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOnGroup: GroupRunnerOptions;

--- a/docs/api/github.md
+++ b/docs/api/github.md
@@ -1330,6 +1330,7 @@ new github.GitHub(project: Project, options?: GitHubOptions)
 | <code><a href="#projen.github.GitHub.addDependabot">addDependabot</a></code> | *No description.* |
 | <code><a href="#projen.github.GitHub.addPullRequestTemplate">addPullRequestTemplate</a></code> | *No description.* |
 | <code><a href="#projen.github.GitHub.addWorkflow">addWorkflow</a></code> | Adds a workflow to the project. |
+| <code><a href="#projen.github.GitHub.runsOnConfig">runsOnConfig</a></code> | Resolves the `runsOn`/`runsOnGroup` config for a job, falling back to the project's global runner selection (`workflowRunsOn`/`workflowRunsOnGroup`) when `options` does not specify one. |
 | <code><a href="#projen.github.GitHub.tryFindWorkflow">tryFindWorkflow</a></code> | Finds a GitHub workflow by name. |
 
 ---
@@ -1466,6 +1467,22 @@ Adds a workflow to the project.
 - *Type:* string
 
 Name of the workflow.
+
+---
+
+##### `runsOnConfig` <a name="runsOnConfig" id="projen.github.GitHub.runsOnConfig"></a>
+
+```typescript
+public runsOnConfig(options?: RunsOnOptions): RunsOnConfig
+```
+
+Resolves the `runsOn`/`runsOnGroup` config for a job, falling back to the project's global runner selection (`workflowRunsOn`/`workflowRunsOnGroup`) when `options` does not specify one.
+
+###### `options`<sup>Optional</sup> <a name="options" id="projen.github.GitHub.runsOnConfig.parameter.options"></a>
+
+- *Type:* projen.RunsOnOptions
+
+per-job runner selection that takes precedence over the project's global default.
 
 ---
 
@@ -6183,11 +6200,36 @@ const autoApproveOptions: github.AutoApproveOptions = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#projen.github.AutoApproveOptions.property.allowedUsernames">allowedUsernames</a></code> | <code>string[]</code> | Only pull requests authored by these Github usernames will be auto-approved. |
-| <code><a href="#projen.github.AutoApproveOptions.property.label">label</a></code> | <code>string</code> | Only pull requests with this label will be auto-approved. |
 | <code><a href="#projen.github.AutoApproveOptions.property.runsOn">runsOn</a></code> | <code>string[]</code> | Github Runner selection labels. |
 | <code><a href="#projen.github.AutoApproveOptions.property.runsOnGroup">runsOnGroup</a></code> | <code>projen.GroupRunnerOptions</code> | Github Runner Group selection options. |
+| <code><a href="#projen.github.AutoApproveOptions.property.allowedUsernames">allowedUsernames</a></code> | <code>string[]</code> | Only pull requests authored by these Github usernames will be auto-approved. |
+| <code><a href="#projen.github.AutoApproveOptions.property.label">label</a></code> | <code>string</code> | Only pull requests with this label will be auto-approved. |
 | <code><a href="#projen.github.AutoApproveOptions.property.secret">secret</a></code> | <code>string</code> | A GitHub secret name which contains a GitHub Access Token with write permissions for the `pull_request` scope. |
+
+---
+
+##### `runsOn`<sup>Optional</sup> <a name="runsOn" id="projen.github.AutoApproveOptions.property.runsOn"></a>
+
+```typescript
+public readonly runsOn: string[];
+```
+
+- *Type:* string[]
+- *Default:* ["ubuntu-latest"]
+
+Github Runner selection labels.
+
+---
+
+##### `runsOnGroup`<sup>Optional</sup> <a name="runsOnGroup" id="projen.github.AutoApproveOptions.property.runsOnGroup"></a>
+
+```typescript
+public readonly runsOnGroup: GroupRunnerOptions;
+```
+
+- *Type:* projen.GroupRunnerOptions
+
+Github Runner Group selection options.
 
 ---
 
@@ -6214,31 +6256,6 @@ public readonly label: string;
 - *Default:* 'auto-approve'
 
 Only pull requests with this label will be auto-approved.
-
----
-
-##### `runsOn`<sup>Optional</sup> <a name="runsOn" id="projen.github.AutoApproveOptions.property.runsOn"></a>
-
-```typescript
-public readonly runsOn: string[];
-```
-
-- *Type:* string[]
-- *Default:* ["ubuntu-latest"]
-
-Github Runner selection labels.
-
----
-
-##### `runsOnGroup`<sup>Optional</sup> <a name="runsOnGroup" id="projen.github.AutoApproveOptions.property.runsOnGroup"></a>
-
-```typescript
-public readonly runsOnGroup: GroupRunnerOptions;
-```
-
-- *Type:* projen.GroupRunnerOptions
-
-Github Runner Group selection options.
 
 ---
 
@@ -6352,12 +6369,38 @@ const autoQueueOptions: github.AutoQueueOptions = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#projen.github.AutoQueueOptions.property.runsOn">runsOn</a></code> | <code>string[]</code> | Github Runner selection labels. |
+| <code><a href="#projen.github.AutoQueueOptions.property.runsOnGroup">runsOnGroup</a></code> | <code>projen.GroupRunnerOptions</code> | Github Runner Group selection options. |
 | <code><a href="#projen.github.AutoQueueOptions.property.allowedUsernames">allowedUsernames</a></code> | <code>string[]</code> | Only pull requests authored by these Github usernames will have auto-queue enabled. |
 | <code><a href="#projen.github.AutoQueueOptions.property.labels">labels</a></code> | <code>string[]</code> | Only pull requests with one of this labels will have auto-queue enabled. |
 | <code><a href="#projen.github.AutoQueueOptions.property.mergeMethod">mergeMethod</a></code> | <code><a href="#projen.github.MergeMethod">MergeMethod</a></code> | The method used to add the PR to the merge queue Any branch protection rules must allow this merge method. |
 | <code><a href="#projen.github.AutoQueueOptions.property.projenCredentials">projenCredentials</a></code> | <code><a href="#projen.github.GithubCredentials">GithubCredentials</a></code> | Choose a method for authenticating with GitHub to enable auto-queue on pull requests. |
-| <code><a href="#projen.github.AutoQueueOptions.property.runsOn">runsOn</a></code> | <code>string[]</code> | Github Runner selection labels. |
 | <code><a href="#projen.github.AutoQueueOptions.property.targetBranches">targetBranches</a></code> | <code>string[]</code> | The branch names that we should auto-queue for. |
+
+---
+
+##### `runsOn`<sup>Optional</sup> <a name="runsOn" id="projen.github.AutoQueueOptions.property.runsOn"></a>
+
+```typescript
+public readonly runsOn: string[];
+```
+
+- *Type:* string[]
+- *Default:* ["ubuntu-latest"]
+
+Github Runner selection labels.
+
+---
+
+##### `runsOnGroup`<sup>Optional</sup> <a name="runsOnGroup" id="projen.github.AutoQueueOptions.property.runsOnGroup"></a>
+
+```typescript
+public readonly runsOnGroup: GroupRunnerOptions;
+```
+
+- *Type:* projen.GroupRunnerOptions
+
+Github Runner Group selection options.
 
 ---
 
@@ -6416,19 +6459,6 @@ with the default token will not trigger any merge queue workflows,
 which results in the PR just not getting merged at all.
 
 > [https://projen.io/docs/integrations/github/](https://projen.io/docs/integrations/github/)
-
----
-
-##### `runsOn`<sup>Optional</sup> <a name="runsOn" id="projen.github.AutoQueueOptions.property.runsOn"></a>
-
-```typescript
-public readonly runsOn: string[];
-```
-
-- *Type:* string[]
-- *Default:* ["ubuntu-latest"]
-
-Github Runner selection labels.
 
 ---
 
@@ -7964,6 +7994,8 @@ const dependencyReviewOptions: github.DependencyReviewOptions = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#projen.github.DependencyReviewOptions.property.runsOn">runsOn</a></code> | <code>string[]</code> | Github Runner selection labels. |
+| <code><a href="#projen.github.DependencyReviewOptions.property.runsOnGroup">runsOnGroup</a></code> | <code>projen.GroupRunnerOptions</code> | Github Runner Group selection options. |
 | <code><a href="#projen.github.DependencyReviewOptions.property.allowGhsas">allowGhsas</a></code> | <code>string[]</code> | GitHub Advisory Database IDs that can be skipped during detection. |
 | <code><a href="#projen.github.DependencyReviewOptions.property.allowLicenses">allowLicenses</a></code> | <code>string[]</code> | List of allowed SPDX license identifiers. |
 | <code><a href="#projen.github.DependencyReviewOptions.property.commentSummaryInPr">commentSummaryInPr</a></code> | <code>string</code> | Whether to post a comment summary on the PR. |
@@ -7972,12 +8004,35 @@ const dependencyReviewOptions: github.DependencyReviewOptions = { ... }
 | <code><a href="#projen.github.DependencyReviewOptions.property.failOnScopes">failOnScopes</a></code> | <code>string[]</code> | Scopes of dependencies to fail on. |
 | <code><a href="#projen.github.DependencyReviewOptions.property.failOnSeverity">failOnSeverity</a></code> | <code>string</code> | The severity level at which the action will fail. |
 | <code><a href="#projen.github.DependencyReviewOptions.property.licenseCheck">licenseCheck</a></code> | <code>boolean</code> | Enable or disable the license check. |
-| <code><a href="#projen.github.DependencyReviewOptions.property.runsOn">runsOn</a></code> | <code>string[]</code> | Github Runner selection labels. |
-| <code><a href="#projen.github.DependencyReviewOptions.property.runsOnGroup">runsOnGroup</a></code> | <code>projen.GroupRunnerOptions</code> | Github Runner Group selection options. |
 | <code><a href="#projen.github.DependencyReviewOptions.property.showOpenSSFScorecard">showOpenSSFScorecard</a></code> | <code>boolean</code> | Show OpenSSF Scorecard scores for dependencies. |
 | <code><a href="#projen.github.DependencyReviewOptions.property.vulnerabilityCheck">vulnerabilityCheck</a></code> | <code>boolean</code> | Enable or disable the vulnerability check. |
 | <code><a href="#projen.github.DependencyReviewOptions.property.warnOnly">warnOnly</a></code> | <code>boolean</code> | When true, the action will only warn and not fail. |
 | <code><a href="#projen.github.DependencyReviewOptions.property.warnOnOpenSSFScorecardLevel">warnOnOpenSSFScorecardLevel</a></code> | <code>number</code> | Score threshold for OpenSSF Scorecard warnings. |
+
+---
+
+##### `runsOn`<sup>Optional</sup> <a name="runsOn" id="projen.github.DependencyReviewOptions.property.runsOn"></a>
+
+```typescript
+public readonly runsOn: string[];
+```
+
+- *Type:* string[]
+- *Default:* ["ubuntu-latest"]
+
+Github Runner selection labels.
+
+---
+
+##### `runsOnGroup`<sup>Optional</sup> <a name="runsOnGroup" id="projen.github.DependencyReviewOptions.property.runsOnGroup"></a>
+
+```typescript
+public readonly runsOnGroup: GroupRunnerOptions;
+```
+
+- *Type:* projen.GroupRunnerOptions
+
+Github Runner Group selection options.
 
 ---
 
@@ -8082,31 +8137,6 @@ public readonly licenseCheck: boolean;
 - *Default:* true
 
 Enable or disable the license check.
-
----
-
-##### `runsOn`<sup>Optional</sup> <a name="runsOn" id="projen.github.DependencyReviewOptions.property.runsOn"></a>
-
-```typescript
-public readonly runsOn: string[];
-```
-
-- *Type:* string[]
-- *Default:* ["ubuntu-latest"]
-
-Github Runner selection labels.
-
----
-
-##### `runsOnGroup`<sup>Optional</sup> <a name="runsOnGroup" id="projen.github.DependencyReviewOptions.property.runsOnGroup"></a>
-
-```typescript
-public readonly runsOnGroup: GroupRunnerOptions;
-```
-
-- *Type:* projen.GroupRunnerOptions
-
-Github Runner Group selection options.
 
 ---
 
@@ -8735,6 +8765,8 @@ const gitHubOptions: github.GitHubOptions = { ... }
 | <code><a href="#projen.github.GitHubOptions.property.pullRequestBackportOptions">pullRequestBackportOptions</a></code> | <code><a href="#projen.github.PullRequestBackportOptions">PullRequestBackportOptions</a></code> | Options for configuring pull request backport. |
 | <code><a href="#projen.github.GitHubOptions.property.pullRequestLint">pullRequestLint</a></code> | <code>boolean</code> | Add a workflow that performs basic checks for pull requests, like validating that PRs follow Conventional Commits. |
 | <code><a href="#projen.github.GitHubOptions.property.pullRequestLintOptions">pullRequestLintOptions</a></code> | <code><a href="#projen.github.PullRequestLintOptions">PullRequestLintOptions</a></code> | Options for configuring a pull request linter. |
+| <code><a href="#projen.github.GitHubOptions.property.workflowRunsOn">workflowRunsOn</a></code> | <code>string[]</code> | Github Runner selection labels. |
+| <code><a href="#projen.github.GitHubOptions.property.workflowRunsOnGroup">workflowRunsOnGroup</a></code> | <code>projen.GroupRunnerOptions</code> | Github Runner Group selection options. |
 | <code><a href="#projen.github.GitHubOptions.property.workflows">workflows</a></code> | <code>boolean</code> | Enables GitHub workflows. |
 
 ---
@@ -8918,6 +8950,31 @@ public readonly pullRequestLintOptions: PullRequestLintOptions;
 - *Default:* see defaults in `PullRequestLintOptions`
 
 Options for configuring a pull request linter.
+
+---
+
+##### `workflowRunsOn`<sup>Optional</sup> <a name="workflowRunsOn" id="projen.github.GitHubOptions.property.workflowRunsOn"></a>
+
+```typescript
+public readonly workflowRunsOn: string[];
+```
+
+- *Type:* string[]
+- *Default:* ["ubuntu-latest"]
+
+Github Runner selection labels.
+
+---
+
+##### `workflowRunsOnGroup`<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.github.GitHubOptions.property.workflowRunsOnGroup"></a>
+
+```typescript
+public readonly workflowRunsOnGroup: GroupRunnerOptions;
+```
+
+- *Type:* projen.GroupRunnerOptions
+
+Github Runner Group selection options.
 
 ---
 
@@ -9929,6 +9986,8 @@ const pullRequestBackportOptions: github.PullRequestBackportOptions = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#projen.github.PullRequestBackportOptions.property.runsOn">runsOn</a></code> | <code>string[]</code> | Github Runner selection labels. |
+| <code><a href="#projen.github.PullRequestBackportOptions.property.runsOnGroup">runsOnGroup</a></code> | <code>projen.GroupRunnerOptions</code> | Github Runner Group selection options. |
 | <code><a href="#projen.github.PullRequestBackportOptions.property.autoApproveBackport">autoApproveBackport</a></code> | <code>boolean</code> | Automatically approve backport PRs if the 'auto approve' workflow is available. |
 | <code><a href="#projen.github.PullRequestBackportOptions.property.backportBranchNamePrefix">backportBranchNamePrefix</a></code> | <code>string</code> | The prefix used to name backport branches. |
 | <code><a href="#projen.github.PullRequestBackportOptions.property.backportPRLabels">backportPRLabels</a></code> | <code>string[]</code> | The labels added to the created backport PR. |
@@ -9936,6 +9995,31 @@ const pullRequestBackportOptions: github.PullRequestBackportOptions = { ... }
 | <code><a href="#projen.github.PullRequestBackportOptions.property.createWithConflicts">createWithConflicts</a></code> | <code>boolean</code> | Should this created Backport PRs with conflicts. |
 | <code><a href="#projen.github.PullRequestBackportOptions.property.labelPrefix">labelPrefix</a></code> | <code>string</code> | The prefix used to detect PRs that should be backported. |
 | <code><a href="#projen.github.PullRequestBackportOptions.property.workflowName">workflowName</a></code> | <code>string</code> | The name of the workflow. |
+
+---
+
+##### `runsOn`<sup>Optional</sup> <a name="runsOn" id="projen.github.PullRequestBackportOptions.property.runsOn"></a>
+
+```typescript
+public readonly runsOn: string[];
+```
+
+- *Type:* string[]
+- *Default:* ["ubuntu-latest"]
+
+Github Runner selection labels.
+
+---
+
+##### `runsOnGroup`<sup>Optional</sup> <a name="runsOnGroup" id="projen.github.PullRequestBackportOptions.property.runsOnGroup"></a>
+
+```typescript
+public readonly runsOnGroup: GroupRunnerOptions;
+```
+
+- *Type:* projen.GroupRunnerOptions
+
+Github Runner Group selection options.
 
 ---
 
@@ -10320,12 +10404,37 @@ const pullRequestLintOptions: github.PullRequestLintOptions = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#projen.github.PullRequestLintOptions.property.contributorStatement">contributorStatement</a></code> | <code>string</code> | Require a contributor statement to be included in the PR description. |
-| <code><a href="#projen.github.PullRequestLintOptions.property.contributorStatementOptions">contributorStatementOptions</a></code> | <code><a href="#projen.github.ContributorStatementOptions">ContributorStatementOptions</a></code> | Options for requiring a contributor statement on Pull Requests. |
 | <code><a href="#projen.github.PullRequestLintOptions.property.runsOn">runsOn</a></code> | <code>string[]</code> | Github Runner selection labels. |
 | <code><a href="#projen.github.PullRequestLintOptions.property.runsOnGroup">runsOnGroup</a></code> | <code>projen.GroupRunnerOptions</code> | Github Runner Group selection options. |
+| <code><a href="#projen.github.PullRequestLintOptions.property.contributorStatement">contributorStatement</a></code> | <code>string</code> | Require a contributor statement to be included in the PR description. |
+| <code><a href="#projen.github.PullRequestLintOptions.property.contributorStatementOptions">contributorStatementOptions</a></code> | <code><a href="#projen.github.ContributorStatementOptions">ContributorStatementOptions</a></code> | Options for requiring a contributor statement on Pull Requests. |
 | <code><a href="#projen.github.PullRequestLintOptions.property.semanticTitle">semanticTitle</a></code> | <code>boolean</code> | Validate that pull request titles follow Conventional Commits. |
 | <code><a href="#projen.github.PullRequestLintOptions.property.semanticTitleOptions">semanticTitleOptions</a></code> | <code><a href="#projen.github.SemanticTitleOptions">SemanticTitleOptions</a></code> | Options for validating the conventional commit title linter. |
+
+---
+
+##### `runsOn`<sup>Optional</sup> <a name="runsOn" id="projen.github.PullRequestLintOptions.property.runsOn"></a>
+
+```typescript
+public readonly runsOn: string[];
+```
+
+- *Type:* string[]
+- *Default:* ["ubuntu-latest"]
+
+Github Runner selection labels.
+
+---
+
+##### `runsOnGroup`<sup>Optional</sup> <a name="runsOnGroup" id="projen.github.PullRequestLintOptions.property.runsOnGroup"></a>
+
+```typescript
+public readonly runsOnGroup: GroupRunnerOptions;
+```
+
+- *Type:* projen.GroupRunnerOptions
+
+Github Runner Group selection options.
 
 ---
 
@@ -10356,31 +10465,6 @@ public readonly contributorStatementOptions: ContributorStatementOptions;
 - *Default:* none
 
 Options for requiring a contributor statement on Pull Requests.
-
----
-
-##### `runsOn`<sup>Optional</sup> <a name="runsOn" id="projen.github.PullRequestLintOptions.property.runsOn"></a>
-
-```typescript
-public readonly runsOn: string[];
-```
-
-- *Type:* string[]
-- *Default:* ["ubuntu-latest"]
-
-Github Runner selection labels.
-
----
-
-##### `runsOnGroup`<sup>Optional</sup> <a name="runsOnGroup" id="projen.github.PullRequestLintOptions.property.runsOnGroup"></a>
-
-```typescript
-public readonly runsOnGroup: GroupRunnerOptions;
-```
-
-- *Type:* projen.GroupRunnerOptions
-
-Github Runner Group selection options.
 
 ---
 
@@ -11074,10 +11158,35 @@ const staleOptions: github.StaleOptions = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#projen.github.StaleOptions.property.issues">issues</a></code> | <code><a href="#projen.github.StaleBehavior">StaleBehavior</a></code> | How to handle stale issues. |
-| <code><a href="#projen.github.StaleOptions.property.pullRequest">pullRequest</a></code> | <code><a href="#projen.github.StaleBehavior">StaleBehavior</a></code> | How to handle stale pull requests. |
 | <code><a href="#projen.github.StaleOptions.property.runsOn">runsOn</a></code> | <code>string[]</code> | Github Runner selection labels. |
 | <code><a href="#projen.github.StaleOptions.property.runsOnGroup">runsOnGroup</a></code> | <code>projen.GroupRunnerOptions</code> | Github Runner Group selection options. |
+| <code><a href="#projen.github.StaleOptions.property.issues">issues</a></code> | <code><a href="#projen.github.StaleBehavior">StaleBehavior</a></code> | How to handle stale issues. |
+| <code><a href="#projen.github.StaleOptions.property.pullRequest">pullRequest</a></code> | <code><a href="#projen.github.StaleBehavior">StaleBehavior</a></code> | How to handle stale pull requests. |
+
+---
+
+##### `runsOn`<sup>Optional</sup> <a name="runsOn" id="projen.github.StaleOptions.property.runsOn"></a>
+
+```typescript
+public readonly runsOn: string[];
+```
+
+- *Type:* string[]
+- *Default:* ["ubuntu-latest"]
+
+Github Runner selection labels.
+
+---
+
+##### `runsOnGroup`<sup>Optional</sup> <a name="runsOnGroup" id="projen.github.StaleOptions.property.runsOnGroup"></a>
+
+```typescript
+public readonly runsOnGroup: GroupRunnerOptions;
+```
+
+- *Type:* projen.GroupRunnerOptions
+
+Github Runner Group selection options.
 
 ---
 
@@ -11104,31 +11213,6 @@ public readonly pullRequest: StaleBehavior;
 - *Default:* By default, pull requests with no activity will be marked as stale after 14 days and closed within 2 days with relevant comments.
 
 How to handle stale pull requests.
-
----
-
-##### `runsOn`<sup>Optional</sup> <a name="runsOn" id="projen.github.StaleOptions.property.runsOn"></a>
-
-```typescript
-public readonly runsOn: string[];
-```
-
-- *Type:* string[]
-- *Default:* ["ubuntu-latest"]
-
-Github Runner selection labels.
-
----
-
-##### `runsOnGroup`<sup>Optional</sup> <a name="runsOnGroup" id="projen.github.StaleOptions.property.runsOnGroup"></a>
-
-```typescript
-public readonly runsOnGroup: GroupRunnerOptions;
-```
-
-- *Type:* projen.GroupRunnerOptions
-
-Github Runner Group selection options.
 
 ---
 

--- a/docs/api/javascript.md
+++ b/docs/api/javascript.md
@@ -11849,7 +11849,9 @@ Container image to use for GitHub workflows.
 
 ---
 
-##### `workflowRunsOn`<sup>Optional</sup> <a name="workflowRunsOn" id="projen.javascript.NodeProjectOptions.property.workflowRunsOn"></a>
+##### ~~`workflowRunsOn`~~<sup>Optional</sup> <a name="workflowRunsOn" id="projen.javascript.NodeProjectOptions.property.workflowRunsOn"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOn` on the project, or `runsOn` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOn: string[];
@@ -11862,7 +11864,9 @@ Github Runner selection labels.
 
 ---
 
-##### `workflowRunsOnGroup`<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.javascript.NodeProjectOptions.property.workflowRunsOnGroup"></a>
+##### ~~`workflowRunsOnGroup`~~<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.javascript.NodeProjectOptions.property.workflowRunsOnGroup"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOnGroup` on the project, or `runsOnGroup` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOnGroup: GroupRunnerOptions;

--- a/docs/api/projen.md
+++ b/docs/api/projen.md
@@ -16328,6 +16328,102 @@ The task steps to execute the script.
 
 ---
 
+### RunsOnConfig <a name="RunsOnConfig" id="projen.RunsOnConfig"></a>
+
+Resolved `runsOn`/`runsOnGroup` config for a job.
+
+Exactly one of the two
+fields is set.
+
+#### Initializer <a name="Initializer" id="projen.RunsOnConfig.Initializer"></a>
+
+```typescript
+import { RunsOnConfig } from 'projen'
+
+const runsOnConfig: RunsOnConfig = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen.RunsOnConfig.property.runsOn">runsOn</a></code> | <code>string[]</code> | Github Runner selection labels. |
+| <code><a href="#projen.RunsOnConfig.property.runsOnGroup">runsOnGroup</a></code> | <code><a href="#projen.GroupRunnerOptions">GroupRunnerOptions</a></code> | Github Runner Group selection options. |
+
+---
+
+##### `runsOn`<sup>Optional</sup> <a name="runsOn" id="projen.RunsOnConfig.property.runsOn"></a>
+
+```typescript
+public readonly runsOn: string[];
+```
+
+- *Type:* string[]
+- *Default:* not set if `runsOnGroup` is used
+
+Github Runner selection labels.
+
+---
+
+##### `runsOnGroup`<sup>Optional</sup> <a name="runsOnGroup" id="projen.RunsOnConfig.property.runsOnGroup"></a>
+
+```typescript
+public readonly runsOnGroup: GroupRunnerOptions;
+```
+
+- *Type:* <a href="#projen.GroupRunnerOptions">GroupRunnerOptions</a>
+- *Default:* not set if `runsOn` is used
+
+Github Runner Group selection options.
+
+---
+
+### RunsOnOptions <a name="RunsOnOptions" id="projen.RunsOnOptions"></a>
+
+Options for selecting the GitHub Runner that a job runs on.
+
+#### Initializer <a name="Initializer" id="projen.RunsOnOptions.Initializer"></a>
+
+```typescript
+import { RunsOnOptions } from 'projen'
+
+const runsOnOptions: RunsOnOptions = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen.RunsOnOptions.property.runsOn">runsOn</a></code> | <code>string[]</code> | Github Runner selection labels. |
+| <code><a href="#projen.RunsOnOptions.property.runsOnGroup">runsOnGroup</a></code> | <code><a href="#projen.GroupRunnerOptions">GroupRunnerOptions</a></code> | Github Runner Group selection options. |
+
+---
+
+##### `runsOn`<sup>Optional</sup> <a name="runsOn" id="projen.RunsOnOptions.property.runsOn"></a>
+
+```typescript
+public readonly runsOn: string[];
+```
+
+- *Type:* string[]
+- *Default:* ["ubuntu-latest"]
+
+Github Runner selection labels.
+
+---
+
+##### `runsOnGroup`<sup>Optional</sup> <a name="runsOnGroup" id="projen.RunsOnOptions.property.runsOnGroup"></a>
+
+```typescript
+public readonly runsOnGroup: GroupRunnerOptions;
+```
+
+- *Type:* <a href="#projen.GroupRunnerOptions">GroupRunnerOptions</a>
+
+Github Runner Group selection options.
+
+---
+
 ### SampleDirOptions <a name="SampleDirOptions" id="projen.SampleDirOptions"></a>
 
 SampleDir options.

--- a/docs/api/release.md
+++ b/docs/api/release.md
@@ -2680,6 +2680,8 @@ const releaseOptions: release.ReleaseOptions = { ... }
 | <code><a href="#projen.release.ReleaseOptions.property.branch">branch</a></code> | <code>string</code> | The default branch name to release from. |
 | <code><a href="#projen.release.ReleaseOptions.property.versionFile">versionFile</a></code> | <code>string</code> | A name of a .json file to set the `version` field in after a bump. |
 | <code><a href="#projen.release.ReleaseOptions.property.githubRelease">githubRelease</a></code> | <code>boolean</code> | Create a GitHub release for each release. |
+| <code><a href="#projen.release.ReleaseOptions.property.runsOn">runsOn</a></code> | <code>string[]</code> | Github Runner selection labels. |
+| <code><a href="#projen.release.ReleaseOptions.property.runsOnGroup">runsOnGroup</a></code> | <code>projen.GroupRunnerOptions</code> | Github Runner Group selection options. |
 | <code><a href="#projen.release.ReleaseOptions.property.tasks">tasks</a></code> | <code>projen.Task[]</code> | The tasks to execute in order to create the release artifacts. |
 | <code><a href="#projen.release.ReleaseOptions.property.workflowNodeVersion">workflowNodeVersion</a></code> | <code>string</code> | Node version to setup in GitHub workflows if any node-based CLI utilities are needed. |
 | <code><a href="#projen.release.ReleaseOptions.property.workflowPermissions">workflowPermissions</a></code> | <code>projen.github.workflows.JobPermissions</code> | Permissions granted to the release workflow job. |
@@ -3028,7 +3030,9 @@ Container image to use for GitHub workflows.
 
 ---
 
-##### `workflowRunsOn`<sup>Optional</sup> <a name="workflowRunsOn" id="projen.release.ReleaseOptions.property.workflowRunsOn"></a>
+##### ~~`workflowRunsOn`~~<sup>Optional</sup> <a name="workflowRunsOn" id="projen.release.ReleaseOptions.property.workflowRunsOn"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOn` on the project, or `runsOn` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOn: string[];
@@ -3041,7 +3045,9 @@ Github Runner selection labels.
 
 ---
 
-##### `workflowRunsOnGroup`<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.release.ReleaseOptions.property.workflowRunsOnGroup"></a>
+##### ~~`workflowRunsOnGroup`~~<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.release.ReleaseOptions.property.workflowRunsOnGroup"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOnGroup` on the project, or `runsOnGroup` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOnGroup: GroupRunnerOptions;
@@ -3112,6 +3118,31 @@ public readonly githubRelease: boolean;
 - *Default:* true
 
 Create a GitHub release for each release.
+
+---
+
+##### `runsOn`<sup>Optional</sup> <a name="runsOn" id="projen.release.ReleaseOptions.property.runsOn"></a>
+
+```typescript
+public readonly runsOn: string[];
+```
+
+- *Type:* string[]
+- *Default:* ["ubuntu-latest"]
+
+Github Runner selection labels.
+
+---
+
+##### `runsOnGroup`<sup>Optional</sup> <a name="runsOnGroup" id="projen.release.ReleaseOptions.property.runsOnGroup"></a>
+
+```typescript
+public readonly runsOnGroup: GroupRunnerOptions;
+```
+
+- *Type:* projen.GroupRunnerOptions
+
+Github Runner Group selection options.
 
 ---
 
@@ -3545,7 +3576,9 @@ Container image to use for GitHub workflows.
 
 ---
 
-##### `workflowRunsOn`<sup>Optional</sup> <a name="workflowRunsOn" id="projen.release.ReleaseProjectOptions.property.workflowRunsOn"></a>
+##### ~~`workflowRunsOn`~~<sup>Optional</sup> <a name="workflowRunsOn" id="projen.release.ReleaseProjectOptions.property.workflowRunsOn"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOn` on the project, or `runsOn` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOn: string[];
@@ -3558,7 +3591,9 @@ Github Runner selection labels.
 
 ---
 
-##### `workflowRunsOnGroup`<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.release.ReleaseProjectOptions.property.workflowRunsOnGroup"></a>
+##### ~~`workflowRunsOnGroup`~~<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.release.ReleaseProjectOptions.property.workflowRunsOnGroup"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOnGroup` on the project, or `runsOnGroup` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOnGroup: GroupRunnerOptions;

--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -5795,7 +5795,9 @@ Container image to use for GitHub workflows.
 
 ---
 
-##### `workflowRunsOn`<sup>Optional</sup> <a name="workflowRunsOn" id="projen.typescript.TypeScriptProjectOptions.property.workflowRunsOn"></a>
+##### ~~`workflowRunsOn`~~<sup>Optional</sup> <a name="workflowRunsOn" id="projen.typescript.TypeScriptProjectOptions.property.workflowRunsOn"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOn` on the project, or `runsOn` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOn: string[];
@@ -5808,7 +5810,9 @@ Github Runner selection labels.
 
 ---
 
-##### `workflowRunsOnGroup`<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.typescript.TypeScriptProjectOptions.property.workflowRunsOnGroup"></a>
+##### ~~`workflowRunsOnGroup`~~<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.typescript.TypeScriptProjectOptions.property.workflowRunsOnGroup"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOnGroup` on the project, or `runsOnGroup` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOnGroup: GroupRunnerOptions;

--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -7506,7 +7506,9 @@ Container image to use for GitHub workflows.
 
 ---
 
-##### `workflowRunsOn`<sup>Optional</sup> <a name="workflowRunsOn" id="projen.web.NextJsProjectOptions.property.workflowRunsOn"></a>
+##### ~~`workflowRunsOn`~~<sup>Optional</sup> <a name="workflowRunsOn" id="projen.web.NextJsProjectOptions.property.workflowRunsOn"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOn` on the project, or `runsOn` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOn: string[];
@@ -7519,7 +7521,9 @@ Github Runner selection labels.
 
 ---
 
-##### `workflowRunsOnGroup`<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.web.NextJsProjectOptions.property.workflowRunsOnGroup"></a>
+##### ~~`workflowRunsOnGroup`~~<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.web.NextJsProjectOptions.property.workflowRunsOnGroup"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOnGroup` on the project, or `runsOnGroup` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOnGroup: GroupRunnerOptions;
@@ -9689,7 +9693,9 @@ Container image to use for GitHub workflows.
 
 ---
 
-##### `workflowRunsOn`<sup>Optional</sup> <a name="workflowRunsOn" id="projen.web.NextJsTypeScriptProjectOptions.property.workflowRunsOn"></a>
+##### ~~`workflowRunsOn`~~<sup>Optional</sup> <a name="workflowRunsOn" id="projen.web.NextJsTypeScriptProjectOptions.property.workflowRunsOn"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOn` on the project, or `runsOn` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOn: string[];
@@ -9702,7 +9708,9 @@ Github Runner selection labels.
 
 ---
 
-##### `workflowRunsOnGroup`<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.web.NextJsTypeScriptProjectOptions.property.workflowRunsOnGroup"></a>
+##### ~~`workflowRunsOnGroup`~~<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.web.NextJsTypeScriptProjectOptions.property.workflowRunsOnGroup"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOnGroup` on the project, or `runsOnGroup` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOnGroup: GroupRunnerOptions;
@@ -12187,7 +12195,9 @@ Container image to use for GitHub workflows.
 
 ---
 
-##### `workflowRunsOn`<sup>Optional</sup> <a name="workflowRunsOn" id="projen.web.ReactProjectOptions.property.workflowRunsOn"></a>
+##### ~~`workflowRunsOn`~~<sup>Optional</sup> <a name="workflowRunsOn" id="projen.web.ReactProjectOptions.property.workflowRunsOn"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOn` on the project, or `runsOn` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOn: string[];
@@ -12200,7 +12210,9 @@ Github Runner selection labels.
 
 ---
 
-##### `workflowRunsOnGroup`<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.web.ReactProjectOptions.property.workflowRunsOnGroup"></a>
+##### ~~`workflowRunsOnGroup`~~<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.web.ReactProjectOptions.property.workflowRunsOnGroup"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOnGroup` on the project, or `runsOnGroup` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOnGroup: GroupRunnerOptions;
@@ -14437,7 +14449,9 @@ Container image to use for GitHub workflows.
 
 ---
 
-##### `workflowRunsOn`<sup>Optional</sup> <a name="workflowRunsOn" id="projen.web.ReactTypeScriptProjectOptions.property.workflowRunsOn"></a>
+##### ~~`workflowRunsOn`~~<sup>Optional</sup> <a name="workflowRunsOn" id="projen.web.ReactTypeScriptProjectOptions.property.workflowRunsOn"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOn` on the project, or `runsOn` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOn: string[];
@@ -14450,7 +14464,9 @@ Github Runner selection labels.
 
 ---
 
-##### `workflowRunsOnGroup`<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.web.ReactTypeScriptProjectOptions.property.workflowRunsOnGroup"></a>
+##### ~~`workflowRunsOnGroup`~~<sup>Optional</sup> <a name="workflowRunsOnGroup" id="projen.web.ReactTypeScriptProjectOptions.property.workflowRunsOnGroup"></a>
+
+- *Deprecated:* use `githubOptions.workflowRunsOnGroup` on the project, or `runsOnGroup` on `ReleaseOptions`
 
 ```typescript
 public readonly workflowRunsOnGroup: GroupRunnerOptions;

--- a/src/cdk/jsii-project.ts
+++ b/src/cdk/jsii-project.ts
@@ -1,5 +1,6 @@
 import type { ValidateTsconfig } from "./jsii-build";
 import { JsiiBuild } from "./jsii-build";
+import { GitHub } from "../github";
 import type {
   GoPublishOptions,
   MavenPublishOptions,
@@ -263,17 +264,17 @@ export class JsiiProject extends TypeScriptProject {
   }
 
   /**
-   * Generates the runs-on config for Jobs.
-   * Throws error if 'runsOn' and 'runsOnGroup' are both set.
-   *
-   * @param options - 'runsOn' or 'runsOnGroup'.
+   * Generates the runs-on config for Jobs, falling back to the project's
+   * global GitHub runner selection (if any).
    */
   private getJobRunsOnConfig(options: JsiiProjectOptions) {
-    return options.workflowRunsOnGroup
-      ? { runsOnGroup: options.workflowRunsOnGroup }
-      : options.workflowRunsOn
-        ? { runsOn: options.workflowRunsOn }
-        : {};
+    const github = this.github ?? GitHub.of(this.root);
+    return (
+      github?.runsOnConfig({
+        runsOn: options.workflowRunsOn,
+        runsOnGroup: options.workflowRunsOnGroup,
+      }) ?? {}
+    );
   }
 }
 

--- a/src/github/auto-approve.ts
+++ b/src/github/auto-approve.ts
@@ -2,13 +2,12 @@ import type { GitHub } from "./github";
 import type { Job } from "./workflows-model";
 import { JobPermission } from "./workflows-model";
 import { Component } from "../component";
-import type { GroupRunnerOptions } from "../runner-options";
-import { filteredRunsOnOptions } from "../runner-options";
+import type { RunsOnOptions } from "../runner-options";
 
 /**
  * Options for 'AutoApprove'
  */
-export interface AutoApproveOptions {
+export interface AutoApproveOptions extends RunsOnOptions {
   /**
    * Only pull requests authored by these Github usernames will be auto-approved.
    * @default ['github-bot']
@@ -36,21 +35,6 @@ export interface AutoApproveOptions {
    * @default "GITHUB_TOKEN"
    */
   readonly secret?: string;
-
-  /**
-   * Github Runner selection labels
-   * @default ["ubuntu-latest"]
-   * @description Defines a target Runner by labels
-   * @throws {Error} if both `runsOn` and `runsOnGroup` are specified
-   */
-  readonly runsOn?: string[];
-
-  /**
-   * Github Runner Group selection options
-   * @description Defines a target Runner Group by name and/or labels
-   * @throws {Error} if both `runsOn` and `runsOnGroup` are specified
-   */
-  readonly runsOnGroup?: GroupRunnerOptions;
 }
 
 /**
@@ -77,7 +61,7 @@ export class AutoApprove extends Component {
     const secret = options.secret ?? "GITHUB_TOKEN";
 
     const approveJob: Job = {
-      ...filteredRunsOnOptions(options.runsOn, options.runsOnGroup),
+      ...github.runsOnConfig(options),
       permissions: {
         pullRequests: JobPermission.WRITE,
       },

--- a/src/github/auto-queue.ts
+++ b/src/github/auto-queue.ts
@@ -3,6 +3,7 @@ import { GitHub } from "./github";
 import type { GithubCredentials } from "./github-credentials";
 import * as workflows from "./workflows-model";
 import { Component } from "../component";
+import type { RunsOnOptions } from "../runner-options";
 
 /**
  * The merge method used to add the PR to the merge queue
@@ -18,7 +19,7 @@ export enum MergeMethod {
 /**
  * Options for 'AutoQueue'
  */
-export interface AutoQueueOptions {
+export interface AutoQueueOptions extends RunsOnOptions {
   /**
    * Only pull requests authored by these Github usernames will have auto-queue enabled.
    * @default - pull requests from all users are eligible for auto-queuing
@@ -49,12 +50,6 @@ export interface AutoQueueOptions {
    * @default MergeMethod.SQUASH
    */
   readonly mergeMethod?: MergeMethod;
-
-  /**
-   * Github Runner selection labels
-   * @default ["ubuntu-latest"]
-   */
-  readonly runsOn?: string[];
 
   /**
    * The branch names that we should auto-queue for
@@ -166,7 +161,7 @@ export class AutoQueue extends Component {
 
     const autoQueueJob: workflows.Job = {
       name: "Set AutoQueue on PR #${{ github.event.number }}",
-      runsOn: options.runsOn ?? ["ubuntu-latest"],
+      ...workflowEngine.runsOnConfig(options),
       permissions: {
         pullRequests: workflows.JobPermission.WRITE,
         contents: workflows.JobPermission.WRITE,

--- a/src/github/dependency-review.ts
+++ b/src/github/dependency-review.ts
@@ -3,13 +3,12 @@ import type { GitHub } from "./github";
 import { WorkflowSteps } from "./workflow-steps";
 import { JobPermission } from "./workflows-model";
 import { Component } from "../component";
-import type { GroupRunnerOptions } from "../runner-options";
-import { filteredRunsOnOptions } from "../runner-options";
+import type { RunsOnOptions } from "../runner-options";
 
 /**
  * Options for the DependencyReview component.
  */
-export interface DependencyReviewOptions {
+export interface DependencyReviewOptions extends RunsOnOptions {
   /**
    * The severity level at which the action will fail.
    *
@@ -93,18 +92,6 @@ export interface DependencyReviewOptions {
    * @default 3
    */
   readonly warnOnOpenSSFScorecardLevel?: number;
-
-  /**
-   * Github Runner selection labels.
-   *
-   * @default ["ubuntu-latest"]
-   */
-  readonly runsOn?: string[];
-
-  /**
-   * Github Runner Group selection options.
-   */
-  readonly runsOnGroup?: GroupRunnerOptions;
 }
 
 /**
@@ -129,7 +116,7 @@ export class DependencyReview extends Component {
 
     workflow.addJobs({
       "dependency-review": {
-        ...filteredRunsOnOptions(options.runsOn, options.runsOnGroup),
+        ...github.runsOnConfig(options),
         permissions: {
           contents: JobPermission.READ,
           ...(commentSummary !== "never"

--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -17,6 +17,12 @@ import { CheckoutSubmodules } from "./workflow-steps";
 import { GithubWorkflow } from "./workflows";
 import { Component } from "../component";
 import type { Project } from "../project";
+import type {
+  GroupRunnerOptions,
+  RunsOnConfig,
+  RunsOnOptions,
+} from "../runner-options";
+import { filteredRunsOnOptions } from "../runner-options";
 
 export interface GitHubOptions {
   /**
@@ -128,6 +134,23 @@ export interface GitHubOptions {
    * @default CheckoutSubmodules.DISABLED
    */
   readonly checkoutSubmodules?: CheckoutSubmodules;
+
+  /**
+   * Github Runner selection labels
+   * @default ["ubuntu-latest"]
+   * @description Defines a target Runner by labels for all workflows.
+   * Can be overridden on a per-component basis.
+   * @throws {Error} if both `workflowRunsOn` and `workflowRunsOnGroup` are specified
+   */
+  readonly workflowRunsOn?: string[];
+
+  /**
+   * Github Runner Group selection options
+   * @description Defines a target Runner Group by name and/or labels for all workflows.
+   * Can be overridden on a per-component basis.
+   * @throws {Error} if both `workflowRunsOn` and `workflowRunsOnGroup` are specified
+   */
+  readonly workflowRunsOnGroup?: GroupRunnerOptions;
 }
 
 export class GitHub extends Component {
@@ -169,6 +192,8 @@ export class GitHub extends Component {
 
   private readonly _downloadLfs?: boolean;
   private readonly _checkoutSubmodules?: CheckoutSubmodules;
+  private readonly _workflowRunsOn?: string[];
+  private readonly _workflowRunsOnGroup?: GroupRunnerOptions;
 
   public constructor(project: Project, options: GitHubOptions = {}) {
     super(project);
@@ -179,6 +204,8 @@ export class GitHub extends Component {
 
     this._downloadLfs = options.downloadLfs;
     this._checkoutSubmodules = options.checkoutSubmodules;
+    this._workflowRunsOn = options.workflowRunsOn;
+    this._workflowRunsOnGroup = options.workflowRunsOnGroup;
 
     if (options.projenCredentials) {
       this.projenCredentials = options.projenCredentials;
@@ -264,5 +291,19 @@ export class GitHub extends Component {
    */
   public get checkoutSubmodules(): CheckoutSubmodules {
     return this._checkoutSubmodules ?? CheckoutSubmodules.DISABLED;
+  }
+
+  /**
+   * Resolves the `runsOn`/`runsOnGroup` config for a job, falling back to the
+   * project's global runner selection (`workflowRunsOn`/`workflowRunsOnGroup`)
+   * when `options` does not specify one.
+   * @param options per-job runner selection that takes precedence over the
+   * project's global default
+   */
+  public runsOnConfig(options: RunsOnOptions = {}): RunsOnConfig {
+    return filteredRunsOnOptions(
+      options.runsOn ?? this._workflowRunsOn,
+      options.runsOnGroup ?? this._workflowRunsOnGroup,
+    );
   }
 }

--- a/src/github/pull-request-backport.ts
+++ b/src/github/pull-request-backport.ts
@@ -6,8 +6,9 @@ import { GithubWorkflow } from "./workflows";
 import { Component } from "../component";
 import { JsonFile } from "../json";
 import { Release } from "../release";
+import type { RunsOnOptions } from "../runner-options";
 
-export interface PullRequestBackportOptions {
+export interface PullRequestBackportOptions extends RunsOnOptions {
   /**
    * The name of the workflow.
    *
@@ -151,7 +152,7 @@ export class PullRequestBackport extends Component {
 
     this.workflow.addJob("backport", {
       name: "Backport PR",
-      runsOn: ["ubuntu-latest"],
+      ...workflowEngine.runsOnConfig(options),
       permissions: {},
       // Only ever run this job if the PR is merged and not a backport PR itself
       if: `github.event.pull_request.merged == true && !${isBackportPr}`,

--- a/src/github/pull-request-lint.ts
+++ b/src/github/pull-request-lint.ts
@@ -4,13 +4,12 @@ import { GitHubActions } from "./actions.const";
 import type { Job } from "./workflows-model";
 import { JobPermission } from "./workflows-model";
 import { Component } from "../component";
-import type { GroupRunnerOptions } from "../runner-options";
-import { filteredRunsOnOptions } from "../runner-options";
+import type { RunsOnOptions } from "../runner-options";
 
 /**
  * Options for PullRequestLint
  */
-export interface PullRequestLintOptions {
+export interface PullRequestLintOptions extends RunsOnOptions {
   /**
    * Validate that pull request titles follow Conventional Commits.
    *
@@ -24,21 +23,6 @@ export interface PullRequestLintOptions {
    * @default - title must start with "feat", "fix", or "chore"
    */
   readonly semanticTitleOptions?: SemanticTitleOptions;
-
-  /**
-   * Github Runner selection labels
-   * @default ["ubuntu-latest"]
-   * @description Defines a target Runner by labels
-   * @throws {Error} if both `runsOn` and `runsOnGroup` are specified
-   */
-  readonly runsOn?: string[];
-
-  /**
-   * Github Runner Group selection options
-   * @description Defines a target Runner Group by name and/or labels
-   * @throws {Error} if both `runsOn` and `runsOnGroup` are specified
-   */
-  readonly runsOnGroup?: GroupRunnerOptions;
 
   /**
    * Require a contributor statement to be included in the PR description.
@@ -148,7 +132,7 @@ export class PullRequestLint extends Component {
       const validateJob: Job = {
         name: "Validate PR title",
         if: prCheck,
-        ...filteredRunsOnOptions(options.runsOn, options.runsOnGroup),
+        ...github.runsOnConfig(options),
         permissions: {
           pullRequests: JobPermission.WRITE,
         },
@@ -202,7 +186,7 @@ export class PullRequestLint extends Component {
         "Contributor statement missing from PR description. Please include the following text in the PR description";
       const contributorStatement: Job = {
         name: "Require Contributor Statement",
-        runsOn: options.runsOn ?? ["ubuntu-latest"],
+        ...github.runsOnConfig(options),
         permissions: {
           pullRequests: JobPermission.READ,
         },

--- a/src/github/stale.ts
+++ b/src/github/stale.ts
@@ -3,13 +3,12 @@ import type { GitHub } from "./github";
 import { renderBehavior } from "./stale-util";
 import { JobPermission } from "./workflows-model";
 import { Component } from "../component";
-import type { GroupRunnerOptions } from "../runner-options";
-import { filteredRunsOnOptions } from "../runner-options";
+import type { RunsOnOptions } from "../runner-options";
 
 /**
  * Options for `Stale`.
  */
-export interface StaleOptions {
+export interface StaleOptions extends RunsOnOptions {
   /**
    * How to handle stale pull requests.
    *
@@ -25,21 +24,6 @@ export interface StaleOptions {
    * stale after 60 days and closed within 7 days.
    */
   readonly issues?: StaleBehavior;
-
-  /**
-   * Github Runner selection labels
-   * @default ["ubuntu-latest"]
-   * @description Defines a target Runner by labels
-   * @throws {Error} if both `runsOn` and `runsOnGroup` are specified
-   */
-  readonly runsOn?: string[];
-
-  /**
-   * Github Runner Group selection options
-   * @description Defines a target Runner Group by name and/or labels
-   * @throws {Error} if both `runsOn` and `runsOnGroup` are specified
-   */
-  readonly runsOnGroup?: GroupRunnerOptions;
 }
 
 /**
@@ -135,7 +119,7 @@ export class Stale extends Component {
 
     stale.addJobs({
       stale: {
-        ...filteredRunsOnOptions(options.runsOn, options.runsOnGroup),
+        ...github.runsOnConfig(options),
         permissions: {
           issues: JobPermission.WRITE,
           pullRequests: JobPermission.WRITE,

--- a/src/javascript/node-project.ts
+++ b/src/javascript/node-project.ts
@@ -59,7 +59,6 @@ import {
   Release,
 } from "../release";
 import type { GroupRunnerOptions } from "../runner-options";
-import { filteredRunsOnOptions } from "../runner-options";
 import type { Task } from "../task";
 import { deepMerge, multipleSelected, normalizePersistedPath } from "../util";
 import {
@@ -668,7 +667,8 @@ export class NodeProject extends GitHubProject {
     const buildWorkflowOptions: BuildWorkflowOptions =
       options.buildWorkflowOptions ?? {};
 
-    if (buildEnabled && (this.github || GitHub.of(this.root))) {
+    const buildWorkflowGithub = this.github ?? GitHub.of(this.root);
+    if (buildEnabled && buildWorkflowGithub) {
       this.buildWorkflow = new BuildWorkflow(this, {
         buildTask: this.buildTask,
         artifactsDirectory: this.artifactsDirectory,
@@ -686,10 +686,7 @@ export class NodeProject extends GitHubProject {
             true,
         }).concat(buildWorkflowOptions.preBuildSteps ?? []),
         postBuildSteps: [...(options.postBuildSteps ?? [])],
-        ...filteredRunsOnOptions(
-          buildWorkflowOptions.runsOn ?? options.workflowRunsOn,
-          buildWorkflowOptions.runsOnGroup ?? options.workflowRunsOnGroup,
-        ),
+        ...buildWorkflowGithub.runsOnConfig(buildWorkflowOptions),
       });
 
       this.buildWorkflow.addPostBuildSteps(

--- a/src/javascript/upgrade-dependencies.ts
+++ b/src/javascript/upgrade-dependencies.ts
@@ -31,7 +31,6 @@ import type { NodeProject } from "../javascript";
 import { NodePackageManager } from "../javascript";
 import { Release } from "../release";
 import type { GroupRunnerOptions } from "../runner-options";
-import { filteredRunsOnOptions } from "../runner-options";
 import type { Task } from "../task";
 import type { TaskStep } from "../task-model";
 import { workflowNameForProject } from "../util/name";
@@ -620,10 +619,7 @@ export class UpgradeDependencies extends Component {
         container: this.containerOptions,
         permissions: this.permissions,
         env: this.options.workflowOptions?.env,
-        ...filteredRunsOnOptions(
-          this.options.workflowOptions?.runsOn,
-          this.options.workflowOptions?.runsOnGroup,
-        ),
+        ...github.runsOnConfig(this.options.workflowOptions),
         steps: steps,
         outputs: {
           [PATCH_CREATED_OUTPUT]: {
@@ -644,6 +640,11 @@ export class UpgradeDependencies extends Component {
 
     const semanticCommit = this.options.semanticCommit ?? "chore";
 
+    // createPr is only called from createWorkflow, which is only reachable
+    // once the constructor has already confirmed the root project has GitHub
+    // enabled - so this is always defined.
+    const github = GitHub.of(this.project.root)!;
+
     return {
       job: WorkflowJobs.pullRequestFromPatch({
         patch: {
@@ -653,10 +654,7 @@ export class UpgradeDependencies extends Component {
         },
         workflowName: workflow.name,
         credentials,
-        ...filteredRunsOnOptions(
-          this.options.workflowOptions?.runsOn,
-          this.options.workflowOptions?.runsOnGroup,
-        ),
+        ...github.runsOnConfig(this.options.workflowOptions),
         pullRequestTitle: `${semanticCommit}(deps): ${this.pullRequestTitle}`,
         pullRequestDescription: "Upgrades project dependencies.",
         gitIdentity: this.gitIdentity,

--- a/src/release/release.ts
+++ b/src/release/release.ts
@@ -197,6 +197,7 @@ export interface ReleaseProjectOptions {
    * @default ["ubuntu-latest"]
    * @description Defines a target Runner by labels
    * @throws {Error} if both `runsOn` and `runsOnGroup` are specified
+   * @deprecated use `githubOptions.workflowRunsOn` on the project, or `runsOn` on `ReleaseOptions`
    */
   readonly workflowRunsOn?: string[];
 
@@ -204,6 +205,7 @@ export interface ReleaseProjectOptions {
    * Github Runner Group selection options
    * @description Defines a target Runner Group by name and/or labels
    * @throws {Error} if both `runsOn` and `runsOnGroup` are specified
+   * @deprecated use `githubOptions.workflowRunsOnGroup` on the project, or `runsOnGroup` on `ReleaseOptions`
    */
   readonly workflowRunsOnGroup?: GroupRunnerOptions;
 
@@ -279,6 +281,21 @@ export interface ReleaseProjectOptions {
  * Options for `Release`.
  */
 export interface ReleaseOptions extends ReleaseProjectOptions {
+  /**
+   * Github Runner selection labels
+   * @default ["ubuntu-latest"]
+   * @description Defines a target Runner by labels
+   * @throws {Error} if both `runsOn` and `runsOnGroup` are specified
+   */
+  readonly runsOn?: string[];
+
+  /**
+   * Github Runner Group selection options
+   * @description Defines a target Runner Group by name and/or labels
+   * @throws {Error} if both `runsOn` and `runsOnGroup` are specified
+   */
+  readonly runsOnGroup?: GroupRunnerOptions;
+
   /**
    * The tasks to execute in order to create the release artifacts. Artifacts are
    * expected to reside under `artifactsDirectory` (defaults to `dist/`) once
@@ -372,8 +389,8 @@ export class Release extends Component {
   private readonly jobs: Record<string, Job> = {};
   private readonly defaultBranch: ReleaseBranch;
   private readonly github?: GitHub;
-  private readonly workflowRunsOn?: string[];
-  private readonly workflowRunsOnGroup?: GroupRunnerOptions;
+  private readonly runsOn?: string[];
+  private readonly runsOnGroup?: GroupRunnerOptions;
   private readonly workflowPermissions: JobPermissions;
   private readonly releaseWorkflowEnv?: { [key: string]: string };
   private readonly releaseTagFilePath: string;
@@ -393,6 +410,12 @@ export class Release extends Component {
     }
 
     this.github = GitHub.of(this.project.root);
+    const runsOnConfig = this.github?.runsOnConfig({
+      runsOn: options.runsOn ?? options.workflowRunsOn,
+      runsOnGroup: options.runsOnGroup ?? options.workflowRunsOnGroup,
+    });
+    this.runsOn = runsOnConfig?.runsOn;
+    this.runsOnGroup = runsOnConfig?.runsOnGroup;
 
     // Determine the tasks to use to create the release artifacts
     if (options.tasks && options.tasks.length > 0) {
@@ -414,8 +437,6 @@ export class Release extends Component {
     this.versionFile = options.versionFile;
     this.releaseTrigger = options.releaseTrigger ?? ReleaseTrigger.continuous();
     this.containerImage = options.workflowContainerImage;
-    this.workflowRunsOn = options.workflowRunsOn;
-    this.workflowRunsOnGroup = options.workflowRunsOnGroup;
     this.workflowPermissions = {
       contents: JobPermission.WRITE,
       ...options.workflowPermissions,
@@ -444,10 +465,7 @@ export class Release extends Component {
       publibVersion: options.jsiiReleaseVersion,
       failureIssue: options.releaseFailureIssue,
       failureIssueLabel: options.releaseFailureIssueLabel,
-      ...filteredWorkflowRunsOnOptions(
-        options.workflowRunsOn,
-        options.workflowRunsOnGroup,
-      ),
+      ...filteredWorkflowRunsOnOptions(this.runsOn, this.runsOnGroup),
       publishTasks: options.publishTasks,
       dryRun: options.publishDryRun,
       workflowNodeVersion: options.workflowNodeVersion,
@@ -796,7 +814,7 @@ export class Release extends Component {
               },
             }
           : undefined,
-        ...filteredRunsOnOptions(this.workflowRunsOn, this.workflowRunsOnGroup),
+        ...filteredRunsOnOptions(this.runsOn, this.runsOnGroup),
       });
 
       workflow.addJob(BUILD_JOBID, taskjob);

--- a/src/runner-options.ts
+++ b/src/runner-options.ts
@@ -3,6 +3,44 @@ export interface GroupRunnerOptions {
   readonly labels?: string[];
 }
 
+/**
+ * Options for selecting the GitHub Runner that a job runs on.
+ */
+export interface RunsOnOptions {
+  /**
+   * Github Runner selection labels
+   * @default ["ubuntu-latest"]
+   * @description Defines a target Runner by labels
+   * @throws {Error} if both `runsOn` and `runsOnGroup` are specified
+   */
+  readonly runsOn?: string[];
+
+  /**
+   * Github Runner Group selection options
+   * @description Defines a target Runner Group by name and/or labels
+   * @throws {Error} if both `runsOn` and `runsOnGroup` are specified
+   */
+  readonly runsOnGroup?: GroupRunnerOptions;
+}
+
+/**
+ * Resolved `runsOn`/`runsOnGroup` config for a job. Exactly one of the two
+ * fields is set.
+ */
+export interface RunsOnConfig {
+  /**
+   * Github Runner selection labels.
+   * @default - not set if `runsOnGroup` is used
+   */
+  readonly runsOn?: string[];
+
+  /**
+   * Github Runner Group selection options.
+   * @default - not set if `runsOn` is used
+   */
+  readonly runsOnGroup?: GroupRunnerOptions;
+}
+
 export function filteredRunsOnOptions(
   runsOn?: string[],
   runsOnGroup?: GroupRunnerOptions,

--- a/test/__snapshots__/inventory.test.ts.snap
+++ b/test/__snapshots__/inventory.test.ts.snap
@@ -5289,6 +5289,7 @@ exports[`inventory 1`] = `
       },
       {
         "default": "["ubuntu-latest"]",
+        "deprecated": true,
         "docs": "Github Runner selection labels.",
         "featured": false,
         "jsonLike": true,
@@ -5310,6 +5311,7 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "deprecated": true,
         "docs": "Github Runner Group selection options.",
         "featured": false,
         "fqn": "projen.GroupRunnerOptions",
@@ -8486,6 +8488,7 @@ exports[`inventory 1`] = `
       },
       {
         "default": "["ubuntu-latest"]",
+        "deprecated": true,
         "docs": "Github Runner selection labels.",
         "featured": false,
         "jsonLike": true,
@@ -8507,6 +8510,7 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "deprecated": true,
         "docs": "Github Runner Group selection options.",
         "featured": false,
         "fqn": "projen.GroupRunnerOptions",
@@ -12701,6 +12705,7 @@ exports[`inventory 1`] = `
       },
       {
         "default": "["ubuntu-latest"]",
+        "deprecated": true,
         "docs": "Github Runner selection labels.",
         "featured": false,
         "jsonLike": true,
@@ -12722,6 +12727,7 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "deprecated": true,
         "docs": "Github Runner Group selection options.",
         "featured": false,
         "fqn": "projen.GroupRunnerOptions",
@@ -15811,6 +15817,7 @@ exports[`inventory 1`] = `
       },
       {
         "default": "["ubuntu-latest"]",
+        "deprecated": true,
         "docs": "Github Runner selection labels.",
         "featured": false,
         "jsonLike": true,
@@ -15832,6 +15839,7 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "deprecated": true,
         "docs": "Github Runner Group selection options.",
         "featured": false,
         "fqn": "projen.GroupRunnerOptions",
@@ -18748,6 +18756,7 @@ exports[`inventory 1`] = `
       },
       {
         "default": "["ubuntu-latest"]",
+        "deprecated": true,
         "docs": "Github Runner selection labels.",
         "featured": false,
         "jsonLike": true,
@@ -18769,6 +18778,7 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "deprecated": true,
         "docs": "Github Runner Group selection options.",
         "featured": false,
         "fqn": "projen.GroupRunnerOptions",
@@ -21823,6 +21833,7 @@ exports[`inventory 1`] = `
       },
       {
         "default": "["ubuntu-latest"]",
+        "deprecated": true,
         "docs": "Github Runner selection labels.",
         "featured": false,
         "jsonLike": true,
@@ -21844,6 +21855,7 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "deprecated": true,
         "docs": "Github Runner Group selection options.",
         "featured": false,
         "fqn": "projen.GroupRunnerOptions",
@@ -25608,6 +25620,7 @@ exports[`inventory 1`] = `
       },
       {
         "default": "["ubuntu-latest"]",
+        "deprecated": true,
         "docs": "Github Runner selection labels.",
         "featured": false,
         "jsonLike": true,
@@ -25629,6 +25642,7 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "deprecated": true,
         "docs": "Github Runner Group selection options.",
         "featured": false,
         "fqn": "projen.GroupRunnerOptions",
@@ -28062,6 +28076,7 @@ exports[`inventory 1`] = `
       },
       {
         "default": "["ubuntu-latest"]",
+        "deprecated": true,
         "docs": "Github Runner selection labels.",
         "featured": false,
         "jsonLike": true,
@@ -28083,6 +28098,7 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "deprecated": true,
         "docs": "Github Runner Group selection options.",
         "featured": false,
         "fqn": "projen.GroupRunnerOptions",
@@ -30816,6 +30832,7 @@ exports[`inventory 1`] = `
       },
       {
         "default": "["ubuntu-latest"]",
+        "deprecated": true,
         "docs": "Github Runner selection labels.",
         "featured": false,
         "jsonLike": true,
@@ -30837,6 +30854,7 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "deprecated": true,
         "docs": "Github Runner Group selection options.",
         "featured": false,
         "fqn": "projen.GroupRunnerOptions",
@@ -33202,6 +33220,7 @@ exports[`inventory 1`] = `
       },
       {
         "default": "["ubuntu-latest"]",
+        "deprecated": true,
         "docs": "Github Runner selection labels.",
         "featured": false,
         "jsonLike": true,
@@ -33223,6 +33242,7 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "deprecated": true,
         "docs": "Github Runner Group selection options.",
         "featured": false,
         "fqn": "projen.GroupRunnerOptions",
@@ -36910,6 +36930,7 @@ exports[`inventory 1`] = `
       },
       {
         "default": "["ubuntu-latest"]",
+        "deprecated": true,
         "docs": "Github Runner selection labels.",
         "featured": false,
         "jsonLike": true,
@@ -36931,6 +36952,7 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "deprecated": true,
         "docs": "Github Runner Group selection options.",
         "featured": false,
         "fqn": "projen.GroupRunnerOptions",
@@ -39652,6 +39674,7 @@ exports[`inventory 1`] = `
       },
       {
         "default": "["ubuntu-latest"]",
+        "deprecated": true,
         "docs": "Github Runner selection labels.",
         "featured": false,
         "jsonLike": true,
@@ -39673,6 +39696,7 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "deprecated": true,
         "docs": "Github Runner Group selection options.",
         "featured": false,
         "fqn": "projen.GroupRunnerOptions",
@@ -42372,6 +42396,7 @@ exports[`inventory 1`] = `
       },
       {
         "default": "["ubuntu-latest"]",
+        "deprecated": true,
         "docs": "Github Runner selection labels.",
         "featured": false,
         "jsonLike": true,
@@ -42393,6 +42418,7 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "deprecated": true,
         "docs": "Github Runner Group selection options.",
         "featured": false,
         "fqn": "projen.GroupRunnerOptions",
@@ -45092,6 +45118,7 @@ exports[`inventory 1`] = `
       },
       {
         "default": "["ubuntu-latest"]",
+        "deprecated": true,
         "docs": "Github Runner selection labels.",
         "featured": false,
         "jsonLike": true,
@@ -45113,6 +45140,7 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "deprecated": true,
         "docs": "Github Runner Group selection options.",
         "featured": false,
         "fqn": "projen.GroupRunnerOptions",

--- a/test/cdk/jsii.test.ts
+++ b/test/cdk/jsii.test.ts
@@ -600,7 +600,9 @@ describe("workflows use global workflowRunsOn option", () => {
       packageId: "PackageId",
     },
     publishToPypi: { distName: "dist-name", module: "module-name" },
-    workflowRunsOn: ["self-hosted", "linux", "x64"],
+    githubOptions: {
+      workflowRunsOn: ["self-hosted", "linux", "x64"],
+    },
   });
 
   const output = synthSnapshot(project);
@@ -651,10 +653,6 @@ describe("workflows use global workflowRunsOn option - runner group extended", (
       packageId: "PackageId",
     },
     publishToPypi: { distName: "dist-name", module: "module-name" },
-    workflowRunsOnGroup: {
-      group: "Default",
-      labels: ["self-hosted", "linux", "x64"],
-    },
     depsUpgradeOptions: {
       workflowOptions: {
         runsOnGroup: {
@@ -664,6 +662,10 @@ describe("workflows use global workflowRunsOn option - runner group extended", (
       },
     },
     githubOptions: {
+      workflowRunsOnGroup: {
+        group: "Default",
+        labels: ["self-hosted", "linux", "x64"],
+      },
       pullRequestLintOptions: {
         runsOnGroup: {
           group: "Default",

--- a/test/github/workflow-runs-on-global.test.ts
+++ b/test/github/workflow-runs-on-global.test.ts
@@ -1,0 +1,416 @@
+import * as YAML from "yaml";
+import type { NodeProjectOptions } from "../../src/javascript";
+import { NodeProject } from "../../src/javascript";
+import { synthSnapshot } from "../util";
+
+/**
+ * Tests that `workflowRunsOn` set on the `GitHub` component propagates
+ * globally to all workflow-generating components without needing
+ * per-component overrides.
+ */
+describe("global workflowRunsOn propagation", () => {
+  describe("workflowRunsOn labels", () => {
+    test("propagates to auto-approve workflow", () => {
+      const project = createProject({
+        githubOptions: {
+          workflowRunsOn: ["self-hosted"],
+        },
+        autoApproveOptions: {
+          allowedUsernames: ["bot"],
+        },
+      });
+
+      const snapshot = synthSnapshot(project);
+      const workflow = YAML.parse(
+        snapshot[".github/workflows/auto-approve.yml"],
+      );
+
+      expect(workflow.jobs.approve["runs-on"]).toEqual("self-hosted");
+    });
+
+    test("propagates to stale workflow", () => {
+      const project = createProject({
+        githubOptions: {
+          workflowRunsOn: ["self-hosted"],
+        },
+        stale: true,
+      });
+
+      const snapshot = synthSnapshot(project);
+      const workflow = YAML.parse(snapshot[".github/workflows/stale.yml"]);
+
+      expect(workflow.jobs.stale["runs-on"]).toEqual("self-hosted");
+    });
+
+    test("propagates to pull-request-lint workflow", () => {
+      const project = createProject({
+        githubOptions: {
+          workflowRunsOn: ["self-hosted"],
+          pullRequestLint: true,
+        },
+      });
+
+      const snapshot = synthSnapshot(project);
+      const workflow = YAML.parse(
+        snapshot[".github/workflows/pull-request-lint.yml"],
+      );
+
+      expect(workflow.jobs.validate["runs-on"]).toEqual("self-hosted");
+    });
+
+    test("propagates to dependency-review workflow", () => {
+      const project = createProject({
+        githubOptions: {
+          workflowRunsOn: ["self-hosted"],
+          dependencyReview: true,
+        },
+      });
+
+      const snapshot = synthSnapshot(project);
+      const workflow = YAML.parse(
+        snapshot[".github/workflows/dependency-review.yml"],
+      );
+
+      expect(workflow.jobs["dependency-review"]["runs-on"]).toEqual(
+        "self-hosted",
+      );
+    });
+
+    test("propagates to auto-queue workflow", () => {
+      const project = createProject({
+        githubOptions: {
+          workflowRunsOn: ["self-hosted"],
+          mergify: false,
+          mergeQueue: true,
+        },
+      });
+
+      const snapshot = synthSnapshot(project);
+      const workflow = YAML.parse(snapshot[".github/workflows/auto-queue.yml"]);
+
+      expect(workflow.jobs.enableAutoQueue["runs-on"]).toEqual("self-hosted");
+    });
+
+    test("propagates to backport workflow", () => {
+      const project = createProject({
+        githubOptions: {
+          workflowRunsOn: ["self-hosted"],
+          pullRequestBackport: true,
+          pullRequestBackportOptions: {
+            branches: ["main"],
+          },
+        },
+      });
+
+      const snapshot = synthSnapshot(project);
+      const workflow = YAML.parse(snapshot[".github/workflows/backport.yml"]);
+
+      expect(workflow.jobs.backport["runs-on"]).toEqual("self-hosted");
+    });
+
+    test("propagates to upgrade workflow", () => {
+      const project = createProject({
+        githubOptions: {
+          workflowRunsOn: ["self-hosted"],
+        },
+        depsUpgrade: true,
+      });
+
+      const snapshot = synthSnapshot(project);
+      const workflow = YAML.parse(
+        snapshot[".github/workflows/upgrade-main.yml"],
+      );
+
+      expect(workflow.jobs.upgrade["runs-on"]).toEqual("self-hosted");
+      expect(workflow.jobs.pr["runs-on"]).toEqual("self-hosted");
+    });
+
+    test("propagates to build workflow", () => {
+      const project = createProject({
+        githubOptions: {
+          workflowRunsOn: ["self-hosted"],
+        },
+      });
+
+      const snapshot = synthSnapshot(project);
+      const workflow = YAML.parse(snapshot[".github/workflows/build.yml"]);
+
+      expect(workflow.jobs.build["runs-on"]).toEqual("self-hosted");
+    });
+
+    test("propagates to release workflow", () => {
+      const project = createProject({
+        githubOptions: {
+          workflowRunsOn: ["self-hosted"],
+        },
+      });
+
+      const snapshot = synthSnapshot(project);
+      const workflow = YAML.parse(snapshot[".github/workflows/release.yml"]);
+
+      expect(workflow.jobs.release["runs-on"]).toEqual("self-hosted");
+    });
+
+    test("propagates multiple labels to all workflows", () => {
+      const project = createProject({
+        githubOptions: {
+          workflowRunsOn: ["self-hosted", "linux", "x64"],
+        },
+        autoApproveOptions: {
+          allowedUsernames: ["bot"],
+        },
+        stale: true,
+      });
+
+      const snapshot = synthSnapshot(project);
+      const build = YAML.parse(snapshot[".github/workflows/build.yml"]);
+      const approve = YAML.parse(
+        snapshot[".github/workflows/auto-approve.yml"],
+      );
+      const stale = YAML.parse(snapshot[".github/workflows/stale.yml"]);
+
+      const expected = ["self-hosted", "linux", "x64"];
+      expect(build.jobs.build["runs-on"]).toEqual(expected);
+      expect(approve.jobs.approve["runs-on"]).toEqual(expected);
+      expect(stale.jobs.stale["runs-on"]).toEqual(expected);
+    });
+  });
+
+  describe("workflowRunsOnGroup", () => {
+    test("propagates runner group to auto-approve workflow", () => {
+      const project = createProject({
+        githubOptions: {
+          workflowRunsOnGroup: {
+            group: "Default",
+            labels: ["self-hosted", "linux", "x64"],
+          },
+        },
+        autoApproveOptions: {
+          allowedUsernames: ["bot"],
+        },
+      });
+
+      const snapshot = synthSnapshot(project);
+      const workflow = YAML.parse(
+        snapshot[".github/workflows/auto-approve.yml"],
+      );
+
+      expect(workflow.jobs.approve["runs-on"]).toEqual({
+        group: "Default",
+        labels: ["self-hosted", "linux", "x64"],
+      });
+    });
+
+    test("propagates runner group to stale workflow", () => {
+      const project = createProject({
+        githubOptions: {
+          workflowRunsOnGroup: {
+            group: "Default",
+            labels: ["self-hosted", "linux"],
+          },
+        },
+        stale: true,
+      });
+
+      const snapshot = synthSnapshot(project);
+      const workflow = YAML.parse(snapshot[".github/workflows/stale.yml"]);
+
+      expect(workflow.jobs.stale["runs-on"]).toEqual({
+        group: "Default",
+        labels: ["self-hosted", "linux"],
+      });
+    });
+
+    test("propagates runner group to upgrade workflow", () => {
+      const project = createProject({
+        githubOptions: {
+          workflowRunsOnGroup: {
+            group: "Default",
+            labels: ["self-hosted", "linux"],
+          },
+        },
+        depsUpgrade: true,
+      });
+
+      const snapshot = synthSnapshot(project);
+      const workflow = YAML.parse(
+        snapshot[".github/workflows/upgrade-main.yml"],
+      );
+
+      expect(workflow.jobs.upgrade["runs-on"]).toEqual({
+        group: "Default",
+        labels: ["self-hosted", "linux"],
+      });
+      expect(workflow.jobs.pr["runs-on"]).toEqual({
+        group: "Default",
+        labels: ["self-hosted", "linux"],
+      });
+    });
+  });
+
+  describe("per-component override takes precedence", () => {
+    test("auto-approve runsOn overrides global workflowRunsOn", () => {
+      const project = createProject({
+        githubOptions: {
+          workflowRunsOn: ["self-hosted"],
+        },
+        autoApproveOptions: {
+          allowedUsernames: ["bot"],
+          runsOn: ["custom-runner"],
+        },
+      });
+
+      const snapshot = synthSnapshot(project);
+      const workflow = YAML.parse(
+        snapshot[".github/workflows/auto-approve.yml"],
+      );
+
+      expect(workflow.jobs.approve["runs-on"]).toEqual("custom-runner");
+    });
+
+    test("stale runsOn overrides global workflowRunsOn", () => {
+      const project = createProject({
+        githubOptions: {
+          workflowRunsOn: ["self-hosted"],
+        },
+        stale: true,
+        staleOptions: {
+          runsOn: ["custom-runner"],
+        },
+      });
+
+      const snapshot = synthSnapshot(project);
+      const workflow = YAML.parse(snapshot[".github/workflows/stale.yml"]);
+
+      expect(workflow.jobs.stale["runs-on"]).toEqual("custom-runner");
+    });
+
+    test("upgrade workflowOptions.runsOn overrides global workflowRunsOn", () => {
+      const project = createProject({
+        githubOptions: {
+          workflowRunsOn: ["self-hosted"],
+        },
+        depsUpgrade: true,
+        depsUpgradeOptions: {
+          workflowOptions: {
+            runsOn: ["custom-runner"],
+          },
+        },
+      });
+
+      const snapshot = synthSnapshot(project);
+      const workflow = YAML.parse(
+        snapshot[".github/workflows/upgrade-main.yml"],
+      );
+
+      expect(workflow.jobs.upgrade["runs-on"]).toEqual("custom-runner");
+      expect(workflow.jobs.pr["runs-on"]).toEqual("custom-runner");
+    });
+
+    test("buildWorkflowOptions.runsOn overrides global workflowRunsOn", () => {
+      const project = createProject({
+        githubOptions: {
+          workflowRunsOn: ["self-hosted"],
+        },
+        buildWorkflowOptions: {
+          runsOn: ["custom-runner"],
+        },
+      });
+
+      const snapshot = synthSnapshot(project);
+      const workflow = YAML.parse(snapshot[".github/workflows/build.yml"]);
+
+      expect(workflow.jobs.build["runs-on"]).toEqual("custom-runner");
+    });
+
+    test("pull-request-lint runsOn overrides global workflowRunsOn", () => {
+      const project = createProject({
+        githubOptions: {
+          workflowRunsOn: ["self-hosted"],
+          pullRequestLint: true,
+          pullRequestLintOptions: {
+            runsOn: ["custom-runner"],
+          },
+        },
+      });
+
+      const snapshot = synthSnapshot(project);
+      const workflow = YAML.parse(
+        snapshot[".github/workflows/pull-request-lint.yml"],
+      );
+
+      expect(workflow.jobs.validate["runs-on"]).toEqual("custom-runner");
+    });
+
+    test("dependency-review runsOn overrides global workflowRunsOn", () => {
+      const project = createProject({
+        githubOptions: {
+          workflowRunsOn: ["self-hosted"],
+          dependencyReview: true,
+          dependencyReviewOptions: {
+            runsOn: ["custom-runner"],
+          },
+        },
+      });
+
+      const snapshot = synthSnapshot(project);
+      const workflow = YAML.parse(
+        snapshot[".github/workflows/dependency-review.yml"],
+      );
+
+      expect(workflow.jobs["dependency-review"]["runs-on"]).toEqual(
+        "custom-runner",
+      );
+    });
+
+    test("auto-queue runsOn overrides global workflowRunsOn", () => {
+      const project = createProject({
+        githubOptions: {
+          workflowRunsOn: ["self-hosted"],
+          mergify: false,
+          mergeQueue: true,
+          mergeQueueOptions: {
+            autoQueueOptions: {
+              runsOn: ["custom-runner"],
+            },
+          },
+        },
+      });
+
+      const snapshot = synthSnapshot(project);
+      const workflow = YAML.parse(snapshot[".github/workflows/auto-queue.yml"]);
+
+      expect(workflow.jobs.enableAutoQueue["runs-on"]).toEqual("custom-runner");
+    });
+
+    test("backport runsOn overrides global workflowRunsOn", () => {
+      const project = createProject({
+        githubOptions: {
+          workflowRunsOn: ["self-hosted"],
+          pullRequestBackport: true,
+          pullRequestBackportOptions: {
+            branches: ["main"],
+            runsOn: ["custom-runner"],
+          },
+        },
+      });
+
+      const snapshot = synthSnapshot(project);
+      const workflow = YAML.parse(snapshot[".github/workflows/backport.yml"]);
+
+      expect(workflow.jobs.backport["runs-on"]).toEqual("custom-runner");
+    });
+  });
+});
+
+type ProjectOptions = Omit<
+  NodeProjectOptions,
+  "outdir" | "defaultReleaseBranch" | "name"
+>;
+function createProject(options: ProjectOptions = {}): NodeProject {
+  return new NodeProject({
+    defaultReleaseBranch: "main",
+    name: "test-project",
+    ...options,
+  });
+}

--- a/test/javascript/node-project.test.ts
+++ b/test/javascript/node-project.test.ts
@@ -1367,7 +1367,9 @@ describe("workflowRunsOn", () => {
   test("use github runner specified in workflowRunsOn", () => {
     // WHEN
     const project = new TestNodeProject({
-      workflowRunsOn: ["self-hosted"],
+      githubOptions: {
+        workflowRunsOn: ["self-hosted"],
+      },
     });
 
     // THEN
@@ -1382,9 +1384,11 @@ describe("workflowRunsOn", () => {
   test("use github runner group specified in workflowRunsOn", () => {
     // WHEN
     const project = new TestNodeProject({
-      workflowRunsOnGroup: {
-        group: "Default",
-        labels: ["self-hosted", "linux", "x64"],
+      githubOptions: {
+        workflowRunsOnGroup: {
+          group: "Default",
+          labels: ["self-hosted", "linux", "x64"],
+        },
       },
     });
 
@@ -1410,7 +1414,9 @@ describe("workflowRunsOn", () => {
 describe("buildWorkflowOptions.runsOn", () => {
   test("overrides workflowRunsOn for the build job", () => {
     const project = new TestNodeProject({
-      workflowRunsOn: ["ubuntu-latest"],
+      githubOptions: {
+        workflowRunsOn: ["ubuntu-latest"],
+      },
       buildWorkflowOptions: {
         runsOn: ["self-hosted"],
       },
@@ -1423,9 +1429,11 @@ describe("buildWorkflowOptions.runsOn", () => {
 
   test("overrides workflowRunsOnGroup for the build job", () => {
     const project = new TestNodeProject({
-      workflowRunsOnGroup: {
-        group: "Default",
-        labels: ["self-hosted", "linux"],
+      githubOptions: {
+        workflowRunsOnGroup: {
+          group: "Default",
+          labels: ["self-hosted", "linux"],
+        },
       },
       buildWorkflowOptions: {
         runsOnGroup: {

--- a/test/release/release.test.ts
+++ b/test/release/release.test.ts
@@ -910,13 +910,16 @@ describe("Single Project", () => {
 
   test("publisher can use custom github runner", () => {
     // GIVEN
-    const project = new TestProject();
+    const project = new TestProject({
+      githubOptions: {
+        workflowRunsOn: ["self-hosted"],
+      },
+    });
 
     const release = new Release(project, {
       tasks: [project.buildTask],
       versionFile: "version.json",
       branch: "main",
-      workflowRunsOn: ["self-hosted"],
       publishTasks: true, // to increase coverage
       artifactsDirectory: "dist",
     });
@@ -934,6 +937,128 @@ describe("Single Project", () => {
     for (let job of Object.keys(workflow.jobs)) {
       expect(workflow.jobs[job]["runs-on"]).toEqual("self-hosted");
     }
+  });
+
+  test("release runsOn overrides global workflowRunsOn", () => {
+    // GIVEN
+    const project = new TestProject({
+      githubOptions: {
+        workflowRunsOn: ["self-hosted"],
+      },
+    });
+
+    const release = new Release(project, {
+      tasks: [project.buildTask],
+      versionFile: "version.json",
+      branch: "main",
+      runsOn: ["custom-runner"],
+      publishTasks: true,
+      artifactsDirectory: "dist",
+    });
+
+    // WHEN
+    release.publisher.publishToNpm();
+
+    // THEN
+    const outdir = synthSnapshot(project);
+    const workflow = YAML.parse(outdir[".github/workflows/release.yml"]);
+    for (let job of Object.keys(workflow.jobs)) {
+      expect(workflow.jobs[job]["runs-on"]).toEqual("custom-runner");
+    }
+  });
+
+  test("release runsOnGroup overrides global workflowRunsOnGroup", () => {
+    // GIVEN
+    const project = new TestProject({
+      githubOptions: {
+        workflowRunsOnGroup: {
+          group: "Default",
+          labels: ["self-hosted", "linux"],
+        },
+      },
+    });
+
+    const release = new Release(project, {
+      tasks: [project.buildTask],
+      versionFile: "version.json",
+      branch: "main",
+      runsOnGroup: {
+        group: "Custom",
+        labels: ["custom-runner"],
+      },
+      artifactsDirectory: "dist",
+    });
+
+    // WHEN
+    release.publisher.publishToNpm();
+
+    // THEN
+    const outdir = synthSnapshot(project);
+    const workflow = YAML.parse(outdir[".github/workflows/release.yml"]);
+    for (let job of Object.keys(workflow.jobs)) {
+      expect(workflow.jobs[job]["runs-on"]).toEqual({
+        group: "Custom",
+        labels: ["custom-runner"],
+      });
+    }
+  });
+
+  test("release falls back to global workflowRunsOn when runsOn not set", () => {
+    // GIVEN
+    const project = new TestProject({
+      githubOptions: {
+        workflowRunsOn: ["self-hosted"],
+      },
+    });
+
+    new Release(project, {
+      tasks: [project.buildTask],
+      versionFile: "version.json",
+      branch: "main",
+      artifactsDirectory: "dist",
+    });
+
+    // THEN
+    const outdir = synthSnapshot(project);
+    const workflow = YAML.parse(outdir[".github/workflows/release.yml"]);
+    expect(workflow.jobs.release["runs-on"]).toEqual("self-hosted");
+  });
+
+  test("deprecated workflowRunsOn on ReleaseOptions still works", () => {
+    // GIVEN
+    const project = new TestProject();
+
+    new Release(project, {
+      tasks: [project.buildTask],
+      versionFile: "version.json",
+      branch: "main",
+      workflowRunsOn: ["self-hosted"],
+      artifactsDirectory: "dist",
+    });
+
+    // THEN
+    const outdir = synthSnapshot(project);
+    const workflow = YAML.parse(outdir[".github/workflows/release.yml"]);
+    expect(workflow.jobs.release["runs-on"]).toEqual("self-hosted");
+  });
+
+  test("explicit runsOn overrides deprecated workflowRunsOn", () => {
+    // GIVEN
+    const project = new TestProject();
+
+    new Release(project, {
+      tasks: [project.buildTask],
+      versionFile: "version.json",
+      branch: "main",
+      workflowRunsOn: ["self-hosted"],
+      runsOn: ["custom-runner"],
+      artifactsDirectory: "dist",
+    });
+
+    // THEN
+    const outdir = synthSnapshot(project);
+    const workflow = YAML.parse(outdir[".github/workflows/release.yml"]);
+    expect(workflow.jobs.release["runs-on"]).toEqual("custom-runner");
   });
 
   test("ability to add post release steps in release workflow with publishToGitHubReleases", () => {
@@ -1146,13 +1271,16 @@ describe("Single Project", () => {
 
   test("if publishTasks is disabled, no publish tasks are created", () => {
     // GIVEN
-    const project = new TestProject();
+    const project = new TestProject({
+      githubOptions: {
+        workflowRunsOn: ["self-hosted"],
+      },
+    });
 
     const release = new Release(project, {
       tasks: [project.buildTask],
       versionFile: "version.json",
       branch: "main",
-      workflowRunsOn: ["self-hosted"],
       artifactsDirectory: "dist",
     });
 


### PR DESCRIPTION
Fixes #2027

Adds a global `workflowRunsOn` / `workflowRunsOnGroup` property to `GitHubOptions` that propagates to all workflow-generating components as their default runner configuration.

Previously, users had to manually set `runsOn` on each component individually (auto-approve, auto-queue, stale, pull-request-lint, dependency-review, upgrade-dependencies, backport, release). Now a single project-level setting flows everywhere, while each component still supports its own `runsOn` / `runsOnGroup` to override when needed.

```typescript
const project = new TypeScriptProject({
  githubOptions: {
    workflowRunsOn: ['self-hosted', 'linux'],
  },
  // all workflows use this runner by default
  autoApproveOptions: {
    runsOn: ['ubuntu-latest'], // override for a specific workflow
  },
});
```

Components updated:
- AutoApprove
- AutoQueue (also added `runsOnGroup` option)
- PullRequestLint
- DependencyReview
- Stale
- PullRequestBackport (added `runsOn` / `runsOnGroup` options, previously hardcoded)
- UpgradeDependencies
- Release (added `runsOn` / `runsOnGroup` options)
- Build workflow (already supported, no change)

`workflowRunsOn` and `workflowRunsOnGroup` have been deprecated from `ReleaseProjectOptions`. The canonical location is now `GitHubOptions`. Use the project-level `workflowRunsOn` or the new `runsOn` / `runsOnGroup` on `ReleaseOptions` for release-specific overrides.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.