### PR TITLE
feat(javascript): warn when removing unmanaged dependencies

### DIFF
--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -1680,6 +1680,8 @@ export class NodePackage extends Component {
       return { devDependencies, peerDependencies, dependencies };
     }
 
+    const unmanagedRemoved: string[] = [];
+
     const readDeps = (
       user: Record<string, string>,
       current: Record<string, string> = {},
@@ -1700,6 +1702,7 @@ export class NodePackage extends Component {
       for (const name of Object.keys(current ?? {})) {
         if (!user[name]) {
           this.project.logger.verbose(`${name}: removed`);
+          unmanagedRemoved.push(name);
         }
       }
     };
@@ -1707,6 +1710,14 @@ export class NodePackage extends Component {
     readDeps(devDependencies, this._prev.devDependencies);
     readDeps(dependencies, this._prev.dependencies);
     readDeps(peerDependencies, this._prev.peerDependencies);
+
+    if (unmanagedRemoved.length > 0) {
+      this.project.logger.warn(
+        `Removing unmanaged dependencies not declared in .projenrc: ${unmanagedRemoved.join(", ")}. ` +
+          "These were likely installed via a package manager (e.g. npm install). " +
+          "To keep them, add them to your .projenrc and run projen again.",
+      );
+    }
 
     return { devDependencies, dependencies, peerDependencies };
   }


### PR DESCRIPTION
﻿## What Problem This Solves

When users install dependencies via a package manager (e.g. `npm install foo`) without going through projen, those dependencies are silently removed on the next `projen` run. This is confusing ΓÇö the user believes they added a dependency, but it disappears without explanation.

Issue #4114 requests a warning to alert users about this behavior and suggest editing the projenrc file.

## Why This Change Was Made

Projen already detects unmanaged dependencies during `renderDependencies()` (comparing the old `package.json` against the current dep registry), but only logs removals at verbose level ΓÇö invisible to normal users. This change elevates that detection to a visible warning with actionable guidance.

## What Changed

- In `NodePackage.renderDependencies()`, removed packages are now collected into an `unmanagedRemoved` array
- After processing all dependency sections, a warning is emitted listing the removed packages and suggesting the user add them to their `.projenrc` file
- The warning message is: *"Removing unmanaged dependencies not declared in .projenrc: {names}. These were likely installed via a package manager (e.g. npm install). To keep them, add them to your .projenrc and run projen again."*

## How Tested

- TypeScript compiles cleanly (`npx tsc --noEmit`)
- All 93 existing `node-package.test.ts` tests pass
- The warning only fires when unmanaged deps exist ΓÇö no behavioral change for projects that manage all deps through projen

Fixes #4114


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

