### PR TITLE
fix(javascript): license check fails for licensed private packages

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -100,7 +100,8 @@
             "--summary",
             "--production",
             "--onlyAllow",
-            "MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0;Python-2.0"
+            "MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0;Python-2.0",
+            "--excludePrivatePackages"
           ],
           "receiveArgs": true
         }

--- a/docs/api/javascript.md
+++ b/docs/api/javascript.md
@@ -9736,6 +9736,7 @@ const licenseCheckerOptions: javascript.LicenseCheckerOptions = { ... }
 | <code><a href="#projen.javascript.LicenseCheckerOptions.property.allow">allow</a></code> | <code>string[]</code> | List of SPDX license identifiers that are allowed to be used. |
 | <code><a href="#projen.javascript.LicenseCheckerOptions.property.deny">deny</a></code> | <code>string[]</code> | List of SPDX license identifiers that are prohibited to be used. |
 | <code><a href="#projen.javascript.LicenseCheckerOptions.property.development">development</a></code> | <code>boolean</code> | Check development dependencies. |
+| <code><a href="#projen.javascript.LicenseCheckerOptions.property.excludePrivatePackages">excludePrivatePackages</a></code> | <code>boolean</code> | Exclude packages marked as private from the check. |
 | <code><a href="#projen.javascript.LicenseCheckerOptions.property.production">production</a></code> | <code>boolean</code> | Check production dependencies. |
 | <code><a href="#projen.javascript.LicenseCheckerOptions.property.taskName">taskName</a></code> | <code>string</code> | The name of the task that is added to check licenses. |
 
@@ -9783,6 +9784,23 @@ public readonly development: boolean;
 - *Default:* false
 
 Check development dependencies.
+
+---
+
+##### `excludePrivatePackages`<sup>Optional</sup> <a name="excludePrivatePackages" id="projen.javascript.LicenseCheckerOptions.property.excludePrivatePackages"></a>
+
+```typescript
+public readonly excludePrivatePackages: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Exclude packages marked as private from the check.
+
+Private packages are local to the repository and not published, so their
+licenses typically don't need to be checked. This also applies to the project
+itself.
 
 ---
 

--- a/src/javascript/license-checker.ts
+++ b/src/javascript/license-checker.ts
@@ -38,6 +38,17 @@ export interface LicenseCheckerOptions {
   readonly deny?: string[];
 
   /**
+   * Exclude packages marked as private from the check.
+   *
+   * Private packages are local to the repository and not published, so their
+   * licenses typically don't need to be checked. This also applies to the project
+   * itself.
+   *
+   * @default true
+   */
+  readonly excludePrivatePackages?: boolean;
+
+  /**
    * The name of the task that is added to check licenses
    *
    * @default "check-licenses"
@@ -60,6 +71,7 @@ export class LicenseChecker extends Component {
       development = false,
       allow: allowedLicenses = [],
       deny: prohibitedLicenses = [],
+      excludePrivatePackages = true,
     } = options;
 
     if (!production && !development) {
@@ -93,6 +105,9 @@ export class LicenseChecker extends Component {
     if (prohibitedLicenses.length) {
       cmd.push("--failOn");
       cmd.push(prohibitedLicenses.join(";"));
+    }
+    if (excludePrivatePackages) {
+      cmd.push("--excludePrivatePackages");
     }
 
     this.project.deps.addDependency("license-checker", DependencyType.BUILD);

--- a/test/javascript/license-checker.test.ts
+++ b/test/javascript/license-checker.test.ts
@@ -1,6 +1,6 @@
 import { javascript } from "../../src";
 import { NodeProject } from "../../src/javascript";
-import { execProjenCLI } from "../util";
+import { execProjenCLI, synthSnapshot } from "../util";
 
 describe("license checker", () => {
   describe("validations", () => {
@@ -50,6 +50,36 @@ describe("license checker", () => {
         });
       }).toThrowErrorMatchingInlineSnapshot(
         `"LicenseChecker: \`allow\` and \`deny\` can not be used at the same time. Choose one or the other."`,
+      );
+    });
+  });
+
+  describe("excludePrivatePackages", () => {
+    const checkLicensesArgs = (project: NodeProject) =>
+      synthSnapshot(project)[".projen/tasks.json"].tasks["check-licenses"]
+        .steps[0].execArgs;
+
+    test("is passed by default", () => {
+      const project = new NodeProject({
+        name: "test",
+        defaultReleaseBranch: "main",
+        packageManager: javascript.NodePackageManager.NPM,
+        checkLicenses: { allow: ["MIT"] },
+      });
+
+      expect(checkLicensesArgs(project)).toContain("--excludePrivatePackages");
+    });
+
+    test("can be disabled explicitly", () => {
+      const project = new NodeProject({
+        name: "test",
+        defaultReleaseBranch: "main",
+        packageManager: javascript.NodePackageManager.NPM,
+        checkLicenses: { allow: ["MIT"], excludePrivatePackages: false },
+      });
+
+      expect(checkLicensesArgs(project)).not.toContain(
+        "--excludePrivatePackages",
       );
     });
   });


### PR DESCRIPTION
The license check fails on private packages that are perfectly well licensed.

`license-checker` reports any package marked as `"private": true` as `UNLICENSED`, ignoring its `license` field. Since the check covers the project's own package and any local workspace packages, a private package trips an `--onlyAllow` check even though its license is declared and acceptable — and there is nothing the user can do about it short of making the package public.

Private packages are now excluded by passing `--excludePrivatePackages` through to `license-checker`. The new `excludePrivatePackages` option defaults to `true` for that reason, and can be set to `false` to restore the previous behaviour.

This changes the generated `check-licenses` task for existing users, as visible in this repository's own `tasks.json`. The check only becomes less strict, so it cannot turn a passing build into a failing one.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
