### PR TITLE
feat(release): support releaseCommitMessageFormat in updateChangelog

### DIFF
--- a/src/release/update-changelog.task.ts
+++ b/src/release/update-changelog.task.ts
@@ -10,6 +10,7 @@
  * - VERSION_FILE: Current semantic version file
  * - CHANGELOG_FILE: Release changelog
  * - PROJECT_CHANGELOG_FILE: Project-level changelog
+ * - RELEASE_COMMIT_MESSAGE_FORMAT: Custom commit message format (optional)
  *
  */
 import type { UpdateChangelogOptions } from "./update-changelog";
@@ -18,6 +19,7 @@ import { updateChangelog } from "./update-changelog";
 const inputChangelog = process.env.CHANGELOG;
 const outputChangelog = process.env.PROJECT_CHANGELOG_FILE;
 const versionFile = process.env.VERSION_FILE;
+const releaseCommitMessageFormat = process.env.RELEASE_COMMIT_MESSAGE_FORMAT;
 
 if (!versionFile) {
   throw new Error("VERSION_FILE is required");
@@ -35,6 +37,7 @@ const opts: UpdateChangelogOptions = {
   inputChangelog,
   outputChangelog,
   versionFile: versionFile,
+  releaseCommitMessageFormat: releaseCommitMessageFormat || undefined,
 };
 
 updateChangelog(process.cwd(), opts).catch((e: Error) => {

--- a/src/release/update-changelog.ts
+++ b/src/release/update-changelog.ts
@@ -30,6 +30,15 @@ export interface UpdateChangelogOptions {
    * Release version.
    */
   versionFile: string;
+
+  /**
+   * Custom commit message format for the changelog update commit.
+   *
+   * Replaces `{{currentTag}}` with the version.
+   *
+   * @default "chore(release): {{currentTag}}"
+   */
+  releaseCommitMessageFormat?: string;
 }
 
 /**
@@ -86,6 +95,13 @@ export async function updateChangelog(
 
   await fs.writeFile(outputChangelog, newChangelog);
 
+  const commitMessageFormat =
+    options.releaseCommitMessageFormat ?? "chore(release): {{currentTag}}";
+  const commitMessage = commitMessageFormat.replace(
+    /\{\{currentTag\}\}/g,
+    version,
+  );
+
   git.run(["add", outputChangelog], { cwd });
-  git.run(["commit", "-m", `chore(release): ${version}`], { cwd });
+  git.run(["commit", "-m", commitMessage], { cwd });
 }

--- a/test/release/update-changelog.test.ts
+++ b/test/release/update-changelog.test.ts
@@ -31,6 +31,19 @@ test("commits new changelog", async () => {
   expect(result.lastCommitContent).toMatch(/.*CHANGELOG\.md.*/g);
 });
 
+test("commits new changelog with custom releaseCommitMessageFormat", async () => {
+  const result = await testUpdateChangelog({
+    updateChangelogOptions: {
+      releaseCommitMessageFormat: "chore(release): @scope/pkg@{{currentTag}}",
+    },
+  });
+
+  expect(result.commits[0]).toMatch(
+    `chore(release): @scope/pkg@${DEFAULT_VERSION}`,
+  );
+  expect(result.lastCommitContent).toMatch(/.*CHANGELOG\.md.*/g);
+});
+
 test("adds a new changelog if missing", async () => {
   const result = await testUpdateChangelog({
     testOptions: {
@@ -180,6 +193,7 @@ async function testUpdateChangelog(opts: TestUpdateChangelogOpts = {}) {
     inputChangelog,
     outputChangelog,
     versionFile: versionFile,
+    ...opts.updateChangelogOptions,
   });
 
   const commits = gitTool


### PR DESCRIPTION
Fixes #2268

Support `releaseCommitMessageFormat` in `updateChangelog` and its task execution so monorepos and custom release setups can format changelog commit messages (e.g. `chore(release): @scope/pkg@{{currentTag}}`) instead of being restricted to the default `chore(release): ${version}`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Validation observed for this change:
- `pnpm test test/release/update-changelog.test.ts`
- `node ./projen.js eslint`

Fixes #2268

<!-- repo-agent-case:6cb51606-6542-48e2-a1dd-43f06425da35 -->