### PR TITLE
fix(cli): show fixed args in task inspection

### DIFF
--- a/src/cli/cmds/run-task.ts
+++ b/src/cli/cmds/run-task.ts
@@ -68,13 +68,20 @@ export function discoverTaskCommands(runtime: TaskRuntime, ya: yargs.Argv) {
     for (const step of task.steps ?? []) {
       if (step.spawn) {
         writeln(`- ${chalk.bold(step.spawn)}`);
-        inspectTask(step.spawn, indent + 2);
       } else if (step.exec) {
         writeln(`- exec: ${step.exec}`);
       } else if (step.execArgs) {
         writeln(`- execArgs: ${step.execArgs.join(" ")}`);
       } else if (step.builtin) {
         writeln(`- builtin: ${step.builtin}`);
+      }
+
+      if (step.args?.length) {
+        writeln(`  args: ${JSON.stringify(step.args)}`);
+      }
+
+      if (step.spawn) {
+        inspectTask(step.spawn, indent + 2);
       }
     }
   }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync } from "fs";
+import { mkdirSync, readFileSync } from "fs";
 import { join } from "path";
 import { directorySnapshot, execProjenCLI, mkdtemp } from "./util";
 import { Project } from "../src/project";
@@ -23,6 +23,58 @@ test('running "projen" with task in root of a project will execute task of the p
 
   await execProjenCLI(project.outdir, ["test"]);
   expect(directorySnapshot(project.outdir)["bar.txt"]).toStrictEqual("foo\n");
+});
+
+test('running "projen task --inspect" displays fixed step args unambiguously', async () => {
+  const project = new Project({ name: "my-project" });
+  const task = project.addTask("inspect-args");
+  const command =
+    `node -e "require('fs').writeFileSync('args.json', ` +
+    `JSON.stringify(process.argv.slice(1)))" -- "$@"`;
+  const args = ["hello world", "semi;colon", "--flag"];
+  task.exec(command, { args });
+  project.synth();
+
+  await execProjenCLI(project.outdir, ["inspect-args"]);
+  expect(readFileSync(join(project.outdir, "args.json"), "utf-8")).toBe(
+    JSON.stringify(args),
+  );
+
+  const output = (await execProjenCLI(
+    project.outdir,
+    ["inspect-args", "--inspect"],
+    { capture: true },
+  )) as string;
+
+  expect(output.trim().split(/\r\n|\n|\r/)).toStrictEqual([
+    `- exec: ${command}`,
+    `  args: ${JSON.stringify(args)}`,
+  ]);
+});
+
+test('running "projen task --inspect" keeps args with their nested step', async () => {
+  const project = new Project({ name: "my-project" });
+  const child = project.addTask("child", { exec: "echo child" });
+  const task = project.addTask("inspect-nested-args");
+  task.execArgs(["echo", "parent"], { args: ["two words", "$HOME"] });
+  task.execArgs(["echo", "no-args"], { args: [] });
+  task.spawn(child, { args: ["child value", "semi;colon"] });
+  project.synth();
+
+  const output = (await execProjenCLI(
+    project.outdir,
+    ["inspect-nested-args", "--inspect"],
+    { capture: true },
+  )) as string;
+
+  expect(output.trim().split(/\r\n|\n|\r/)).toStrictEqual([
+    "- execArgs: echo parent",
+    '  args: ["two words","$HOME"]',
+    "- execArgs: echo no-args",
+    "- child",
+    '  args: ["child value","semi;colon"]',
+    "  - exec: echo child",
+  ]);
 });
 
 test('running "projen" with task in root of a project that receives args will pass through --help flag', async () => {


### PR DESCRIPTION
Fixes #3518

## Summary

- Include fixed step arguments in task `--inspect` output.
- Serialize argument arrays as JSON so whitespace and shell-significant characters remain unambiguous.
- Keep spawned-step args associated with the spawning step.

## Testing

- `node ./projen.js compile`
- `node ./projen.js test test/cli.test.ts --runInBand`
- `node ./projen.js test test/cli/run-task.test.ts --runInBand`
- `node ./projen.js eslint`
- `git diff --check`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.