### PR TITLE
feat(javascript): define javascript-test-runner mixin

### DIFF
--- a/docs/api/javascript.md
+++ b/docs/api/javascript.md
@@ -8263,6 +8263,51 @@ Only present when reason is `DEPS_RESOLVED`.
 
 ---
 
+### JavaScriptTestRunnerOptions <a name="JavaScriptTestRunnerOptions" id="projen.javascript.JavaScriptTestRunnerOptions"></a>
+
+#### Initializer <a name="Initializer" id="projen.javascript.JavaScriptTestRunnerOptions.Initializer"></a>
+
+```typescript
+import { javascript } from 'projen'
+
+const javaScriptTestRunnerOptions: javascript.JavaScriptTestRunnerOptions = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen.javascript.JavaScriptTestRunnerOptions.property.coverageDirectory">coverageDirectory</a></code> | <code>string</code> | The directory where coverage files are output, if coverage collection is enabled for the configured test runner. |
+| <code><a href="#projen.javascript.JavaScriptTestRunnerOptions.property.updateSnapshot">updateSnapshot</a></code> | <code><a href="#projen.javascript.UpdateSnapshot">UpdateSnapshot</a></code> | Whether to update snapshots in task "test" (which is executed in task "build" and build workflows), or create a separate task "test:update" for updating snapshots. |
+
+---
+
+##### `coverageDirectory`<sup>Optional</sup> <a name="coverageDirectory" id="projen.javascript.JavaScriptTestRunnerOptions.property.coverageDirectory"></a>
+
+```typescript
+public readonly coverageDirectory: string;
+```
+
+- *Type:* string
+- *Default:* "coverage"
+
+The directory where coverage files are output, if coverage collection is enabled for the configured test runner.
+
+---
+
+##### `updateSnapshot`<sup>Optional</sup> <a name="updateSnapshot" id="projen.javascript.JavaScriptTestRunnerOptions.property.updateSnapshot"></a>
+
+```typescript
+public readonly updateSnapshot: UpdateSnapshot;
+```
+
+- *Type:* <a href="#projen.javascript.UpdateSnapshot">UpdateSnapshot</a>
+- *Default:* ALWAYS
+
+Whether to update snapshots in task "test" (which is executed in task "build" and build workflows), or create a separate task "test:update" for updating snapshots.
+
+---
+
 ### JestConfigOptions <a name="JestConfigOptions" id="projen.javascript.JestConfigOptions"></a>
 
 #### Initializer <a name="Initializer" id="projen.javascript.JestConfigOptions.Initializer"></a>
@@ -24926,6 +24971,76 @@ public readonly os: string[];
 
 ## Classes <a name="Classes" id="Classes"></a>
 
+### JavaScriptTestRunner <a name="JavaScriptTestRunner" id="projen.javascript.JavaScriptTestRunner"></a>
+
+- *Implements:* constructs.IMixin
+
+Wires up a {@link IJavaScriptTestRunner} onto a project: requests its dependencies, registers its coverage output as ignored, and creates the "test", "test:update" and "test:watch" tasks from its {@link RunTestConfig}.
+
+Unlike its runner, this mixin holds no test-kind-specific logic (no Jest
+or Node.js-specific behavior) - it only knows how to apply the generic
+shape of an `IJavaScriptTestRunner` to a project.
+
+#### Initializers <a name="Initializers" id="projen.javascript.JavaScriptTestRunner.Initializer"></a>
+
+```typescript
+import { javascript } from 'projen'
+
+new javascript.JavaScriptTestRunner(runner: IJavaScriptTestRunner)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen.javascript.JavaScriptTestRunner.Initializer.parameter.runner">runner</a></code> | <code><a href="#projen.javascript.IJavaScriptTestRunner">IJavaScriptTestRunner</a></code> | *No description.* |
+
+---
+
+##### `runner`<sup>Required</sup> <a name="runner" id="projen.javascript.JavaScriptTestRunner.Initializer.parameter.runner"></a>
+
+- *Type:* <a href="#projen.javascript.IJavaScriptTestRunner">IJavaScriptTestRunner</a>
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#projen.javascript.JavaScriptTestRunner.applyTo">applyTo</a></code> | Applies the mixin functionality to the target construct. |
+| <code><a href="#projen.javascript.JavaScriptTestRunner.supports">supports</a></code> | Determines whether this mixin can be applied to the given construct. |
+
+---
+
+##### `applyTo` <a name="applyTo" id="projen.javascript.JavaScriptTestRunner.applyTo"></a>
+
+```typescript
+public applyTo(construct: IConstruct): void
+```
+
+Applies the mixin functionality to the target construct.
+
+###### `construct`<sup>Required</sup> <a name="construct" id="projen.javascript.JavaScriptTestRunner.applyTo.parameter.construct"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+##### `supports` <a name="supports" id="projen.javascript.JavaScriptTestRunner.supports"></a>
+
+```typescript
+public supports(construct: IConstruct): boolean
+```
+
+Determines whether this mixin can be applied to the given construct.
+
+###### `construct`<sup>Required</sup> <a name="construct" id="projen.javascript.JavaScriptTestRunner.supports.parameter.construct"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+
+
+
 ### JestReporter <a name="JestReporter" id="projen.javascript.JestReporter"></a>
 
 #### Initializers <a name="Initializers" id="projen.javascript.JestReporter.Initializer"></a>
