### PR TITLE
feat(github): use gh CLI instead of enable-pull-request-automerge action

### DIFF
--- a/.github/workflows/auto-queue.yml
+++ b/.github/workflows/auto-queue.yml
@@ -15,9 +15,9 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      - id: auto_edce8315
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
-          pull-request-number: ${{ github.event.number }}
-          merge-method: squash
+      - id: auto-queue-pr
+        env:
+          GH_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: gh pr merge --auto --squash "$PR_NUMBER" --repo "$GH_REPO"

--- a/src/github/auto-queue.ts
+++ b/src/github/auto-queue.ts
@@ -150,6 +150,20 @@ export class AutoQueue extends Component {
       options.projenCredentials ?? workflowEngine.projenCredentials;
     const mergeMethod = options.mergeMethod ?? MergeMethod.SQUASH;
 
+    // The merge method is interpolated into a shell command below. Even though the
+    // type system restricts this to `MergeMethod`, that guarantee does not hold for
+    // consumers in other jsii languages or plain JavaScript, so validate explicitly.
+    const validMergeMethods = Object.values(MergeMethod);
+    if (!validMergeMethods.includes(mergeMethod)) {
+      const allowed = Object.entries(MergeMethod)
+        .map(([name, value]) => `MergeMethod.${name} ("${value}")`)
+        .join(", ");
+      throw new Error(
+        `Invalid mergeMethod "${mergeMethod}" in AutoQueueOptions. ` +
+          `Set 'mergeMethod' to one of: ${allowed}, or leave it unset to default to MergeMethod.SQUASH.`,
+      );
+    }
+
     const autoQueueJob: workflows.Job = {
       name: "Set AutoQueue on PR #${{ github.event.number }}",
       runsOn: options.runsOn ?? ["ubuntu-latest"],
@@ -162,11 +176,12 @@ export class AutoQueue extends Component {
       steps: [
         ...credentials.setupSteps,
         {
-          uses: "peter-evans/enable-pull-request-automerge@v3",
-          with: {
-            token: credentials.tokenRef,
-            "pull-request-number": "${{ github.event.number }}",
-            "merge-method": mergeMethod,
+          id: "auto-queue-pr",
+          run: `gh pr merge --auto --${mergeMethod} "$PR_NUMBER" --repo "$GH_REPO"`,
+          env: {
+            GH_TOKEN: credentials.tokenRef,
+            GH_REPO: "${{ github.repository }}",
+            PR_NUMBER: "${{ github.event.number }}",
           },
         },
       ],

--- a/test/github/__snapshots__/merge-queue.test.ts.snap
+++ b/test/github/__snapshots__/merge-queue.test.ts.snap
@@ -18,12 +18,12 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      - id: auto_edce8315
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
-          pull-request-number: \${{ github.event.number }}
-          merge-method: squash
+      - id: auto-queue-pr
+        env:
+          GH_TOKEN: \${{ secrets.PROJEN_GITHUB_TOKEN }}
+          GH_REPO: \${{ github.repository }}
+          PR_NUMBER: \${{ github.event.number }}
+        run: gh pr merge --auto --squash "$PR_NUMBER" --repo "$GH_REPO"
 "
 `;
 
@@ -50,12 +50,12 @@ jobs:
       contents: write
     if: (github.event.action == 'opened' || (github.event.action == 'edited' && github.event.changes.base))
     steps:
-      - id: auto_edce8315
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
-          pull-request-number: \${{ github.event.number }}
-          merge-method: squash
+      - id: auto-queue-pr
+        env:
+          GH_TOKEN: \${{ secrets.PROJEN_GITHUB_TOKEN }}
+          GH_REPO: \${{ github.repository }}
+          PR_NUMBER: \${{ github.event.number }}
+        run: gh pr merge --auto --squash "$PR_NUMBER" --repo "$GH_REPO"
 "
 `;
 
@@ -78,11 +78,11 @@ jobs:
       contents: write
     if: (contains(github.event.pull_request.labels.*.name, 'abc')) && (github.event.pull_request.user.login == 'foo')
     steps:
-      - id: auto_edce8315
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: \${{ secrets.shh }}
-          pull-request-number: \${{ github.event.number }}
-          merge-method: merge
+      - id: auto-queue-pr
+        env:
+          GH_TOKEN: \${{ secrets.shh }}
+          GH_REPO: \${{ github.repository }}
+          PR_NUMBER: \${{ github.event.number }}
+        run: gh pr merge --auto --merge "$PR_NUMBER" --repo "$GH_REPO"
 "
 `;

--- a/test/github/merge-queue.test.ts
+++ b/test/github/merge-queue.test.ts
@@ -15,8 +15,7 @@ describe("merge-queue", () => {
     const autoQueue = snapshot[`.github/workflows/auto-queue.yml`];
 
     expect(autoQueue).toBeDefined();
-    expect(autoQueue).toContain("enable-pull-request-automerge");
-    expect(autoQueue).toContain("merge-method: squash");
+    expect(autoQueue).toContain("gh pr merge --auto --squash");
     expect(autoQueue).toMatchSnapshot();
   });
 
@@ -69,8 +68,8 @@ describe("merge-queue", () => {
     expect(autoQueue).toContain(
       "if: (contains(github.event.pull_request.labels.*.name, 'abc')) && (github.event.pull_request.user.login == 'foo')",
     );
-    expect(autoQueue).toContain("merge-method: merge");
-    expect(autoQueue).toContain("token: ${{ secrets.shh }}");
+    expect(autoQueue).toContain("gh pr merge --auto --merge");
+    expect(autoQueue).toContain("GH_TOKEN: ${{ secrets.shh }}");
     expect(autoQueue).toContain("runs-on: gpu");
     expect(autoQueue).toMatchSnapshot();
   });
@@ -138,6 +137,71 @@ describe("merge-queue", () => {
     const autoQueue = snapshot[`.github/workflows/auto-queue.yml`];
 
     expect(autoQueue).toMatchSnapshot();
+  });
+
+  test.each([
+    [MergeMethod.SQUASH, "squash"],
+    [MergeMethod.MERGE, "merge"],
+    [MergeMethod.REBASE, "rebase"],
+  ])("mergeMethod %s produces a gh pr merge --%s step", (mergeMethod, flag) => {
+    const project = new TestProject({
+      githubOptions: {
+        mergeQueue: true,
+        mergeQueueOptions: {
+          autoQueueOptions: { mergeMethod },
+        },
+      },
+    });
+
+    const autoQueue =
+      synthSnapshot(project)[".github/workflows/auto-queue.yml"];
+
+    expect(autoQueue).toContain(
+      `run: gh pr merge --auto --${flag} "$PR_NUMBER" --repo "$GH_REPO"`,
+    );
+  });
+
+  test.each([
+    ["squash; echo pwned"],
+    ["squash && rm -rf /"],
+    ["$(echo squash)"],
+    ["SQUASH"],
+    ["fast-forward"],
+    [""],
+  ])("invalid mergeMethod %p throws", (mergeMethod) => {
+    expect(
+      () =>
+        new TestProject({
+          githubOptions: {
+            mergeQueue: true,
+            mergeQueueOptions: {
+              autoQueueOptions: {
+                // Simulates a caller from another jsii language or plain JS,
+                // where the enum provides no runtime guarantee
+                mergeMethod: mergeMethod as MergeMethod,
+              },
+            },
+          },
+        }),
+    ).toThrow(/Invalid mergeMethod/);
+  });
+
+  test("invalid mergeMethod error lists all valid values", async () => {
+    expect(
+      () =>
+        new TestProject({
+          githubOptions: {
+            mergeQueue: true,
+            mergeQueueOptions: {
+              autoQueueOptions: {
+                mergeMethod: "squash; echo pwned" as MergeMethod,
+              },
+            },
+          },
+        }),
+    ).toThrow(
+      /Invalid mergeMethod "squash; echo pwned" in AutoQueueOptions\. Set 'mergeMethod' to one of: MergeMethod\.SQUASH \("squash"\), MergeMethod\.MERGE \("merge"\), MergeMethod\.REBASE \("rebase"\), or leave it unset to default to MergeMethod\.SQUASH\./,
+    );
   });
 
   test("autoqueue branches must be subset of merge queue branches", async () => {


### PR DESCRIPTION
Projects with `mergeQueue` enabled no longer depend on a third-party GitHub Action to set auto-merge on pull requests. The `peter-evans/enable-pull-request-automerge` action states in its own README that using it is no longer necessary, because the same functionality is built into the GitHub CLI. Dropping it removes an external action from a workflow that runs with `pull_request_target` and holds a write-scoped token, and it removes one more thing to keep upgraded.

Auto-queue behaves exactly as before, including the configured merge method and the token requirements. The only visible change is in the generated `auto-queue.yml`: the action step becomes a `gh pr merge --auto` step, so expect a small workflow diff the next time you run projen. Nothing needs to be reconfigured.

Setting an invalid merge method now fails when you synthesize instead of when the workflow runs. This matters for anyone configuring projen from Python, Java, .NET or plain JavaScript, where the `MergeMethod` enum is not enforced at runtime and a bad value would previously have been passed straight through into the workflow. The error names the value you supplied and lists the accepted ones.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
