### PR TITLE
feat(typescript): add typecheckTests option

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -564,6 +564,15 @@
       "description": "Run tests",
       "steps": [
         {
+          "name": "Type-check the test suite",
+          "execArgs": [
+            "tsc",
+            "--noEmit",
+            "-p",
+            "test/tsconfig.json"
+          ]
+        },
+        {
           "execArgs": [
             "jest",
             "--passWithNoTests",

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -144,6 +144,7 @@ const project = new TypeScriptProject({
     },
   },
 
+  typecheckTests: true,
   jestOptions: {
     // makes it very hard to iterate with jest --watch
     coverageText: false,

--- a/docs/api/awscdk.md
+++ b/docs/api/awscdk.md
@@ -9264,6 +9264,7 @@ const awsCdkConstructLibraryOptions: awscdk.AwsCdkConstructLibraryOptions = { ..
 | <code><a href="#projen.awscdk.AwsCdkConstructLibraryOptions.property.tsconfigDev">tsconfigDev</a></code> | <code>projen.javascript.TypescriptConfigOptions</code> | Custom tsconfig options for the development tsconfig.json file (used for testing). |
 | <code><a href="#projen.awscdk.AwsCdkConstructLibraryOptions.property.tsconfigDevFile">tsconfigDevFile</a></code> | <code>string</code> | The name (and path) of the development tsconfig file. |
 | <code><a href="#projen.awscdk.AwsCdkConstructLibraryOptions.property.tsJestOptions">tsJestOptions</a></code> | <code>projen.typescript.TsJestOptions</code> | Options for ts-jest. |
+| <code><a href="#projen.awscdk.AwsCdkConstructLibraryOptions.property.typecheckTests">typecheckTests</a></code> | <code>boolean</code> | Type-check the test suite as part of the `test` task. |
 | <code><a href="#projen.awscdk.AwsCdkConstructLibraryOptions.property.typescriptVersion">typescriptVersion</a></code> | <code>string</code> | TypeScript version to use. |
 | <code><a href="#projen.awscdk.AwsCdkConstructLibraryOptions.property.author">author</a></code> | <code>string</code> | The name of the library author. |
 | <code><a href="#projen.awscdk.AwsCdkConstructLibraryOptions.property.authorAddress">authorAddress</a></code> | <code>string</code> | Email or URL of the library author. |
@@ -11499,6 +11500,21 @@ public readonly tsJestOptions: TsJestOptions;
 - *Type:* projen.typescript.TsJestOptions
 
 Options for ts-jest.
+
+---
+
+##### `typecheckTests`<sup>Optional</sup> <a name="typecheckTests" id="projen.awscdk.AwsCdkConstructLibraryOptions.property.typecheckTests"></a>
+
+```typescript
+public readonly typecheckTests: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Type-check the test suite as part of the `test` task.
+
+Adds a `tsc --noEmit` step against the development tsconfig.
 
 ---
 
@@ -14245,6 +14261,7 @@ const awsCdkTypeScriptAppOptions: awscdk.AwsCdkTypeScriptAppOptions = { ... }
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.tsconfigDev">tsconfigDev</a></code> | <code>projen.javascript.TypescriptConfigOptions</code> | Custom tsconfig options for the development tsconfig.json file (used for testing). |
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.tsconfigDevFile">tsconfigDevFile</a></code> | <code>string</code> | The name (and path) of the development tsconfig file. |
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.tsJestOptions">tsJestOptions</a></code> | <code>projen.typescript.TsJestOptions</code> | Options for ts-jest. |
+| <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.typecheckTests">typecheckTests</a></code> | <code>boolean</code> | Type-check the test suite as part of the `test` task. |
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.typescriptVersion">typescriptVersion</a></code> | <code>string</code> | TypeScript version to use. |
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.buildCommand">buildCommand</a></code> | <code>string</code> | A command to execute before synthesis. |
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.cdkout">cdkout</a></code> | <code>string</code> | cdk.out directory. |
@@ -16473,6 +16490,21 @@ public readonly tsJestOptions: TsJestOptions;
 - *Type:* projen.typescript.TsJestOptions
 
 Options for ts-jest.
+
+---
+
+##### `typecheckTests`<sup>Optional</sup> <a name="typecheckTests" id="projen.awscdk.AwsCdkTypeScriptAppOptions.property.typecheckTests"></a>
+
+```typescript
+public readonly typecheckTests: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Type-check the test suite as part of the `test` task.
+
+Adds a `tsc --noEmit` step against the development tsconfig.
 
 ---
 

--- a/docs/api/cdk.md
+++ b/docs/api/cdk.md
@@ -4036,6 +4036,7 @@ const constructLibraryOptions: cdk.ConstructLibraryOptions = { ... }
 | <code><a href="#projen.cdk.ConstructLibraryOptions.property.tsconfigDev">tsconfigDev</a></code> | <code>projen.javascript.TypescriptConfigOptions</code> | Custom tsconfig options for the development tsconfig.json file (used for testing). |
 | <code><a href="#projen.cdk.ConstructLibraryOptions.property.tsconfigDevFile">tsconfigDevFile</a></code> | <code>string</code> | The name (and path) of the development tsconfig file. |
 | <code><a href="#projen.cdk.ConstructLibraryOptions.property.tsJestOptions">tsJestOptions</a></code> | <code>projen.typescript.TsJestOptions</code> | Options for ts-jest. |
+| <code><a href="#projen.cdk.ConstructLibraryOptions.property.typecheckTests">typecheckTests</a></code> | <code>boolean</code> | Type-check the test suite as part of the `test` task. |
 | <code><a href="#projen.cdk.ConstructLibraryOptions.property.typescriptVersion">typescriptVersion</a></code> | <code>string</code> | TypeScript version to use. |
 | <code><a href="#projen.cdk.ConstructLibraryOptions.property.author">author</a></code> | <code>string</code> | The name of the library author. |
 | <code><a href="#projen.cdk.ConstructLibraryOptions.property.authorAddress">authorAddress</a></code> | <code>string</code> | Email or URL of the library author. |
@@ -6263,6 +6264,21 @@ Options for ts-jest.
 
 ---
 
+##### `typecheckTests`<sup>Optional</sup> <a name="typecheckTests" id="projen.cdk.ConstructLibraryOptions.property.typecheckTests"></a>
+
+```typescript
+public readonly typecheckTests: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Type-check the test suite as part of the `test` task.
+
+Adds a `tsc --noEmit` step against the development tsconfig.
+
+---
+
 ##### `typescriptVersion`<sup>Optional</sup> <a name="typescriptVersion" id="projen.cdk.ConstructLibraryOptions.property.typescriptVersion"></a>
 
 ```typescript
@@ -7854,6 +7870,7 @@ const jsiiProjectOptions: cdk.JsiiProjectOptions = { ... }
 | <code><a href="#projen.cdk.JsiiProjectOptions.property.tsconfigDev">tsconfigDev</a></code> | <code>projen.javascript.TypescriptConfigOptions</code> | Custom tsconfig options for the development tsconfig.json file (used for testing). |
 | <code><a href="#projen.cdk.JsiiProjectOptions.property.tsconfigDevFile">tsconfigDevFile</a></code> | <code>string</code> | The name (and path) of the development tsconfig file. |
 | <code><a href="#projen.cdk.JsiiProjectOptions.property.tsJestOptions">tsJestOptions</a></code> | <code>projen.typescript.TsJestOptions</code> | Options for ts-jest. |
+| <code><a href="#projen.cdk.JsiiProjectOptions.property.typecheckTests">typecheckTests</a></code> | <code>boolean</code> | Type-check the test suite as part of the `test` task. |
 | <code><a href="#projen.cdk.JsiiProjectOptions.property.typescriptVersion">typescriptVersion</a></code> | <code>string</code> | TypeScript version to use. |
 | <code><a href="#projen.cdk.JsiiProjectOptions.property.author">author</a></code> | <code>string</code> | The name of the library author. |
 | <code><a href="#projen.cdk.JsiiProjectOptions.property.authorAddress">authorAddress</a></code> | <code>string</code> | Email or URL of the library author. |
@@ -10077,6 +10094,21 @@ public readonly tsJestOptions: TsJestOptions;
 - *Type:* projen.typescript.TsJestOptions
 
 Options for ts-jest.
+
+---
+
+##### `typecheckTests`<sup>Optional</sup> <a name="typecheckTests" id="projen.cdk.JsiiProjectOptions.property.typecheckTests"></a>
+
+```typescript
+public readonly typecheckTests: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Type-check the test suite as part of the `test` task.
+
+Adds a `tsc --noEmit` step against the development tsconfig.
 
 ---
 

--- a/docs/api/cdk8s.md
+++ b/docs/api/cdk8s.md
@@ -6795,6 +6795,7 @@ const cdk8sTypeScriptAppOptions: cdk8s.Cdk8sTypeScriptAppOptions = { ... }
 | <code><a href="#projen.cdk8s.Cdk8sTypeScriptAppOptions.property.tsconfigDev">tsconfigDev</a></code> | <code>projen.javascript.TypescriptConfigOptions</code> | Custom tsconfig options for the development tsconfig.json file (used for testing). |
 | <code><a href="#projen.cdk8s.Cdk8sTypeScriptAppOptions.property.tsconfigDevFile">tsconfigDevFile</a></code> | <code>string</code> | The name (and path) of the development tsconfig file. |
 | <code><a href="#projen.cdk8s.Cdk8sTypeScriptAppOptions.property.tsJestOptions">tsJestOptions</a></code> | <code>projen.typescript.TsJestOptions</code> | Options for ts-jest. |
+| <code><a href="#projen.cdk8s.Cdk8sTypeScriptAppOptions.property.typecheckTests">typecheckTests</a></code> | <code>boolean</code> | Type-check the test suite as part of the `test` task. |
 | <code><a href="#projen.cdk8s.Cdk8sTypeScriptAppOptions.property.typescriptVersion">typescriptVersion</a></code> | <code>string</code> | TypeScript version to use. |
 | <code><a href="#projen.cdk8s.Cdk8sTypeScriptAppOptions.property.cdk8sVersion">cdk8sVersion</a></code> | <code>string</code> | Minimum version of the cdk8s to depend on. |
 | <code><a href="#projen.cdk8s.Cdk8sTypeScriptAppOptions.property.cdk8sCliVersion">cdk8sCliVersion</a></code> | <code>string</code> | Minimum version of the cdk8s-cli to depend on. |
@@ -9020,6 +9021,21 @@ Options for ts-jest.
 
 ---
 
+##### `typecheckTests`<sup>Optional</sup> <a name="typecheckTests" id="projen.cdk8s.Cdk8sTypeScriptAppOptions.property.typecheckTests"></a>
+
+```typescript
+public readonly typecheckTests: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Type-check the test suite as part of the `test` task.
+
+Adds a `tsc --noEmit` step against the development tsconfig.
+
+---
+
 ##### `typescriptVersion`<sup>Optional</sup> <a name="typescriptVersion" id="projen.cdk8s.Cdk8sTypeScriptAppOptions.property.typescriptVersion"></a>
 
 ```typescript
@@ -9394,6 +9410,7 @@ const constructLibraryCdk8sOptions: cdk8s.ConstructLibraryCdk8sOptions = { ... }
 | <code><a href="#projen.cdk8s.ConstructLibraryCdk8sOptions.property.tsconfigDev">tsconfigDev</a></code> | <code>projen.javascript.TypescriptConfigOptions</code> | Custom tsconfig options for the development tsconfig.json file (used for testing). |
 | <code><a href="#projen.cdk8s.ConstructLibraryCdk8sOptions.property.tsconfigDevFile">tsconfigDevFile</a></code> | <code>string</code> | The name (and path) of the development tsconfig file. |
 | <code><a href="#projen.cdk8s.ConstructLibraryCdk8sOptions.property.tsJestOptions">tsJestOptions</a></code> | <code>projen.typescript.TsJestOptions</code> | Options for ts-jest. |
+| <code><a href="#projen.cdk8s.ConstructLibraryCdk8sOptions.property.typecheckTests">typecheckTests</a></code> | <code>boolean</code> | Type-check the test suite as part of the `test` task. |
 | <code><a href="#projen.cdk8s.ConstructLibraryCdk8sOptions.property.typescriptVersion">typescriptVersion</a></code> | <code>string</code> | TypeScript version to use. |
 | <code><a href="#projen.cdk8s.ConstructLibraryCdk8sOptions.property.author">author</a></code> | <code>string</code> | The name of the library author. |
 | <code><a href="#projen.cdk8s.ConstructLibraryCdk8sOptions.property.authorAddress">authorAddress</a></code> | <code>string</code> | Email or URL of the library author. |
@@ -11624,6 +11641,21 @@ public readonly tsJestOptions: TsJestOptions;
 - *Type:* projen.typescript.TsJestOptions
 
 Options for ts-jest.
+
+---
+
+##### `typecheckTests`<sup>Optional</sup> <a name="typecheckTests" id="projen.cdk8s.ConstructLibraryCdk8sOptions.property.typecheckTests"></a>
+
+```typescript
+public readonly typecheckTests: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Type-check the test suite as part of the `test` task.
+
+Adds a `tsc --noEmit` step against the development tsconfig.
 
 ---
 

--- a/docs/api/cdktf.md
+++ b/docs/api/cdktf.md
@@ -1742,6 +1742,7 @@ const constructLibraryCdktfOptions: cdktf.ConstructLibraryCdktfOptions = { ... }
 | <code><a href="#projen.cdktf.ConstructLibraryCdktfOptions.property.tsconfigDev">tsconfigDev</a></code> | <code>projen.javascript.TypescriptConfigOptions</code> | Custom tsconfig options for the development tsconfig.json file (used for testing). |
 | <code><a href="#projen.cdktf.ConstructLibraryCdktfOptions.property.tsconfigDevFile">tsconfigDevFile</a></code> | <code>string</code> | The name (and path) of the development tsconfig file. |
 | <code><a href="#projen.cdktf.ConstructLibraryCdktfOptions.property.tsJestOptions">tsJestOptions</a></code> | <code>projen.typescript.TsJestOptions</code> | Options for ts-jest. |
+| <code><a href="#projen.cdktf.ConstructLibraryCdktfOptions.property.typecheckTests">typecheckTests</a></code> | <code>boolean</code> | Type-check the test suite as part of the `test` task. |
 | <code><a href="#projen.cdktf.ConstructLibraryCdktfOptions.property.typescriptVersion">typescriptVersion</a></code> | <code>string</code> | TypeScript version to use. |
 | <code><a href="#projen.cdktf.ConstructLibraryCdktfOptions.property.author">author</a></code> | <code>string</code> | The name of the library author. |
 | <code><a href="#projen.cdktf.ConstructLibraryCdktfOptions.property.authorAddress">authorAddress</a></code> | <code>string</code> | Email or URL of the library author. |
@@ -3968,6 +3969,21 @@ public readonly tsJestOptions: TsJestOptions;
 - *Type:* projen.typescript.TsJestOptions
 
 Options for ts-jest.
+
+---
+
+##### `typecheckTests`<sup>Optional</sup> <a name="typecheckTests" id="projen.cdktf.ConstructLibraryCdktfOptions.property.typecheckTests"></a>
+
+```typescript
+public readonly typecheckTests: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Type-check the test suite as part of the `test` task.
+
+Adds a `tsc --noEmit` step against the development tsconfig.
 
 ---
 

--- a/docs/api/cdktn.md
+++ b/docs/api/cdktn.md
@@ -4333,6 +4333,7 @@ const cdktnTypeScriptAppOptions: cdktn.CdktnTypeScriptAppOptions = { ... }
 | <code><a href="#projen.cdktn.CdktnTypeScriptAppOptions.property.tsconfigDev">tsconfigDev</a></code> | <code>projen.javascript.TypescriptConfigOptions</code> | Custom tsconfig options for the development tsconfig.json file (used for testing). |
 | <code><a href="#projen.cdktn.CdktnTypeScriptAppOptions.property.tsconfigDevFile">tsconfigDevFile</a></code> | <code>string</code> | The name (and path) of the development tsconfig file. |
 | <code><a href="#projen.cdktn.CdktnTypeScriptAppOptions.property.tsJestOptions">tsJestOptions</a></code> | <code>projen.typescript.TsJestOptions</code> | Options for ts-jest. |
+| <code><a href="#projen.cdktn.CdktnTypeScriptAppOptions.property.typecheckTests">typecheckTests</a></code> | <code>boolean</code> | Type-check the test suite as part of the `test` task. |
 | <code><a href="#projen.cdktn.CdktnTypeScriptAppOptions.property.typescriptVersion">typescriptVersion</a></code> | <code>string</code> | TypeScript version to use. |
 | <code><a href="#projen.cdktn.CdktnTypeScriptAppOptions.property.cdktnVersion">cdktnVersion</a></code> | <code>string</code> | Minimum version of the CDKTN to depend on. |
 | <code><a href="#projen.cdktn.CdktnTypeScriptAppOptions.property.cdktnCliVersion">cdktnCliVersion</a></code> | <code>string</code> | Version range of the CDKTN CLI to depend on. |
@@ -6556,6 +6557,21 @@ Options for ts-jest.
 
 ---
 
+##### `typecheckTests`<sup>Optional</sup> <a name="typecheckTests" id="projen.cdktn.CdktnTypeScriptAppOptions.property.typecheckTests"></a>
+
+```typescript
+public readonly typecheckTests: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Type-check the test suite as part of the `test` task.
+
+Adds a `tsc --noEmit` step against the development tsconfig.
+
+---
+
 ##### `typescriptVersion`<sup>Optional</sup> <a name="typescriptVersion" id="projen.cdktn.CdktnTypeScriptAppOptions.property.typescriptVersion"></a>
 
 ```typescript
@@ -6900,6 +6916,7 @@ const constructLibraryCdktnOptions: cdktn.ConstructLibraryCdktnOptions = { ... }
 | <code><a href="#projen.cdktn.ConstructLibraryCdktnOptions.property.tsconfigDev">tsconfigDev</a></code> | <code>projen.javascript.TypescriptConfigOptions</code> | Custom tsconfig options for the development tsconfig.json file (used for testing). |
 | <code><a href="#projen.cdktn.ConstructLibraryCdktnOptions.property.tsconfigDevFile">tsconfigDevFile</a></code> | <code>string</code> | The name (and path) of the development tsconfig file. |
 | <code><a href="#projen.cdktn.ConstructLibraryCdktnOptions.property.tsJestOptions">tsJestOptions</a></code> | <code>projen.typescript.TsJestOptions</code> | Options for ts-jest. |
+| <code><a href="#projen.cdktn.ConstructLibraryCdktnOptions.property.typecheckTests">typecheckTests</a></code> | <code>boolean</code> | Type-check the test suite as part of the `test` task. |
 | <code><a href="#projen.cdktn.ConstructLibraryCdktnOptions.property.typescriptVersion">typescriptVersion</a></code> | <code>string</code> | TypeScript version to use. |
 | <code><a href="#projen.cdktn.ConstructLibraryCdktnOptions.property.author">author</a></code> | <code>string</code> | The name of the library author. |
 | <code><a href="#projen.cdktn.ConstructLibraryCdktnOptions.property.authorAddress">authorAddress</a></code> | <code>string</code> | Email or URL of the library author. |
@@ -9128,6 +9145,21 @@ public readonly tsJestOptions: TsJestOptions;
 - *Type:* projen.typescript.TsJestOptions
 
 Options for ts-jest.
+
+---
+
+##### `typecheckTests`<sup>Optional</sup> <a name="typecheckTests" id="projen.cdktn.ConstructLibraryCdktnOptions.property.typecheckTests"></a>
+
+```typescript
+public readonly typecheckTests: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Type-check the test suite as part of the `test` task.
+
+Adds a `tsc --noEmit` step against the development tsconfig.
 
 ---
 

--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -4387,6 +4387,7 @@ const typeScriptProjectOptions: typescript.TypeScriptProjectOptions = { ... }
 | <code><a href="#projen.typescript.TypeScriptProjectOptions.property.tsconfigDev">tsconfigDev</a></code> | <code>projen.javascript.TypescriptConfigOptions</code> | Custom tsconfig options for the development tsconfig.json file (used for testing). |
 | <code><a href="#projen.typescript.TypeScriptProjectOptions.property.tsconfigDevFile">tsconfigDevFile</a></code> | <code>string</code> | The name (and path) of the development tsconfig file. |
 | <code><a href="#projen.typescript.TypeScriptProjectOptions.property.tsJestOptions">tsJestOptions</a></code> | <code><a href="#projen.typescript.TsJestOptions">TsJestOptions</a></code> | Options for ts-jest. |
+| <code><a href="#projen.typescript.TypeScriptProjectOptions.property.typecheckTests">typecheckTests</a></code> | <code>boolean</code> | Type-check the test suite as part of the `test` task. |
 | <code><a href="#projen.typescript.TypeScriptProjectOptions.property.typescriptVersion">typescriptVersion</a></code> | <code>string</code> | TypeScript version to use. |
 
 ---
@@ -6595,6 +6596,21 @@ public readonly tsJestOptions: TsJestOptions;
 - *Type:* <a href="#projen.typescript.TsJestOptions">TsJestOptions</a>
 
 Options for ts-jest.
+
+---
+
+##### `typecheckTests`<sup>Optional</sup> <a name="typecheckTests" id="projen.typescript.TypeScriptProjectOptions.property.typecheckTests"></a>
+
+```typescript
+public readonly typecheckTests: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Type-check the test suite as part of the `test` task.
+
+Adds a `tsc --noEmit` step against the development tsconfig.
 
 ---
 

--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -8255,6 +8255,7 @@ const nextJsTypeScriptProjectOptions: web.NextJsTypeScriptProjectOptions = { ...
 | <code><a href="#projen.web.NextJsTypeScriptProjectOptions.property.tsconfigDev">tsconfigDev</a></code> | <code>projen.javascript.TypescriptConfigOptions</code> | Custom tsconfig options for the development tsconfig.json file (used for testing). |
 | <code><a href="#projen.web.NextJsTypeScriptProjectOptions.property.tsconfigDevFile">tsconfigDevFile</a></code> | <code>string</code> | The name (and path) of the development tsconfig file. |
 | <code><a href="#projen.web.NextJsTypeScriptProjectOptions.property.tsJestOptions">tsJestOptions</a></code> | <code>projen.typescript.TsJestOptions</code> | Options for ts-jest. |
+| <code><a href="#projen.web.NextJsTypeScriptProjectOptions.property.typecheckTests">typecheckTests</a></code> | <code>boolean</code> | Type-check the test suite as part of the `test` task. |
 | <code><a href="#projen.web.NextJsTypeScriptProjectOptions.property.typescriptVersion">typescriptVersion</a></code> | <code>string</code> | TypeScript version to use. |
 
 ---
@@ -10491,6 +10492,21 @@ public readonly tsJestOptions: TsJestOptions;
 - *Type:* projen.typescript.TsJestOptions
 
 Options for ts-jest.
+
+---
+
+##### `typecheckTests`<sup>Optional</sup> <a name="typecheckTests" id="projen.web.NextJsTypeScriptProjectOptions.property.typecheckTests"></a>
+
+```typescript
+public readonly typecheckTests: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Type-check the test suite as part of the `test` task.
+
+Adds a `tsc --noEmit` step against the development tsconfig.
 
 ---
 
@@ -13038,6 +13054,7 @@ const reactTypeScriptProjectOptions: web.ReactTypeScriptProjectOptions = { ... }
 | <code><a href="#projen.web.ReactTypeScriptProjectOptions.property.tsconfigDev">tsconfigDev</a></code> | <code>projen.javascript.TypescriptConfigOptions</code> | Custom tsconfig options for the development tsconfig.json file (used for testing). |
 | <code><a href="#projen.web.ReactTypeScriptProjectOptions.property.tsconfigDevFile">tsconfigDevFile</a></code> | <code>string</code> | The name (and path) of the development tsconfig file. |
 | <code><a href="#projen.web.ReactTypeScriptProjectOptions.property.tsJestOptions">tsJestOptions</a></code> | <code>projen.typescript.TsJestOptions</code> | Options for ts-jest. |
+| <code><a href="#projen.web.ReactTypeScriptProjectOptions.property.typecheckTests">typecheckTests</a></code> | <code>boolean</code> | Type-check the test suite as part of the `test` task. |
 | <code><a href="#projen.web.ReactTypeScriptProjectOptions.property.typescriptVersion">typescriptVersion</a></code> | <code>string</code> | TypeScript version to use. |
 | <code><a href="#projen.web.ReactTypeScriptProjectOptions.property.rewire">rewire</a></code> | <code>{[ key: string ]: any}</code> | Rewire webpack configuration. |
 
@@ -15247,6 +15264,21 @@ public readonly tsJestOptions: TsJestOptions;
 - *Type:* projen.typescript.TsJestOptions
 
 Options for ts-jest.
+
+---
+
+##### `typecheckTests`<sup>Optional</sup> <a name="typecheckTests" id="projen.web.ReactTypeScriptProjectOptions.property.typecheckTests"></a>
+
+```typescript
+public readonly typecheckTests: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Type-check the test suite as part of the `test` task.
+
+Adds a `tsc --noEmit` step against the development tsconfig.
 
 ---
 

--- a/src/typescript/typescript.ts
+++ b/src/typescript/typescript.ts
@@ -378,6 +378,15 @@ export interface TypeScriptProjectOptions extends NodeProjectOptions {
    * Options for ts-jest
    */
   readonly tsJestOptions?: TsJestOptions;
+
+  /**
+   * Type-check the test suite as part of the `test` task.
+   *
+   * Adds a `tsc --noEmit` step against the development tsconfig.
+   *
+   * @default false
+   */
+  readonly typecheckTests?: boolean;
 }
 
 /**
@@ -539,6 +548,13 @@ export class TypeScriptProject extends NodeProject {
       } else {
         this.addJestNoCompile(this.jest, options?.tsJestOptions);
       }
+    }
+
+    if (options.typecheckTests ?? false) {
+      this.testTask.prependSteps({
+        name: "Type-check the test suite",
+        execArgs: ["tsc", "--noEmit", "-p", this.tsconfigDev.fileName],
+      });
     }
 
     // Linter tool selection

--- a/test/__snapshots__/inventory.test.ts.snap
+++ b/test/__snapshots__/inventory.test.ts.snap
@@ -5096,6 +5096,23 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "default": "false",
+        "docs": "Type-check the test suite as part of the \`test\` task.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "typecheckTests",
+        "optional": true,
+        "parent": "TypeScriptProjectOptions",
+        "path": [
+          "typecheckTests",
+        ],
+        "simpleType": "boolean",
+        "switch": "typecheck-tests",
+        "type": {
+          "primitive": "boolean",
+        },
+      },
+      {
         "default": ""latest"",
         "docs": "TypeScript version to use.",
         "featured": false,
@@ -8317,6 +8334,23 @@ exports[`inventory 1`] = `
         "switch": "ts-jest-options",
         "type": {
           "fqn": "projen.typescript.TsJestOptions",
+        },
+      },
+      {
+        "default": "false",
+        "docs": "Type-check the test suite as part of the \`test\` task.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "typecheckTests",
+        "optional": true,
+        "parent": "TypeScriptProjectOptions",
+        "path": [
+          "typecheckTests",
+        ],
+        "simpleType": "boolean",
+        "switch": "typecheck-tests",
+        "type": {
+          "primitive": "boolean",
         },
       },
       {
@@ -12556,6 +12590,23 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "default": "false",
+        "docs": "Type-check the test suite as part of the \`test\` task.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "typecheckTests",
+        "optional": true,
+        "parent": "TypeScriptProjectOptions",
+        "path": [
+          "typecheckTests",
+        ],
+        "simpleType": "boolean",
+        "switch": "typecheck-tests",
+        "type": {
+          "primitive": "boolean",
+        },
+      },
+      {
         "default": ""latest"",
         "docs": "TypeScript version to use.",
         "featured": false,
@@ -15649,6 +15700,23 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "default": "false",
+        "docs": "Type-check the test suite as part of the \`test\` task.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "typecheckTests",
+        "optional": true,
+        "parent": "TypeScriptProjectOptions",
+        "path": [
+          "typecheckTests",
+        ],
+        "simpleType": "boolean",
+        "switch": "typecheck-tests",
+        "type": {
+          "primitive": "boolean",
+        },
+      },
+      {
         "default": ""latest"",
         "docs": "TypeScript version to use.",
         "featured": false,
@@ -18604,6 +18672,23 @@ exports[`inventory 1`] = `
         "switch": "ts-jest-options",
         "type": {
           "fqn": "projen.typescript.TsJestOptions",
+        },
+      },
+      {
+        "default": "false",
+        "docs": "Type-check the test suite as part of the \`test\` task.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "typecheckTests",
+        "optional": true,
+        "parent": "TypeScriptProjectOptions",
+        "path": [
+          "typecheckTests",
+        ],
+        "simpleType": "boolean",
+        "switch": "typecheck-tests",
+        "type": {
+          "primitive": "boolean",
         },
       },
       {
@@ -21662,6 +21747,23 @@ exports[`inventory 1`] = `
         "switch": "ts-jest-options",
         "type": {
           "fqn": "projen.typescript.TsJestOptions",
+        },
+      },
+      {
+        "default": "false",
+        "docs": "Type-check the test suite as part of the \`test\` task.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "typecheckTests",
+        "optional": true,
+        "parent": "TypeScriptProjectOptions",
+        "path": [
+          "typecheckTests",
+        ],
+        "simpleType": "boolean",
+        "switch": "typecheck-tests",
+        "type": {
+          "primitive": "boolean",
         },
       },
       {
@@ -25449,6 +25551,23 @@ exports[`inventory 1`] = `
         "switch": "ts-jest-options",
         "type": {
           "fqn": "projen.typescript.TsJestOptions",
+        },
+      },
+      {
+        "default": "false",
+        "docs": "Type-check the test suite as part of the \`test\` task.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "typecheckTests",
+        "optional": true,
+        "parent": "TypeScriptProjectOptions",
+        "path": [
+          "typecheckTests",
+        ],
+        "simpleType": "boolean",
+        "switch": "typecheck-tests",
+        "type": {
+          "primitive": "boolean",
         },
       },
       {
@@ -30680,6 +30799,23 @@ exports[`inventory 1`] = `
         "switch": "ts-jest-options",
         "type": {
           "fqn": "projen.typescript.TsJestOptions",
+        },
+      },
+      {
+        "default": "false",
+        "docs": "Type-check the test suite as part of the \`test\` task.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "typecheckTests",
+        "optional": true,
+        "parent": "TypeScriptProjectOptions",
+        "path": [
+          "typecheckTests",
+        ],
+        "simpleType": "boolean",
+        "switch": "typecheck-tests",
+        "type": {
+          "primitive": "boolean",
         },
       },
       {
@@ -39525,6 +39661,23 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "default": "false",
+        "docs": "Type-check the test suite as part of the \`test\` task.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "typecheckTests",
+        "optional": true,
+        "parent": "TypeScriptProjectOptions",
+        "path": [
+          "typecheckTests",
+        ],
+        "simpleType": "boolean",
+        "switch": "typecheck-tests",
+        "type": {
+          "primitive": "boolean",
+        },
+      },
+      {
         "default": ""latest"",
         "docs": "TypeScript version to use.",
         "featured": false,
@@ -42247,6 +42400,23 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "default": "false",
+        "docs": "Type-check the test suite as part of the \`test\` task.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "typecheckTests",
+        "optional": true,
+        "parent": "TypeScriptProjectOptions",
+        "path": [
+          "typecheckTests",
+        ],
+        "simpleType": "boolean",
+        "switch": "typecheck-tests",
+        "type": {
+          "primitive": "boolean",
+        },
+      },
+      {
         "default": ""latest"",
         "docs": "TypeScript version to use.",
         "featured": false,
@@ -44966,6 +45136,23 @@ exports[`inventory 1`] = `
         "switch": "ts-jest-options",
         "type": {
           "fqn": "projen.typescript.TsJestOptions",
+        },
+      },
+      {
+        "default": "false",
+        "docs": "Type-check the test suite as part of the \`test\` task.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "typecheckTests",
+        "optional": true,
+        "parent": "TypeScriptProjectOptions",
+        "path": [
+          "typecheckTests",
+        ],
+        "simpleType": "boolean",
+        "switch": "typecheck-tests",
+        "type": {
+          "primitive": "boolean",
         },
       },
       {

--- a/test/inventory.test.ts
+++ b/test/inventory.test.ts
@@ -138,7 +138,7 @@ test("all allowed default values can be discovered and rendered", () => {
   });
 });
 
-function throwIfNotRenderable(option: inventory.ProjectOption) {
+function throwIfNotRenderable(option: inventory.InventoryProjectOption) {
   return (
     option.default === undefined ||
     option.default === "undefined" ||

--- a/test/typescript/typescript.test.ts
+++ b/test/typescript/typescript.test.ts
@@ -169,6 +169,54 @@ test("tsconfigDevFile can be used to control the name of the tsconfig dev file",
   expect(snapshot["tsconfig.foo.json"]).not.toBeUndefined();
 });
 
+describe("typecheckTests", () => {
+  const typecheckStep = (tsconfig: string) => ({
+    name: "Type-check the test suite",
+    execArgs: ["tsc", "--noEmit", "-p", tsconfig],
+  });
+
+  test("is disabled by default", () => {
+    const prj = new TypeScriptProject({
+      name: "test",
+      defaultReleaseBranch: "main",
+    });
+
+    const tasks = synthSnapshot(prj)[".projen/tasks.json"].tasks;
+    expect(tasks["typecheck:tests"]).toBeUndefined();
+    expect(tasks.test.steps).not.toContainEqual(
+      typecheckStep("test/tsconfig.json"),
+    );
+  });
+
+  test("prepends a type-check step to the test task", () => {
+    const prj = new TypeScriptProject({
+      name: "test",
+      defaultReleaseBranch: "main",
+      typecheckTests: true,
+    });
+
+    const tasks = synthSnapshot(prj)[".projen/tasks.json"].tasks;
+    expect(tasks["typecheck:tests"]).toBeUndefined();
+    expect(tasks.test.steps[0]).toStrictEqual(
+      typecheckStep("test/tsconfig.json"),
+    );
+  });
+
+  test("uses the dev tsconfig file name", () => {
+    const prj = new TypeScriptProject({
+      name: "test",
+      defaultReleaseBranch: "main",
+      typecheckTests: true,
+      tsconfigDevFile: "tsconfig.foo.json",
+    });
+
+    const tasks = synthSnapshot(prj)[".projen/tasks.json"].tasks;
+    expect(tasks.test.steps[0]).toStrictEqual(
+      typecheckStep("tsconfig.foo.json"),
+    );
+  });
+});
+
 test("projenrc.ts", () => {
   const prj = new TypeScriptProject({
     name: "test",


### PR DESCRIPTION
Adds a `typecheckTests` option to `TypeScriptProject`, defaulting to `false`. When enabled, it prepends a type-check step to the `test` task:

```
tsc --noEmit -p <tsconfigDev>
```

Being part of the existing `test` task, the check also gates `build` and CI.

Defaulting to `false` because this could prevent builds from projects that legitimately decided they want this behavior. The causation chain is somewhat complicated though: When `ts-jest` runs with a tsconfig that sets `isolatedModules: true` it automatically switched to transpile-only mode. Type errors in test files then fail neither `jest` nor eslint. This is documented in `ts-jest`, but might not be obvious to users.

`projen` falls into the above case. So we enable the option for projen itself. That surfaced three existing errors in `test/inventory.test.ts`: `throwIfNotRenderable` was typed as taking a `ProjectOption` but reads `simpleType`, which is only declared on `InventoryProjectOption`. All call sites already pass inventory options, so the parameter type is widened accordingly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