@@ -25331,6 +25446,66 @@ new javascript.WatchPlugin(name: string, options?: any)
 
 
 
+## Protocols <a name="Protocols" id="Protocols"></a>
+
+### IJavaScriptTestRunner <a name="IJavaScriptTestRunner" id="projen.javascript.IJavaScriptTestRunner"></a>
+
+- *Extends:* projen.ITestRunner
+
+- *Implemented By:* <a href="#projen.javascript.IJavaScriptTestRunner">IJavaScriptTestRunner</a>
+
+A runner that can execute the tests for a JavaScript project.
+
+Implementations (e.g. `Jest`, `NodeNativeTest`) are self-contained
+components: they can be used directly, or composed onto a project through
+the {@link JavaScriptTestRunner} mixin.
+
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen.javascript.IJavaScriptTestRunner.property.testMatch">testMatch</a></code> | <code>projen.TestMatch</code> | Glob patterns matching the files that contain tests. |
+| <code><a href="#projen.javascript.IJavaScriptTestRunner.property.updateSnapshot">updateSnapshot</a></code> | <code><a href="#projen.javascript.UpdateSnapshot">UpdateSnapshot</a></code> | Whether snapshots are updated in task "test", or in a separate "test:update" task. |
+| <code><a href="#projen.javascript.IJavaScriptTestRunner.property.coverageDirectory">coverageDirectory</a></code> | <code>string</code> | The directory where coverage files are output, if coverage collection is enabled for the configured test runner. |
+
+---
+
+##### `testMatch`<sup>Required</sup> <a name="testMatch" id="projen.javascript.IJavaScriptTestRunner.property.testMatch"></a>
+
+```typescript
+public readonly testMatch: TestMatch;
+```
+
+- *Type:* projen.TestMatch
+
+Glob patterns matching the files that contain tests.
+
+---
+
+##### `updateSnapshot`<sup>Required</sup> <a name="updateSnapshot" id="projen.javascript.IJavaScriptTestRunner.property.updateSnapshot"></a>
+
+```typescript
+public readonly updateSnapshot: UpdateSnapshot;
+```
+
+- *Type:* <a href="#projen.javascript.UpdateSnapshot">UpdateSnapshot</a>
+
+Whether snapshots are updated in task "test", or in a separate "test:update" task.
+
+---
+
+##### `coverageDirectory`<sup>Optional</sup> <a name="coverageDirectory" id="projen.javascript.IJavaScriptTestRunner.property.coverageDirectory"></a>
+
+```typescript
+public readonly coverageDirectory: string;
+```
+
+- *Type:* string
+
+The directory where coverage files are output, if coverage collection is enabled for the configured test runner.
+
+---
 
 ## Enums <a name="Enums" id="Enums"></a>
 
@@ -26798,6 +26973,11 @@ from TypeScript 5.0 onwards.
 
 
 ### UpdateSnapshot <a name="UpdateSnapshot" id="projen.javascript.UpdateSnapshot"></a>
+
+Whether to update snapshots in task "test" (which is executed in task "build" and build workflows), or create a separate task "test:update" for updating snapshots.
+
+Shared by every `IJavaScriptTestRunner` implementation (`Jest`,
+`NodeNativeTest`), so it lives here rather than in any one of them.
 
 #### Members <a name="Members" id="Members"></a>
 

--- a/docs/api/projen.md
+++ b/docs/api/projen.md
@@ -10960,6 +10960,303 @@ Sets the default shell used to run all task commands.
 ---
 
 
