### PR TITLE
fix(github): dependency review check blocks the merge queue

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -4,12 +4,14 @@ name: dependency-review
 on:
   pull_request: {}
   workflow_dispatch: {}
+  merge_group: {}
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
+    if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')
     steps:
       - name: Checkout
         id: checkout

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -443,6 +443,12 @@ new AiInstructions(project, {
     - **Actionable error messages**: Error messages must tell the user what to do to resolve the problem, not just what went wrong. Name the exact options or values involved and state the required action.
     - **Mutually exclusive options**: When two options cannot be used together, throw an error at construction time instead of silently picking one. Use the established message pattern: \`Only one of 'optionA' or 'optionB' may be specified, not both.\`
     - **Deprecating options**: When replacing a deprecated option with a new one, keep the deprecated option working as before, mark it with \`@deprecated\` pointing to the replacement, and throw if both are set: \`Only one of 'newOption' or 'deprecatedOption' may be specified, not both. Remove the deprecated 'deprecatedOption'.\``,
+
+    `## Code comments
+
+    - **Keep comments to a minimum**: Prefer self-documenting code. Only comment where the code cannot explain itself.
+    - **Keep comments short**: A comment is a simple sentence explaining what the code does or why, no longer than 120 characters per line.
+    - **No history in comments**: Do not narrate past decisions, alternatives considered, or issue numbers. That belongs in commit messages, PR descriptions or ADRs.`,
   ],
 });
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,3 +68,9 @@ This project's configuration is defined in the .projenrc file at the root of the
     - **Actionable error messages**: Error messages must tell the user what to do to resolve the problem, not just what went wrong. Name the exact options or values involved and state the required action.
     - **Mutually exclusive options**: When two options cannot be used together, throw an error at construction time instead of silently picking one. Use the established message pattern: `Only one of 'optionA' or 'optionB' may be specified, not both.`
     - **Deprecating options**: When replacing a deprecated option with a new one, keep the deprecated option working as before, mark it with `@deprecated` pointing to the replacement, and throw if both are set: `Only one of 'newOption' or 'deprecatedOption' may be specified, not both. Remove the deprecated 'deprecatedOption'.`
+
+## Code comments
+
+    - **Keep comments to a minimum**: Prefer self-documenting code. Only comment where the code cannot explain itself.
+    - **Keep comments short**: A comment is a simple sentence explaining what the code does or why, no longer than 120 characters per line.
+    - **No history in comments**: Do not narrate past decisions, alternatives considered, or issue numbers. That belongs in commit messages, PR descriptions or ADRs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,3 +68,9 @@ This project's configuration is defined in the .projenrc file at the root of the
     - **Actionable error messages**: Error messages must tell the user what to do to resolve the problem, not just what went wrong. Name the exact options or values involved and state the required action.
     - **Mutually exclusive options**: When two options cannot be used together, throw an error at construction time instead of silently picking one. Use the established message pattern: `Only one of 'optionA' or 'optionB' may be specified, not both.`
     - **Deprecating options**: When replacing a deprecated option with a new one, keep the deprecated option working as before, mark it with `@deprecated` pointing to the replacement, and throw if both are set: `Only one of 'newOption' or 'deprecatedOption' may be specified, not both. Remove the deprecated 'deprecatedOption'.`
+
+## Code comments
+
+    - **Keep comments to a minimum**: Prefer self-documenting code. Only comment where the code cannot explain itself.
+    - **Keep comments short**: A comment is a simple sentence explaining what the code does or why, no longer than 120 characters per line.
+    - **No history in comments**: Do not narrate past decisions, alternatives considered, or issue numbers. That belongs in commit messages, PR descriptions or ADRs.

--- a/src/github/dependency-review.ts
+++ b/src/github/dependency-review.ts
@@ -112,10 +112,12 @@ export class DependencyReview extends Component {
     workflow.on({
       pullRequest: {},
       workflowDispatch: {},
+      mergeGroup: {},
     });
 
     workflow.addJobs({
       "dependency-review": {
+        if: "(github.event_name == 'pull_request' || github.event_name == 'pull_request_target')",
         ...github.runsOnConfig(options),
         permissions: {
           contents: JobPermission.READ,

--- a/test/github/dependency-review.test.ts
+++ b/test/github/dependency-review.test.ts
@@ -34,13 +34,25 @@ describe("DependencyReview", () => {
   test("adds a dependency-review workflow when enabled", () => {
     const project = createProject();
     const wf = dependencyReviewWorkflow(project);
-    expect(wf.on).toEqual({ pull_request: {}, workflow_dispatch: {} });
+    expect(wf.on).toEqual({
+      pull_request: {},
+      workflow_dispatch: {},
+      merge_group: {},
+    });
     const job = wf.jobs["dependency-review"];
     expect(job).toBeDefined();
     const reviewStep = job.steps.find(
       (s: any) => s.name === "Dependency Review",
     );
     expect(reviewStep.uses).toMatch(/^actions\/dependency-review-action@/);
+  });
+
+  test("job is skipped outside of a pull request so it can be a required check", () => {
+    const project = createProject();
+    const wf = dependencyReviewWorkflow(project);
+    expect(wf.jobs["dependency-review"].if).toBe(
+      "(github.event_name == 'pull_request' || github.event_name == 'pull_request_target')",
+    );
   });
 
   test("auto-populates failOnSeverity from auditDepsOptions.level", () => {


### PR DESCRIPTION
The `dependency-review` workflow could not be used as a required status check. It only triggered on `pull_request`, so once a pull request entered a merge queue the check never reported back and the pull request sat in the queue until it timed out. Anyone who enabled `dependencyReview` and then protected their branch with it ran into a stuck merge queue.

The workflow now also triggers on `merge_group`, and the job carries a condition so that it is skipped whenever it runs outside of a pull request context. GitHub reports a skipped job as successful, which is exactly what a required check needs in a merge group, while the actual dependency review still only runs where the action can compare the base and head of a pull request. This is the same approach `pull-request-lint` already takes, so the two workflows now behave consistently in a merge queue.

The condition accepts both `pull_request` and `pull_request_target` so the behaviour holds for users who point the workflow at the target event to review dependencies from forks.

Also adds a short set of code comment rules to this repository's AI agent instructions, since generated comments have been trending towards narrating decisions instead of explaining code.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
