### PR TITLE
chore: upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
       contents: read
     if: ${{ !needs.build.outputs.self_mutation_happened }}
     steps:
-      - uses: actions/setup-java@v5.7.0
+      - uses: actions/setup-java@v6.0.0
         with:
           distribution: corretto
           java-version: "11"

--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -151,8 +151,8 @@ jobs:
       - name: Checkout
         id: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-      - id: auto_0499a831
-        uses: actions/setup-java@v5.7.0
+      - id: auto_a4e4946d
+        uses: actions/setup-java@v6.0.0
         with:
           java-version: ${{ matrix.java-version }}
           distribution: ${{ matrix.java-distribution }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,7 +213,7 @@ jobs:
     environment: release
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
-      - uses: actions/setup-java@v5.7.0
+      - uses: actions/setup-java@v6.0.0
         with:
           distribution: corretto
           java-version: "11"

--- a/resources/github-actions.jsonc
+++ b/resources/github-actions.jsonc
@@ -56,8 +56,8 @@
       "isImmutable": true
     },
     "actions/setup-java": {
-      "major": "v5",
-      "pin": "v5.7.0",
+      "major": "v6",
+      "pin": "v6.0.0",
       "isImmutable": true
     },
     "actions/setup-node": {

--- a/scripts/update-github-actions.js
+++ b/scripts/update-github-actions.js
@@ -133,9 +133,7 @@ async function openTrackingIssue(action, newMajor, openIssues) {
       body: [
         `A new major version line of \`${action}\` is available: **v${newMajor}**.`,
         "",
-        "Major upgrades are never applied automatically. To adopt it, review the",
-        `[release notes](https://github.com/${action}/releases) and update the`,
-        '"major" field of this action in `resources/github-actions.jsonc`.',
+        `Major upgrades are never applied automatically. To adopt it, review the [release notes](https://github.com/${action}/releases) and update the "major" field of this action in \`resources/github-actions.jsonc\`.`,
         "",
         "---",
         '*Automatically created by the "update-github-actions" task.*',

--- a/src/github/actions.const.ts
+++ b/src/github/actions.const.ts
@@ -18,8 +18,8 @@ export class GitHubActions {
   public static readonly ACTIONS_SETUP_DOTNET = "actions/setup-dotnet@v6.0.0";
   /** actions/setup-go at v7.0.0 (immutable) */
   public static readonly ACTIONS_SETUP_GO = "actions/setup-go@v7.0.0";
-  /** actions/setup-java at v5.7.0 (immutable) */
-  public static readonly ACTIONS_SETUP_JAVA = "actions/setup-java@v5.7.0";
+  /** actions/setup-java at v6.0.0 (immutable) */
+  public static readonly ACTIONS_SETUP_JAVA = "actions/setup-java@v6.0.0";
   /** actions/setup-node at v7.0.0 (immutable) */
   public static readonly ACTIONS_SETUP_NODE = "actions/setup-node@v7.0.0";
   /** actions/setup-python at v7.0.0 (immutable) */


### PR DESCRIPTION
## Summary
- Bumps the approved major line for `actions/setup-java` from v5 to v6 in `resources/github-actions.jsonc`, pinned to the immutable `v6.0.0` release.
- Fixes a mid-sentence line break in the tracking-issue body template in `scripts/update-github-actions.js` (the sentence "review the release notes and update the ..." was split across three array entries, producing an awkward wrap in the rendered issue body — visible on #4909).
- Regenerated `src/github/actions.const.ts` and the derived `.github/workflows/*.yml` via `npx projen`.

## Breaking changes check
Reviewed the [v6.0.0 release notes](https://github.com/actions/setup-java/releases/tag/v6.0.0). The two breaking items (removal of legacy Adopt/AdoptOpenJDK distributions, renamed GPG/Maven credential env var inputs) don't affect this repo's usage, which only sets `distribution`, `java-version`, and `cache`.

## Testing
- Ran `npx projen` twice from a clean checkout; output stabilized (second run was a no-op).
- Verified `src/github/actions.const.ts` and all three workflow ymls now reference `actions/setup-java@v6.0.0`.
- Could not run the full jest suite (`test/github/workflows.test.ts`, `test/release/release.test.ts`, `test/cdk/jsii.test.ts`, `test/integ.test.ts`) in this sandbox due to repeated environment instability during the jsii compile step; those suites' snapshots (`*.snap` files referencing `v5.7.0`) will need `-u` to refresh in CI/locally.

Closes #4909