+### TestRunner <a name="TestRunner" id="projen.TestRunner"></a>
+
+- *Implements:* <a href="#projen.ITestRunner">ITestRunner</a>
+
+A runner that executes a project's tests.
+
+A runner is a {@link FutureComponent}: create it standalone and it is
+attached to a project by whoever consumes it.
+
+#### Initializers <a name="Initializers" id="projen.TestRunner.Initializer"></a>
+
+```typescript
+import { TestRunner } from 'projen'
+
+new TestRunner()
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#projen.TestRunner.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#projen.TestRunner.with">with</a></code> | Applies one or more mixins to this construct. |
+| <code><a href="#projen.TestRunner.postProjectCreation">postProjectCreation</a></code> | Called once, right after `postSynthesize()`, only when the project is created for the first time. |
+| <code><a href="#projen.TestRunner.postSynthesize">postSynthesize</a></code> | Called after synthesis. |
+| <code><a href="#projen.TestRunner.preSynthesize">preSynthesize</a></code> | Called before synthesis. |
+| <code><a href="#projen.TestRunner.projectCreation">projectCreation</a></code> | Called once, right after `synthesize()`, only when the project is created for the first time. |
+| <code><a href="#projen.TestRunner.synthesize">synthesize</a></code> | Synthesizes files to the project output directory. |
+| <code><a href="#projen.TestRunner.attach">attach</a></code> | Attach the component to a scope. Only now does it become usable. |
+| <code><a href="#projen.TestRunner.tryAttach">tryAttach</a></code> | Attach the component if it isn't already, without caring *where*. |
+| <code><a href="#projen.TestRunner.configFor">configFor</a></code> | Produce the configuration to test the given project. |
+
+---
+
+##### `toString` <a name="toString" id="projen.TestRunner.toString"></a>
+
+```typescript
+public toString(): string
+```
+
+Returns a string representation of this construct.
+
+##### `with` <a name="with" id="projen.TestRunner.with"></a>
+
+```typescript
+public with(mixins: ...IMixin[]): IConstruct
+```
+
+Applies one or more mixins to this construct.
+
+Mixins are applied in order. The list of constructs is captured at the
+start of the call, so constructs added by a mixin will not be visited.
+Use multiple `with()` calls if subsequent mixins should apply to added
+constructs.
+
+###### `mixins`<sup>Required</sup> <a name="mixins" id="projen.TestRunner.with.parameter.mixins"></a>
+
+- *Type:* ...constructs.IMixin[]
+
+The mixins to apply.
+
+---
+
+##### `postProjectCreation` <a name="postProjectCreation" id="projen.TestRunner.postProjectCreation"></a>
+
+```typescript
+public postProjectCreation(initProject: InitProject): void
+```
+
+Called once, right after `postSynthesize()`, only when the project is created for the first time.
+
+It does not run on later `projen` invocations. It only fires for `projen new` (or `Projects.createProject`).
+It is also skipped when post-synthesis steps are disabled, e.g. `--no-post` or `PROJEN_DISABLE_POST`.
+Use it for one-off setup that can be turned off by the user, like running a task to give the user immediate
+feedback on their new project. Order across components is not guaranteed.
+
+###### `initProject`<sup>Required</sup> <a name="initProject" id="projen.TestRunner.postProjectCreation.parameter.initProject"></a>
+
+- *Type:* <a href="#projen.InitProject">InitProject</a>
+
+Details about how the project was created, e.g. its type and the original CLI args.
+
+---
+
+##### `postSynthesize` <a name="postSynthesize" id="projen.TestRunner.postSynthesize"></a>
+
+```typescript
+public postSynthesize(): void
+```
+
+Called after synthesis.
+
+Order is *not* guaranteed.
+
+##### `preSynthesize` <a name="preSynthesize" id="projen.TestRunner.preSynthesize"></a>
+
+```typescript
+public preSynthesize(): void
+```
+
+Called before synthesis.
+
+##### `projectCreation` <a name="projectCreation" id="projen.TestRunner.projectCreation"></a>
+
+```typescript
+public projectCreation(initProject: InitProject): void
+```
+
+Called once, right after `synthesize()`, only when the project is created for the first time.
+
+It does not run on later `projen` invocations. It only fires for `projen new` (or `Projects.createProject`).
+Use it for deterministic, one-off file generation. Order across components is not guaranteed.
+
+###### `initProject`<sup>Required</sup> <a name="initProject" id="projen.TestRunner.projectCreation.parameter.initProject"></a>
+
+- *Type:* <a href="#projen.InitProject">InitProject</a>
+
+Details about how the project was created, e.g. its type and the original CLI args.
+
+---
+
+##### `synthesize` <a name="synthesize" id="projen.TestRunner.synthesize"></a>
+
+```typescript
+public synthesize(): void
+```
+
+Synthesizes files to the project output directory.
+
+##### `attach` <a name="attach" id="projen.TestRunner.attach"></a>
+
+```typescript
+public attach(scope: IConstruct, id?: string): FutureComponent
+```
+
+Attach the component to a scope. Only now does it become usable.
+
+Returns the real, unwrapped component (not the proxy). A component may be
+attached exactly once; attaching an already-attached component throws (copy
+it first to attach a variant elsewhere). Use `tryAttach()` if you don't care
+whether it has already been attached.
+
+###### `scope`<sup>Required</sup> <a name="scope" id="projen.TestRunner.attach.parameter.scope"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+###### `id`<sup>Optional</sup> <a name="id" id="projen.TestRunner.attach.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+##### `tryAttach` <a name="tryAttach" id="projen.TestRunner.tryAttach"></a>
+
+```typescript
+public tryAttach(scope: IConstruct, id?: string): FutureComponent
+```
+
+Attach the component if it isn't already, without caring *where*.
+
+Unlike `attach()`, never throws on an already-attached component: if attached
+anywhere at all, the existing instance is returned and `scope` is ignored.
+Use `attach()` when attaching to a specific scope is part of your contract
+and a pre-existing attachment elsewhere would be a bug.
+
+###### `scope`<sup>Required</sup> <a name="scope" id="projen.TestRunner.tryAttach.parameter.scope"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+###### `id`<sup>Optional</sup> <a name="id" id="projen.TestRunner.tryAttach.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+##### `configFor` <a name="configFor" id="projen.TestRunner.configFor"></a>
+
+```typescript
+public configFor(): RunTestConfig
+```
+
+Produce the configuration to test the given project.
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#projen.TestRunner.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#projen.TestRunner.isComponent">isComponent</a></code> | Test whether the given construct is a component. |
+
+---
+
+##### `isConstruct` <a name="isConstruct" id="projen.TestRunner.isConstruct"></a>
+
+```typescript
+import { TestRunner } from 'projen'
+
+TestRunner.isConstruct(x: any)
+```
+
+Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
+
+###### `x`<sup>Required</sup> <a name="x" id="projen.TestRunner.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+Any object.
+
+---
+
+##### `isComponent` <a name="isComponent" id="projen.TestRunner.isComponent"></a>
+
+```typescript
+import { TestRunner } from 'projen'
+
+TestRunner.isComponent(x: any)
+```
+
+Test whether the given construct is a component.
+
+###### `x`<sup>Required</sup> <a name="x" id="projen.TestRunner.isComponent.parameter.x"></a>
+
+- *Type:* any
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen.TestRunner.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#projen.TestRunner.property.project">project</a></code> | <code><a href="#projen.Project">Project</a></code> | *No description.* |
+| <code><a href="#projen.TestRunner.property.attached">attached</a></code> | <code>boolean</code> | Whether `attach()` has been called. |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="projen.TestRunner.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- *Type:* constructs.Node
+
+The tree node.
+
+---
+
+##### `project`<sup>Required</sup> <a name="project" id="projen.TestRunner.property.project"></a>
+
+```typescript
+public readonly project: Project;
+```
+
+- *Type:* <a href="#projen.Project">Project</a>
+
+---
+
+##### `attached`<sup>Required</sup> <a name="attached" id="projen.TestRunner.property.attached"></a>
+
+```typescript
+public readonly attached: boolean;
+```
+
+- *Type:* boolean
+
+Whether `attach()` has been called.
+
+A convenience for tests/introspection;
+prefer `tryAttach()` over reading this and branching.
+
+---
+
+
 ### TextFile <a name="TextFile" id="projen.TextFile"></a>
 
 A text file.
@@ -17150,6 +17447,51 @@ Github Runner Group selection options.
 
 ---
 
+### RunTestConfig <a name="RunTestConfig" id="projen.RunTestConfig"></a>
+
+The resolved configuration needed to run a project's tests: dependencies, and the steps for each of the testing tasks.
+
+#### Initializer <a name="Initializer" id="projen.RunTestConfig.Initializer"></a>
+
+```typescript
+import { RunTestConfig } from 'projen'
+
+const runTestConfig: RunTestConfig = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen.RunTestConfig.property.dependencies">dependencies</a></code> | <code><a href="#projen.DependencyRequest">DependencyRequest</a>[]</code> | Dependencies required to run the tests. |
+| <code><a href="#projen.RunTestConfig.property.steps">steps</a></code> | <code><a href="#projen.TaskStep">TaskStep</a>[]</code> | The task steps to run for each of the "test", "test:update" and "test:watch" tasks. |
+
+---
+
+##### `dependencies`<sup>Required</sup> <a name="dependencies" id="projen.RunTestConfig.property.dependencies"></a>
+
+```typescript
+public readonly dependencies: DependencyRequest[];
+```
+
+- *Type:* <a href="#projen.DependencyRequest">DependencyRequest</a>[]
+
+Dependencies required to run the tests.
+
+---
+
+##### `steps`<sup>Required</sup> <a name="steps" id="projen.RunTestConfig.property.steps"></a>
+
+```typescript
+public readonly steps: TaskStep[];
+```
+
+- *Type:* <a href="#projen.TaskStep">TaskStep</a>[]
+
+The task steps to run for each of the "test", "test:update" and "test:watch" tasks.
+
+---
+
 ### SampleDirOptions <a name="SampleDirOptions" id="projen.SampleDirOptions"></a>
 
 SampleDir options.
