### PR TITLE
feat(javascript): support package.json config

### DIFF
--- a/docs/api/awscdk.md
+++ b/docs/api/awscdk.md
@@ -9154,6 +9154,7 @@ const awsCdkConstructLibraryOptions: awscdk.AwsCdkConstructLibraryOptions = { ..
 | <code><a href="#projen.awscdk.AwsCdkConstructLibraryOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.awscdk.AwsCdkConstructLibraryOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.awscdk.AwsCdkConstructLibraryOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.javascript.CodeArtifactOptions</code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.awscdk.AwsCdkConstructLibraryOptions.property.config">config</a></code> | <code>{[ key: string ]: any}</code> | Configuration values available to package scripts at runtime. |
 | <code><a href="#projen.awscdk.AwsCdkConstructLibraryOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.awscdk.AwsCdkConstructLibraryOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.awscdk.AwsCdkConstructLibraryOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
@@ -9880,6 +9881,23 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `config`<sup>Optional</sup> <a name="config" id="projen.awscdk.AwsCdkConstructLibraryOptions.property.config"></a>
+
+```typescript
+public readonly config: {[ key: string ]: any};
+```
+
+- *Type:* {[ key: string ]: any}
+- *Default:* no package configuration
+
+Configuration values available to package scripts at runtime.
+
+Values should be JSON-serializable.
+
+> [https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config)
 
 ---
 
@@ -14151,6 +14169,7 @@ const awsCdkTypeScriptAppOptions: awscdk.AwsCdkTypeScriptAppOptions = { ... }
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.javascript.CodeArtifactOptions</code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.config">config</a></code> | <code>{[ key: string ]: any}</code> | Configuration values available to package scripts at runtime. |
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.awscdk.AwsCdkTypeScriptAppOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
@@ -14870,6 +14889,23 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `config`<sup>Optional</sup> <a name="config" id="projen.awscdk.AwsCdkTypeScriptAppOptions.property.config"></a>
+
+```typescript
+public readonly config: {[ key: string ]: any};
+```
+
+- *Type:* {[ key: string ]: any}
+- *Default:* no package configuration
+
+Configuration values available to package scripts at runtime.
+
+Values should be JSON-serializable.
+
+> [https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config)
 
 ---
 

--- a/docs/api/cdk.md
+++ b/docs/api/cdk.md
@@ -3926,6 +3926,7 @@ const constructLibraryOptions: cdk.ConstructLibraryOptions = { ... }
 | <code><a href="#projen.cdk.ConstructLibraryOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.cdk.ConstructLibraryOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.cdk.ConstructLibraryOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.javascript.CodeArtifactOptions</code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.cdk.ConstructLibraryOptions.property.config">config</a></code> | <code>{[ key: string ]: any}</code> | Configuration values available to package scripts at runtime. |
 | <code><a href="#projen.cdk.ConstructLibraryOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.cdk.ConstructLibraryOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.cdk.ConstructLibraryOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
@@ -4641,6 +4642,23 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `config`<sup>Optional</sup> <a name="config" id="projen.cdk.ConstructLibraryOptions.property.config"></a>
+
+```typescript
+public readonly config: {[ key: string ]: any};
+```
+
+- *Type:* {[ key: string ]: any}
+- *Default:* no package configuration
+
+Configuration values available to package scripts at runtime.
+
+Values should be JSON-serializable.
+
+> [https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config)
 
 ---
 
@@ -7760,6 +7778,7 @@ const jsiiProjectOptions: cdk.JsiiProjectOptions = { ... }
 | <code><a href="#projen.cdk.JsiiProjectOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.cdk.JsiiProjectOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.cdk.JsiiProjectOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.javascript.CodeArtifactOptions</code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.cdk.JsiiProjectOptions.property.config">config</a></code> | <code>{[ key: string ]: any}</code> | Configuration values available to package scripts at runtime. |
 | <code><a href="#projen.cdk.JsiiProjectOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.cdk.JsiiProjectOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.cdk.JsiiProjectOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
@@ -8474,6 +8493,23 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `config`<sup>Optional</sup> <a name="config" id="projen.cdk.JsiiProjectOptions.property.config"></a>
+
+```typescript
+public readonly config: {[ key: string ]: any};
+```
+
+- *Type:* {[ key: string ]: any}
+- *Default:* no package configuration
+
+Configuration values available to package scripts at runtime.
+
+Values should be JSON-serializable.
+
+> [https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config)
 
 ---
 

--- a/docs/api/cdk8s.md
+++ b/docs/api/cdk8s.md
@@ -6685,6 +6685,7 @@ const cdk8sTypeScriptAppOptions: cdk8s.Cdk8sTypeScriptAppOptions = { ... }
 | <code><a href="#projen.cdk8s.Cdk8sTypeScriptAppOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.cdk8s.Cdk8sTypeScriptAppOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.cdk8s.Cdk8sTypeScriptAppOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.javascript.CodeArtifactOptions</code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.cdk8s.Cdk8sTypeScriptAppOptions.property.config">config</a></code> | <code>{[ key: string ]: any}</code> | Configuration values available to package scripts at runtime. |
 | <code><a href="#projen.cdk8s.Cdk8sTypeScriptAppOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.cdk8s.Cdk8sTypeScriptAppOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.cdk8s.Cdk8sTypeScriptAppOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
@@ -7398,6 +7399,23 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `config`<sup>Optional</sup> <a name="config" id="projen.cdk8s.Cdk8sTypeScriptAppOptions.property.config"></a>
+
+```typescript
+public readonly config: {[ key: string ]: any};
+```
+
+- *Type:* {[ key: string ]: any}
+- *Default:* no package configuration
+
+Configuration values available to package scripts at runtime.
+
+Values should be JSON-serializable.
+
+> [https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config)
 
 ---
 
@@ -9300,6 +9318,7 @@ const constructLibraryCdk8sOptions: cdk8s.ConstructLibraryCdk8sOptions = { ... }
 | <code><a href="#projen.cdk8s.ConstructLibraryCdk8sOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.cdk8s.ConstructLibraryCdk8sOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.cdk8s.ConstructLibraryCdk8sOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.javascript.CodeArtifactOptions</code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.cdk8s.ConstructLibraryCdk8sOptions.property.config">config</a></code> | <code>{[ key: string ]: any}</code> | Configuration values available to package scripts at runtime. |
 | <code><a href="#projen.cdk8s.ConstructLibraryCdk8sOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.cdk8s.ConstructLibraryCdk8sOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.cdk8s.ConstructLibraryCdk8sOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
@@ -10021,6 +10040,23 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `config`<sup>Optional</sup> <a name="config" id="projen.cdk8s.ConstructLibraryCdk8sOptions.property.config"></a>
+
+```typescript
+public readonly config: {[ key: string ]: any};
+```
+
+- *Type:* {[ key: string ]: any}
+- *Default:* no package configuration
+
+Configuration values available to package scripts at runtime.
+
+Values should be JSON-serializable.
+
+> [https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config)
 
 ---
 

--- a/docs/api/cdktf.md
+++ b/docs/api/cdktf.md
@@ -1632,6 +1632,7 @@ const constructLibraryCdktfOptions: cdktf.ConstructLibraryCdktfOptions = { ... }
 | <code><a href="#projen.cdktf.ConstructLibraryCdktfOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.cdktf.ConstructLibraryCdktfOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.cdktf.ConstructLibraryCdktfOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.javascript.CodeArtifactOptions</code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.cdktf.ConstructLibraryCdktfOptions.property.config">config</a></code> | <code>{[ key: string ]: any}</code> | Configuration values available to package scripts at runtime. |
 | <code><a href="#projen.cdktf.ConstructLibraryCdktfOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.cdktf.ConstructLibraryCdktfOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.cdktf.ConstructLibraryCdktfOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
@@ -2349,6 +2350,23 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `config`<sup>Optional</sup> <a name="config" id="projen.cdktf.ConstructLibraryCdktfOptions.property.config"></a>
+
+```typescript
+public readonly config: {[ key: string ]: any};
+```
+
+- *Type:* {[ key: string ]: any}
+- *Default:* no package configuration
+
+Configuration values available to package scripts at runtime.
+
+Values should be JSON-serializable.
+
+> [https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config)
 
 ---
 

--- a/docs/api/cdktn.md
+++ b/docs/api/cdktn.md
@@ -4223,6 +4223,7 @@ const cdktnTypeScriptAppOptions: cdktn.CdktnTypeScriptAppOptions = { ... }
 | <code><a href="#projen.cdktn.CdktnTypeScriptAppOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.cdktn.CdktnTypeScriptAppOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.cdktn.CdktnTypeScriptAppOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.javascript.CodeArtifactOptions</code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.cdktn.CdktnTypeScriptAppOptions.property.config">config</a></code> | <code>{[ key: string ]: any}</code> | Configuration values available to package scripts at runtime. |
 | <code><a href="#projen.cdktn.CdktnTypeScriptAppOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.cdktn.CdktnTypeScriptAppOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.cdktn.CdktnTypeScriptAppOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
@@ -4934,6 +4935,23 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `config`<sup>Optional</sup> <a name="config" id="projen.cdktn.CdktnTypeScriptAppOptions.property.config"></a>
+
+```typescript
+public readonly config: {[ key: string ]: any};
+```
+
+- *Type:* {[ key: string ]: any}
+- *Default:* no package configuration
+
+Configuration values available to package scripts at runtime.
+
+Values should be JSON-serializable.
+
+> [https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config)
 
 ---
 
@@ -6806,6 +6824,7 @@ const constructLibraryCdktnOptions: cdktn.ConstructLibraryCdktnOptions = { ... }
 | <code><a href="#projen.cdktn.ConstructLibraryCdktnOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.cdktn.ConstructLibraryCdktnOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.cdktn.ConstructLibraryCdktnOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.javascript.CodeArtifactOptions</code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.cdktn.ConstructLibraryCdktnOptions.property.config">config</a></code> | <code>{[ key: string ]: any}</code> | Configuration values available to package scripts at runtime. |
 | <code><a href="#projen.cdktn.ConstructLibraryCdktnOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.cdktn.ConstructLibraryCdktnOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.cdktn.ConstructLibraryCdktnOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
@@ -7525,6 +7544,23 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `config`<sup>Optional</sup> <a name="config" id="projen.cdktn.ConstructLibraryCdktnOptions.property.config"></a>
+
+```typescript
+public readonly config: {[ key: string ]: any};
+```
+
+- *Type:* {[ key: string ]: any}
+- *Default:* no package configuration
+
+Configuration values available to package scripts at runtime.
+
+Values should be JSON-serializable.
+
+> [https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config)
 
 ---
 

--- a/docs/api/javascript.md
+++ b/docs/api/javascript.md
@@ -12580,6 +12580,7 @@ const nodePackageOptions: javascript.NodePackageOptions = { ... }
 | <code><a href="#projen.javascript.NodePackageOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.javascript.NodePackageOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.javascript.NodePackageOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code><a href="#projen.javascript.CodeArtifactOptions">CodeArtifactOptions</a></code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.javascript.NodePackageOptions.property.config">config</a></code> | <code>{[ key: string ]: any}</code> | Configuration values available to package scripts at runtime. |
 | <code><a href="#projen.javascript.NodePackageOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.javascript.NodePackageOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.javascript.NodePackageOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
@@ -12828,6 +12829,23 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `config`<sup>Optional</sup> <a name="config" id="projen.javascript.NodePackageOptions.property.config"></a>
+
+```typescript
+public readonly config: {[ key: string ]: any};
+```
+
+- *Type:* {[ key: string ]: any}
+- *Default:* no package configuration
+
+Configuration values available to package scripts at runtime.
+
+Values should be JSON-serializable.
+
+> [https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config)
 
 ---
 
@@ -13362,6 +13380,7 @@ const nodeProjectOptions: javascript.NodeProjectOptions = { ... }
 | <code><a href="#projen.javascript.NodeProjectOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.javascript.NodeProjectOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.javascript.NodeProjectOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code><a href="#projen.javascript.CodeArtifactOptions">CodeArtifactOptions</a></code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.javascript.NodeProjectOptions.property.config">config</a></code> | <code>{[ key: string ]: any}</code> | Configuration values available to package scripts at runtime. |
 | <code><a href="#projen.javascript.NodeProjectOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.javascript.NodeProjectOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.javascript.NodeProjectOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
@@ -14041,6 +14060,23 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `config`<sup>Optional</sup> <a name="config" id="projen.javascript.NodeProjectOptions.property.config"></a>
+
+```typescript
+public readonly config: {[ key: string ]: any};
+```
+
+- *Type:* {[ key: string ]: any}
+- *Default:* no package configuration
+
+Configuration values available to package scripts at runtime.
+
+Values should be JSON-serializable.
+
+> [https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config)
 
 ---
 

--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -4298,6 +4298,7 @@ const typeScriptProjectOptions: typescript.TypeScriptProjectOptions = { ... }
 | <code><a href="#projen.typescript.TypeScriptProjectOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.typescript.TypeScriptProjectOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.typescript.TypeScriptProjectOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.javascript.CodeArtifactOptions</code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.typescript.TypeScriptProjectOptions.property.config">config</a></code> | <code>{[ key: string ]: any}</code> | Configuration values available to package scripts at runtime. |
 | <code><a href="#projen.typescript.TypeScriptProjectOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.typescript.TypeScriptProjectOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.typescript.TypeScriptProjectOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
@@ -4997,6 +4998,23 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `config`<sup>Optional</sup> <a name="config" id="projen.typescript.TypeScriptProjectOptions.property.config"></a>
+
+```typescript
+public readonly config: {[ key: string ]: any};
+```
+
+- *Type:* {[ key: string ]: any}
+- *Default:* no package configuration
+
+Configuration values available to package scripts at runtime.
+
+Values should be JSON-serializable.
+
+> [https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config)
 
 ---
 

--- a/docs/api/web.md
+++ b/docs/api/web.md
@@ -5975,6 +5975,7 @@ const nextJsProjectOptions: web.NextJsProjectOptions = { ... }
 | <code><a href="#projen.web.NextJsProjectOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.web.NextJsProjectOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.web.NextJsProjectOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.javascript.CodeArtifactOptions</code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.web.NextJsProjectOptions.property.config">config</a></code> | <code>{[ key: string ]: any}</code> | Configuration values available to package scripts at runtime. |
 | <code><a href="#projen.web.NextJsProjectOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.web.NextJsProjectOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.web.NextJsProjectOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
@@ -6684,6 +6685,23 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `config`<sup>Optional</sup> <a name="config" id="projen.web.NextJsProjectOptions.property.config"></a>
+
+```typescript
+public readonly config: {[ key: string ]: any};
+```
+
+- *Type:* {[ key: string ]: any}
+- *Default:* no package configuration
+
+Configuration values available to package scripts at runtime.
+
+Values should be JSON-serializable.
+
+> [https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config)
 
 ---
 
@@ -8145,6 +8163,7 @@ const nextJsTypeScriptProjectOptions: web.NextJsTypeScriptProjectOptions = { ...
 | <code><a href="#projen.web.NextJsTypeScriptProjectOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.web.NextJsTypeScriptProjectOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.web.NextJsTypeScriptProjectOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.javascript.CodeArtifactOptions</code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.web.NextJsTypeScriptProjectOptions.property.config">config</a></code> | <code>{[ key: string ]: any}</code> | Configuration values available to package scripts at runtime. |
 | <code><a href="#projen.web.NextJsTypeScriptProjectOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.web.NextJsTypeScriptProjectOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.web.NextJsTypeScriptProjectOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
@@ -8872,6 +8891,23 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `config`<sup>Optional</sup> <a name="config" id="projen.web.NextJsTypeScriptProjectOptions.property.config"></a>
+
+```typescript
+public readonly config: {[ key: string ]: any};
+```
+
+- *Type:* {[ key: string ]: any}
+- *Default:* no package configuration
+
+Configuration values available to package scripts at runtime.
+
+Values should be JSON-serializable.
+
+> [https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config)
 
 ---
 
@@ -10707,6 +10743,7 @@ const reactProjectOptions: web.ReactProjectOptions = { ... }
 | <code><a href="#projen.web.ReactProjectOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.web.ReactProjectOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.web.ReactProjectOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.javascript.CodeArtifactOptions</code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.web.ReactProjectOptions.property.config">config</a></code> | <code>{[ key: string ]: any}</code> | Configuration values available to package scripts at runtime. |
 | <code><a href="#projen.web.ReactProjectOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.web.ReactProjectOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.web.ReactProjectOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
@@ -11389,6 +11426,23 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `config`<sup>Optional</sup> <a name="config" id="projen.web.ReactProjectOptions.property.config"></a>
+
+```typescript
+public readonly config: {[ key: string ]: any};
+```
+
+- *Type:* {[ key: string ]: any}
+- *Default:* no package configuration
+
+Configuration values available to package scripts at runtime.
+
+Values should be JSON-serializable.
+
+> [https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config)
 
 ---
 
@@ -12944,6 +12998,7 @@ const reactTypeScriptProjectOptions: web.ReactTypeScriptProjectOptions = { ... }
 | <code><a href="#projen.web.ReactTypeScriptProjectOptions.property.bundledDeps">bundledDeps</a></code> | <code>string[]</code> | List of dependencies to bundle into this module. |
 | <code><a href="#projen.web.ReactTypeScriptProjectOptions.property.bunVersion">bunVersion</a></code> | <code>string</code> | The version of Bun to use if using Bun as a package manager. |
 | <code><a href="#projen.web.ReactTypeScriptProjectOptions.property.codeArtifactOptions">codeArtifactOptions</a></code> | <code>projen.javascript.CodeArtifactOptions</code> | Options for npm packages using AWS CodeArtifact. |
+| <code><a href="#projen.web.ReactTypeScriptProjectOptions.property.config">config</a></code> | <code>{[ key: string ]: any}</code> | Configuration values available to package scripts at runtime. |
 | <code><a href="#projen.web.ReactTypeScriptProjectOptions.property.dedupeDeps">dedupeDeps</a></code> | <code>boolean</code> | Add a `dedupe` task that deduplicates project dependencies. |
 | <code><a href="#projen.web.ReactTypeScriptProjectOptions.property.deleteOrphanedLockFiles">deleteOrphanedLockFiles</a></code> | <code>boolean</code> | Automatically delete lockfiles from package managers that are not the active one. |
 | <code><a href="#projen.web.ReactTypeScriptProjectOptions.property.deps">deps</a></code> | <code>string[]</code> | Runtime dependencies of this module. |
@@ -13644,6 +13699,23 @@ public readonly codeArtifactOptions: CodeArtifactOptions;
 Options for npm packages using AWS CodeArtifact.
 
 This is required if publishing packages to, or installing scoped packages from AWS CodeArtifact
+
+---
+
+##### `config`<sup>Optional</sup> <a name="config" id="projen.web.ReactTypeScriptProjectOptions.property.config"></a>
+
+```typescript
+public readonly config: {[ key: string ]: any};
+```
+
+- *Type:* {[ key: string ]: any}
+- *Default:* no package configuration
+
+Configuration values available to package scripts at runtime.
+
+Values should be JSON-serializable.
+
+> [https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config)
 
 ---
 

--- a/src/javascript/node-package.ts
+++ b/src/javascript/node-package.ts
@@ -141,6 +141,16 @@ export interface NodePackageOptions {
   readonly keywords?: string[];
 
   /**
+   * Configuration values available to package scripts at runtime.
+   *
+   * Values should be JSON-serializable.
+   *
+   * @see https://docs.npmjs.com/cli/v11/configuring-npm/package-json#config
+   * @default - no package configuration
+   */
+  readonly config?: Record<string, any>;
+
+  /**
    * Module entrypoint (`main` in `package.json`)
    *
    * Set to an empty string to not include `main` in your package.json
@@ -848,6 +858,7 @@ export class NodePackage extends Component {
       bundledDependencies: [],
       ...this.renderPackageResolutions(),
       keywords: () => this.renderKeywords(),
+      config: options.config,
       engines: () => this.renderEngines(),
       devEngines: () => this.renderDevEngines(),
       main: this.entrypoint !== "" ? this.entrypoint : undefined,

--- a/test/__snapshots__/inventory.test.ts.snap
+++ b/test/__snapshots__/inventory.test.ts.snap
@@ -2959,6 +2959,28 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "default": "- no package configuration",
+        "docs": "Configuration values available to package scripts at runtime.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "config",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "config",
+        ],
+        "simpleType": "unknown",
+        "switch": "config",
+        "type": {
+          "collection": {
+            "elementtype": {
+              "primitive": "any",
+            },
+            "kind": "map",
+          },
+        },
+      },
+      {
         "default": "- for CDK 1.x the default is "3.2.27", for CDK 2.x the default is
 "10.5.1".",
         "docs": "Minimum version of the \`constructs\` library to depend on.",
@@ -6092,6 +6114,28 @@ exports[`inventory 1`] = `
         "switch": "compress-assembly",
         "type": {
           "primitive": "boolean",
+        },
+      },
+      {
+        "default": "- no package configuration",
+        "docs": "Configuration values available to package scripts at runtime.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "config",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "config",
+        ],
+        "simpleType": "unknown",
+        "switch": "config",
+        "type": {
+          "collection": {
+            "elementtype": {
+              "primitive": "any",
+            },
+            "kind": "map",
+          },
         },
       },
       {
@@ -10567,6 +10611,28 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "default": "- no package configuration",
+        "docs": "Configuration values available to package scripts at runtime.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "config",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "config",
+        ],
+        "simpleType": "unknown",
+        "switch": "config",
+        "type": {
+          "collection": {
+            "elementtype": {
+              "primitive": "any",
+            },
+            "kind": "map",
+          },
+        },
+      },
+      {
         "default": ""10.1.42"",
         "docs": "Minimum version of the \`constructs\` library to depend on.",
         "featured": false,
@@ -13543,6 +13609,28 @@ exports[`inventory 1`] = `
         "switch": "compress-assembly",
         "type": {
           "primitive": "boolean",
+        },
+      },
+      {
+        "default": "- no package configuration",
+        "docs": "Configuration values available to package scripts at runtime.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "config",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "config",
+        ],
+        "simpleType": "unknown",
+        "switch": "config",
+        "type": {
+          "collection": {
+            "elementtype": {
+              "primitive": "any",
+            },
+            "kind": "map",
+          },
         },
       },
       {
@@ -16620,6 +16708,28 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "default": "- no package configuration",
+        "docs": "Configuration values available to package scripts at runtime.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "config",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "config",
+        ],
+        "simpleType": "unknown",
+        "switch": "config",
+        "type": {
+          "collection": {
+            "elementtype": {
+              "primitive": "any",
+            },
+            "kind": "map",
+          },
+        },
+      },
+      {
         "default": ""^10.7.2"",
         "docs": "Minimum version of the \`constructs\` library to depend on.",
         "featured": false,
@@ -19627,6 +19737,28 @@ exports[`inventory 1`] = `
         "switch": "compress-assembly",
         "type": {
           "primitive": "boolean",
+        },
+      },
+      {
+        "default": "- no package configuration",
+        "docs": "Configuration values available to package scripts at runtime.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "config",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "config",
+        ],
+        "simpleType": "unknown",
+        "switch": "config",
+        "type": {
+          "collection": {
+            "elementtype": {
+              "primitive": "any",
+            },
+            "kind": "map",
+          },
         },
       },
       {
@@ -23451,6 +23583,28 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "default": "- no package configuration",
+        "docs": "Configuration values available to package scripts at runtime.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "config",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "config",
+        ],
+        "simpleType": "unknown",
+        "switch": "config",
+        "type": {
+          "collection": {
+            "elementtype": {
+              "primitive": "any",
+            },
+            "kind": "map",
+          },
+        },
+      },
+      {
         "default": "- defaults to the value of authorName or "" if \`authorName\` is undefined.",
         "docs": "License copyright owner.",
         "featured": false,
@@ -26391,6 +26545,28 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "default": "- no package configuration",
+        "docs": "Configuration values available to package scripts at runtime.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "config",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "config",
+        ],
+        "simpleType": "unknown",
+        "switch": "config",
+        "type": {
+          "collection": {
+            "elementtype": {
+              "primitive": "any",
+            },
+            "kind": "map",
+          },
+        },
+      },
+      {
         "default": "- defaults to the value of authorName or "" if \`authorName\` is undefined.",
         "docs": "License copyright owner.",
         "featured": false,
@@ -28844,6 +29020,28 @@ exports[`inventory 1`] = `
         "switch": "commit-generated",
         "type": {
           "primitive": "boolean",
+        },
+      },
+      {
+        "default": "- no package configuration",
+        "docs": "Configuration values available to package scripts at runtime.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "config",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "config",
+        ],
+        "simpleType": "unknown",
+        "switch": "config",
+        "type": {
+          "collection": {
+            "elementtype": {
+              "primitive": "any",
+            },
+            "kind": "map",
+          },
         },
       },
       {
@@ -31600,6 +31798,28 @@ exports[`inventory 1`] = `
         "switch": "commit-generated",
         "type": {
           "primitive": "boolean",
+        },
+      },
+      {
+        "default": "- no package configuration",
+        "docs": "Configuration values available to package scripts at runtime.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "config",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "config",
+        ],
+        "simpleType": "unknown",
+        "switch": "config",
+        "type": {
+          "collection": {
+            "elementtype": {
+              "primitive": "any",
+            },
+            "kind": "map",
+          },
         },
       },
       {
@@ -35257,6 +35477,28 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "default": "- no package configuration",
+        "docs": "Configuration values available to package scripts at runtime.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "config",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "config",
+        ],
+        "simpleType": "unknown",
+        "switch": "config",
+        "type": {
+          "collection": {
+            "elementtype": {
+              "primitive": "any",
+            },
+            "kind": "map",
+          },
+        },
+      },
+      {
         "default": "- defaults to the value of authorName or "" if \`authorName\` is undefined.",
         "docs": "License copyright owner.",
         "featured": false,
@@ -37698,6 +37940,28 @@ exports[`inventory 1`] = `
         "switch": "commit-generated",
         "type": {
           "primitive": "boolean",
+        },
+      },
+      {
+        "default": "- no package configuration",
+        "docs": "Configuration values available to package scripts at runtime.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "config",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "config",
+        ],
+        "simpleType": "unknown",
+        "switch": "config",
+        "type": {
+          "collection": {
+            "elementtype": {
+              "primitive": "any",
+            },
+            "kind": "map",
+          },
         },
       },
       {
@@ -40462,6 +40726,28 @@ exports[`inventory 1`] = `
         },
       },
       {
+        "default": "- no package configuration",
+        "docs": "Configuration values available to package scripts at runtime.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "config",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "config",
+        ],
+        "simpleType": "unknown",
+        "switch": "config",
+        "type": {
+          "collection": {
+            "elementtype": {
+              "primitive": "any",
+            },
+            "kind": "map",
+          },
+        },
+      },
+      {
         "default": "- defaults to the value of authorName or "" if \`authorName\` is undefined.",
         "docs": "License copyright owner.",
         "featured": false,
@@ -43198,6 +43484,28 @@ exports[`inventory 1`] = `
         "switch": "commit-generated",
         "type": {
           "primitive": "boolean",
+        },
+      },
+      {
+        "default": "- no package configuration",
+        "docs": "Configuration values available to package scripts at runtime.",
+        "featured": false,
+        "jsonLike": true,
+        "name": "config",
+        "optional": true,
+        "parent": "NodePackageOptions",
+        "path": [
+          "config",
+        ],
+        "simpleType": "unknown",
+        "switch": "config",
+        "type": {
+          "collection": {
+            "elementtype": {
+              "primitive": "any",
+            },
+            "kind": "map",
+          },
         },
       },
       {

--- a/test/javascript/node-package.test.ts
+++ b/test/javascript/node-package.test.ts
@@ -170,6 +170,49 @@ test("single bugs field present", () => {
   expect(snps["package.json"].bugs.email).toStrictEqual(_email);
 });
 
+test("package.json config preserves JSON-compatible values", () => {
+  const project = new TestProject();
+  const config = {
+    port: 3000,
+    feature: {
+      enabled: true,
+    },
+    message: "hello world",
+    values: ["one", 2, false],
+    optional: null,
+  };
+
+  new NodePackage(project, { config });
+
+  expect(synthSnapshot(project)["package.json"].config).toStrictEqual(config);
+});
+
+test("package.json config is omitted by default and preserves an empty object", () => {
+  const defaultProject = new TestProject();
+  new NodePackage(defaultProject, {});
+  const defaultManifest = synthSnapshot(defaultProject)["package.json"];
+  expect(defaultManifest).not.toHaveProperty("config");
+
+  const emptyConfigProject = new TestProject();
+  new NodePackage(emptyConfigProject, { config: {} });
+  const { config, ...unchangedManifest } =
+    synthSnapshot(emptyConfigProject)["package.json"];
+  expect(config).toStrictEqual({});
+  expect(unchangedManifest).toStrictEqual(defaultManifest);
+});
+
+test("NodeProject inherits the package.json config option", () => {
+  const project = new NodeProject({
+    name: "test",
+    clobber: false,
+    config: { port: 3000 },
+  });
+
+  expect(synthSnapshot(project)["package.json"].config).toStrictEqual({
+    port: 3000,
+  });
+});
+
 test('lockfile updated (install twice) after "*"s are resolved', () => {
   const taskMock = jest
     .spyOn(Tasks.prototype, "runTask")


### PR DESCRIPTION
## Summary

- add `config` to `NodePackageOptions`
- preserve nested JSON-compatible values in the synthesized `package.json`
- expose the option through projects that inherit `NodePackageOptions`

## Testing

- `npm ci`
- `node ./projen.js compile`
- `node ./projen.js test test/javascript/node-package.test.ts --runInBand` (96 tests; local Jest/Corepack caches redirected off the full system drive)
- `node ./projen.js test test/inventory.test.ts --runInBand` (2,539 tests)
- `node ./projen.js compat`
- `node ./projen.js docgen`
- `node ./projen.js eslint`
- `git diff --check`

Fixes #2973

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.