### PR TITLE
fix: cleanup can delete files outside the project directory

### DIFF
--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -17,7 +17,10 @@ export function cleanup(dir: string, newFiles: string[], exclude: string[]) {
       removeFiles(findGeneratedFiles(dir, exclude));
     }
   } catch (e: any) {
-    logging.warn(`warning: failed to clean up generated files: ${e.stack}`);
+    logging.warn(
+      `Could not clean up previously generated files, so outdated files may be left behind in your project. ` +
+        `Synthesis continues, but you may need to delete them yourself. Error: ${e.stack}`,
+    );
   }
 }
 
@@ -64,7 +67,91 @@ function findOrphanedFiles(
 ) {
   return oldFiles
     .filter((old) => !newFiles.includes(old))
-    .map((f: string) => path.resolve(dir, f));
+    .map((f: string) => resolveWithinDir(dir, f))
+    .filter((f): f is string => f !== undefined);
+}
+
+/**
+ * Resolves a file path taken from the file manifest against the project
+ * directory, making sure the result stays inside of it.
+ *
+ * The file manifest is checked into the repository and is therefore untrusted
+ * input: without this check, a manifest containing `../` or absolute path
+ * entries would make cleanup delete files outside of the project directory.
+ *
+ * @returns the absolute path to delete, or `undefined` if the entry does not
+ * resolve to a location inside `dir`.
+ */
+function resolveWithinDir(dir: string, file: string): string | undefined {
+  const skip = (reason: string) => {
+    logging.warn(
+      `Not deleting ${JSON.stringify(file)} during cleanup because ${reason}. ` +
+        `projen only removes generated files inside your project directory. ` +
+        `This entry in ${FILE_MANIFEST} should not be there - review it (and who changed it) in version control, ` +
+        `and delete the file yourself if you really no longer need it.`,
+    );
+    return undefined;
+  };
+
+  if (typeof file !== "string" || file.trim() === "") {
+    return skip("it is not a file path");
+  }
+
+  if (path.isAbsolute(file)) {
+    return skip("it is an absolute path instead of a path in your project");
+  }
+
+  const baseDir = realpathOfClosestExisting(dir);
+  const resolved = path.resolve(baseDir, file);
+
+  if (!isPathInside(baseDir, resolved)) {
+    return skip("it points outside of your project directory");
+  }
+
+  // the entry might traverse outside of the project through a symlinked
+  // directory, which `path.resolve` cannot detect. The last path segment is
+  // intentionally kept as-is: removing a symlink inside the project only
+  // deletes the link itself, not its target.
+  const realParent = realpathOfClosestExisting(path.dirname(resolved));
+  if (!isPathInside(baseDir, path.join(realParent, path.basename(resolved)))) {
+    return skip(
+      "it points outside of your project directory through a symlink",
+    );
+  }
+
+  return resolved;
+}
+
+function isPathInside(dir: string, file: string): boolean {
+  const relative = path.relative(dir, file);
+  return (
+    relative !== "" &&
+    !relative.startsWith(`..${path.sep}`) &&
+    relative !== ".." &&
+    !path.isAbsolute(relative)
+  );
+}
+
+/**
+ * Resolves symlinks in `p`, falling back to the closest existing ancestor for
+ * paths that do not exist (yet).
+ */
+function realpathOfClosestExisting(p: string): string {
+  const missing = new Array<string>();
+  let current = path.resolve(p);
+
+  while (true) {
+    try {
+      return path.join(fs.realpathSync(current), ...missing);
+    } catch {
+      const parent = path.dirname(current);
+      if (parent === current) {
+        return path.resolve(p);
+      }
+      missing.unshift(path.basename(current));
+      current = parent;
+    }
+  }
 }
 
 function getFilesFromManifest(dir: string): string[] {
@@ -74,13 +161,19 @@ function getFilesFromManifest(dir: string): string[] {
       const fileManifest = JSON.parse(
         fs.readFileSync(fileManifestPath, "utf-8"),
       );
-      if (fileManifest.files) {
+      if (Array.isArray(fileManifest.files)) {
         return fileManifest.files;
+      }
+      if (fileManifest.files) {
+        logging.debug(
+          `"files" in ${FILE_MANIFEST} is not a list of files, so it cannot be used to find files to clean up. Falling back to scanning your project for projen-generated files.`,
+        );
       }
     }
   } catch (e: any) {
     logging.warn(
-      `warning: unable to get files to clean from file manifest: ${e.stack}`,
+      `Could not read the list of generated files from ${FILE_MANIFEST}, so projen will scan your project for generated files instead. ` +
+        `Check that the file exists in version control and contains valid JSON. Error: ${e.stack}`,
     );
   }
 

--- a/test/cleanup.test.ts
+++ b/test/cleanup.test.ts
@@ -1,9 +1,17 @@
-import { readFileSync } from "fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
 import { join } from "path";
 import { directorySnapshot, TestProject } from "./util";
 import { DependencyType, JsonFile, SampleFile, TextFile } from "../src";
 import { cleanup, FILE_MANIFEST } from "../src/cleanup";
-import { PROJEN_MARKER } from "../src/common";
+import { PROJEN_DIR, PROJEN_MARKER } from "../src/common";
 
 test("cleanup uses cache file", () => {
   // GIVEN
@@ -127,4 +135,99 @@ test("cleanup empty files", () => {
   expect(deletedFiles).not.toEqual(fileList);
   expect(deletedFiles).toContain(emptyFile.path);
   expect(deletedFiles).toMatchSnapshot();
+});
+
+describe("cleanup does not escape the project directory", () => {
+  let root: string;
+  let outdir: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "projen-cleanup-"));
+    outdir = join(root, "repo");
+    mkdirSync(join(outdir, PROJEN_DIR), { recursive: true });
+    // a file that cleanup is legitimately allowed to remove, to prove that
+    // cleanup still processed the (sanitized) manifest
+    writeFileSync(join(outdir, "orphaned.txt"), "delete me");
+  });
+
+  const writeManifest = (files: any[]) =>
+    writeFileSync(
+      join(outdir, FILE_MANIFEST),
+      JSON.stringify({ files: ["orphaned.txt", ...files] }),
+    );
+
+  const writeVictim = () => {
+    const victim = join(root, "victim.txt");
+    writeFileSync(victim, "do not delete me");
+    return victim;
+  };
+
+  test("for parent directory traversal", () => {
+    // GIVEN
+    const victim = writeVictim();
+    writeManifest(["../victim.txt", "repo/../../victim.txt"]);
+
+    // WHEN
+    cleanup(outdir, [], []);
+
+    // THEN
+    expect(existsSync(victim)).toBe(true);
+    expect(existsSync(join(outdir, "orphaned.txt"))).toBe(false);
+  });
+
+  test("for absolute paths", () => {
+    // GIVEN
+    const victim = writeVictim();
+    writeManifest([victim]);
+
+    // WHEN
+    cleanup(outdir, [], []);
+
+    // THEN
+    expect(existsSync(victim)).toBe(true);
+    expect(existsSync(join(outdir, "orphaned.txt"))).toBe(false);
+  });
+
+  test("for symlinked directories", () => {
+    // GIVEN
+    const victim = writeVictim();
+    try {
+      symlinkSync(root, join(outdir, "link"), "dir");
+    } catch {
+      // symlink creation is not permitted (e.g. Windows without privileges)
+      return;
+    }
+    writeManifest(["link/victim.txt"]);
+
+    // WHEN
+    cleanup(outdir, [], []);
+
+    // THEN
+    expect(existsSync(victim)).toBe(true);
+    expect(existsSync(join(outdir, "orphaned.txt"))).toBe(false);
+  });
+
+  test("for the project directory itself", () => {
+    // GIVEN
+    writeManifest([".", "..", ""]);
+
+    // WHEN
+    cleanup(outdir, [], []);
+
+    // THEN
+    expect(existsSync(outdir)).toBe(true);
+    expect(existsSync(root)).toBe(true);
+    expect(existsSync(join(outdir, "orphaned.txt"))).toBe(false);
+  });
+
+  test("for non-string manifest entries", () => {
+    // GIVEN
+    writeManifest([null, 42, { path: "../victim.txt" }]);
+
+    // WHEN
+    cleanup(outdir, [], []);
+
+    // THEN
+    expect(existsSync(join(outdir, "orphaned.txt"))).toBe(false);
+  });
 });


### PR DESCRIPTION
Old file cleanup would resolve and delete files outside the project directory if a path as in `.projen/files.json`. Let's stop that.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