@@ -18354,6 +18696,34 @@ public readonly shell: TaskShell;
 The shell used to run this step, overriding the task/project shell.
 
 > [{@link TaskCommonOptions.shell }]({@link TaskCommonOptions.shell })
+
+---
+
+### TestMatchOptions <a name="TestMatchOptions" id="projen.TestMatchOptions"></a>
+
+#### Initializer <a name="Initializer" id="projen.TestMatchOptions.Initializer"></a>
+
+```typescript
+import { TestMatchOptions } from 'projen'
+
+const testMatchOptions: TestMatchOptions = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen.TestMatchOptions.property.defaultValue">defaultValue</a></code> | <code>string[]</code> | *No description.* |
+
+---
+
+##### `defaultValue`<sup>Required</sup> <a name="defaultValue" id="projen.TestMatchOptions.property.defaultValue"></a>
+
+```typescript
+public readonly defaultValue: string[];
+```
+
+- *Type:* string[]
 
 ---
 
@@ -20688,6 +21058,83 @@ the project to produce a snapshot for.
 
 
 
+### TestMatch <a name="TestMatch" id="projen.TestMatch"></a>
+
+Glob patterns matching the files that contain tests.
+
+#### Initializers <a name="Initializers" id="projen.TestMatch.Initializer"></a>
+
+```typescript
+import { TestMatch } from 'projen'
+
+new TestMatch(options: TestMatchOptions)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#projen.TestMatch.Initializer.parameter.options">options</a></code> | <code><a href="#projen.TestMatchOptions">TestMatchOptions</a></code> | *No description.* |
+
+---
+
+##### `options`<sup>Required</sup> <a name="options" id="projen.TestMatch.Initializer.parameter.options"></a>
+
+- *Type:* <a href="#projen.TestMatchOptions">TestMatchOptions</a>
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#projen.TestMatch.add">add</a></code> | Adds a test match pattern. |
+| <code><a href="#projen.TestMatch.deferred">deferred</a></code> | Lazily resolved, so that `TestMatch` (via `add`/ `remove`) can still be changed after construction and be reflected here. |
+| <code><a href="#projen.TestMatch.remove">remove</a></code> | Removes a test match pattern, if configured. |
+
+---
+
+##### `add` <a name="add" id="projen.TestMatch.add"></a>
+
+```typescript
+public add(pattern: string): void
+```
+
+Adds a test match pattern.
+
+###### `pattern`<sup>Required</sup> <a name="pattern" id="projen.TestMatch.add.parameter.pattern"></a>
+
+- *Type:* string
+
+glob pattern to match for tests.
+
+---
+
+##### `deferred` <a name="deferred" id="projen.TestMatch.deferred"></a>
+
+```typescript
+public deferred(): string[]
+```
+
+Lazily resolved, so that `TestMatch` (via `add`/ `remove`) can still be changed after construction and be reflected here.
+
+##### `remove` <a name="remove" id="projen.TestMatch.remove"></a>
+
+```typescript
+public remove(pattern: string): void
+```
+
+Removes a test match pattern, if configured.
+
+###### `pattern`<sup>Required</sup> <a name="pattern" id="projen.TestMatch.remove.parameter.pattern"></a>
+
+- *Type:* string
+
+glob pattern to remove.
+
+---
+
+
+
+
 ## Protocols <a name="Protocols" id="Protocols"></a>
 
 ### ICompareString <a name="ICompareString" id="projen.ICompareString"></a>
