### PR TITLE
feat(javascript): expose the pnpm-workspace.yaml file on PnpmWorkspaceYaml

### DIFF
--- a/docs/api/javascript.md
+++ b/docs/api/javascript.md
@@ -4507,6 +4507,7 @@ Returns the `PnpmWorkspaceYaml` instance associated with a project or `undefined
 | --- | --- | --- |
 | <code><a href="#projen.javascript.PnpmWorkspaceYaml.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#projen.javascript.PnpmWorkspaceYaml.property.project">project</a></code> | <code>projen.Project</code> | *No description.* |
+| <code><a href="#projen.javascript.PnpmWorkspaceYaml.property.file">file</a></code> | <code>projen.YamlFile</code> | The underlying `pnpm-workspace.yaml` file. |
 
 ---
 
@@ -4529,6 +4530,18 @@ public readonly project: Project;
 ```
 
 - *Type:* projen.Project
+
+---
+
+##### `file`<sup>Required</sup> <a name="file" id="projen.javascript.PnpmWorkspaceYaml.property.file"></a>
+
+```typescript
+public readonly file: YamlFile;
+```
+
+- *Type:* projen.YamlFile
+
+The underlying `pnpm-workspace.yaml` file.
 
 ---
 

--- a/src/javascript/pnpm-workspace.ts
+++ b/src/javascript/pnpm-workspace.ts
@@ -27,10 +27,15 @@ export class PnpmWorkspaceYaml extends Component {
     return project.components.find(isIt);
   }
 
+  /**
+   * The underlying `pnpm-workspace.yaml` file.
+   */
+  public readonly file: YamlFile;
+
   constructor(project: Project, options: PnpmWorkspaceYamlOptions = {}) {
     super(project);
 
-    new YamlFile(project, "pnpm-workspace.yaml", {
+    this.file = new YamlFile(project, "pnpm-workspace.yaml", {
       omitEmpty: true,
       obj: () => toJson_PnpmWorkspaceYamlSchema(options),
       readonly: false,

--- a/test/javascript/pnpm-workspace.test.ts
+++ b/test/javascript/pnpm-workspace.test.ts
@@ -75,7 +75,6 @@ test("file can be customized after construction", () => {
 
   new PnpmWorkspaceYaml(project, { onlyBuiltDependencies: ["esbuild"] });
 
-  // Some settings are not known at construction time, so they have to be applied later.
   PnpmWorkspaceYaml.of(project)?.file.addOverride("packages", ["packages/*"]);
 
   const files = synthSnapshot(project);

--- a/test/javascript/pnpm-workspace.test.ts
+++ b/test/javascript/pnpm-workspace.test.ts
@@ -60,3 +60,28 @@ test("of() returns undefined when there is no PnpmWorkspaceYaml component", () =
 
   expect(PnpmWorkspaceYaml.of(project)).toBeUndefined();
 });
+
+test("exposes the underlying pnpm-workspace.yaml file", () => {
+  const project = new TestProject();
+  const pnpmWorkspaceYaml = new PnpmWorkspaceYaml(project, {
+    onlyBuiltDependencies: ["esbuild"],
+  });
+
+  expect(pnpmWorkspaceYaml.file.path).toBe("pnpm-workspace.yaml");
+});
+
+test("file can be customized after construction", () => {
+  const project = new TestProject();
+
+  new PnpmWorkspaceYaml(project, { onlyBuiltDependencies: ["esbuild"] });
+
+  // Some settings are not known at construction time, so they have to be applied later.
+  PnpmWorkspaceYaml.of(project)?.file.addOverride("packages", ["packages/*"]);
+
+  const files = synthSnapshot(project);
+  const workspaceYaml = YAML.parse(files["pnpm-workspace.yaml"]);
+  expect(workspaceYaml).toStrictEqual({
+    onlyBuiltDependencies: ["esbuild"],
+    packages: ["packages/*"],
+  });
+});


### PR DESCRIPTION
Fixes #4873

`PnpmWorkspaceYaml.of()` returned a component with no public members, so there was no supported way to modify `pnpm-workspace.yaml` after construction — the `YamlFile` it created was never assigned. The only route was `tryFindObjectFile("pnpm-workspace.yaml")` plus `addOverride`.

This exposes it as a `readonly file`, matching `Eslint.file` and `TypescriptConfig.file`:

```ts
PnpmWorkspaceYaml.of(project)?.file.addOverride("packages", ["packages/*"]);
```

Per the discussion on the issue, `options` is intentionally left unexposed.

Two tests added: one asserting the accessor, and one covering the actual use case — constructing with `onlyBuiltDependencies`, then adding `packages` afterwards, and checking both land in the synthesized YAML.

Verified with the full suite: 146 suites, 4633 tests, 364 snapshots passing. `jsii` compiles clean. `docs/api/javascript.md` is the `projen docgen` output.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
