### PR TITLE
feat(github-actions): upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
       contents: read
     if: ${{ !needs.build.outputs.self_mutation_happened }}
     steps:
-      - uses: actions/setup-java@v5.7.0
+      - uses: actions/setup-java@v6.0.0
         with:
           distribution: corretto
           java-version: "11"

--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -151,8 +151,8 @@ jobs:
       - name: Checkout
         id: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-      - id: auto_0499a831
-        uses: actions/setup-java@v5.7.0
+      - id: auto_a4e4946d
+        uses: actions/setup-java@v6.0.0
         with:
           java-version: ${{ matrix.java-version }}
           distribution: ${{ matrix.java-distribution }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,7 +213,7 @@ jobs:
     environment: release
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
-      - uses: actions/setup-java@v5.7.0
+      - uses: actions/setup-java@v6.0.0
         with:
           distribution: corretto
           java-version: "11"

--- a/resources/github-actions.jsonc
+++ b/resources/github-actions.jsonc
@@ -56,8 +56,8 @@
       "isImmutable": true
     },
     "actions/setup-java": {
-      "major": "v5",
-      "pin": "v5.7.0",
+      "major": "v6",
+      "pin": "v6.0.0",
       "isImmutable": true
     },
     "actions/setup-node": {

--- a/scripts/update-github-actions.js
+++ b/scripts/update-github-actions.js
@@ -133,9 +133,7 @@ async function openTrackingIssue(action, newMajor, openIssues) {
       body: [
         `A new major version line of \`${action}\` is available: **v${newMajor}**.`,
         "",
-        "Major upgrades are never applied automatically. To adopt it, review the",
-        `[release notes](https://github.com/${action}/releases) and update the`,
-        '"major" field of this action in `resources/github-actions.jsonc`.',
+        `Major upgrades are never applied automatically. To adopt it, review the [release notes](https://github.com/${action}/releases) and update the "major" field of this action in \`resources/github-actions.jsonc\`.`,
         "",
         "---",
         '*Automatically created by the "update-github-actions" task.*',

--- a/src/github/actions.const.ts
+++ b/src/github/actions.const.ts
@@ -18,8 +18,8 @@ export class GitHubActions {
   public static readonly ACTIONS_SETUP_DOTNET = "actions/setup-dotnet@v6.0.0";
   /** actions/setup-go at v7.0.0 (immutable) */
   public static readonly ACTIONS_SETUP_GO = "actions/setup-go@v7.0.0";
-  /** actions/setup-java at v5.7.0 (immutable) */
-  public static readonly ACTIONS_SETUP_JAVA = "actions/setup-java@v5.7.0";
+  /** actions/setup-java at v6.0.0 (immutable) */
+  public static readonly ACTIONS_SETUP_JAVA = "actions/setup-java@v6.0.0";
   /** actions/setup-node at v7.0.0 (immutable) */
   public static readonly ACTIONS_SETUP_NODE = "actions/setup-node@v7.0.0";
   /** actions/setup-python at v7.0.0 (immutable) */

--- a/test/__snapshots__/integ.test.ts.snap
+++ b/test/__snapshots__/integ.test.ts.snap
@@ -403,7 +403,7 @@ jobs:
       contents: read
     if: \${{ !needs.build.outputs.self_mutation_happened }}
     steps:
-      - uses: actions/setup-java@v5.7.0
+      - uses: actions/setup-java@v6.0.0
         with:
           distribution: corretto
           java-version: "11"
@@ -697,7 +697,7 @@ jobs:
       contents: read
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
-      - uses: actions/setup-java@v5.7.0
+      - uses: actions/setup-java@v6.0.0
         with:
           distribution: corretto
           java-version: "11"

--- a/test/cdk/__snapshots__/jsii.test.ts.snap
+++ b/test/cdk/__snapshots__/jsii.test.ts.snap
@@ -1901,7 +1901,7 @@ exports[`language bindings release workflow includes release_maven job 1`] = `
   "runs-on": "ubuntu-latest",
   "steps": [
     {
-      "uses": "actions/setup-java@v5.7.0",
+      "uses": "actions/setup-java@v6.0.0",
       "with": {
         "distribution": "corretto",
         "java-version": "11",
@@ -2396,7 +2396,7 @@ exports[`language bindings snapshot java 1`] = `
   "runs-on": "ubuntu-latest",
   "steps": [
     {
-      "uses": "actions/setup-java@v5.7.0",
+      "uses": "actions/setup-java@v6.0.0",
       "with": {
         "distribution": "corretto",
         "java-version": "11",

--- a/test/github/__snapshots__/workflows.test.ts.snap
+++ b/test/github/__snapshots__/workflows.test.ts.snap
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - uses: actions/setup-java@v5.7.0
+      - uses: actions/setup-java@v6.0.0
         with:
           distribution: corretto
           java-version: "11"
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - uses: actions/setup-java@v5.7.0
+      - uses: actions/setup-java@v6.0.0
         with:
           distribution: temurin
           java-version: "17"
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - uses: actions/setup-java@v5.7.0
+      - uses: actions/setup-java@v6.0.0
         with:
           distribution: corretto
           java-version: "11"

--- a/test/release/__snapshots__/release.test.ts.snap
+++ b/test/release/__snapshots__/release.test.ts.snap
@@ -3999,7 +3999,7 @@ jobs:
       packages: write
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
-      - uses: actions/setup-java@v5.7.0
+      - uses: actions/setup-java@v6.0.0
         with:
           distribution: corretto
           java-version: "11"
@@ -5910,7 +5910,7 @@ jobs:
       contents: read
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
-      - uses: actions/setup-java@v5.7.0
+      - uses: actions/setup-java@v6.0.0
         with:
           distribution: corretto
           java-version: "11"


### PR DESCRIPTION
Fixes #4909

`actions/setup-java` v6.0.0 has been out past the cooldown window for a while, so this adopts it as the new approved major line. I checked the v6 release notes for anything that would affect us: it drops the legacy AdoptOpenJDK distributions and renames a couple of GPG/Maven credential env var inputs, but this repo only ever passes `distribution`, `java-version`, and `cache` to the action, so neither change touches us. The bump is otherwise a plain patch to `resources/github-actions.jsonc`, pinned to the immutable `v6.0.0` tag, with the derived `src/github/actions.const.ts` and workflow YAML regenerated by projen itself.

While I was in `update-github-actions.js`, I also fixed a line break that's been rendering awkwardly in the auto-opened tracking issues (visible on #4909 itself): the sentence "review the release notes and update the ... field" was split across three separate array entries in the issue body template, which puts a hard newline in the middle of the sentence once GitHub renders it. Joined them into one line so it reads normally.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