@@ -21051,6 +21498,29 @@ Produce the configuration to run the given entrypoint.
 - *Type:* string
 
 ---
+
+
+### ITestRunner <a name="ITestRunner" id="projen.ITestRunner"></a>
+
+- *Implemented By:* <a href="#projen.TestRunner">TestRunner</a>, projen.javascript.IJavaScriptTestRunner, <a href="#projen.ITestRunner">ITestRunner</a>
+
+A test runner that can produce the configuration to execute a file of a particular type.
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#projen.ITestRunner.configFor">configFor</a></code> | Produce the configuration to test the given project. |
+
+---
+
+##### `configFor` <a name="configFor" id="projen.ITestRunner.configFor"></a>
+
+```typescript
+public configFor(): RunTestConfig
+```
+
+Produce the configuration to test the given project.
 
 
 ## Enums <a name="Enums" id="Enums"></a>

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ export * from "./task";
 export * from "./tasks";
 export type * from "./task-model";
 export * from "./task-shell";
+export * from "./test-runner";
 export * from "./testing";
 export * from "./textfile";
 export * from "./toml";

--- a/src/javascript/index.ts
+++ b/src/javascript/index.ts
@@ -1,5 +1,6 @@
 export * from "./bundler";
 export * from "./eslint";
+export * from "./javascript-test-runner";
 export * from "./jest";
 export * from "./license-checker";
 export * from "./node-config";

