### PR TITLE
fix(build): pin post-build job checkouts to PR head SHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: .repo
       - name: Install Dependencies
@@ -114,7 +114,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: .repo
       - name: Install Dependencies
@@ -160,7 +160,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: .repo
       - name: Install Dependencies
@@ -207,7 +207,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: .repo
       - name: Install Dependencies

--- a/src/build/build-workflow.ts
+++ b/src/build/build-workflow.ts
@@ -37,6 +37,7 @@ import {
   NOT_FORK,
   PULL_REQUEST_REF,
   PULL_REQUEST_REPOSITORY,
+  PULL_REQUEST_SHA,
   SELF_MUTATION_CONDITION,
   SELF_MUTATION_HAPPENED_OUTPUT,
   SELF_MUTATION_STEP,
@@ -377,7 +378,7 @@ export class BuildWorkflow extends Component {
       steps.push(
         WorkflowSteps.checkout({
           with: {
-            ref: PULL_REQUEST_REF,
+            ref: PULL_REQUEST_SHA,
             repository: PULL_REQUEST_REPOSITORY,
             ...(this.github.downloadLfs ? { lfs: true } : {}),
             ...(this.github.checkoutSubmodules !== CheckoutSubmodules.DISABLED

--- a/src/build/private/consts.ts
+++ b/src/build/private/consts.ts
@@ -1,4 +1,5 @@
 export const PULL_REQUEST_REF = "${{ github.event.pull_request.head.ref }}";
+export const PULL_REQUEST_SHA = "${{ github.event.pull_request.head.sha }}";
 export const PULL_REQUEST_REPOSITORY =
   "${{ github.event.pull_request.head.repo.full_name }}";
 export const BUILD_JOBID = "build";

--- a/src/cdk/jsii-build.ts
+++ b/src/cdk/jsii-build.ts
@@ -10,8 +10,8 @@ import type {
   JsiiPythonTarget,
 } from "./jsii-project";
 import {
-  PULL_REQUEST_REF,
   PULL_REQUEST_REPOSITORY,
+  PULL_REQUEST_SHA,
 } from "../build/private/consts";
 import { WorkflowSteps } from "../github/workflow-steps";
 import type { Job, Step, Tools } from "../github/workflows-model";
@@ -534,7 +534,7 @@ export class JsiiBuild implements IMixin {
         WorkflowSteps.checkout({
           with: {
             path: REPO_TEMP_DIRECTORY,
-            ref: PULL_REQUEST_REF,
+            ref: PULL_REQUEST_SHA,
             repository: PULL_REQUEST_REPOSITORY,
             ...(project.github?.downloadLfs ? { lfs: true } : {}),
           },

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -378,7 +378,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v6
         with:
-          ref: \${{ github.event.pull_request.head.ref }}
+          ref: \${{ github.event.pull_request.head.sha }}
           repository: \${{ github.event.pull_request.head.repo.full_name }}
           path: .repo
       - name: Install Dependencies
@@ -425,7 +425,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v6
         with:
-          ref: \${{ github.event.pull_request.head.ref }}
+          ref: \${{ github.event.pull_request.head.sha }}
           repository: \${{ github.event.pull_request.head.repo.full_name }}
           path: .repo
       - name: Install Dependencies
@@ -471,7 +471,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v6
         with:
-          ref: \${{ github.event.pull_request.head.ref }}
+          ref: \${{ github.event.pull_request.head.sha }}
           repository: \${{ github.event.pull_request.head.repo.full_name }}
           path: .repo
       - name: Install Dependencies

--- a/test/build/build-workflow.test.ts
+++ b/test/build/build-workflow.test.ts
@@ -141,6 +141,50 @@ describe("addPostBuildJob", () => {
   });
 });
 
+describe("checkout ref", () => {
+  test("post-build job commands checkout is pinned to the PR head SHA", () => {
+    const p = new TestProject();
+    const bw = new BuildWorkflow(p, {
+      buildTask: p.buildTask,
+      artifactsDirectory: "dist",
+    });
+
+    bw.addPostBuildJobCommands("post-job", ["echo hello"], {
+      checkoutRepo: true,
+    });
+
+    const workflows = synthWorkflows(p);
+    const build = yaml.parse(workflows[".github/workflows/build.yml"]);
+    const checkoutStep = build.jobs["post-job"].steps.find((s: any) =>
+      s.uses?.startsWith("actions/checkout"),
+    );
+    expect(checkoutStep.with.ref).toBe(
+      "${{ github.event.pull_request.head.sha }}",
+    );
+    expect(checkoutStep.with.repository).toBe(
+      "${{ github.event.pull_request.head.repo.full_name }}",
+    );
+  });
+
+  test("self-mutation checkout uses the PR head ref to push back to the branch", () => {
+    const p = new TestProject();
+    new BuildWorkflow(p, {
+      buildTask: p.buildTask,
+      artifactsDirectory: "dist",
+      mutableBuild: true,
+    });
+
+    const workflows = synthWorkflows(p);
+    const build = yaml.parse(workflows[".github/workflows/build.yml"]);
+    const checkoutStep = build.jobs["self-mutation"].steps.find((s: any) =>
+      s.uses?.startsWith("actions/checkout"),
+    );
+    expect(checkoutStep.with.ref).toBe(
+      "${{ github.event.pull_request.head.ref }}",
+    );
+  });
+});
+
 function synthWorkflows(p: Project): any {
   const snapshot = synthSnapshot(p);
   const filtered = Object.keys(snapshot)

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -371,7 +371,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v6
         with:
-          ref: \${{ github.event.pull_request.head.ref }}
+          ref: \${{ github.event.pull_request.head.sha }}
           repository: \${{ github.event.pull_request.head.repo.full_name }}
           path: .repo
       - name: Install Dependencies
@@ -2232,7 +2232,7 @@ exports[`language bindings snapshot dotnet 1`] = `
       "uses": "actions/checkout@v6",
       "with": {
         "path": ".repo",
-        "ref": "\${{ github.event.pull_request.head.ref }}",
+        "ref": "\${{ github.event.pull_request.head.sha }}",
         "repository": "\${{ github.event.pull_request.head.repo.full_name }}",
       },
     },
@@ -2309,7 +2309,7 @@ exports[`language bindings snapshot go 1`] = `
       "uses": "actions/checkout@v6",
       "with": {
         "path": ".repo",
-        "ref": "\${{ github.event.pull_request.head.ref }}",
+        "ref": "\${{ github.event.pull_request.head.sha }}",
         "repository": "\${{ github.event.pull_request.head.repo.full_name }}",
       },
     },
@@ -2386,7 +2386,7 @@ exports[`language bindings snapshot java 1`] = `
       "uses": "actions/checkout@v6",
       "with": {
         "path": ".repo",
-        "ref": "\${{ github.event.pull_request.head.ref }}",
+        "ref": "\${{ github.event.pull_request.head.sha }}",
         "repository": "\${{ github.event.pull_request.head.repo.full_name }}",
       },
     },
@@ -2456,7 +2456,7 @@ exports[`language bindings snapshot js 1`] = `
       "uses": "actions/checkout@v6",
       "with": {
         "path": ".repo",
-        "ref": "\${{ github.event.pull_request.head.ref }}",
+        "ref": "\${{ github.event.pull_request.head.sha }}",
         "repository": "\${{ github.event.pull_request.head.repo.full_name }}",
       },
     },
@@ -2532,7 +2532,7 @@ exports[`language bindings snapshot python 1`] = `
       "uses": "actions/checkout@v6",
       "with": {
         "path": ".repo",
-        "ref": "\${{ github.event.pull_request.head.ref }}",
+        "ref": "\${{ github.event.pull_request.head.sha }}",
         "repository": "\${{ github.event.pull_request.head.repo.full_name }}",
       },
     },

--- a/test/cdk/jsii-build.test.ts
+++ b/test/cdk/jsii-build.test.ts
@@ -1,3 +1,4 @@
+import * as YAML from "yaml";
 import { javascript, Project } from "../../src";
 import { JsiiBuild, ValidateTsconfig } from "../../src/cdk";
 import { TypeScriptProject } from "../../src/typescript";
@@ -143,6 +144,33 @@ describe("JsiiBuild", () => {
       const output = synthSnapshot(project);
       const releaseWorkflow = output[".github/workflows/release.yml"];
       expect(releaseWorkflow).toContain(".repo/packages/my-lib");
+    });
+
+    it("pins packaging job checkouts to the PR head SHA", () => {
+      const project = createTypeScriptProject();
+      project.with(
+        new JsiiBuild({
+          publishToMaven: {
+            javaPackage: "com.example",
+            mavenGroupId: "com.example",
+            mavenArtifactId: "test",
+          },
+        }),
+      );
+
+      const output = synthSnapshot(project);
+      const buildWorkflow = YAML.parse(output[".github/workflows/build.yml"]);
+      for (const jobName of ["package-js", "package-java"]) {
+        const checkoutStep = buildWorkflow.jobs[jobName].steps.find((s: any) =>
+          s.uses?.startsWith("actions/checkout"),
+        );
+        expect(checkoutStep.with.ref).toBe(
+          "${{ github.event.pull_request.head.sha }}",
+        );
+        expect(checkoutStep.with.repository).toBe(
+          "${{ github.event.pull_request.head.repo.full_name }}",
+        );
+      }
     });
   });
 });

--- a/test/jsii/__snapshots__/jsii.test.ts.snap
+++ b/test/jsii/__snapshots__/jsii.test.ts.snap
@@ -371,7 +371,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v6
         with:
-          ref: \${{ github.event.pull_request.head.ref }}
+          ref: \${{ github.event.pull_request.head.sha }}
           repository: \${{ github.event.pull_request.head.repo.full_name }}
           path: .repo
       - name: Install Dependencies
@@ -2029,7 +2029,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v6
         with:
-          ref: \${{ github.event.pull_request.head.ref }}
+          ref: \${{ github.event.pull_request.head.sha }}
           repository: \${{ github.event.pull_request.head.repo.full_name }}
           path: .repo
       - name: Install Dependencies
@@ -3685,7 +3685,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v6
         with:
-          ref: \${{ github.event.pull_request.head.ref }}
+          ref: \${{ github.event.pull_request.head.sha }}
           repository: \${{ github.event.pull_request.head.repo.full_name }}
           path: .repo
       - name: Install Dependencies


### PR DESCRIPTION
The post-build jobs of the build workflow (the jsii packaging jobs and jobs added via `addPostBuildJobCommands`) check out the pull request branch by ref. Because a branch can move while a workflow run is still in progress, a packaging job could in principle operate on a newer commit than the one the preceding build job compiled and tested. This is not exploitable in any meaningful way — these jobs run with read-only permissions and their outputs only feed back into the same pull request — but it is an unnecessary inconsistency within a single workflow run.

This change pins these read-only checkouts to `github.event.pull_request.head.sha`, so every job in a run operates on the exact commit that triggered it. As a side effect, this also resolves the `actions/cache-poisoning/poisonable-step` code scanning alerts on this repository, since an immutable SHA checkout in a `pull_request`-triggered workflow no longer matches the untrusted-checkout pattern.

The self-mutation job intentionally continues to use the branch ref, because it needs to push changes back to the pull request branch.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