--- a/src/javascript/javascript-test-runner.ts
+++ b/src/javascript/javascript-test-runner.ts
@@ -1,0 +1,164 @@
+import * as path from "path";
+import type { IConstruct, IMixin } from "constructs";
+import { Project } from "../project";
+import type { ITestRunner, RunTestConfig, TestMatch } from "../test-runner";
+
+/**
+ * The default directory used for coverage test reports.
+ */
+export const DEFAULT_COVERAGE_DIR = "coverage";
+
+/**
+ * The default directory used for JUnit-compatible test reports.
+ */
+export const DEFAULT_TEST_REPORTS_DIR = "test-reports";
+
+/**
+ * The steps to run for each of the test tasks.
+ */
+enum RunTestStepKind {
+  /**
+   * Default step for "test" task.
+   */
+  TEST = "test",
+
+  /**
+   * Default step for "test:update" task.
+   */
+  UPDATE = "update",
+
+  /**
+   * Default step for "test:watch" task.
+   */
+  WATCH = "watch",
+}
+
+/**
+ * Whether to update snapshots in task "test" (which is executed in task
+ * "build" and build workflows), or create a separate task "test:update" for
+ * updating snapshots.
+ *
+ * Shared by every `IJavaScriptTestRunner` implementation (`Jest`,
+ * `NodeNativeTest`), so it lives here rather than in any one of them.
+ */
+export enum UpdateSnapshot {
+  /**
+   * Always update snapshots in "test" task.
+   */
+  ALWAYS = "always",
+
+  /**
+   * Never update snapshots in "test" task and create a separate "test:update" task.
+   */
+  NEVER = "never",
+}
+
+export interface JavaScriptTestRunnerOptions {
+  /**
+   * The directory where coverage files are output, if coverage collection
+   * is enabled for the configured test runner.
+   *
+   * @default "coverage"
+   */
+  readonly coverageDirectory?: string;
+
+  /**
+   * Whether to update snapshots in task "test" (which is executed in task "build" and build workflows),
+   * or create a separate task "test:update" for updating snapshots.
+   *
+   * @default - ALWAYS
+   */
+  readonly updateSnapshot?: UpdateSnapshot;
+}
+
+/**
+ * A runner that can execute the tests for a JavaScript project.
+ *
+ * Implementations (e.g. `Jest`, `NodeNativeTest`) are self-contained
+ * components: they can be used directly, or composed onto a project through
+ * the {@link JavaScriptTestRunner} mixin.
+ */
+export interface IJavaScriptTestRunner extends ITestRunner {
+  /**
+   * Glob patterns matching the files that contain tests.
+   */
+  readonly testMatch: TestMatch;
+
+  /**
+   * Whether snapshots are updated in task "test", or in a separate
+   * "test:update" task.
+   */
+  readonly updateSnapshot: UpdateSnapshot;
+
+  /**
+   * The directory where coverage files are output, if coverage collection
+   * is enabled for the configured test runner.
+   */
+  readonly coverageDirectory?: string;
+}
+
+/**
+ * Wires up a {@link IJavaScriptTestRunner} onto a project: requests its
+ * dependencies, registers its coverage output as ignored, and creates the
+ * "test", "test:update" and "test:watch" tasks from its {@link RunTestConfig}.
+ *
+ * Unlike its runner, this mixin holds no test-kind-specific logic (no Jest
+ * or Node.js-specific behavior) - it only knows how to apply the generic
+ * shape of an `IJavaScriptTestRunner` to a project.
+ */
+export class JavaScriptTestRunner implements IMixin {
+  constructor(private readonly runner: IJavaScriptTestRunner) {}
+
+  public supports(construct: IConstruct): construct is Project {
+    return construct instanceof Project;
+  }
+
+  public applyTo(construct: IConstruct): void {
+    if (!this.supports(construct)) {
+      return;
+    }
+
+    const project = construct;
+    const runner = this.runner;
+
+    if (runner.coverageDirectory) {
+      const coverageDirectoryPath = path.posix.join(
+        "/",
+        runner.coverageDirectory,
+        "/",
+      );
+      project.addPackageIgnore(coverageDirectoryPath);
+      project.addGitIgnore(coverageDirectoryPath);
+    }
+
+    const { dependencies, steps }: RunTestConfig = runner.configFor();
+
+    // Register any runner dependencies
+    for (const dep of dependencies) {
+      project.deps.requestDependency(dep);
+    }
+
+    const updateStep = steps.find((s) => s.name === RunTestStepKind.UPDATE);
+    const testUpdate = project.tasks.tryFind("test:update");
+    if (updateStep && !testUpdate) {
+      project.addTask("test:update", {
+        description: "Update test snapshots",
+        steps: [{ ...updateStep, name: undefined }],
+      });
+    }
+
+    const testStep = steps.find((s) => s.name === RunTestStepKind.TEST);
+    if (testStep) {
+      project.testTask.addSteps({ ...testStep, name: undefined });
+    }
+
+    const watchStep = steps.find((s) => s.name === RunTestStepKind.WATCH);
+    const testWatch = project.tasks.tryFind("test:watch");
+    if (watchStep && !testWatch) {
+      project.addTask("test:watch", {
+        description: "Run tests in watch mode",
+        steps: [{ ...watchStep, name: undefined }],
+      });
+    }
+  }
+}

--- a/src/javascript/jest.ts
+++ b/src/javascript/jest.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
 import type { IConstruct } from "constructs";
+import { UpdateSnapshot } from "./javascript-test-runner";
 import { Component } from "../component";
 import { NodeProject } from "../javascript";
 import { JsonFile } from "../json";
@@ -696,18 +697,6 @@ export interface CoverageThreshold {
   readonly functions?: number;
   readonly lines?: number;
   readonly statements?: number;
-}
-
-export enum UpdateSnapshot {
-  /**
-   * Always update snapshots in "test" task.
-   */
-  ALWAYS = "always",
-
-  /**
-   * Never update snapshots in "test" task and create a separate "test:update" task.
-   */
-  NEVER = "never",
 }
 
 export interface HasteConfig {

--- a/src/test-runner.ts
+++ b/src/test-runner.ts
@@ -1,0 +1,91 @@
+import { FutureComponent } from "./component";
+import type { DependencyRequest } from "./dependencies";
+import type { TaskStep } from "./task-model";
+
+export interface TestMatchOptions {
+  readonly defaultValue: string[];
+}
+
+/**
+ * Glob patterns matching the files that contain tests.
+ */
+export class TestMatch {
+  private readonly _patterns = new Set<string>();
+  private readonly _defaultValue;
+
+  constructor(options: TestMatchOptions) {
+    this._defaultValue = options.defaultValue;
+  }
+
+  /**
+   * Adds a test match pattern.
+   * @param pattern glob pattern to match for tests
+   */
+  public add(pattern: string) {
+    this._patterns.add(pattern);
+  }
+
+  /**
+   * Removes a test match pattern, if configured.
+   * @param pattern glob pattern to remove
+   */
+  public remove(pattern: string) {
+    this._patterns.delete(pattern);
+  }
+
+  /**
+   * Lazily resolved, so that `TestMatch` (via `add`/ `remove`) can
+   * still be changed after construction and be reflected here.
+   */
+  public deferred(): string[] {
+    return this._patterns.size > 0
+      ? Array.from(this._patterns)
+      : this._defaultValue;
+  }
+}
+
+/**
+ * The resolved configuration needed to run a project's tests:
+ * dependencies, and the steps for each of the testing tasks.
+ */
+export interface RunTestConfig {
+  /**
+   * Dependencies required to run the tests.
+   */
+  readonly dependencies: DependencyRequest[];
+
+  /**
+   * The task steps to run for each of the "test", "test:update" and
+   * "test:watch" tasks.
+   */
+  readonly steps: TaskStep[];
+}
+
+/**
+ * A test runner that can produce the configuration to execute a file of a
+ * particular type.
+ */
+export interface ITestRunner {
+  /**
+   * Produce the configuration to test the given project.
+   */
+  configFor(): RunTestConfig;
+}
+
+/**
+ * A runner that executes a project's tests.
+ *
+ * A runner is a {@link FutureComponent}: create it standalone and it is
+ * attached to a project by whoever consumes it.
+ */
+export abstract class TestRunner
+  extends FutureComponent
+  implements ITestRunner
+{
+  public configFor(): RunTestConfig {
+    return {
+      dependencies: [],
+      steps: [{ execArgs: [] }],
+    };
+  }
+}

--- a/test/javascript/javascript-test-runner.test.ts
+++ b/test/javascript/javascript-test-runner.test.ts
@@ -1,0 +1,116 @@
+import {
+  JavaScriptTestRunner,
+  UpdateSnapshot,
+} from "../../src/javascript/javascript-test-runner";
+import type { IJavaScriptTestRunner } from "../../src/javascript/javascript-test-runner";
+import type { RunTestConfig } from "../../src/test-runner";
+import { TestMatch } from "../../src/test-runner";
+import { synthSnapshot, TestProject } from "../util";
+
+class StubTestRunner implements IJavaScriptTestRunner {
+  public readonly testMatch = new TestMatch({ defaultValue: ["**/*.test.js"] });
+  public readonly updateSnapshot: UpdateSnapshot;
+  public readonly coverageDirectory?: string;
+
+  constructor(
+    private readonly config: RunTestConfig,
+    options: {
+      updateSnapshot?: UpdateSnapshot;
+      coverageDirectory?: string;
+    } = {},
+  ) {
+    this.updateSnapshot = options.updateSnapshot ?? UpdateSnapshot.ALWAYS;
+    this.coverageDirectory = options.coverageDirectory;
+  }
+
+  public configFor(): RunTestConfig {
+    return this.config;
+  }
+}
+
+test("applyTo() adds the test task from the runner's config", () => {
+  const project = new TestProject();
+  const runner = new StubTestRunner({
+    dependencies: [{ name: "some-test-framework" }],
+    steps: [{ name: "test", execArgs: ["some-test-framework"] }],
+  });
+
+  project.with(new JavaScriptTestRunner(runner));
+
+  expect(project.testTask.steps).toContainEqual(
+    expect.objectContaining({ execArgs: ["some-test-framework"] }),
+  );
+  expect(project.deps.tryGetDependency("some-test-framework")).toBeDefined();
+});
+
+test("applyTo() creates a test:update task when the runner has an update step", () => {
+  const project = new TestProject();
+  const runner = new StubTestRunner(
+    {
+      dependencies: [],
+      steps: [
+        { name: "test", execArgs: ["run-tests"] },
+        { name: "update", execArgs: ["run-tests", "--update"] },
+      ],
+    },
+    { updateSnapshot: UpdateSnapshot.NEVER },
+  );
+
+  project.with(new JavaScriptTestRunner(runner));
+
+  const updateTask = project.tasks.tryFind("test:update");
+  expect(updateTask).toBeDefined();
+  expect(updateTask!.steps).toContainEqual(
+    expect.objectContaining({ execArgs: ["run-tests", "--update"] }),
+  );
+});
+
+test("applyTo() creates a test:watch task when the runner has a watch step", () => {
+  const project = new TestProject();
+  const runner = new StubTestRunner({
+    dependencies: [],
+    steps: [
+      { name: "test", execArgs: ["run-tests"] },
+      { name: "watch", execArgs: ["run-tests", "--watch"] },
+    ],
+  });
+
+  project.with(new JavaScriptTestRunner(runner));
+
+  const watchTask = project.tasks.tryFind("test:watch");
+  expect(watchTask).toBeDefined();
+  expect(watchTask!.steps).toContainEqual(
+    expect.objectContaining({ execArgs: ["run-tests", "--watch"] }),
+  );
+});
+
+test("applyTo() registers the coverage directory as ignored", () => {
+  const project = new TestProject();
+  const runner = new StubTestRunner(
+    { dependencies: [], steps: [] },
+    { coverageDirectory: "coverage" },
+  );
+
+  project.with(new JavaScriptTestRunner(runner));
+
+  const gitignore = synthSnapshot(project)[".gitignore"];
+  expect(gitignore).toContain("/coverage/");
+});
+
+test("supports() only matches Project constructs", () => {
+  const runner = new StubTestRunner({ dependencies: [], steps: [] });
+  const mixin = new JavaScriptTestRunner(runner);
+
+  expect(mixin.supports(new TestProject())).toBe(true);
+  expect(mixin.supports({} as any)).toBe(false);
+});
+
+test("applyTo() is a no-op for constructs it doesn't support", () => {
+  const runner = new StubTestRunner({
+    dependencies: [{ name: "some-test-framework" }],
+    steps: [{ name: "test", execArgs: ["some-test-framework"] }],
+  });
+  const mixin = new JavaScriptTestRunner(runner);
+
+  expect(() => mixin.applyTo({} as any)).not.toThrow();
+});

--- a/test/test-runner.test.ts
+++ b/test/test-runner.test.ts
@@ -1,0 +1,41 @@
+import { TestProject } from "./util";
+import { TestMatch, TestRunner } from "../src/test-runner";
+
+class MinimalTestRunner extends TestRunner {}
+
+test("TestRunner.configFor() defaults to an empty dependency and step list", () => {
+  const project = new TestProject();
+  const runner = new MinimalTestRunner().attach(project);
+
+  expect(runner.configFor()).toEqual({
+    dependencies: [],
+    steps: [{ execArgs: [] }],
+  });
+});
+
+test("TestMatch.deferred() returns the default value when no patterns were added", () => {
+  const testMatch = new TestMatch({ defaultValue: ["**/*.test.ts"] });
+
+  expect(testMatch.deferred()).toEqual(["**/*.test.ts"]);
+});
+
+test("TestMatch.add() overrides the default value with the added patterns", () => {
+  const testMatch = new TestMatch({ defaultValue: ["**/*.test.ts"] });
+
+  testMatch.add("**/*.spec.ts");
+  testMatch.add("**/*.integ.ts");
+
+  expect(testMatch.deferred()).toEqual(
+    expect.arrayContaining(["**/*.spec.ts", "**/*.integ.ts"]),
+  );
+  expect(testMatch.deferred()).not.toContain("**/*.test.ts");
+});
+
+test("TestMatch.remove() falls back to the default value once all added patterns are removed", () => {
+  const testMatch = new TestMatch({ defaultValue: ["**/*.test.ts"] });
+
+  testMatch.add("**/*.spec.ts");
+  testMatch.remove("**/*.spec.ts");
+
+  expect(testMatch.deferred()).toEqual(["**/*.test.ts"]);
+});


### PR DESCRIPTION
Defines a generic TestRunner abstract class (ITestRunner, RunTestConfig, TestMatch) and a JavaScriptTestRunner mixin that wires an IJavaScriptTestRunner's RunTestConfig onto a project (test/test:update/test:watch tasks, dependencies, coverage ignoring). No Jest or Node-specific rendering logic lives here. Concrete runners (Jest, NodeNativeTest) implement IJavaScriptTestRunner directly and are composed via project.with(new JavaScriptTestRunner(...)) in follow-up PRs.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
